### PR TITLE
chore: migrate `ShowHideColumns` feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -367,9 +367,6 @@ export const lightdashConfigMock: LightdashConfig = {
     metricDashboardFilters: {
         enabled: undefined,
     },
-    showHideColumns: {
-        enabled: undefined,
-    },
     appRuntime: {
         enabled: false,
         lightdashOrigin: 'https://test.lightdash.cloud',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1274,9 +1274,6 @@ export type LightdashConfig = {
     metricDashboardFilters: {
         enabled: boolean | undefined;
     };
-    showHideColumns: {
-        enabled: boolean | undefined;
-    };
     appRuntime: AppRuntimeConfig;
     enabledFeatureFlags: Set<string>;
 };
@@ -2291,11 +2288,6 @@ export const parseConfig = (): LightdashConfig => {
         metricDashboardFilters: {
             enabled: process.env.METRIC_DASHBOARD_FILTERS_ENABLED
                 ? process.env.METRIC_DASHBOARD_FILTERS_ENABLED === 'true'
-                : undefined,
-        },
-        showHideColumns: {
-            enabled: process.env.SHOW_HIDE_COLUMNS_ENABLED
-                ? process.env.SHOW_HIDE_COLUMNS_ENABLED === 'true'
                 : undefined,
         },
         appRuntime: parseAppRuntimeConfig(siteUrl),

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -53,8 +53,6 @@ export class FeatureFlagModel {
                 this.getUserImpersonationEnabled.bind(this),
             [FeatureFlags.MetricDashboardFilters]:
                 this.getMetricDashboardFiltersEnabled.bind(this),
-            [FeatureFlags.ShowHideColumns]:
-                this.getShowHideColumnsEnabled.bind(this),
             [FeatureFlags.EnableTimezoneSupport]:
                 this.getEnableTimezoneSupportEnabled.bind(this),
             [FeatureFlags.EnableDataApps]:
@@ -283,31 +281,6 @@ export class FeatureFlagModel {
             (user
                 ? await isFeatureFlagEnabled(
                       FeatureFlags.MetricDashboardFilters,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private async getShowHideColumnsEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.showHideColumns.enabled ??
-            (user
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.ShowHideColumns,
                       {
                           userUuid: user.userUuid,
                           organizationUuid: user.organizationUuid,


### PR DESCRIPTION
## Summary

Migrates `show-hide-columns` from PostHog-backed to DB-backed feature-flag resolution. **The flag itself is unchanged** — it's still `FeatureFlags.ShowHideColumns` in the enum, still consumed by the frontend (`useServerFeatureFlag` in `ExplorerResults`, `Layout`, `DashboardChartTile`, and `useCartesianChartConfig`). What's removed is the legacy resolution path:

- `getShowHideColumnsEnabled` handler in `FeatureFlagModel.ts` (was: `lightdashConfig.showHideColumns.enabled ?? PostHog`)
- `lightdashConfig.showHideColumns` config field + `SHOW_HIDE_COLUMNS_ENABLED` env-var parser
- Corresponding mock entry

After this change, the flag flows through the standard resolution chain: env-var allowlist → (no handler) → DB lookup → (PostHog fallback, soon to be removed in a final cleanup).

The DB flag has been created across all 165 customer DBs with `default_enabled: true`, matching PostHog's prior "everyone @ 100%" targeting. No regression for any customer.

**Pre-flight check:** `git grep SHOW_HIDE_COLUMNS_ENABLED` in lightdash-cloud returned zero matches — no per-customer env-var overrides to preserve.

Part of the [Internal Feature Flags](https://linear.app/lightdash/project/internal-feature-flags-a5adb03b9cc1/overview) PostHog teardown.

## Test plan
- [x] Backend unit tests pass (`FeatureFlagModel.test.ts` — 8/8)
- [x] Lint clean
- [ ] Verify on a pivoted chart: user-configurable column limit control still renders and limits columns as before