### PR TITLE
feat(data-apps): add starter templates for app generation

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -12,6 +12,9 @@ the hood, Claude Code runs inside an isolated sandbox, reads the project's dbt m
 builds it with Vite, and deploys the artifacts to S3. The resulting app is served in a sandboxed iframe and can query
 Lightdash metrics through a secure postMessage bridge.
 
+When creating a new app, users start from a **Starter Template** (Dashboard / Slide Show / PDF Report / Custom) and
+answer a few clarifying questions to seed the first prompt. See [Starter Templates](#starter-templates) below.
+
 The feature is enterprise-only, gated behind the `APP_RUNTIME_ENABLED` flag and the `view:DataApp` / `create:DataApp` / `manage:DataApp` permission scopes (see [Permissions](#permissions) below).
 
 ---
@@ -52,8 +55,41 @@ flowchart LR
    - `apps/{appUuid}/versions/{version}/source.tar` — source code (restored for future iterations)
 
 7. **Preview serving** — The built app is served through an Express router at `/api/apps/{appUuid}/versions/{version}/`.
-   Authentication uses short-lived JWT tokens. The iframe runs with `sandbox="allow-scripts"` (no same-origin access) and
-   strict CSP headers.
+   Authentication uses short-lived JWT tokens. The iframe runs with `sandbox="allow-scripts allow-modals"` (no
+   same-origin access) and strict CSP headers.
+
+### Starter Templates
+
+To avoid the blank-page problem, the **new-app** flow opens with a 3-stage wizard instead of an empty chat:
+
+1. **Pick a template** - `Dashboard`, `Slide Show`, `PDF Report`, or `Custom`. Each describes a layout intent.
+2. **Answer 2-3 clarifying questions** - template-specific (e.g., topic, audience, key metrics for Dashboard).
+   "Custom" skips this stage.
+3. **Review & generate** - the wizard composes a starting prompt from the answers, prefills the textarea, and
+   the user can edit it before hitting send.
+
+Templates are **only meaningful for v1**. Iteration prompts (v2+) never see the wizard.
+
+How the template flows through the stack:
+
+- The frontend sends a structured `template: 'dashboard' | 'slideshow' | 'pdf' | 'custom'` field on
+  `POST /api/v1/ee/projects/{projectUuid}/apps/`, alongside the user's prompt.
+- The backend `AppGenerateService` carries `template` into the `appGeneratePipeline` job payload.
+- During the `catalog` stage in `writeCatalogAndPrompt`, the backend prepends a template-specific instruction block
+  (from `AppGenerateService/templates.ts`) to the prompt before writing it to `/tmp/prompt.txt`. This is the same
+  prepend slot used today for chart references and image references.
+- For `template === 'custom'`, no instructions are prepended - Claude only sees the user's free-text prompt.
+- Templates are **not persisted** in `app_versions` - they only influence the first generation. If the original
+  intent matters later, it's captured by the resulting code, not the row.
+
+Where the template metadata lives:
+
+| Concern                                | Location                                                                                     |
+| -------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Enum + request type                    | `packages/common/src/ee/apps/types.ts` (`DATA_APP_TEMPLATES`, `DataAppTemplate`)             |
+| Backend instructions                   | `packages/backend/src/ee/services/AppGenerateService/templates.ts`                           |
+| Frontend metadata + prompt composition | `packages/frontend/src/features/apps/templates.ts`                                           |
+| Wizard UI                              | `AppTemplatePicker.tsx`, `AppTemplateQuestions.tsx`; orchestrated by `pages/AppGenerate.tsx` |
 
 ### Iteration
 
@@ -175,11 +211,16 @@ Preview router: `packages/backend/src/routers/appPreviewRouter.ts`
 
 ### Iframe Sandboxing
 
-The preview iframe uses `sandbox="allow-scripts"` without `allow-same-origin`. This means:
+The preview iframe uses `sandbox="allow-scripts allow-modals"` without `allow-same-origin`. This means:
 
 - The iframe cannot access the parent page's cookies or storage
 - The iframe cannot make credentialed requests to the Lightdash API directly
 - All API communication goes through a `postMessage` bridge
+
+`allow-modals` is enabled so that PDF Report templates (and any generated app that wants a Print button) can call
+`window.print()`. It also enables `alert`/`confirm`/`prompt`, which are an accepted trade-off: the iframe is still
+isolated from the parent origin, the browser attributes dialog origins to the iframe, and a malicious app could
+already build an equivalent in-iframe HTML form.
 
 ### PostMessage Bridge (`useAppSdkBridge`)
 
@@ -359,15 +400,15 @@ scopes, all defined in `packages/common/src/authorization/scopes.ts`:
 
 ### Permission matrix
 
-| Action                                       | Project admin | Space admin/editor | Space viewer | App creator (personal app) |
-| -------------------------------------------- | ------------- | ------------------ | ------------ | -------------------------- |
-| View an app in a space                       | ✓             | ✓                  | ✓            | (creator viewed via space) |
-| View own personal app                        | ✓             | —                  | —            | ✓                          |
-| View someone else's personal app             | ✓             | —                  | —            | —                          |
-| Create a new app                             | ✓             | ✓                  | ✗            | n/a                        |
-| Iterate / cancel / update / move / delete    | ✓             | ✓ (in their space) | ✗            | ✓ (own personal app)       |
-| Pin to homepage                              | ✓             | ✓ (in their space) | ✗            | — (personal apps can't be pinned) |
-| Restore / permanently delete                 | ✓             | ✗                  | ✗            | ✗                          |
+| Action                                    | Project admin | Space admin/editor | Space viewer | App creator (personal app)        |
+| ----------------------------------------- | ------------- | ------------------ | ------------ | --------------------------------- |
+| View an app in a space                    | ✓             | ✓                  | ✓            | (creator viewed via space)        |
+| View own personal app                     | ✓             | —                  | —            | ✓                                 |
+| View someone else's personal app          | ✓             | —                  | —            | —                                 |
+| Create a new app                          | ✓             | ✓                  | ✗            | n/a                               |
+| Iterate / cancel / update / move / delete | ✓             | ✓ (in their space) | ✗            | ✓ (own personal app)              |
+| Pin to homepage                           | ✓             | ✓ (in their space) | ✗            | — (personal apps can't be pinned) |
+| Restore / permanently delete              | ✓             | ✗                  | ✗            | ✗                                 |
 
 The "App creator" column applies while an app is still personal (`space_uuid IS NULL`). Once moved into a space, the
 app's permissions follow the space — the creator no longer has special rights unless they also have a space role.

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -60,6 +60,7 @@ export class AppGenerateController extends BaseController {
             body.appUuid,
             body.chartUuids,
             body.dashboardUuid,
+            body.template,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -19,6 +19,7 @@ import {
     type AppVersionChartResource,
     type AppVersionResources,
     type ChartReference,
+    type DataAppTemplate,
     type SessionUser,
     type TogglePinnedItemInfo,
 } from '@lightdash/common';
@@ -50,6 +51,7 @@ import type { DashboardService } from '../../../services/DashboardService/Dashbo
 import type { SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
+import { getTemplateInstructions } from './templates';
 
 type AppGenerateServiceDeps = {
     lightdashConfig: LightdashConfig;
@@ -867,6 +869,7 @@ export class AppGenerateService extends BaseService {
         s3Client: S3Client,
         bucket: string,
         chartReferences: ChartReference[] | undefined,
+        template: DataAppTemplate | undefined,
     ): Promise<{
         durationMs: number;
         tableCount: number;
@@ -899,6 +902,14 @@ export class AppGenerateService extends BaseService {
                 chartReferences,
             );
             finalPrompt = referenceBlock + finalPrompt;
+        }
+
+        // Prepend starter-template instructions, when one was selected on creation
+        if (template) {
+            const templateInstructions = getTemplateInstructions(template);
+            if (templateInstructions) {
+                finalPrompt = `${templateInstructions}\n\n${finalPrompt}`;
+            }
         }
 
         // Resolve image from staging, copy to version path, and write to sandbox
@@ -1730,7 +1741,7 @@ export class AppGenerateService extends BaseService {
         imageId: string | undefined,
         chartReferences: ChartReference[] | undefined,
     ): Promise<void> {
-        const { appUuid, version, projectUuid, prompt } = payload;
+        const { appUuid, version, projectUuid, prompt, template } = payload;
         const durations: Record<string, number> = { ...extraDurations };
         const shouldRun = (stage: AppVersionStatus) =>
             AppGenerateService.shouldRunStage(currentStatus, stage);
@@ -1766,6 +1777,7 @@ export class AppGenerateService extends BaseService {
                     s3Client,
                     bucket,
                     chartReferences,
+                    template,
                 );
                 durations.catalogMs = catalogResult.durationMs;
                 catalogStats = {
@@ -2123,6 +2135,7 @@ export class AppGenerateService extends BaseService {
         preGeneratedAppUuid?: string,
         chartUuids?: string[],
         dashboardUuid?: string,
+        template?: DataAppTemplate,
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
         const organizationUuid = await this.getProjectOrgUuid(projectUuid);
@@ -2196,6 +2209,7 @@ export class AppGenerateService extends BaseService {
                 version,
                 promptLength: prompt.length,
                 hasImage: imageId !== undefined,
+                template: template ?? null,
             },
         });
 
@@ -2206,6 +2220,7 @@ export class AppGenerateService extends BaseService {
             organizationUuid: user.organizationUuid!,
             userUuid: user.userUuid,
             prompt,
+            template,
             imageId,
             isIteration: false,
             chartReferences:

--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -1,0 +1,47 @@
+import { assertUnreachable, type DataAppTemplate } from '@lightdash/common';
+
+const DASHBOARD_INSTRUCTIONS = `[Starter template: Dashboard]
+Build a single-page dashboard layout:
+- Use a CSS grid layout with 2–4 columns of cards (assume a desktop viewport).
+- Place the most important KPI tiles (single big-number cards) at the top of the page.
+- Below the KPI row, render charts in a grid; group related metrics together.
+- Include a clear page title and a short subtitle/description at the top.
+- Keep card titles concise. Avoid long paragraphs of body copy.
+- Default to a dense, scannable layout.`;
+
+const SLIDESHOW_INSTRUCTIONS = `[Starter template: Slide Show]
+Build a slideshow-style data app:
+- Render one slide at a time, occupying the full viewport.
+- Each slide focuses on a single chart or insight, with a headline and a short caption.
+- Provide previous/next navigation (buttons and keyboard arrow keys) and a slide counter.
+- Open with a title slide and close with a summary slide.
+- Use large typography suitable for presenting on a screen.`;
+
+const PDF_REPORT_INSTRUCTIONS = `[Starter template: PDF Report]
+Build a print-optimized report:
+- Layout for A4/Letter portrait pages with comfortable margins.
+- Use a clean, document-style typography hierarchy (title, section headings, body).
+- Render charts at fixed widths so they reflow across pages cleanly.
+- Include a title page header (title, subtitle, generated-on date) and section dividers.
+- Apply CSS \`@media print\` rules and \`page-break-inside: avoid\` on cards and figures.
+- Prefer narrative copy with charts as supporting evidence, not a dense dashboard grid.`;
+
+export const getTemplateInstructions = (
+    template: DataAppTemplate,
+): string | null => {
+    switch (template) {
+        case 'dashboard':
+            return DASHBOARD_INSTRUCTIONS;
+        case 'slideshow':
+            return SLIDESHOW_INSTRUCTIONS;
+        case 'pdf':
+            return PDF_REPORT_INSTRUCTIONS;
+        case 'custom':
+            return null;
+        default:
+            return assertUnreachable(
+                template,
+                `Unknown data app template: ${template}`,
+            );
+    }
+};

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6883,6 +6883,20 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppTemplate: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['dashboard'] },
+                { dataType: 'enum', enums: ['slideshow'] },
+                { dataType: 'enum', enums: ['pdf'] },
+                { dataType: 'enum', enums: ['custom'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     GenerateAppRequestBody: {
         dataType: 'refAlias',
         type: {
@@ -6895,6 +6909,7 @@ const models: TsoaRoute.Models = {
                 },
                 appUuid: { dataType: 'string' },
                 imageId: { dataType: 'string' },
+                template: { ref: 'DataAppTemplate' },
                 prompt: { dataType: 'string', required: true },
             },
             validators: {},
@@ -8844,11 +8859,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9326,11 +9341,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9345,11 +9360,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9364,11 +9379,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9383,11 +9398,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9402,11 +9417,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9472,8 +9487,8 @@ const models: TsoaRoute.Models = {
                     artifactType: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['chart'] },
                             { dataType: 'enum', enums: ['dashboard'] },
+                            { dataType: 'enum', enums: ['chart'] },
                         ],
                         required: true,
                     },
@@ -9869,8 +9884,8 @@ const models: TsoaRoute.Models = {
                     artifactType: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['chart'] },
                             { dataType: 'enum', enums: ['dashboard'] },
+                            { dataType: 'enum', enums: ['chart'] },
                         ],
                         required: true,
                     },
@@ -29549,11 +29564,11 @@ const models: TsoaRoute.Models = {
                                 dataType: 'double',
                                 required: true,
                             },
+                            chartCount: { dataType: 'double', required: true },
                             dashboardCount: {
                                 dataType: 'double',
                                 required: true,
                             },
-                            chartCount: { dataType: 'double', required: true },
                         },
                     },
                 ],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8271,6 +8271,10 @@
             "ApiGenerateAppResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__appUuid-string--version-number__"
             },
+            "DataAppTemplate": {
+                "type": "string",
+                "enum": ["dashboard", "slideshow", "pdf", "custom"]
+            },
             "GenerateAppRequestBody": {
                 "properties": {
                     "dashboardUuid": {
@@ -8287,6 +8291,9 @@
                     },
                     "imageId": {
                         "type": "string"
+                    },
+                    "template": {
+                        "$ref": "#/components/schemas/DataAppTemplate"
                     },
                     "prompt": {
                         "type": "string"
@@ -10310,6 +10317,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -10570,7 +10590,7 @@
                     },
                     "artifactType": {
                         "type": "string",
-                        "enum": ["chart", "dashboard"]
+                        "enum": ["dashboard", "chart"]
                     }
                 },
                 "required": [
@@ -10941,7 +10961,7 @@
                     },
                     "artifactType": {
                         "type": "string",
-                        "enum": ["chart", "dashboard"]
+                        "enum": ["dashboard", "chart"]
                     },
                     "threadUuid": {
                         "type": "string"
@@ -30861,11 +30881,11 @@
                                 "type": "number",
                                 "format": "double"
                             },
-                            "dashboardCount": {
+                            "chartCount": {
                                 "type": "number",
                                 "format": "double"
                             },
-                            "chartCount": {
+                            "dashboardCount": {
                                 "type": "number",
                                 "format": "double"
                             }
@@ -30874,8 +30894,8 @@
                             "appCount",
                             "nestedSpaceCount",
                             "schedulerCount",
-                            "dashboardCount",
-                            "chartCount"
+                            "chartCount",
+                            "dashboardCount"
                         ],
                         "type": "object"
                     }

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -36,8 +36,17 @@ export type ApiAppImageUploadResponse = ApiSuccess<{
     imageId: string;
 }>;
 
+export const DATA_APP_TEMPLATES = [
+    'dashboard',
+    'slideshow',
+    'pdf',
+    'custom',
+] as const;
+export type DataAppTemplate = (typeof DATA_APP_TEMPLATES)[number];
+
 export type GenerateAppRequestBody = {
     prompt: string;
+    template?: DataAppTemplate; // starter template selected on app creation; ignored on iteration
     imageId?: string;
     appUuid?: string; // pre-generated UUID so images can be scoped to the app in S3
     chartUuids?: string[]; // saved chart UUIDs to resolve and pass as structured metric queries

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -2,6 +2,7 @@ import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
     type ChartReference,
+    type DataAppTemplate,
     type EmbedArtifactVersionJobPayload,
     type GenerateArtifactQuestionJobPayload,
     type SlackPromptJobPayload,
@@ -40,6 +41,7 @@ export type AppGeneratePipelineJobPayload = TraceTaskBase & {
     appUuid: string;
     version: number;
     prompt: string;
+    template?: DataAppTemplate; // starter template selected on creation; absent on iteration
     imageId?: string;
     isIteration: boolean;
     chartReferences?: ChartReference[];

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -9,10 +9,13 @@ type Props = {
 /**
  * Renders a sandboxed app preview iframe with a postMessage fetch proxy.
  *
- * The iframe has `sandbox="allow-scripts"` (no `allow-same-origin`),
- * so it cannot access the parent's cookies. The SDK inside the iframe
- * routes all API calls through postMessage, and this component's bridge
- * executes them using the current user's session.
+ * The iframe has `sandbox="allow-scripts allow-modals"` (no `allow-same-origin`),
+ * so it cannot access the parent's cookies. `allow-modals` lets generated apps
+ * call `window.print()` (needed for PDF Report templates) - it also enables
+ * `alert`/`confirm`/`prompt`, which is acceptable here since the iframe is
+ * already isolated from parent origin. The SDK inside the iframe routes all
+ * API calls through postMessage, and this component's bridge executes them
+ * using the current user's session.
  */
 const AppIframePreview: FC<Props> = ({ src, onQueryEvent }) => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -24,7 +27,7 @@ const AppIframePreview: FC<Props> = ({ src, onQueryEvent }) => {
             src={src}
             style={{ width: '100%', height: '100%', border: 'none' }}
             title="App preview"
-            sandbox="allow-scripts"
+            sandbox="allow-scripts allow-modals"
             allow=""
             onLoad={handleIframeLoad}
         />

--- a/packages/frontend/src/features/apps/AppTemplatePicker.module.css
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.module.css
@@ -1,0 +1,46 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--mantine-spacing-md);
+    padding: var(--mantine-spacing-xl);
+    margin: auto;
+    max-width: 560px;
+    width: 100%;
+}
+
+.heading {
+    text-align: center;
+    margin-bottom: var(--mantine-spacing-xs);
+}
+
+.card {
+    padding: var(--mantine-spacing-md);
+    border: 1px solid var(--mantine-color-default-border);
+    transition:
+        border-color 120ms ease,
+        background-color 120ms ease;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+
+    &:hover {
+        border-color: var(--mantine-color-blue-5);
+
+        @mixin light {
+            background-color: var(--mantine-color-ldGray-1);
+        }
+        @mixin dark {
+            background-color: var(--mantine-color-ldDark-4);
+        }
+    }
+}
+
+.cardIcon {
+    flex-shrink: 0;
+}
+
+.cardTitle {
+    line-height: 1.2;
+}

--- a/packages/frontend/src/features/apps/AppTemplatePicker.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.tsx
@@ -1,0 +1,65 @@
+import { type DataAppTemplate } from '@lightdash/common';
+import { Group, SimpleGrid, Stack, Text, ThemeIcon } from '@mantine-8/core';
+import { type FC } from 'react';
+import { PolymorphicPaperButton } from '../../components/common/PolymorphicPaperButton';
+import classes from './AppTemplatePicker.module.css';
+import { TEMPLATES } from './templates';
+
+type Props = {
+    onSelect: (template: DataAppTemplate) => void;
+};
+
+const AppTemplatePicker: FC<Props> = ({ onSelect }) => (
+    <div className={classes.wrapper}>
+        <Stack gap={4} className={classes.heading}>
+            <Text fw={600} size="lg">
+                Build a data app
+            </Text>
+            <Text size="sm" c="dimmed">
+                Pick a starting point - you can customize the prompt before
+                generating.
+            </Text>
+        </Stack>
+        <SimpleGrid cols={{ base: 1, xs: 2 }} spacing="sm">
+            {TEMPLATES.map((template) => {
+                const Icon = template.icon;
+                return (
+                    <PolymorphicPaperButton
+                        key={template.id}
+                        component="button"
+                        type="button"
+                        className={classes.card}
+                        onClick={() => onSelect(template.id)}
+                        radius="md"
+                    >
+                        <Group gap="sm" wrap="nowrap" align="flex-start">
+                            <ThemeIcon
+                                size="lg"
+                                radius="md"
+                                variant="light"
+                                color="gray"
+                                className={classes.cardIcon}
+                            >
+                                <Icon size={20} />
+                            </ThemeIcon>
+                            <Stack gap={2}>
+                                <Text
+                                    fw={600}
+                                    size="sm"
+                                    className={classes.cardTitle}
+                                >
+                                    {template.title}
+                                </Text>
+                                <Text size="xs" c="dimmed">
+                                    {template.description}
+                                </Text>
+                            </Stack>
+                        </Group>
+                    </PolymorphicPaperButton>
+                );
+            })}
+        </SimpleGrid>
+    </div>
+);
+
+export default AppTemplatePicker;

--- a/packages/frontend/src/features/apps/AppTemplateQuestions.module.css
+++ b/packages/frontend/src/features/apps/AppTemplateQuestions.module.css
@@ -1,0 +1,27 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-md);
+    padding: var(--mantine-spacing-xl);
+    margin: auto;
+    max-width: 560px;
+    width: 100%;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-sm);
+}
+
+.headerTitle {
+    flex: 1;
+    line-height: 1.2;
+}
+
+.footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: var(--mantine-spacing-xs);
+}

--- a/packages/frontend/src/features/apps/AppTemplateQuestions.tsx
+++ b/packages/frontend/src/features/apps/AppTemplateQuestions.tsx
@@ -1,0 +1,78 @@
+import { Button, Stack, Text, TextInput, ThemeIcon } from '@mantine-8/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { type FC } from 'react';
+import classes from './AppTemplateQuestions.module.css';
+import { type TemplateDefinition } from './templates';
+
+type Props = {
+    template: TemplateDefinition;
+    answers: Record<string, string>;
+    onAnswersChange: (answers: Record<string, string>) => void;
+    onBack: () => void;
+    onContinue: () => void;
+};
+
+const AppTemplateQuestions: FC<Props> = ({
+    template,
+    answers,
+    onAnswersChange,
+    onBack,
+    onContinue,
+}) => {
+    const Icon = template.icon;
+    const allRequiredAnswered = template.questions.every(
+        (q) => !q.required || (answers[q.id] ?? '').trim().length > 0,
+    );
+
+    const setAnswer = (id: string, value: string) => {
+        onAnswersChange({ ...answers, [id]: value });
+    };
+
+    return (
+        <div className={classes.wrapper}>
+            <div className={classes.header}>
+                <ThemeIcon size="lg" radius="md" variant="light" color="gray">
+                    <Icon size={20} />
+                </ThemeIcon>
+                <Stack gap={2} className={classes.headerTitle}>
+                    <Text fw={600} size="md">
+                        {template.title}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                        Answer a few questions and we'll draft your prompt.
+                    </Text>
+                </Stack>
+            </div>
+            <Stack gap="sm">
+                {template.questions.map((question) => (
+                    <TextInput
+                        key={question.id}
+                        label={question.label}
+                        placeholder={question.placeholder}
+                        value={answers[question.id] ?? ''}
+                        onChange={(e) =>
+                            setAnswer(question.id, e.currentTarget.value)
+                        }
+                        withAsterisk={question.required}
+                        autoFocus={question === template.questions[0]}
+                    />
+                ))}
+            </Stack>
+            <div className={classes.footer}>
+                <Button
+                    variant="subtle"
+                    color="gray"
+                    leftSection={<IconArrowLeft size={14} />}
+                    onClick={onBack}
+                >
+                    Back
+                </Button>
+                <Button onClick={onContinue} disabled={!allRequiredAnswered}>
+                    Continue
+                </Button>
+            </div>
+        </div>
+    );
+};
+
+export default AppTemplateQuestions;

--- a/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
@@ -1,10 +1,15 @@
-import { type ApiError, type ApiGenerateAppResponse } from '@lightdash/common';
+import {
+    type ApiError,
+    type ApiGenerateAppResponse,
+    type DataAppTemplate,
+} from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
 type GenerateAppParams = {
     projectUuid: string;
     prompt: string;
+    template?: DataAppTemplate;
     imageId?: string;
     appUuid?: string; // pre-generated UUID so images are scoped to the app in S3
     chartUuids?: string[];
@@ -16,6 +21,7 @@ type GenerateAppResult = ApiGenerateAppResponse['results'];
 const generateApp = async ({
     projectUuid,
     prompt,
+    template,
     imageId,
     appUuid,
     chartUuids,
@@ -26,6 +32,7 @@ const generateApp = async ({
         url: `/ee/projects/${projectUuid}/apps/`,
         body: JSON.stringify({
             prompt,
+            template,
             imageId,
             appUuid,
             chartUuids,

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -1,0 +1,160 @@
+import { type DataAppTemplate } from '@lightdash/common';
+import {
+    IconFileText,
+    IconLayoutDashboard,
+    IconPresentation,
+    IconSparkles,
+    type Icon as TablerIcon,
+} from '@tabler/icons-react';
+
+export type TemplateQuestion = {
+    id: string;
+    label: string;
+    placeholder?: string;
+    required?: boolean;
+};
+
+export type TemplateDefinition = {
+    id: DataAppTemplate;
+    title: string;
+    description: string;
+    icon: TablerIcon;
+    questions: TemplateQuestion[];
+    composePrompt: (answers: Record<string, string>) => string;
+};
+
+const sentence = (s: string | undefined): string => {
+    const trimmed = (s ?? '').trim();
+    if (!trimmed) return '';
+    return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+};
+
+const optionalSentence = (
+    prefix: string,
+    s: string | undefined,
+): string | null => {
+    const trimmed = (s ?? '').trim();
+    if (!trimmed) return null;
+    return sentence(`${prefix}${trimmed}`);
+};
+
+const joinNonEmpty = (parts: (string | null)[]): string =>
+    parts.filter((p): p is string => p !== null && p.length > 0).join(' ');
+
+export const TEMPLATES: TemplateDefinition[] = [
+    {
+        id: 'dashboard',
+        title: 'Dashboard',
+        description: 'A grid of KPIs and charts for at-a-glance reporting.',
+        icon: IconLayoutDashboard,
+        questions: [
+            {
+                id: 'topic',
+                label: "What's the dashboard about?",
+                placeholder: 'e.g. Revenue overview',
+                required: true,
+            },
+            {
+                id: 'audience',
+                label: 'Who is the audience?',
+                placeholder: 'e.g. Sales leadership',
+            },
+            {
+                id: 'kpis',
+                label: 'Which key metrics should stand out?',
+                placeholder: 'e.g. ARR, customer count, churn rate',
+            },
+        ],
+        composePrompt: (a) =>
+            joinNonEmpty([
+                sentence(`Build a dashboard about ${a.topic ?? ''}`),
+                optionalSentence('The audience is ', a.audience),
+                optionalSentence(
+                    'Highlight these key metrics at the top: ',
+                    a.kpis,
+                ),
+            ]),
+    },
+    {
+        id: 'slideshow',
+        title: 'Slide Show',
+        description:
+            'A guided narrative - one chart per slide, navigated linearly.',
+        icon: IconPresentation,
+        questions: [
+            {
+                id: 'topic',
+                label: "What's the story about?",
+                placeholder: 'e.g. Q3 sales performance',
+                required: true,
+            },
+            {
+                id: 'audience',
+                label: 'Who will be presenting this to whom?',
+                placeholder: 'e.g. CFO presenting to the board',
+            },
+            {
+                id: 'arc',
+                label: 'What story arc do you want?',
+                placeholder:
+                    'e.g. Headline result → drivers → risks → next steps',
+            },
+        ],
+        composePrompt: (a) =>
+            joinNonEmpty([
+                sentence(`Build a slideshow about ${a.topic ?? ''}`),
+                optionalSentence('The presentation context: ', a.audience),
+                optionalSentence('Follow this story arc: ', a.arc),
+            ]),
+    },
+    {
+        id: 'pdf',
+        title: 'PDF Report',
+        description:
+            'A print-friendly document with sections and supporting charts.',
+        icon: IconFileText,
+        questions: [
+            {
+                id: 'topic',
+                label: "What's the report about?",
+                placeholder: 'e.g. Monthly investor update',
+                required: true,
+            },
+            {
+                id: 'audience',
+                label: 'Who is the report for?',
+                placeholder: 'e.g. Investors',
+            },
+            {
+                id: 'sections',
+                label: 'What sections should it have?',
+                placeholder: 'e.g. Summary, KPIs, Growth, Risks, Outlook',
+            },
+        ],
+        composePrompt: (a) =>
+            joinNonEmpty([
+                sentence(`Build a PDF report about ${a.topic ?? ''}`),
+                optionalSentence('The report is for ', a.audience),
+                optionalSentence(
+                    'Organize it into these sections: ',
+                    a.sections,
+                ),
+            ]),
+    },
+    {
+        id: 'custom',
+        title: 'Custom',
+        description: 'Start from scratch and describe whatever you want.',
+        icon: IconSparkles,
+        questions: [],
+        composePrompt: () => '',
+    },
+];
+
+export const getTemplate = (id: DataAppTemplate): TemplateDefinition => {
+    const t = TEMPLATES.find((x) => x.id === id);
+    if (!t) {
+        throw new Error(`Unknown data app template: ${id}`);
+    }
+    return t;
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -6,6 +6,7 @@ import {
     isAppVersionInProgress,
     ResourceViewItemType,
     type ApiAppVersionSummary,
+    type DataAppTemplate,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -68,6 +69,8 @@ import {
     type SelectedChart,
     type SelectedDashboard,
 } from '../features/apps/AppResourcePicker';
+import AppTemplatePicker from '../features/apps/AppTemplatePicker';
+import AppTemplateQuestions from '../features/apps/AppTemplateQuestions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -79,6 +82,7 @@ import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
 import QueryInspector from '../features/apps/QueryInspector';
+import { getTemplate } from '../features/apps/templates';
 import { useContentAction } from '../hooks/useContent';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../hooks/useSpaces';
@@ -173,6 +177,19 @@ const AppGenerate: FC = () => {
     const location = useLocation();
     const queryClient = useQueryClient();
     const [prompt, setPrompt] = useState('');
+    // Starter-template wizard state (only meaningful for v1 of a new app).
+    // 'pick'      → show the 4 template cards (replaces the empty state)
+    // 'questions' → show clarifying-questions form for the selected template
+    // 'confirm'   → wizard collapses; user reviews/edits the prefilled prompt
+    //               in the existing textarea and submits as normal.
+    const [selectedTemplate, setSelectedTemplate] =
+        useState<DataAppTemplate | null>(null);
+    const [templateAnswers, setTemplateAnswers] = useState<
+        Record<string, string>
+    >({});
+    const [wizardStage, setWizardStage] = useState<
+        'pick' | 'questions' | 'confirm'
+    >('pick');
     const [imageAttachment, setImageAttachment] = useState<{
         file: File;
         previewUrl: string;
@@ -250,6 +267,9 @@ const AppGenerate: FC = () => {
         setLocalMessages([]);
         setPreviewApp(null);
         setTrackedQueries([]);
+        setSelectedTemplate(null);
+        setTemplateAnswers({});
+        setWizardStage('pick');
         versionCacheRef.current.clear();
         versionCacheAppRef.current = undefined;
         sentImagesByPrompt.current.forEach((url) => URL.revokeObjectURL(url));
@@ -434,6 +454,19 @@ const AppGenerate: FC = () => {
         () => [...historyMessages, ...localMessages],
         [historyMessages, localMessages],
     );
+
+    // The starter-template wizard only shows for v1 of a brand-new app -
+    // before the URL has an appUuid and before any messages exist.
+    const isNewApp = !urlAppUuid && !activeAppUuid;
+    // While the wizard is in pick/questions, the chat input area is hidden
+    // - the wizard's own buttons drive the flow. When stage='confirm', the
+    // input area reappears with the composed prompt prefilled for the user
+    // to review and edit before submitting.
+    const wizardCoversInput =
+        isNewApp &&
+        messages.length === 0 &&
+        !isLoading &&
+        wizardStage !== 'confirm';
 
     // `hasNextPage` reflects the server's "more pages exist" signal, but we
     // accumulate versions across fetches in `versionCacheRef` — so even if the
@@ -723,6 +756,7 @@ const AppGenerate: FC = () => {
                 {
                     projectUuid,
                     prompt: trimmed,
+                    template: selectedTemplate ?? undefined,
                     imageId,
                     appUuid: newAppUuid,
                     chartUuids,
@@ -731,6 +765,35 @@ const AppGenerate: FC = () => {
                 callbacks,
             );
         }
+    };
+
+    const handleTemplateSelect = (template: DataAppTemplate) => {
+        setSelectedTemplate(template);
+        setTemplateAnswers({});
+        if (template === 'custom') {
+            // Skip clarifying questions - drop straight into the existing
+            // free-text input area.
+            setWizardStage('confirm');
+            setPrompt('');
+            return;
+        }
+        setWizardStage('questions');
+    };
+
+    const handleTemplateBack = () => {
+        setWizardStage('pick');
+        setTemplateAnswers({});
+    };
+
+    const handleTemplateContinue = () => {
+        if (!selectedTemplate) return;
+        const composed =
+            getTemplate(selectedTemplate).composePrompt(templateAnswers);
+        setPrompt(composed);
+        setWizardStage('confirm');
+        // Move focus to the textarea so the user can immediately tweak the
+        // composed prompt before sending.
+        setTimeout(() => textareaRef.current?.focus(), 0);
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -794,24 +857,40 @@ const AppGenerate: FC = () => {
                                 </Group>
                             )}
                             {messages.length === 0 && !isLoading ? (
-                                <Box className={classes.emptyChat}>
-                                    <ThemeIcon
-                                        size="xl"
-                                        radius="xl"
-                                        variant="light"
-                                        color="gray"
-                                    >
-                                        <IconSparkles size={24} />
-                                    </ThemeIcon>
-                                    <Text fw={600} size="lg">
-                                        Build a data app
-                                    </Text>
-                                    <Text size="sm" c="dimmed" maw={280}>
-                                        Describe what you want to build and I'll
-                                        generate a data app connected to your
-                                        project.
-                                    </Text>
-                                </Box>
+                                isNewApp && wizardStage === 'pick' ? (
+                                    <AppTemplatePicker
+                                        onSelect={handleTemplateSelect}
+                                    />
+                                ) : isNewApp &&
+                                  wizardStage === 'questions' &&
+                                  selectedTemplate ? (
+                                    <AppTemplateQuestions
+                                        template={getTemplate(selectedTemplate)}
+                                        answers={templateAnswers}
+                                        onAnswersChange={setTemplateAnswers}
+                                        onBack={handleTemplateBack}
+                                        onContinue={handleTemplateContinue}
+                                    />
+                                ) : (
+                                    <Box className={classes.emptyChat}>
+                                        <ThemeIcon
+                                            size="xl"
+                                            radius="xl"
+                                            variant="light"
+                                            color="gray"
+                                        >
+                                            <IconSparkles size={24} />
+                                        </ThemeIcon>
+                                        <Text fw={600} size="lg">
+                                            Build a data app
+                                        </Text>
+                                        <Text size="sm" c="dimmed" maw={280}>
+                                            Describe what you want to build and
+                                            I'll generate a data app connected
+                                            to your project.
+                                        </Text>
+                                    </Box>
+                                )
                             ) : (
                                 <>
                                     {messages.map((msg, i) =>
@@ -1005,137 +1084,154 @@ const AppGenerate: FC = () => {
                         </Box>
 
                         {/* Chat Input */}
-                        <Box className={classes.chatInputArea}>
-                            <input
-                                ref={fileInputRef}
-                                type="file"
-                                accept="image/png,image/jpeg,image/gif,image/webp"
-                                onChange={handleFileInputChange}
-                                hidden
-                            />
-                            <Box className={classes.inputWrapper}>
-                                <Box className={classes.textareaColumn}>
-                                    <Textarea
-                                        ref={textareaRef}
-                                        placeholder="Describe the app you want to build..."
-                                        autosize
-                                        minRows={1}
-                                        maxRows={6}
-                                        value={prompt}
-                                        onChange={(e) =>
-                                            setPrompt(e.currentTarget.value)
-                                        }
-                                        onKeyDown={handleKeyDown}
-                                        onPaste={handlePaste}
-                                        disabled={isLoading}
-                                        classNames={{
-                                            root: classes.textareaRoot,
-                                            input: classes.textarea,
-                                            wrapper: classes.textareaWrapper,
-                                        }}
-                                    />
-                                </Box>
-                                {isBuilding ? (
-                                    <ActionIcon
-                                        size="sm"
-                                        radius="xl"
-                                        variant="filled"
-                                        color="red"
-                                        onClick={handleCancel}
-                                        loading={isCancelling}
-                                        className={classes.submitButton}
-                                    >
-                                        <IconPlayerStop size={14} />
-                                    </ActionIcon>
-                                ) : (
-                                    <ActionIcon
-                                        size="sm"
-                                        radius="xl"
-                                        variant="filled"
-                                        color="violet"
-                                        onClick={() => void handleSubmit()}
-                                        disabled={!prompt.trim() || isLoading}
-                                        loading={isGenerating || isIterating}
-                                        className={classes.submitButton}
-                                    >
-                                        <IconArrowUp size={14} />
-                                    </ActionIcon>
-                                )}
-                            </Box>
-                            <Group gap="xs" pt="xs">
-                                <QueryButton
-                                    selectedCharts={selectedCharts}
-                                    onSelect={(chart) =>
-                                        setSelectedCharts((prev) => [
-                                            ...prev,
-                                            chart,
-                                        ])
-                                    }
-                                    disabled={isLoading}
+                        {!wizardCoversInput && (
+                            <Box className={classes.chatInputArea}>
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    accept="image/png,image/jpeg,image/gif,image/webp"
+                                    onChange={handleFileInputChange}
+                                    hidden
                                 />
-                                <DashboardButton
-                                    selected={selectedDashboard}
-                                    onSelect={setSelectedDashboard}
-                                    disabled={isLoading}
-                                />
-                                <ImageButton
-                                    onClick={() =>
-                                        fileInputRef.current?.click()
-                                    }
-                                    disabled={isLoading || !!imageAttachment}
-                                />
-                            </Group>
-                            <Box
-                                className={classes.resourceSections}
-                                onDragOver={handleDragOver}
-                                onDrop={handleDrop}
-                            >
-                                {selectedCharts.length > 0 ||
-                                selectedDashboard ||
-                                imageAttachment ? (
-                                    <>
-                                        {selectedCharts.length > 0 && (
-                                            <SelectedQuerySection
-                                                charts={selectedCharts}
-                                                onRemove={(uuid) =>
-                                                    setSelectedCharts((prev) =>
-                                                        prev.filter(
-                                                            (c) =>
-                                                                c.uuid !== uuid,
-                                                        ),
-                                                    )
-                                                }
-                                            />
-                                        )}
-                                        {selectedDashboard && (
-                                            <SelectedDashboardSection
-                                                dashboard={selectedDashboard}
-                                                onRemove={() =>
-                                                    setSelectedDashboard(null)
-                                                }
-                                            />
-                                        )}
-                                        {imageAttachment && (
-                                            <SelectedImageSection
-                                                images={[
-                                                    {
-                                                        previewUrl:
-                                                            imageAttachment.previewUrl,
-                                                    },
-                                                ]}
-                                                onRemove={() => clearImage()}
-                                            />
-                                        )}
-                                    </>
-                                ) : (
-                                    <Box className={classes.resourceEmpty}>
-                                        <Text size="xs" c="dimmed">
-                                            Resources
-                                        </Text>
+                                <Box className={classes.inputWrapper}>
+                                    <Box className={classes.textareaColumn}>
+                                        <Textarea
+                                            ref={textareaRef}
+                                            placeholder="Describe the app you want to build..."
+                                            autosize
+                                            minRows={1}
+                                            maxRows={6}
+                                            value={prompt}
+                                            onChange={(e) =>
+                                                setPrompt(e.currentTarget.value)
+                                            }
+                                            onKeyDown={handleKeyDown}
+                                            onPaste={handlePaste}
+                                            disabled={isLoading}
+                                            classNames={{
+                                                root: classes.textareaRoot,
+                                                input: classes.textarea,
+                                                wrapper:
+                                                    classes.textareaWrapper,
+                                            }}
+                                        />
                                     </Box>
-                                )}
+                                    {isBuilding ? (
+                                        <ActionIcon
+                                            size="sm"
+                                            radius="xl"
+                                            variant="filled"
+                                            color="red"
+                                            onClick={handleCancel}
+                                            loading={isCancelling}
+                                            className={classes.submitButton}
+                                        >
+                                            <IconPlayerStop size={14} />
+                                        </ActionIcon>
+                                    ) : (
+                                        <ActionIcon
+                                            size="sm"
+                                            radius="xl"
+                                            variant="filled"
+                                            color="violet"
+                                            onClick={() => void handleSubmit()}
+                                            disabled={
+                                                !prompt.trim() || isLoading
+                                            }
+                                            loading={
+                                                isGenerating || isIterating
+                                            }
+                                            className={classes.submitButton}
+                                        >
+                                            <IconArrowUp size={14} />
+                                        </ActionIcon>
+                                    )}
+                                </Box>
+                                <Group gap="xs" pt="xs">
+                                    <QueryButton
+                                        selectedCharts={selectedCharts}
+                                        onSelect={(chart) =>
+                                            setSelectedCharts((prev) => [
+                                                ...prev,
+                                                chart,
+                                            ])
+                                        }
+                                        disabled={isLoading}
+                                    />
+                                    <DashboardButton
+                                        selected={selectedDashboard}
+                                        onSelect={setSelectedDashboard}
+                                        disabled={isLoading}
+                                    />
+                                    <ImageButton
+                                        onClick={() =>
+                                            fileInputRef.current?.click()
+                                        }
+                                        disabled={
+                                            isLoading || !!imageAttachment
+                                        }
+                                    />
+                                </Group>
+                                <Box
+                                    className={classes.resourceSections}
+                                    onDragOver={handleDragOver}
+                                    onDrop={handleDrop}
+                                >
+                                    {selectedCharts.length > 0 ||
+                                    selectedDashboard ||
+                                    imageAttachment ? (
+                                        <>
+                                            {selectedCharts.length > 0 && (
+                                                <SelectedQuerySection
+                                                    charts={selectedCharts}
+                                                    onRemove={(uuid) =>
+                                                        setSelectedCharts(
+                                                            (prev) =>
+                                                                prev.filter(
+                                                                    (c) =>
+                                                                        c.uuid !==
+                                                                        uuid,
+                                                                ),
+                                                        )
+                                                    }
+                                                />
+                                            )}
+                                            {selectedDashboard && (
+                                                <SelectedDashboardSection
+                                                    dashboard={
+                                                        selectedDashboard
+                                                    }
+                                                    onRemove={() =>
+                                                        setSelectedDashboard(
+                                                            null,
+                                                        )
+                                                    }
+                                                />
+                                            )}
+                                            {imageAttachment && (
+                                                <SelectedImageSection
+                                                    images={[
+                                                        {
+                                                            previewUrl:
+                                                                imageAttachment.previewUrl,
+                                                        },
+                                                    ]}
+                                                    onRemove={() =>
+                                                        clearImage()
+                                                    }
+                                                />
+                                            )}
+                                        </>
+                                    ) : (
+                                        <Box className={classes.resourceEmpty}>
+                                            <Text size="xs" c="dimmed">
+                                                Resources
+                                            </Text>
+                                        </Box>
+                                    )}
+                                </Box>
                             </Box>
-                        </Box>
+                        )}
                     </Box>
                 </Panel>
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-356/add-starter-templates-for-data-app-generation

Closes: https://linear.app/lightdash/issue/GLITCH-357/ask-clarifying-questions-before-generating-a-data-app

### Description:
Replaces the empty-state on new-app creation with a 3-stage wizard (pick template → answer clarifying questions → review composed prompt). Templates: Dashboard, Slide Show, PDF Report, Custom.

Backend prepends template-specific instructions to the prompt before invoking Claude in the sandbox; 'custom' short-circuits to the existing free-text flow. Templates only apply to v1 — iteration is unchanged. No DB migration; template choice is ephemeral.

Also enables allow-modals on the preview iframe so PDF Report templates can call window.print().


### Overview:
#### Pick a template
<img width="2594" height="1643" alt="template-choice" src="https://github.com/user-attachments/assets/96b36bc8-19be-405a-b7f9-e7de65575371" />

#### Dashboard
<img width="2594" height="1643" alt="dashboard" src="https://github.com/user-attachments/assets/ad8f14dc-9eff-492d-bb25-a93faa5bba3c" />


#### PDF Report
<img width="2594" height="1643" alt="pdf-report" src="https://github.com/user-attachments/assets/085a427f-b16b-48cc-8563-86f7b5870f54" />


#### Slide Show
<img width="2594" height="1643" alt="slide-show" src="https://github.com/user-attachments/assets/76491840-eda3-4076-88ad-9df5d46d263f" />


#### Pre-submit
<img width="2594" height="1643" alt="pre-submit" src="https://github.com/user-attachments/assets/aaa942cf-9d65-4d43-bc2c-8858ced933d7" />




