### PR TITLE
chore: migrate `ChangeChartExplore` feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -364,9 +364,6 @@ export const lightdashConfigMock: LightdashConfig = {
     userImpersonation: {
         enabled: undefined,
     },
-    changeChartExplore: {
-        enabled: undefined,
-    },
     showHideRows: {
         enabled: undefined,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1271,9 +1271,6 @@ export type LightdashConfig = {
     userImpersonation: {
         enabled: boolean | undefined;
     };
-    changeChartExplore: {
-        enabled: boolean | undefined;
-    };
     showHideRows: {
         enabled: boolean | undefined;
     };
@@ -2293,11 +2290,6 @@ export const parseConfig = (): LightdashConfig => {
                 process.env.USER_IMPERSONATION_ENABLED === 'true'
                     ? true
                     : undefined,
-        },
-        changeChartExplore: {
-            enabled: process.env.CHANGE_CHART_EXPLORE_ENABLED
-                ? process.env.CHANGE_CHART_EXPLORE_ENABLED === 'true'
-                : undefined,
         },
         showHideRows: {
             enabled: process.env.SHOW_HIDE_ROWS_ENABLED

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -51,8 +51,6 @@ export class FeatureFlagModel {
                 this.getGoogleChatEnabled.bind(this),
             [FeatureFlags.UserImpersonation]:
                 this.getUserImpersonationEnabled.bind(this),
-            [FeatureFlags.ChangeChartExplore]:
-                this.getChangeChartExploreEnabled.bind(this),
             [FeatureFlags.ShowHideRows]: this.getShowHideRowsEnabled.bind(this),
             [FeatureFlags.MetricDashboardFilters]:
                 this.getMetricDashboardFiltersEnabled.bind(this),
@@ -270,31 +268,6 @@ export class FeatureFlagModel {
                       userUuid: user.userUuid,
                       organizationUuid: user.organizationUuid,
                   })
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private async getChangeChartExploreEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.changeChartExplore.enabled ??
-            (user
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.ChangeChartExplore,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
                 : false);
         return {
             id: featureFlagId,


### PR DESCRIPTION
## Summary

Migrates `change-chart-explore` from PostHog-backed to DB-backed feature-flag resolution. **The flag itself is unchanged** — it's still `FeatureFlags.ChangeChartExplore` in the enum, still consumed by the frontend (`useServerFeatureFlag`). What's removed is the legacy resolution path:

- `getChangeChartExploreEnabled` handler in `FeatureFlagModel.ts` (was: `lightdashConfig.changeChartExplore.enabled ?? PostHog`)
- `lightdashConfig.changeChartExplore` config field + `CHANGE_CHART_EXPLORE_ENABLED` env-var parser
- Corresponding mock entry

After this change, the flag flows through the standard resolution chain: env-var allowlist → (no handler) → DB lookup → (PostHog fallback, soon to be removed in a final cleanup).

The DB flag has been created across all 165 customer DBs with `default_enabled: true`, matching PostHog's prior "everyone @ 100%" targeting. No regression for any customer.

**Pre-flight check:** `git grep CHANGE_CHART_EXPLORE_ENABLED` in lightdash-cloud returned zero matches — no per-customer env-var overrides to preserve.

Part of the [Internal Feature Flags](https://linear.app/lightdash/project/internal-feature-flags-a5adb03b9cc1/overview) PostHog teardown.

## Test plan
- [x] Backend unit tests pass (`FeatureFlagModel.test.ts` — 8/8)
- [x] Lint clean
- [ ] Verify in any chart UI: "Change explore" action in chart header still appears (DB flag now serves enabled=true)