### PR TITLE
feat(scim): wire SCIM into Account + CASL ability system [SPK-371]

### DIFF
--- a/packages/backend/src/ee/authentication/middleware.mock.ts
+++ b/packages/backend/src/ee/authentication/middleware.mock.ts
@@ -1,9 +1,32 @@
-import { SessionServiceAccount } from '@lightdash/common';
+import {
+    ServiceAccount,
+    ServiceAccountScope,
+    SessionServiceAccount,
+} from '@lightdash/common';
 import express from 'express';
 import { BaseService } from '../../services/BaseService';
 
-export const mockServiceAccount: SessionServiceAccount = {
+export const mockServiceAccount: ServiceAccount = {
+    uuid: 'test-service-account-uuid',
+    createdByUserUuid: 'admin-user-uuid',
     organizationUuid: 'test-org-uuid',
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    expiresAt: null,
+    description: 'test scim token',
+    lastUsedAt: null,
+    rotatedAt: null,
+    scopes: [ServiceAccountScope.SCIM_MANAGE],
+};
+
+const mockOrganization = {
+    organizationUuid: 'test-org-uuid',
+    name: 'Test Org',
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+};
+
+const mockAdminUser = {
+    userUuid: 'admin-user-uuid',
+    userId: 1,
 };
 
 export const mockRequest = {
@@ -18,6 +41,14 @@ export const mockRequest = {
     services: {
         getServiceAccountService: jest.fn().mockReturnValue({
             authenticateScim: jest.fn().mockResolvedValue(mockServiceAccount),
+        }),
+        getOrganizationService: jest.fn().mockReturnValue({
+            getOrganizationByUuid: jest
+                .fn()
+                .mockResolvedValue(mockOrganization),
+        }),
+        getUserService: jest.fn().mockReturnValue({
+            getAdminUser: jest.fn().mockResolvedValue(mockAdminUser),
         }),
     },
 } as unknown as express.Request;

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -85,12 +85,66 @@ export const isScimAuthenticated: RequestHandler = async (req, res, next) => {
                 path: req.path,
                 routePath: req.route.path,
             });
-        if (serviceAccount) {
-            req.serviceAccount = serviceAccount;
-            next();
-        } else {
+        if (!serviceAccount) {
             throw new Error('Invalid SCIM token. Authentication failed.');
         }
+        req.serviceAccount = serviceAccount;
+
+        // Build CASL abilities from the service account scopes so that
+        // SCIM operations go through the same audited authorization path
+        // as regular service-account API requests.
+        const builder = new AbilityBuilder<MemberAbility>(Ability);
+        applyServiceAccountAbilities({
+            scopes: serviceAccount.scopes,
+            organizationUuid: serviceAccount.organizationUuid,
+            builder,
+        });
+        const organization = await req.services
+            .getOrganizationService()
+            .getOrganizationByUuid(serviceAccount.organizationUuid);
+
+        const adminUser = await req.services
+            .getUserService()
+            .getAdminUser(
+                serviceAccount.createdByUserUuid,
+                serviceAccount.organizationUuid,
+            );
+
+        // TODO: This uses the hacky method of copying over an admin user. Long-term, we'll want to have a proper
+        // service-account/principle-user unrelated to a real admin-user.
+        // @see https://github.com/lightdash/lightdash/issues/15466
+        req.user = {
+            userUuid: adminUser.userUuid,
+            email: 'service-account@lightdash.com',
+            firstName: 'service account',
+            lastName: serviceAccount.description,
+            organizationUuid: serviceAccount.organizationUuid,
+            organizationName: organization.name,
+            organizationCreatedAt: serviceAccount.createdAt,
+            isTrackingAnonymized: false,
+            isMarketingOptedIn: false,
+            isSetupComplete: true,
+            userId: adminUser.userId,
+            role: getRoleForScopes(serviceAccount.scopes),
+            ability: builder.build(),
+            isActive: true,
+            abilityRules: builder.rules,
+            createdAt: serviceAccount.createdAt,
+            updatedAt: serviceAccount.createdAt,
+        };
+
+        if (req?.account?.isAuthenticated()) {
+            Logger.warn(
+                buildAccountExistsWarning('ServiceAccount'),
+                req.account?.authentication?.type,
+            );
+        }
+        req.account = fromServiceAccount(req.user, token);
+        const requestContext = requestContextFromExpress(req);
+        req.account.requestContext = requestContext;
+        req.user.requestContext = requestContext;
+
+        next();
     } catch (error) {
         next(
             new ScimError({

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -8,7 +8,6 @@ import {
     ServiceAccount,
     ServiceAccountScope,
     ServiceAccountWithToken,
-    SessionServiceAccount,
     SessionUser,
     UnexpectedDatabaseError,
 } from '@lightdash/common';
@@ -274,7 +273,7 @@ export class ServiceAccountService extends BaseService {
             path: string;
             routePath: string;
         },
-    ): Promise<SessionServiceAccount | null> {
+    ): Promise<ServiceAccount | null> {
         // return null if token is empty
         if (token === '') return null;
 
@@ -307,10 +306,7 @@ export class ServiceAccountService extends BaseService {
                 if (!isSameMinute(dbToken.lastUsedAt, new Date())) {
                     await this.serviceAccountModel.updateUsedDate(dbToken.uuid);
                 }
-                // finally return organization uuid
-                return {
-                    organizationUuid: dbToken.organizationUuid,
-                };
+                return dbToken;
             }
         } catch (error) {
             return null;

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -333,11 +333,17 @@ const applyServiceAccountStaticAbilities: Record<
             organizationUuid,
         });
     },
-    // TODO migrate SCIM permissions to abilities
     [ServiceAccountScope.SCIM_MANAGE]: ({
-        organizationUuid: _organizationUuid,
-        builder: { can: _can },
-    }) => {},
+        organizationUuid,
+        builder: { can },
+    }) => {
+        can('manage', 'OrganizationMemberProfile', {
+            organizationUuid,
+        });
+        can('manage', 'Group', {
+            organizationUuid,
+        });
+    },
 };
 
 export const applyServiceAccountAbilities = ({


### PR DESCRIPTION
## Summary

Part 1 of 3 for [SPK-371](https://linear.app/lightdash/issue/SPK-371) — wires SCIM into the standard Account + CASL authorization path so subsequent PRs can add audited ability checks to SCIM user/group operations.

- Define CASL abilities for the `SCIM_MANAGE` service-account scope: `manage` on `OrganizationMemberProfile` and `Group` (was a TODO stub granting nothing).
- `isScimAuthenticated` middleware now builds a full `Account` (matching `authenticateServiceAccount`) and attaches it to `req.account` so controllers/services can call `createAuditedAbility(account)`.
- `ServiceAccountService.authenticateScim` now returns the full `ServiceAccount` (with `scopes` / `createdByUserUuid` / `createdAt` / `description`) instead of just `{ organizationUuid }`, since the middleware needs those fields to construct the `SessionUser` / `Account`.
- Updates the SCIM middleware test mock to match the new middleware shape (full `ServiceAccount`, `getOrganizationService` + `getUserService` on `req.services`).

No behavioral change for existing SCIM endpoints — they still work via the `req.serviceAccount.organizationUuid` they were using before. This PR is pure infrastructure.

## Stack

Bottom of a 3-PR stack:
1. **This PR** — wire SCIM into Account + CASL
2. Add audited ability checks to SCIM user operations (#22415)
3. Add audited ability checks to SCIM group operations (#22416)

## Test plan

- [x] `pnpm jest src/ee/authentication/middleware.test.ts` — all 5 tests pass
- [x] Existing ScimService unit tests pass
- [x] Backend typecheck passes
- [x] Manual: SCIM token still authenticates and existing SCIM endpoints continue to work end-to-end
