### PR TITLE
feat(scim): emit audit events for SCIM group operations [SPK-371]

### DIFF
--- a/packages/backend/src/ee/authentication/middleware.mock.ts
+++ b/packages/backend/src/ee/authentication/middleware.mock.ts
@@ -1,9 +1,32 @@
-import { SessionServiceAccount } from '@lightdash/common';
+import {
+    ServiceAccount,
+    ServiceAccountScope,
+    SessionServiceAccount,
+} from '@lightdash/common';
 import express from 'express';
 import { BaseService } from '../../services/BaseService';
 
-export const mockServiceAccount: SessionServiceAccount = {
+export const mockServiceAccount: ServiceAccount = {
+    uuid: 'test-service-account-uuid',
+    createdByUserUuid: 'admin-user-uuid',
     organizationUuid: 'test-org-uuid',
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    expiresAt: null,
+    description: 'test scim token',
+    lastUsedAt: null,
+    rotatedAt: null,
+    scopes: [ServiceAccountScope.SCIM_MANAGE],
+};
+
+const mockOrganization = {
+    organizationUuid: 'test-org-uuid',
+    name: 'Test Org',
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+};
+
+const mockAdminUser = {
+    userUuid: 'admin-user-uuid',
+    userId: 1,
 };
 
 export const mockRequest = {
@@ -18,6 +41,14 @@ export const mockRequest = {
     services: {
         getServiceAccountService: jest.fn().mockReturnValue({
             authenticateScim: jest.fn().mockResolvedValue(mockServiceAccount),
+        }),
+        getOrganizationService: jest.fn().mockReturnValue({
+            getOrganizationByUuid: jest
+                .fn()
+                .mockResolvedValue(mockOrganization),
+        }),
+        getUserService: jest.fn().mockReturnValue({
+            getAdminUser: jest.fn().mockResolvedValue(mockAdminUser),
         }),
     },
 } as unknown as express.Request;

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -85,12 +85,66 @@ export const isScimAuthenticated: RequestHandler = async (req, res, next) => {
                 path: req.path,
                 routePath: req.route.path,
             });
-        if (serviceAccount) {
-            req.serviceAccount = serviceAccount;
-            next();
-        } else {
+        if (!serviceAccount) {
             throw new Error('Invalid SCIM token. Authentication failed.');
         }
+        req.serviceAccount = serviceAccount;
+
+        // Build CASL abilities from the service account scopes so that
+        // SCIM operations go through the same audited authorization path
+        // as regular service-account API requests.
+        const builder = new AbilityBuilder<MemberAbility>(Ability);
+        applyServiceAccountAbilities({
+            scopes: serviceAccount.scopes,
+            organizationUuid: serviceAccount.organizationUuid,
+            builder,
+        });
+        const organization = await req.services
+            .getOrganizationService()
+            .getOrganizationByUuid(serviceAccount.organizationUuid);
+
+        const adminUser = await req.services
+            .getUserService()
+            .getAdminUser(
+                serviceAccount.createdByUserUuid,
+                serviceAccount.organizationUuid,
+            );
+
+        // TODO: This uses the hacky method of copying over an admin user. Long-term, we'll want to have a proper
+        // service-account/principle-user unrelated to a real admin-user.
+        // @see https://github.com/lightdash/lightdash/issues/15466
+        req.user = {
+            userUuid: adminUser.userUuid,
+            email: 'service-account@lightdash.com',
+            firstName: 'service account',
+            lastName: serviceAccount.description,
+            organizationUuid: serviceAccount.organizationUuid,
+            organizationName: organization.name,
+            organizationCreatedAt: serviceAccount.createdAt,
+            isTrackingAnonymized: false,
+            isMarketingOptedIn: false,
+            isSetupComplete: true,
+            userId: adminUser.userId,
+            role: getRoleForScopes(serviceAccount.scopes),
+            ability: builder.build(),
+            isActive: true,
+            abilityRules: builder.rules,
+            createdAt: serviceAccount.createdAt,
+            updatedAt: serviceAccount.createdAt,
+        };
+
+        if (req?.account?.isAuthenticated()) {
+            Logger.warn(
+                buildAccountExistsWarning('ServiceAccount'),
+                req.account?.authentication?.type,
+            );
+        }
+        req.account = fromServiceAccount(req.user, token);
+        const requestContext = requestContextFromExpress(req);
+        req.account.requestContext = requestContext;
+        req.user.requestContext = requestContext;
+
+        next();
     } catch (error) {
         next(
             new ScimError({

--- a/packages/backend/src/ee/controllers/scimGroupController.ts
+++ b/packages/backend/src/ee/controllers/scimGroupController.ts
@@ -82,6 +82,7 @@ export class ScimGroupController extends BaseController {
     ): Promise<ScimListResponse<ScimGroup>> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
         return this.getScimService().listGroups({
+            account: req.account!,
             organizationUuid,
             filter,
             itemsPerPage: count,
@@ -123,7 +124,11 @@ export class ScimGroupController extends BaseController {
         @Path() id: string,
     ): Promise<ScimGroup> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
-        return this.getScimService().getGroup(organizationUuid, id);
+        return this.getScimService().getGroup(
+            req.account!,
+            organizationUuid,
+            id,
+        );
     }
 
     /**
@@ -143,7 +148,11 @@ export class ScimGroupController extends BaseController {
         @Body() body: ScimUpsertGroup,
     ): Promise<ScimGroup> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
-        return this.getScimService().createGroup(organizationUuid, body);
+        return this.getScimService().createGroup(
+            req.account!,
+            organizationUuid,
+            body,
+        );
     }
 
     /**
@@ -165,6 +174,7 @@ export class ScimGroupController extends BaseController {
         @Body() body: ScimPatch,
     ): Promise<ScimGroup> {
         return this.getScimService().updateGroup(
+            req.account!,
             req.serviceAccount?.organizationUuid as string,
             id,
             body,
@@ -190,7 +200,12 @@ export class ScimGroupController extends BaseController {
         @Body() body: ScimUpsertGroup,
     ): Promise<ScimGroup> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
-        return this.getScimService().replaceGroup(organizationUuid, id, body);
+        return this.getScimService().replaceGroup(
+            req.account!,
+            organizationUuid,
+            id,
+            body,
+        );
     }
 
     /**
@@ -209,7 +224,11 @@ export class ScimGroupController extends BaseController {
         @Path() id: string,
     ): Promise<void> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
-        await this.getScimService().deleteGroup(organizationUuid, id);
+        await this.getScimService().deleteGroup(
+            req.account!,
+            organizationUuid,
+            id,
+        );
         this.setStatus(204);
     }
 }

--- a/packages/backend/src/ee/controllers/scimUserController.ts
+++ b/packages/backend/src/ee/controllers/scimUserController.ts
@@ -96,6 +96,7 @@ export class ScimUserController extends BaseController {
     ): Promise<ScimListResponse<ScimUser>> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
         const users = await this.getScimService().listUsers({
+            account: req.account!,
             organizationUuid,
             filter,
             startIndex,
@@ -157,6 +158,7 @@ export class ScimUserController extends BaseController {
     ): Promise<ScimUser> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
         const user = await this.getScimService().getUser({
+            account: req.account!,
             organizationUuid,
             userUuid,
         });
@@ -181,6 +183,7 @@ export class ScimUserController extends BaseController {
     ): Promise<ScimUser> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
         const user = await this.getScimService().createUser({
+            account: req.account!,
             organizationUuid,
             user: body,
         });
@@ -208,6 +211,7 @@ export class ScimUserController extends BaseController {
     ): Promise<ScimUser> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
         const user = await this.getScimService().updateUser({
+            account: req.account!,
             organizationUuid,
             userUuid,
             user: body,
@@ -235,6 +239,7 @@ export class ScimUserController extends BaseController {
     ): Promise<ScimUser> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
         const user = await this.getScimService().patchUser({
+            account: req.account!,
             organizationUuid,
             userUuid,
             patchOp: body,
@@ -259,6 +264,7 @@ export class ScimUserController extends BaseController {
     ): Promise<void> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
         await this.getScimService().deleteUser({
+            account: req.account!,
             organizationUuid,
             userUuid,
         });

--- a/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
@@ -1,8 +1,11 @@
+import { Ability } from '@casl/ability';
 import {
     OrganizationMemberProfile,
     OrganizationMemberRole,
+    PossibleAbilities,
     ProjectType,
     Role,
+    ServiceAcctAccount,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
@@ -16,6 +19,48 @@ import { UserModel } from '../../../models/UserModel';
 import { CommercialFeatureFlagModel } from '../../models/CommercialFeatureFlagModel';
 import { ServiceAccountModel } from '../../models/ServiceAccountModel';
 import { ScimService } from './ScimService';
+
+// Mock SCIM service-account Account for tests that exercise audited ability checks.
+export const mockScimAccount = {
+    authentication: {
+        type: 'service-account' as const,
+        source: 'test-scim-token',
+    },
+    user: {
+        type: 'registered' as const,
+        id: 'scim-service-account-user-uuid',
+        userUuid: 'scim-service-account-user-uuid',
+        email: 'service-account@lightdash.com',
+        firstName: 'service account',
+        lastName: 'SCIM',
+        isActive: true,
+        role: OrganizationMemberRole.ADMIN,
+        ability: new Ability<PossibleAbilities>([
+            { subject: 'OrganizationMemberProfile', action: ['manage'] },
+            { subject: 'Group', action: ['manage'] },
+        ]),
+        abilityRules: [] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        isTrackingAnonymized: false,
+        isMarketingOptedIn: false,
+        isSetupComplete: true,
+        userId: 1,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+    },
+    organization: {
+        organizationUuid: 'org-uuid',
+        name: 'Test Organization',
+        createdAt: new Date('2024-01-01'),
+    },
+    isAuthenticated: () => true,
+    isRegisteredUser: () => true,
+    isAnonymousUser: () => false,
+    isSessionUser: () => false,
+    isJwtUser: () => false,
+    isServiceAccount: () => true,
+    isPatUser: () => false,
+    isOauthUser: () => false,
+} as ServiceAcctAccount;
 
 // Mock user for testing
 export const mockUser: OrganizationMemberProfile = {

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -6,7 +6,11 @@ import {
 } from '@lightdash/common';
 import { ScimPatch } from 'scim-patch';
 import { ScimService } from './ScimService';
-import { mockUser, ScimServiceArgumentsMock } from './ScimService.mock';
+import {
+    mockScimAccount,
+    mockUser,
+    ScimServiceArgumentsMock,
+} from './ScimService.mock';
 
 describe('ScimService', () => {
     const service = new ScimService(ScimServiceArgumentsMock);
@@ -200,6 +204,7 @@ describe('ScimService', () => {
 
             // Call createUser
             await service.createUser({
+                account: mockScimAccount,
                 user: scimUser,
                 organizationUuid: 'org-uuid',
             });
@@ -241,6 +246,7 @@ describe('ScimService', () => {
 
             // Call createUser
             await service.createUser({
+                account: mockScimAccount,
                 user: scimUser,
                 organizationUuid: 'org-uuid',
             });
@@ -283,6 +289,7 @@ describe('ScimService', () => {
             // Call createUser with the invalid role and expect it to throw an error
             await expect(
                 service.createUser({
+                    account: mockScimAccount,
                     user: scimUser,
                     organizationUuid: 'org-uuid',
                 }),
@@ -322,6 +329,7 @@ describe('ScimService', () => {
             };
 
             await service.updateUser({
+                account: mockScimAccount,
                 user: scimUser,
                 userUuid: mockUser.userUuid,
                 organizationUuid: mockUser.organizationUuid,
@@ -375,6 +383,7 @@ describe('ScimService', () => {
             // Call updateUser with the invalid role and expect it to throw an error
             await expect(
                 service.updateUser({
+                    account: mockScimAccount,
                     user: scimUser,
                     userUuid: mockUser.userUuid,
                     organizationUuid: mockUser.organizationUuid,
@@ -411,6 +420,7 @@ describe('ScimService', () => {
 
             // Call updateUser with the valid role
             await service.updateUser({
+                account: mockScimAccount,
                 user: scimUser,
                 userUuid: mockUser.userUuid,
                 organizationUuid: mockUser.organizationUuid,
@@ -474,6 +484,7 @@ describe('ScimService', () => {
 
             // Call updateUser with roles
             await service.updateUser({
+                account: mockScimAccount,
                 user: scimUser,
                 userUuid: mockUser.userUuid,
                 organizationUuid: mockUser.organizationUuid,
@@ -528,6 +539,7 @@ describe('ScimService', () => {
 
             // Call updateUser with organization role
             await service.updateUser({
+                account: mockScimAccount,
                 user: scimUser,
                 userUuid: mockUser.userUuid,
                 organizationUuid: mockUser.organizationUuid,
@@ -563,6 +575,7 @@ describe('ScimService', () => {
 
             // Call patchUser with the patch operation
             await service.patchUser({
+                account: mockScimAccount,
                 userUuid: mockUser.userUuid,
                 organizationUuid: mockUser.organizationUuid,
                 patchOp,

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     AlreadyExistsError,
     ForbiddenError,
     getErrorMessage,
@@ -251,14 +252,31 @@ export class ScimService extends BaseService {
 
     // Retrieve a single SCIM user by ID
     async getUser({
+        account,
         userUuid,
         organizationUuid,
     }: {
+        account: Account;
         userUuid: string;
         organizationUuid: string;
     }): Promise<ScimUser> {
         this.logger.info('SCIM: Getting user', { userUuid, organizationUuid });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'view',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid,
+                        userUuid,
+                        metadata: {
+                            userUuid,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             const user =
                 await this.organizationMemberProfileModel.getOrganizationMemberByUuid(
                     organizationUuid,
@@ -308,11 +326,13 @@ export class ScimService extends BaseService {
 
     // List all SCIM users in an organization
     async listUsers({
+        account,
         organizationUuid,
         startIndex = 1,
         itemsPerPage = 100,
         filter,
     }: {
+        account: Account;
         organizationUuid: string;
         startIndex?: number;
         itemsPerPage?: number;
@@ -325,6 +345,15 @@ export class ScimService extends BaseService {
             filter,
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'view',
+                    subject('OrganizationMemberProfile', { organizationUuid }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             const parsedFilter = filter ? parse(filter) : null;
             this.logger.info('SCIM: Parsed filter', { parsedFilter });
 
@@ -440,9 +469,11 @@ export class ScimService extends BaseService {
 
     // Create a SCIM user
     async createUser({
+        account,
         user,
         organizationUuid,
     }: {
+        account: Account;
         user: ScimUpsertUser;
         organizationUuid: string;
     }): Promise<ScimUser> {
@@ -456,6 +487,20 @@ export class ScimService extends BaseService {
             extensionRole: user[ScimSchemaType.LIGHTDASH_USER_EXTENSION]?.role,
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'create',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid,
+                        metadata: {
+                            userName: user.userName,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             // Validate roles if provided
             const { allScimRoles } = await this.getAllRoles(organizationUuid);
             if (user.roles !== undefined) {
@@ -570,10 +615,12 @@ export class ScimService extends BaseService {
 
     // Update an existing SCIM user
     async updateUser({
+        account,
         user,
         userUuid,
         organizationUuid,
     }: {
+        account: Account;
         user: ScimUpsertUser;
         userUuid: string;
         organizationUuid: string;
@@ -590,6 +637,21 @@ export class ScimService extends BaseService {
             extensionRole: user[ScimSchemaType.LIGHTDASH_USER_EXTENSION]?.role,
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'update',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid,
+                        userUuid,
+                        metadata: {
+                            userUuid,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             // Validate roles if provided
             if (user.roles !== undefined) {
                 const { allScimRoles } =
@@ -854,10 +916,12 @@ export class ScimService extends BaseService {
     }
 
     async patchUser({
+        account,
         userUuid,
         organizationUuid,
         patchOp,
     }: {
+        account: Account;
         userUuid: string;
         organizationUuid: string;
         patchOp: ScimPatch;
@@ -873,6 +937,21 @@ export class ScimService extends BaseService {
             })),
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'update',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid,
+                        userUuid,
+                        metadata: {
+                            userUuid,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             // get existing user (and make sure user is in the organization)
             const dbUser =
                 await this.organizationMemberProfileModel.getOrganizationMemberByUuid(
@@ -900,6 +979,7 @@ export class ScimService extends BaseService {
             });
             // apply updates to user
             const patchedUser = await this.updateUser({
+                account,
                 user: patchedDbUserObj as ScimUpsertUser,
                 userUuid,
                 organizationUuid,
@@ -954,9 +1034,11 @@ export class ScimService extends BaseService {
 
     // Delete a SCIM user by ID
     async deleteUser({
+        account,
         userUuid,
         organizationUuid,
     }: {
+        account: Account;
         userUuid: string;
         organizationUuid: string;
     }): Promise<void> {
@@ -965,6 +1047,21 @@ export class ScimService extends BaseService {
             organizationUuid,
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'delete',
+                    subject('OrganizationMemberProfile', {
+                        organizationUuid,
+                        userUuid,
+                        metadata: {
+                            userUuid,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             // get existing user (and make sure user is in the organization)
             const dbUser =
                 await this.organizationMemberProfileModel.getOrganizationMemberByUuid(

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1146,6 +1146,7 @@ export class ScimService extends BaseService {
     }
 
     async getGroup(
+        account: Account,
         organizationUuid: string,
         groupUuid: string,
     ): Promise<ScimGroup> {
@@ -1154,6 +1155,20 @@ export class ScimService extends BaseService {
             organizationUuid,
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'view',
+                    subject('Group', {
+                        organizationUuid,
+                        metadata: {
+                            groupUuid,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             const group = await this.groupsModel.getGroupWithMembers(groupUuid);
             if (group.organizationUuid !== organizationUuid) {
                 this.logger.info('SCIM: Group not found in organization', {
@@ -1198,11 +1213,13 @@ export class ScimService extends BaseService {
     }
 
     async listGroups({
+        account,
         organizationUuid,
         startIndex = 1,
         itemsPerPage = 100,
         filter,
     }: {
+        account: Account;
         organizationUuid: string;
         startIndex?: number;
         itemsPerPage?: number;
@@ -1215,6 +1232,15 @@ export class ScimService extends BaseService {
             filter,
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'view',
+                    subject('Group', { organizationUuid }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             const parsedFilter = filter ? parse(filter) : null;
             this.logger.info('SCIM: Parsed group filter', { parsedFilter });
 
@@ -1286,6 +1312,7 @@ export class ScimService extends BaseService {
     }
 
     async createGroup(
+        account: Account,
         organizationUuid: string,
         groupToCreate: ScimUpsertGroup,
     ): Promise<ScimGroup> {
@@ -1296,6 +1323,20 @@ export class ScimService extends BaseService {
             memberUuids: groupToCreate.members?.map((m) => m.value) || [],
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'create',
+                    subject('Group', {
+                        organizationUuid,
+                        metadata: {
+                            groupName: groupToCreate.displayName,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             if (!groupToCreate.displayName) {
                 throw new ScimError({
                     detail: 'displayName is required',
@@ -1376,6 +1417,7 @@ export class ScimService extends BaseService {
     }
 
     async replaceGroup(
+        account: Account,
         organizationUuid: string,
         groupUuid: string,
         groupToUpdate: ScimUpsertGroup,
@@ -1388,6 +1430,20 @@ export class ScimService extends BaseService {
             memberUuids: groupToUpdate.members?.map((m) => m.value) || [],
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'update',
+                    subject('Group', {
+                        organizationUuid,
+                        metadata: {
+                            groupUuid,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             if (!groupToUpdate.displayName) {
                 throw new ScimError({
                     detail: 'displayName is required',
@@ -1500,6 +1556,7 @@ export class ScimService extends BaseService {
     }
 
     async updateGroup(
+        account: Account,
         organizationUuid: string,
         groupUuid: string,
         patchOp: ScimPatch,
@@ -1515,6 +1572,20 @@ export class ScimService extends BaseService {
             })),
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'update',
+                    subject('Group', {
+                        organizationUuid,
+                        metadata: {
+                            groupUuid,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             const existingGroup =
                 await this.groupsModel.getGroupWithMembers(groupUuid);
             if (existingGroup.organizationUuid !== organizationUuid) {
@@ -1631,6 +1702,7 @@ export class ScimService extends BaseService {
     }
 
     async deleteGroup(
+        account: Account,
         organizationUuid: string,
         groupUuid: string,
     ): Promise<void> {
@@ -1639,6 +1711,20 @@ export class ScimService extends BaseService {
             groupUuid,
         });
         try {
+            const auditedAbility = this.createAuditedAbility(account);
+            if (
+                auditedAbility.cannot(
+                    'delete',
+                    subject('Group', {
+                        organizationUuid,
+                        metadata: {
+                            groupUuid,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             const group = await this.groupsModel.getGroup(groupUuid);
             if (group.organizationUuid !== organizationUuid) {
                 this.logger.info(

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -8,7 +8,6 @@ import {
     ServiceAccount,
     ServiceAccountScope,
     ServiceAccountWithToken,
-    SessionServiceAccount,
     SessionUser,
     UnexpectedDatabaseError,
 } from '@lightdash/common';
@@ -274,7 +273,7 @@ export class ServiceAccountService extends BaseService {
             path: string;
             routePath: string;
         },
-    ): Promise<SessionServiceAccount | null> {
+    ): Promise<ServiceAccount | null> {
         // return null if token is empty
         if (token === '') return null;
 
@@ -307,10 +306,7 @@ export class ServiceAccountService extends BaseService {
                 if (!isSameMinute(dbToken.lastUsedAt, new Date())) {
                     await this.serviceAccountModel.updateUsedDate(dbToken.uuid);
                 }
-                // finally return organization uuid
-                return {
-                    organizationUuid: dbToken.organizationUuid,
-                };
+                return dbToken;
             }
         } catch (error) {
             return null;

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -333,11 +333,17 @@ const applyServiceAccountStaticAbilities: Record<
             organizationUuid,
         });
     },
-    // TODO migrate SCIM permissions to abilities
     [ServiceAccountScope.SCIM_MANAGE]: ({
-        organizationUuid: _organizationUuid,
-        builder: { can: _can },
-    }) => {},
+        organizationUuid,
+        builder: { can },
+    }) => {
+        can('manage', 'OrganizationMemberProfile', {
+            organizationUuid,
+        });
+        can('manage', 'Group', {
+            organizationUuid,
+        });
+    },
 };
 
 export const applyServiceAccountAbilities = ({


### PR DESCRIPTION
## Summary

Part 3 of 3 for [SPK-371](https://linear.app/lightdash/issue/SPK-371) — adds audited CASL ability checks to **all** SCIM group operations (read + write) so that audit events are emitted automatically via `CaslAuditWrapper`.

| Method | HTTP | CASL Action | Subject | Audit Metadata |
|---|---|---|---|---|
| `listGroups` | GET `/Groups` | `view` | `Group { organizationUuid }` | — |
| `getGroup` | GET `/Groups/{id}` | `view` | `Group { organizationUuid }` | `{ groupUuid }` |
| `createGroup` | POST `/Groups` | `create` | `Group { organizationUuid }` | `{ groupName }` |
| `updateGroup` | PATCH `/Groups/{id}` | `update` | `Group { organizationUuid }` | `{ groupUuid }` |
| `replaceGroup` | PUT `/Groups/{id}` | `update` | `Group { organizationUuid }` | `{ groupUuid }` |
| `deleteGroup` | DELETE `/Groups/{id}` | `delete` | `Group { organizationUuid }` | `{ groupUuid }` |

Reuses the existing `Group` CASL subject so audit logs are consistent across SCIM and UI sources.

Closes [SPK-371](https://linear.app/lightdash/issue/SPK-371) once merged.

## Stack

PR 3 of 3:
1. Wire SCIM into Account + CASL (#22414)
2. Audit SCIM user operations (#22415)
3. **This PR** — audit SCIM group operations

## Test plan

- [x] All 6 SCIM group endpoints (list, get, POST, PATCH, PUT, DELETE) tested end-to-end with a valid SCIM token
- [ ] Backend typecheck passes
- [ ] Existing ScimService unit tests pass
- [ ] Manual: trigger SCIM CRUD via Okta sandbox; confirm audit events appear in the winston audit log with `actor.type === 'service-account'` and the metadata above
