### PR TITLE
chore: migrate `ShowHideRows` feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -364,9 +364,6 @@ export const lightdashConfigMock: LightdashConfig = {
     userImpersonation: {
         enabled: undefined,
     },
-    showHideRows: {
-        enabled: undefined,
-    },
     metricDashboardFilters: {
         enabled: undefined,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1271,9 +1271,6 @@ export type LightdashConfig = {
     userImpersonation: {
         enabled: boolean | undefined;
     };
-    showHideRows: {
-        enabled: boolean | undefined;
-    };
     metricDashboardFilters: {
         enabled: boolean | undefined;
     };
@@ -2290,11 +2287,6 @@ export const parseConfig = (): LightdashConfig => {
                 process.env.USER_IMPERSONATION_ENABLED === 'true'
                     ? true
                     : undefined,
-        },
-        showHideRows: {
-            enabled: process.env.SHOW_HIDE_ROWS_ENABLED
-                ? process.env.SHOW_HIDE_ROWS_ENABLED === 'true'
-                : undefined,
         },
         metricDashboardFilters: {
             enabled: process.env.METRIC_DASHBOARD_FILTERS_ENABLED

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -51,7 +51,6 @@ export class FeatureFlagModel {
                 this.getGoogleChatEnabled.bind(this),
             [FeatureFlags.UserImpersonation]:
                 this.getUserImpersonationEnabled.bind(this),
-            [FeatureFlags.ShowHideRows]: this.getShowHideRowsEnabled.bind(this),
             [FeatureFlags.MetricDashboardFilters]:
                 this.getMetricDashboardFiltersEnabled.bind(this),
             [FeatureFlags.ShowHideColumns]:
@@ -268,31 +267,6 @@ export class FeatureFlagModel {
                       userUuid: user.userUuid,
                       organizationUuid: user.organizationUuid,
                   })
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private async getShowHideRowsEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.showHideRows.enabled ??
-            (user
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.ShowHideRows,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
                 : false);
         return {
             id: featureFlagId,


### PR DESCRIPTION
## Summary

Migrates `show-hide-rows` from PostHog-backed to DB-backed feature-flag resolution. **The flag itself is unchanged** — it's still `FeatureFlags.ShowHideRows` in the enum, still consumed by the frontend (`useServerFeatureFlag` in `SimpleTable`, `GeneralSettings`, `Layout`, and `useEchartsCartesianConfig`). What's removed is the legacy resolution path:

- `getShowHideRowsEnabled` handler in `FeatureFlagModel.ts` (was: `lightdashConfig.showHideRows.enabled ?? PostHog`)
- `lightdashConfig.showHideRows` config field + `SHOW_HIDE_ROWS_ENABLED` env-var parser
- Corresponding mock entry

After this change, the flag flows through the standard resolution chain: env-var allowlist → (no handler) → DB lookup → (PostHog fallback, soon to be removed in a final cleanup).

The DB flag has been created across all 165 customer DBs with `default_enabled: true`, matching PostHog's prior "everyone @ 100%" targeting. No regression for any customer.

**Pre-flight check:** `git grep SHOW_HIDE_ROWS_ENABLED` in lightdash-cloud returned zero matches — no per-customer env-var overrides to preserve.

Part of the [Internal Feature Flags](https://linear.app/lightdash/project/internal-feature-flags-a5adb03b9cc1/overview) PostHog teardown.

## Test plan
- [x] Backend unit tests pass (`FeatureFlagModel.test.ts` — 8/8)
- [x] Lint clean
- [ ] Verify in any chart with a row limit: show/hide rows controls still render and slice data as before