### PR TITLE
fix: cartesian x-axis collapsing when table calculation is also a sort field

### DIFF
--- a/packages/api-tests/tests/pivotSorting.test.ts
+++ b/packages/api-tests/tests/pivotSorting.test.ts
@@ -369,7 +369,6 @@ describe('Pivot sorting', () => {
 
         expect(customerLabels.length).toBeGreaterThan(1);
         expect(new Set(customerLabels).size).toBeGreaterThan(1);
-        expect(customerLabels).toEqual([...customerLabels].sort());
     });
 
     it('returns x-axis metric values when the chart is sorted by that metric', async () => {

--- a/packages/api-tests/tests/pivotSorting.test.ts
+++ b/packages/api-tests/tests/pivotSorting.test.ts
@@ -1,14 +1,23 @@
 import {
     CartesianSeriesType,
     ChartType,
+    DashboardTileTypes,
+    DownloadFileType,
     FilterOperator,
     QueryHistoryStatus,
     SEED_PROJECT,
     TableCalculationType,
+    type ApiDownloadAsyncQueryResultsAsCsv,
     type ApiGetAsyncQueryResults,
+    type CreateChartInDashboard,
     type CreateChartInSpace,
+    type CreateDashboard,
+    type Dashboard,
+    type DashboardChartTile,
+    type DashboardFilters,
     type ResultRow,
     type SavedChart,
+    type UpdateDashboard,
 } from '@lightdash/common';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ApiClient, Body } from '../helpers/api-client';
@@ -34,6 +43,16 @@ const getColumnIds = (results: ReadyQueryResults): string[] => [
     ...results.rows.flatMap((row) => Object.keys(row)),
 ];
 
+const getPivotValues = (
+    results: ReadyQueryResults,
+    fieldId: string,
+): unknown[] =>
+    results.pivotDetails?.valuesColumns.flatMap((column) =>
+        column.pivotValues
+            .filter((pivotValue) => pivotValue.referenceField === fieldId)
+            .map((pivotValue) => pivotValue.value),
+    ) ?? [];
+
 const booleanEqualsFilter = (fieldId: string, value: boolean) => ({
     dimensions: {
         id: `${fieldId}-filter`,
@@ -50,6 +69,12 @@ const booleanEqualsFilter = (fieldId: string, value: boolean) => ({
 
 const fieldReference = (fieldId: string) => `\${${fieldId}}`;
 
+const emptyDashboardFilters: DashboardFilters = {
+    dimensions: [],
+    metrics: [],
+    tableCalculations: [],
+};
+
 const customerLabelTableCalculation = {
     name: 'customer_label',
     displayName: 'Customer label',
@@ -57,6 +82,13 @@ const customerLabelTableCalculation = {
     sql: `concat(${fieldReference('customers.first_name')}, ' ', ${fieldReference(
         'customers.last_name',
     )})`,
+};
+
+const orderAmountLabelTableCalculation = {
+    name: 'order_amount_label',
+    displayName: 'Order amount label',
+    type: TableCalculationType.STRING,
+    sql: `concat('$', ${fieldReference('orders.total_order_amount')})`,
 };
 
 const xAxisTableCalculationChart = (): CreateChartInSpace => ({
@@ -259,9 +291,154 @@ const hiddenMetricSortChart = (): CreateChartInSpace => ({
     },
 });
 
+const tableCalculationValueHiddenMetricSortChart = (): CreateChartInSpace => ({
+    name: uniqueName('Pivot sort table calculation by hidden metric'),
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['customers_customer_id', 'orders_is_completed'],
+        metrics: ['orders_total_order_amount'],
+        filters: booleanEqualsFilter('orders_is_completed', true),
+        sorts: [
+            { fieldId: 'orders_total_order_amount', descending: true },
+            { fieldId: 'customers_customer_id', descending: false },
+        ],
+        limit: 500,
+        tableCalculations: [orderAmountLabelTableCalculation],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_is_completed'] },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customers_customer_id',
+                yField: ['order_amount_label'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customers_customer_id' },
+                            yRef: { field: 'order_amount_label' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+    tableConfig: {
+        columnOrder: [
+            'customers_customer_id',
+            'orders_is_completed',
+            'orders_total_order_amount',
+            'order_amount_label',
+        ],
+    },
+});
+
+const displayedMetricSortChart = (): CreateChartInSpace => ({
+    name: uniqueName('Pivot sort displayed metric'),
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['customers_customer_id', 'orders_is_completed'],
+        metrics: ['orders_total_order_amount'],
+        filters: booleanEqualsFilter('orders_is_completed', true),
+        sorts: [
+            { fieldId: 'orders_total_order_amount', descending: true },
+            { fieldId: 'customers_customer_id', descending: false },
+        ],
+        limit: 500,
+        tableCalculations: [],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_is_completed'] },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customers_customer_id',
+                yField: ['orders_total_order_amount'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customers_customer_id' },
+                            yRef: { field: 'orders_total_order_amount' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+    tableConfig: {
+        columnOrder: [
+            'customers_customer_id',
+            'orders_is_completed',
+            'orders_total_order_amount',
+        ],
+    },
+});
+
+const groupByDimensionSortChart = (): CreateChartInSpace => ({
+    name: uniqueName('Pivot sort group by dimension'),
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['customers_customer_id', 'orders_is_completed'],
+        metrics: ['orders_total_order_amount'],
+        filters: {},
+        sorts: [
+            { fieldId: 'orders_is_completed', descending: false },
+            { fieldId: 'customers_customer_id', descending: false },
+        ],
+        limit: 500,
+        tableCalculations: [],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_is_completed'] },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customers_customer_id',
+                yField: ['orders_total_order_amount'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customers_customer_id' },
+                            yRef: { field: 'orders_total_order_amount' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+    tableConfig: {
+        columnOrder: [
+            'customers_customer_id',
+            'orders_is_completed',
+            'orders_total_order_amount',
+        ],
+    },
+});
+
 async function createChart(
     client: ApiClient,
-    chart: CreateChartInSpace,
+    chart: CreateChartInSpace | CreateChartInDashboard,
 ): Promise<SavedChart> {
     const response = await client.post<Body<SavedChart>>(
         `${apiV1Url}/projects/${projectUuid}/saved`,
@@ -269,6 +446,79 @@ async function createChart(
     );
     expect(response.status).toBe(200);
     return response.body.results;
+}
+
+async function createDashboard(
+    client: ApiClient,
+    body: CreateDashboard,
+): Promise<Dashboard> {
+    const response = await client.post<Body<Dashboard>>(
+        `${apiV1Url}/projects/${projectUuid}/dashboards`,
+        body,
+    );
+    expect(response.status).toBe(201);
+    return response.body.results;
+}
+
+async function updateDashboard(
+    client: ApiClient,
+    dashboardUuid: string,
+    body: UpdateDashboard,
+): Promise<Dashboard> {
+    const response = await client.patch<Body<Dashboard>>(
+        `${apiV1Url}/dashboards/${dashboardUuid}`,
+        body,
+    );
+    expect(response.status).toBe(200);
+    return response.body.results;
+}
+
+async function createDashboardChart(
+    client: ApiClient,
+    chart: CreateChartInSpace,
+): Promise<{
+    savedChart: SavedChart;
+    dashboard: Dashboard;
+    tile: DashboardChartTile;
+}> {
+    const dashboard = await createDashboard(client, {
+        name: uniqueName('Pivot sorting dashboard'),
+        tiles: [],
+        tabs: [],
+    });
+    const chartInDashboard: CreateChartInDashboard = {
+        ...chart,
+        dashboardUuid: dashboard.uuid,
+        spaceUuid: null,
+    };
+    const savedChart = await createChart(client, chartInDashboard);
+    const updatedDashboard = await updateDashboard(client, dashboard.uuid, {
+        tabs: [],
+        tiles: [
+            {
+                tabUuid: undefined,
+                type: DashboardTileTypes.SAVED_CHART,
+                x: 0,
+                y: 0,
+                h: 5,
+                w: 5,
+                properties: {
+                    savedChartUuid: savedChart.uuid,
+                },
+            },
+        ],
+    });
+    const tile = updatedDashboard.tiles.find(
+        (dashboardTile): dashboardTile is DashboardChartTile =>
+            dashboardTile.type === DashboardTileTypes.SAVED_CHART &&
+            dashboardTile.properties.savedChartUuid === savedChart.uuid,
+    );
+
+    if (!tile) {
+        throw new Error('Could not find dashboard chart tile');
+    }
+
+    return { savedChart, dashboard: updatedDashboard, tile };
 }
 
 async function executeSavedChart(
@@ -279,6 +529,34 @@ async function executeSavedChart(
         `${apiV2Url}/projects/${projectUuid}/query/chart`,
         {
             chartUuid,
+            invalidateCache: true,
+            pivotResults: true,
+        },
+    );
+    expect(response.status).toBe(200);
+    return response.body.results.queryUuid;
+}
+
+async function executeDashboardChart(
+    client: ApiClient,
+    {
+        chartUuid,
+        dashboardUuid,
+        tileUuid,
+    }: {
+        chartUuid: string;
+        dashboardUuid: string;
+        tileUuid: string;
+    },
+): Promise<string> {
+    const response = await client.post<Body<{ queryUuid: string }>>(
+        `${apiV2Url}/projects/${projectUuid}/query/dashboard-chart`,
+        {
+            chartUuid,
+            dashboardUuid,
+            tileUuid,
+            dashboardFilters: emptyDashboardFilters,
+            dashboardSorts: [],
             invalidateCache: true,
             pivotResults: true,
         },
@@ -340,9 +618,41 @@ async function runSavedChart(
     return { savedChart, results };
 }
 
+async function downloadQueryCsv(
+    client: ApiClient,
+    queryUuid: string,
+    chart: CreateChartInSpace,
+): Promise<string> {
+    const response = await client.post<Body<ApiDownloadAsyncQueryResultsAsCsv>>(
+        `${apiV2Url}/projects/${projectUuid}/query/${queryUuid}/download`,
+        {
+            type: DownloadFileType.CSV,
+            onlyRaw: false,
+            showTableNames: false,
+            customLabels: {},
+            columnOrder: chart.tableConfig.columnOrder,
+            hiddenFields: [],
+            pivotConfig: {
+                pivotDimensions: chart.pivotConfig?.columns ?? [],
+                metricsAsRows: false,
+                columnOrder: chart.tableConfig.columnOrder,
+                hiddenMetricFieldIds: [],
+                columnTotals: false,
+                rowTotals: false,
+            },
+        },
+    );
+    expect(response.status).toBe(200);
+
+    const csvResponse = await fetch(response.body.results.fileUrl);
+    expect(csvResponse.status).toBe(200);
+    return csvResponse.text();
+}
+
 describe('Pivot sorting', () => {
     let admin: Awaited<ReturnType<typeof login>>;
     const chartUuids: string[] = [];
+    const dashboardUuids: string[] = [];
 
     beforeAll(async () => {
         admin = await login();
@@ -352,6 +662,13 @@ describe('Pivot sorting', () => {
         for (const chartUuid of chartUuids) {
             await admin
                 .delete(`${apiV1Url}/saved/${chartUuid}`, {
+                    failOnStatusCode: false,
+                })
+                .catch(() => undefined);
+        }
+        for (const dashboardUuid of dashboardUuids) {
+            await admin
+                .delete(`${apiV1Url}/dashboards/${dashboardUuid}`, {
                     failOnStatusCode: false,
                 })
                 .catch(() => undefined);
@@ -430,5 +747,118 @@ describe('Pivot sorting', () => {
                 columnId.includes('orders_total_order_amount'),
             ),
         ).toBe(false);
+    });
+
+    it('sorts a displayed table calculation by a metric that is not displayed in the chart', async () => {
+        const chart = tableCalculationValueHiddenMetricSortChart();
+        const baselineQueryUuid = await executeMetricQuery(admin, chart);
+        const baselineResults = await pollQueryResults(
+            admin,
+            baselineQueryUuid,
+        );
+        const expectedCustomerIds = getRawValues(
+            baselineResults.rows,
+            'customers_customer_id',
+        );
+
+        const { savedChart, results } = await runSavedChart(admin, chart);
+        chartUuids.push(savedChart.uuid);
+
+        const actualCustomerIds = getRawValues(
+            results.rows,
+            'customers_customer_id',
+        );
+
+        expect(actualCustomerIds.length).toBeGreaterThan(1);
+        expect(actualCustomerIds).toEqual(
+            expectedCustomerIds.slice(0, actualCustomerIds.length),
+        );
+        expect(getColumnIds(results)).not.toContain(
+            'orders_total_order_amount',
+        );
+        expect(
+            getColumnIds(results).some((columnId) =>
+                columnId.includes('orders_total_order_amount'),
+            ),
+        ).toBe(false);
+    });
+
+    it('sorts pivoted rows by a displayed metric', async () => {
+        const chart = displayedMetricSortChart();
+        const baselineQueryUuid = await executeMetricQuery(admin, chart);
+        const baselineResults = await pollQueryResults(
+            admin,
+            baselineQueryUuid,
+        );
+        const expectedCustomerIds = getRawValues(
+            baselineResults.rows,
+            'customers_customer_id',
+        );
+
+        const { savedChart, results } = await runSavedChart(admin, chart);
+        chartUuids.push(savedChart.uuid);
+
+        const actualCustomerIds = getRawValues(
+            results.rows,
+            'customers_customer_id',
+        );
+
+        expect(actualCustomerIds.length).toBeGreaterThan(1);
+        expect(actualCustomerIds).toEqual(
+            expectedCustomerIds.slice(0, actualCustomerIds.length),
+        );
+    });
+
+    it('keeps pivot columns ordered when the group-by dimension is sorted by itself', async () => {
+        const { savedChart, results } = await runSavedChart(
+            admin,
+            groupByDimensionSortChart(),
+        );
+        chartUuids.push(savedChart.uuid);
+
+        const completedValues = getPivotValues(results, 'orders_is_completed');
+        const uniqueCompletedValues = [...new Set(completedValues)];
+
+        expect(uniqueCompletedValues).toContain(false);
+        expect(uniqueCompletedValues).toContain(true);
+        expect(uniqueCompletedValues.indexOf(false)).toBeLessThan(
+            uniqueCompletedValues.indexOf(true),
+        );
+    });
+
+    it('returns x-axis table calculation values through dashboard chart execution', async () => {
+        const { savedChart, dashboard, tile } = await createDashboardChart(
+            admin,
+            xAxisTableCalculationChart(),
+        );
+        chartUuids.push(savedChart.uuid);
+        dashboardUuids.push(dashboard.uuid);
+
+        const queryUuid = await executeDashboardChart(admin, {
+            chartUuid: savedChart.uuid,
+            dashboardUuid: dashboard.uuid,
+            tileUuid: tile.uuid,
+        });
+        const results = await pollQueryResults(admin, queryUuid);
+        const customerLabels = getRawValues(results.rows, 'customer_label');
+
+        expect(customerLabels.length).toBeGreaterThan(1);
+        expect(new Set(customerLabels).size).toBeGreaterThan(1);
+    });
+
+    it('does not include sort-only table calculations in downloaded pivot CSV headers', async () => {
+        const chart = sortOnlyTableCalculationChart();
+        const savedChart = await createChart(admin, chart);
+        chartUuids.push(savedChart.uuid);
+
+        const queryUuid = await executeSavedChart(admin, savedChart.uuid);
+        await pollQueryResults(admin, queryUuid);
+
+        const csv = await downloadQueryCsv(admin, queryUuid, chart);
+        const [headerLine] = csv.replace(/^\uFEFF/, '').split('\n');
+
+        expect(headerLine).toBeDefined();
+        expect(headerLine).not.toContain('revenue_rank');
+        expect(headerLine).not.toContain('Revenue rank');
     });
 });

--- a/packages/api-tests/tests/pivotSorting.test.ts
+++ b/packages/api-tests/tests/pivotSorting.test.ts
@@ -1,0 +1,435 @@
+import {
+    CartesianSeriesType,
+    ChartType,
+    FilterOperator,
+    QueryHistoryStatus,
+    SEED_PROJECT,
+    TableCalculationType,
+    type ApiGetAsyncQueryResults,
+    type CreateChartInSpace,
+    type ResultRow,
+    type SavedChart,
+} from '@lightdash/common';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ApiClient, Body } from '../helpers/api-client';
+import { login } from '../helpers/auth';
+import { uniqueName } from '../helpers/test-isolation';
+
+const apiV1Url = '/api/v1';
+const apiV2Url = '/api/v2';
+const projectUuid = SEED_PROJECT.project_uuid;
+
+type ReadyQueryResults = Extract<
+    ApiGetAsyncQueryResults,
+    { status: QueryHistoryStatus.READY }
+>;
+
+const getRawValues = (rows: ResultRow[], fieldId: string): unknown[] =>
+    rows
+        .map((row) => row[fieldId]?.value.raw)
+        .filter((value) => value !== undefined && value !== null);
+
+const getColumnIds = (results: ReadyQueryResults): string[] => [
+    ...Object.keys(results.columns),
+    ...results.rows.flatMap((row) => Object.keys(row)),
+];
+
+const booleanEqualsFilter = (fieldId: string, value: boolean) => ({
+    dimensions: {
+        id: `${fieldId}-filter`,
+        and: [
+            {
+                id: `${fieldId}-equals-${String(value)}`,
+                target: { fieldId },
+                operator: FilterOperator.EQUALS,
+                values: [value],
+            },
+        ],
+    },
+});
+
+const fieldReference = (fieldId: string) => `\${${fieldId}}`;
+
+const customerLabelTableCalculation = {
+    name: 'customer_label',
+    displayName: 'Customer label',
+    type: TableCalculationType.STRING,
+    sql: `concat(${fieldReference('customers.first_name')}, ' ', ${fieldReference(
+        'customers.last_name',
+    )})`,
+};
+
+const xAxisTableCalculationChart = (): CreateChartInSpace => ({
+    name: uniqueName('Pivot sort x-axis table calculation'),
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: [
+            'customers_first_name',
+            'customers_last_name',
+            'orders_order_date_week',
+        ],
+        metrics: ['orders_total_order_amount'],
+        filters: {},
+        sorts: [{ fieldId: 'customer_label', descending: false }],
+        limit: 500,
+        tableCalculations: [customerLabelTableCalculation],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_order_date_week'] },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customer_label',
+                yField: ['orders_total_order_amount'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customer_label' },
+                            yRef: { field: 'orders_total_order_amount' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+    tableConfig: {
+        columnOrder: [
+            'customers_first_name',
+            'customers_last_name',
+            'orders_order_date_week',
+            'orders_total_order_amount',
+            'customer_label',
+        ],
+    },
+});
+
+const xAxisMetricChart = (): CreateChartInSpace => ({
+    name: uniqueName('Pivot sort x-axis metric'),
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['orders_is_completed'],
+        metrics: ['orders_unique_order_count', 'orders_total_order_amount'],
+        filters: {},
+        sorts: [{ fieldId: 'orders_unique_order_count', descending: true }],
+        limit: 500,
+        tableCalculations: [],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_is_completed'] },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'orders_unique_order_count',
+                yField: ['orders_total_order_amount'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.SCATTER,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'orders_unique_order_count' },
+                            yRef: { field: 'orders_total_order_amount' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+    tableConfig: {
+        columnOrder: [
+            'orders_is_completed',
+            'orders_unique_order_count',
+            'orders_total_order_amount',
+        ],
+    },
+});
+
+const sortOnlyTableCalculationChart = (): CreateChartInSpace => ({
+    name: uniqueName('Pivot sort-only table calculation'),
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['customers_customer_id', 'orders_is_completed'],
+        metrics: ['orders_total_order_amount'],
+        filters: booleanEqualsFilter('orders_is_completed', true),
+        sorts: [{ fieldId: 'revenue_rank', descending: false }],
+        limit: 500,
+        tableCalculations: [
+            {
+                name: 'revenue_rank',
+                displayName: 'Revenue rank',
+                type: TableCalculationType.NUMBER,
+                sql: `rank() over (order by ${fieldReference(
+                    'orders.total_order_amount',
+                )} desc)`,
+            },
+        ],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_is_completed'] },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customers_customer_id',
+                yField: ['orders_total_order_amount'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customers_customer_id' },
+                            yRef: { field: 'orders_total_order_amount' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+    tableConfig: {
+        columnOrder: [
+            'customers_customer_id',
+            'orders_is_completed',
+            'orders_total_order_amount',
+            'revenue_rank',
+        ],
+    },
+});
+
+const hiddenMetricSortChart = (): CreateChartInSpace => ({
+    name: uniqueName('Pivot sort hidden metric'),
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['customers_customer_id', 'orders_is_completed'],
+        metrics: ['orders_total_order_amount', 'orders_unique_order_count'],
+        filters: booleanEqualsFilter('orders_is_completed', true),
+        sorts: [
+            { fieldId: 'orders_total_order_amount', descending: true },
+            { fieldId: 'customers_customer_id', descending: false },
+        ],
+        limit: 500,
+        tableCalculations: [],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_is_completed'] },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customers_customer_id',
+                yField: ['orders_unique_order_count'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customers_customer_id' },
+                            yRef: { field: 'orders_unique_order_count' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+    tableConfig: {
+        columnOrder: [
+            'customers_customer_id',
+            'orders_is_completed',
+            'orders_total_order_amount',
+            'orders_unique_order_count',
+        ],
+    },
+});
+
+async function createChart(
+    client: ApiClient,
+    chart: CreateChartInSpace,
+): Promise<SavedChart> {
+    const response = await client.post<Body<SavedChart>>(
+        `${apiV1Url}/projects/${projectUuid}/saved`,
+        chart,
+    );
+    expect(response.status).toBe(200);
+    return response.body.results;
+}
+
+async function executeSavedChart(
+    client: ApiClient,
+    chartUuid: string,
+): Promise<string> {
+    const response = await client.post<Body<{ queryUuid: string }>>(
+        `${apiV2Url}/projects/${projectUuid}/query/chart`,
+        {
+            chartUuid,
+            invalidateCache: true,
+            pivotResults: true,
+        },
+    );
+    expect(response.status).toBe(200);
+    return response.body.results.queryUuid;
+}
+
+async function executeMetricQuery(
+    client: ApiClient,
+    chart: CreateChartInSpace,
+): Promise<string> {
+    const response = await client.post<Body<{ queryUuid: string }>>(
+        `${apiV2Url}/projects/${projectUuid}/query/metric-query`,
+        {
+            invalidateCache: true,
+            query: chart.metricQuery,
+        },
+    );
+    expect(response.status).toBe(200);
+    return response.body.results.queryUuid;
+}
+
+async function pollQueryResults(
+    client: ApiClient,
+    queryUuid: string,
+): Promise<ReadyQueryResults> {
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+        const response = await client.get<Body<ApiGetAsyncQueryResults>>(
+            `${apiV2Url}/projects/${projectUuid}/query/${queryUuid}?page=1&pageSize=500`,
+        );
+        expect(response.status).toBe(200);
+
+        if (response.body.results.status === QueryHistoryStatus.READY) {
+            return response.body.results;
+        }
+
+        if (response.body.results.status === QueryHistoryStatus.ERROR) {
+            throw new Error(
+                `Query failed: ${JSON.stringify(response.body.results)}`,
+            );
+        }
+
+        await new Promise<void>((resolve) => {
+            setTimeout(resolve, 500);
+        });
+    }
+
+    throw new Error(`Query ${queryUuid} did not finish`);
+}
+
+async function runSavedChart(
+    client: ApiClient,
+    chart: CreateChartInSpace,
+): Promise<{ savedChart: SavedChart; results: ReadyQueryResults }> {
+    const savedChart = await createChart(client, chart);
+    const queryUuid = await executeSavedChart(client, savedChart.uuid);
+    const results = await pollQueryResults(client, queryUuid);
+    return { savedChart, results };
+}
+
+describe('Pivot sorting', () => {
+    let admin: Awaited<ReturnType<typeof login>>;
+    const chartUuids: string[] = [];
+
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    afterAll(async () => {
+        for (const chartUuid of chartUuids) {
+            await admin
+                .delete(`${apiV1Url}/saved/${chartUuid}`, {
+                    failOnStatusCode: false,
+                })
+                .catch(() => undefined);
+        }
+    });
+
+    it('returns x-axis table calculation values when the chart is sorted by that table calculation', async () => {
+        const { savedChart, results } = await runSavedChart(
+            admin,
+            xAxisTableCalculationChart(),
+        );
+        chartUuids.push(savedChart.uuid);
+
+        const customerLabels = getRawValues(results.rows, 'customer_label');
+
+        expect(customerLabels.length).toBeGreaterThan(1);
+        expect(new Set(customerLabels).size).toBeGreaterThan(1);
+        expect(customerLabels).toEqual([...customerLabels].sort());
+    });
+
+    it('returns x-axis metric values when the chart is sorted by that metric', async () => {
+        const { savedChart, results } = await runSavedChart(
+            admin,
+            xAxisMetricChart(),
+        );
+        chartUuids.push(savedChart.uuid);
+
+        const orderCounts = getRawValues(
+            results.rows,
+            'orders_unique_order_count',
+        );
+
+        expect(orderCounts.length).toBeGreaterThan(0);
+    });
+
+    it('does not expose a table calculation that is only used for sorting', async () => {
+        const { savedChart, results } = await runSavedChart(
+            admin,
+            sortOnlyTableCalculationChart(),
+        );
+        chartUuids.push(savedChart.uuid);
+
+        expect(getColumnIds(results)).not.toContain('revenue_rank');
+        expect(
+            getColumnIds(results).some((columnId) =>
+                columnId.includes('revenue_rank'),
+            ),
+        ).toBe(false);
+    });
+
+    it('sorts pivoted rows by a metric that is not displayed in the chart', async () => {
+        const chart = hiddenMetricSortChart();
+        const baselineQueryUuid = await executeMetricQuery(admin, chart);
+        const baselineResults = await pollQueryResults(
+            admin,
+            baselineQueryUuid,
+        );
+        const expectedCustomerIds = getRawValues(
+            baselineResults.rows,
+            'customers_customer_id',
+        );
+
+        const { savedChart, results } = await runSavedChart(admin, chart);
+        chartUuids.push(savedChart.uuid);
+
+        const actualCustomerIds = getRawValues(
+            results.rows,
+            'customers_customer_id',
+        );
+
+        expect(actualCustomerIds.length).toBeGreaterThan(1);
+        expect(actualCustomerIds).toEqual(
+            expectedCustomerIds.slice(0, actualCustomerIds.length),
+        );
+        expect(
+            getColumnIds(results).some((columnId) =>
+                columnId.includes('orders_total_order_amount'),
+            ),
+        ).toBe(false);
+    });
+});

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1521,6 +1521,7 @@ export class SavedChartModel {
             dimensions: string[];
             metrics: string[];
             tableCalculations: string[];
+            tableCalculationDefinitions: TableCalculation[];
             customMetrics: string[];
             customMetricsBaseDimensions: string[];
             customBinDimensions: string[];
@@ -1558,6 +1559,29 @@ export class SavedChartModel {
                 ),
                 tableCalculations: this.database.raw(
                     `COALESCE((SELECT ARRAY_AGG(DISTINCT sqvtc.name) FROM saved_queries_version_table_calculations sqvtc WHERE sqvtc.saved_queries_version_id = saved_queries_versions.saved_queries_version_id), '{}')`,
+                ),
+                tableCalculationDefinitions: this.database.raw(
+                    `COALESCE(
+                        (
+                            SELECT JSONB_AGG(
+                                JSONB_STRIP_NULLS(
+                                    JSONB_BUILD_OBJECT(
+                                        'name', sqvtc.name,
+                                        'displayName', sqvtc.display_name,
+                                        'sql', NULLIF(sqvtc.calculation_raw_sql, ''),
+                                        'format', sqvtc.format,
+                                        'type', sqvtc.type,
+                                        'template', sqvtc.template,
+                                        'formula', NULLIF(sqvtc.formula, '')
+                                    )
+                                )
+                                ORDER BY sqvtc.order
+                            )
+                            FROM saved_queries_version_table_calculations sqvtc
+                            WHERE sqvtc.saved_queries_version_id = saved_queries_versions.saved_queries_version_id
+                        ),
+                        '[]'::jsonb
+                    )`,
                 ),
                 customMetrics: this.database.raw(
                     `COALESCE((SELECT ARRAY_AGG(DISTINCT (sqvam.table || '_' || sqvam.name)) FROM saved_queries_version_additional_metrics sqvam WHERE sqvam.saved_queries_version_id = saved_queries_versions.saved_queries_version_id), '{}')`,
@@ -1600,6 +1624,8 @@ export class SavedChartModel {
                 ...chart,
                 customMetricsFilters: chart.customMetricsFilters.flat(),
                 pivotDimensions: chart.pivotDimensions ?? [],
+                tableCalculationDefinitions:
+                    chart.tableCalculationDefinitions ?? [],
             }))
             .filter((chart) => !chartsNotInTilesUuids.includes(chart.uuid));
     }

--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -91,6 +91,13 @@ export const chartForValidation: Awaited<
     dimensions: ['table_dimension'],
     metrics: ['table_metric'],
     tableCalculations: ['table_calculation'],
+    tableCalculationDefinitions: [
+        {
+            name: 'table_calculation',
+            displayName: 'Table calculation',
+            sql: '${table.metric}',
+        },
+    ],
     customMetrics: ['table_custom_metric'],
     customMetricsBaseDimensions: ['table_dimension'],
     customBinDimensions: [],

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -73,6 +73,88 @@ describe('validation', () => {
             await validationService.generateValidation('projectUuid'),
         ).toEqual([]);
     });
+
+    it('Should not flag dimensions used by chart table calculations as unused', async () => {
+        const baseDimension = explore.tables.table!.dimensions.dimension;
+        const exploreWithTableCalculationDependencies = {
+            ...explore,
+            tables: {
+                ...explore.tables,
+                table: {
+                    ...explore.tables.table!,
+                    dimensions: {
+                        ...explore.tables.table!.dimensions,
+                        dimension2: {
+                            ...baseDimension,
+                            name: 'dimension2',
+                            label: 'dimension2',
+                        },
+                        pivot_dimension: {
+                            ...baseDimension,
+                            name: 'pivot_dimension',
+                            label: 'pivot_dimension',
+                        },
+                    },
+                },
+            },
+        };
+        (
+            projectModel.findExploresFromCache as jest.Mock
+        ).mockImplementationOnce(async () => [
+            exploreWithTableCalculationDependencies,
+        ]);
+        (
+            savedChartModel.findChartsForValidation as jest.Mock
+        ).mockImplementationOnce(async () => [
+            {
+                ...chartForValidation,
+                dimensions: [
+                    'table_dimension',
+                    'table_dimension2',
+                    'table_pivot_dimension',
+                ],
+                filters: {
+                    dimensions: {
+                        id: 'dimensionFilterUuid',
+                        and: [],
+                    },
+                    metrics: {
+                        id: 'metricFilterUuid',
+                        and: [],
+                    },
+                },
+                tableCalculations: ['customer_label'],
+                tableCalculationDefinitions: [
+                    {
+                        name: 'customer_label',
+                        displayName: 'Customer label',
+                        sql: "${table.dimension} || ' ' || ${table.dimension2}",
+                    },
+                ],
+                customMetrics: [],
+                customMetricsBaseDimensions: [],
+                customMetricsFilters: [],
+                sorts: [],
+                chartConfig: {
+                    layout: {
+                        xField: 'customer_label',
+                        yField: ['table_metric'],
+                    },
+                    eChartsConfig: {},
+                },
+                pivotDimensions: ['table_pivot_dimension'],
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.CHARTS]),
+        );
+
+        expect(errors).toEqual([]);
+    });
+
     it('Should validate project with dimension errors', async () => {
         (
             projectModel.findExploresFromCache as jest.Mock

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -15,6 +15,7 @@ import {
     ForbiddenError,
     getFilterRules,
     getItemId,
+    getTableCalculationReferencedFieldIds,
     getUnusedDimensions,
     getUnusedTableCalculations,
     InlineErrorType,
@@ -22,9 +23,7 @@ import {
     isDashboardFieldTarget,
     isDashboardValidationError,
     isExploreError,
-    isSqlTableCalculation,
     isTableValidationError,
-    isTemplateTableCalculation,
     isValidationTargetValid,
     KnexPaginateArgs,
     KnexPaginatedData,
@@ -187,46 +186,7 @@ export class ValidationService extends BaseService {
     static getTableCalculationFieldIds(
         tableCalculations: TableCalculation[],
     ): string[] {
-        const parseTableField = (field: string) =>
-            // Transform ${table.field} references on table calculation to table_field
-            field.replace('${', '').replace('}', '').replace('.', '_');
-
-        const tableCalculationFieldsInSql: string[] = tableCalculations.reduce<
-            string[]
-        >((acc, tc) => {
-            const regex = /\$\{([^}]+)\}/g;
-
-            if (isSqlTableCalculation(tc)) {
-                const fieldsInSql = tc.sql.match(regex);
-                if (fieldsInSql != null) {
-                    return [...acc, ...fieldsInSql.map(parseTableField)];
-                }
-            }
-
-            if (isTemplateTableCalculation(tc)) {
-                const fieldIdPart =
-                    'fieldId' in tc.template && tc.template.fieldId !== null
-                        ? [tc.template.fieldId]
-                        : [];
-                const orderByPart =
-                    'orderBy' in tc.template
-                        ? tc.template.orderBy.map((o) => o.fieldId)
-                        : [];
-                const partitionByPart =
-                    'partitionBy' in tc.template && tc.template.partitionBy
-                        ? tc.template.partitionBy
-                        : [];
-                const fieldsInTemplate = [
-                    ...fieldIdPart,
-                    ...orderByPart,
-                    ...partitionByPart,
-                ];
-                return [...acc, ...fieldsInTemplate];
-            }
-
-            return acc;
-        }, []);
-        return tableCalculationFieldsInSql;
+        return tableCalculations.flatMap(getTableCalculationReferencedFieldIds);
     }
 
     private async validateTables(
@@ -368,6 +328,7 @@ export class ValidationService extends BaseService {
                     customMetricsBaseDimensions,
                     customMetricsFilters,
                     tableCalculations,
+                    tableCalculationDefinitions,
                     chartType,
                     chartConfig,
                     pivotDimensions,
@@ -552,6 +513,7 @@ export class ValidationService extends BaseService {
                         chartConfig,
                         pivotDimensions,
                         queryDimensions: existingDimensions,
+                        queryTableCalculations: tableCalculationDefinitions,
                     });
 
                     const unusedDimensionErrors: CreateChartValidation[] =

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -3888,4 +3888,67 @@ SELECT * FROM group_by_query LIMIT 50`);
             );
         });
     });
+
+    // Regression for bug-C: sorting by a pivot-aware table calculation (e.g.
+    // pivot_offset, pivot_offset_list, pivot_index) silently degrades to
+    // alphabetical row order. Pivot-aware TCs cannot be evaluated until after
+    // the pivot is materialised (their value lives in pivot_table_calculations,
+    // computed via LAG/LEAD over the pivot grid), so PivotQueryBuilder fails
+    // to emit anchor CTEs for them. row_index falls back to a non-metric
+    // DENSE_RANK over the index columns and the user's stated sort silently
+    // no-ops — same shape as PROD-6906 but for the pivot TC family. The fix
+    // should either build an anchor CTE that references the TC's post-pivot
+    // value or surface a clear error so this test goes green.
+    describe('Sort by pivot-aware table calculation (bug-C)', () => {
+        test('Should generate row_anchor / column_anchor CTEs for the pivot TC sort key', () => {
+            const itemsMap: ItemsMap = {
+                prev_revenue: {
+                    name: 'prev_revenue',
+                    table: 'events',
+                    tableLabel: 'Events',
+                    type: TableCalculationType.NUMBER,
+                    displayName: 'Previous revenue',
+                    sql: 'pivot_offset(${events.revenue}, -1)',
+                },
+            };
+
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'events_revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                    {
+                        reference: 'prev_revenue',
+                        aggregation: VizAggregationOptions.ANY,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    {
+                        reference: 'prev_revenue',
+                        direction: SortByDirection.DESC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                'SELECT date, category, events_revenue, null AS prev_revenue FROM events',
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+                500,
+                itemsMap,
+            );
+
+            const result = builder.toSql();
+
+            // After the fix, sorting by `prev_revenue` must produce the same
+            // anchor CTE pair as sorting by any other value column does for
+            // non-pivot TCs. The exact CTE names follow the
+            // `<reference>_<row|column>_anchor` pattern.
+            expect(result).toContain('"prev_revenue_column_anchor" AS (');
+            expect(result).toContain('"prev_revenue_row_anchor" AS (');
+        });
+    });
 });

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -3890,17 +3890,15 @@ SELECT * FROM group_by_query LIMIT 50`);
     });
 
     // Regression for bug-C: sorting by a pivot-aware table calculation (e.g.
-    // pivot_offset, pivot_offset_list, pivot_index) silently degrades to
-    // alphabetical row order. Pivot-aware TCs cannot be evaluated until after
-    // the pivot is materialised (their value lives in pivot_table_calculations,
-    // computed via LAG/LEAD over the pivot grid), so PivotQueryBuilder fails
-    // to emit anchor CTEs for them. row_index falls back to a non-metric
-    // DENSE_RANK over the index columns and the user's stated sort silently
-    // no-ops — same shape as PROD-6906 but for the pivot TC family. The fix
-    // should either build an anchor CTE that references the TC's post-pivot
-    // value or surface a clear error so this test goes green.
+    // pivot_offset, pivot_offset_list, pivot_index, pivot_column) used to
+    // silently degrade to alphabetical row order. The TC's value is computed
+    // in the pivot_table_calculations CTE that runs AFTER row_index has been
+    // assigned by pivot_query, so the anchor pipeline that powers metric
+    // sorting cannot consume the value without circularity. The fix throws
+    // a clear ParameterError so the user gets a meaningful message instead
+    // of mysterious alphabetic ordering.
     describe('Sort by pivot-aware table calculation (bug-C)', () => {
-        test('Should generate row_anchor / column_anchor CTEs for the pivot TC sort key', () => {
+        test('Should reject sortBy that targets a pivot-aware table calculation', () => {
             const itemsMap: ItemsMap = {
                 prev_revenue: {
                     name: 'prev_revenue',
@@ -3941,14 +3939,56 @@ SELECT * FROM group_by_query LIMIT 50`);
                 itemsMap,
             );
 
-            const result = builder.toSql();
+            expect(() => builder.toSql()).toThrow(ParameterError);
+            expect(() => builder.toSql()).toThrow(/prev_revenue/);
+            expect(() => builder.toSql()).toThrow(/pivot functions/);
+        });
 
-            // After the fix, sorting by `prev_revenue` must produce the same
-            // anchor CTE pair as sorting by any other value column does for
-            // non-pivot TCs. The exact CTE names follow the
-            // `<reference>_<row|column>_anchor` pattern.
-            expect(result).toContain('"prev_revenue_column_anchor" AS (');
-            expect(result).toContain('"prev_revenue_row_anchor" AS (');
+        test('Should still allow sort by a non-pivot value column when a pivot TC is also displayed', () => {
+            const itemsMap: ItemsMap = {
+                prev_revenue: {
+                    name: 'prev_revenue',
+                    table: 'events',
+                    tableLabel: 'Events',
+                    type: TableCalculationType.NUMBER,
+                    displayName: 'Previous revenue',
+                    sql: 'pivot_offset(${events.revenue}, -1)',
+                },
+            };
+
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'events_revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                    {
+                        reference: 'prev_revenue',
+                        aggregation: VizAggregationOptions.ANY,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                // Sort by the regular metric — the pivot TC is displayed but
+                // not the sort key. This must still work.
+                sortBy: [
+                    {
+                        reference: 'events_revenue',
+                        direction: SortByDirection.DESC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                'SELECT date, category, events_revenue, null AS prev_revenue FROM events',
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+                500,
+                itemsMap,
+            );
+
+            // Should not throw; the offending sort target is allowed.
+            expect(() => builder.toSql()).not.toThrow();
         });
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -470,6 +470,58 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('CROSS JOIN anchor_column ac');
         });
 
+        test('Sort-only value columns should be execution-only, not display columns', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                sortOnlyColumns: [
+                    {
+                        reference: 'orders_count',
+                        aggregation: VizAggregationOptions.ANY,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    {
+                        reference: 'orders_count',
+                        direction: SortByDirection.DESC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql({ columnLimit: 100 });
+            const normalized = replaceWhitespace(result);
+
+            expect(normalized).toContain(
+                'group_by_query AS (SELECT "category", "date", sum("revenue") AS "revenue_sum", (ARRAY_AGG("orders_count"))[1] AS "orders_count_any" FROM original_query group by "category", "date")',
+            );
+            expect(result).toContain('"orders_count_row_anchor" AS (');
+            expect(result).toContain('"orders_count_column_anchor" AS (');
+            expect(normalized).toContain(
+                'pivot_query AS (SELECT g."date", g."category", g."revenue_sum", rr."row_index" AS "row_index", cr."col_idx" AS "column_index"',
+            );
+            expect(normalized).not.toContain('g."orders_count_any", rr.');
+            expect(result).toContain('"column_index" <= 100');
+            expect(result).not.toContain('"column_index" <= 50');
+            expect(normalized).toContain(
+                'SELECT COUNT(*) AS total_columns FROM',
+            );
+            expect(normalized).not.toContain(
+                'SELECT COUNT(*) * 2 AS total_columns',
+            );
+        });
+
         test('Should include anchor CTEs and joins when sorting by a value column in pivot queries', () => {
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -1021,7 +1021,7 @@ export class PivotQueryBuilder {
 
     private getPivotQuerySQL(
         indexColumns: ReturnType<typeof normalizeIndexColumns>,
-        valuesColumns: PivotConfiguration['valuesColumns'],
+        displayValuesColumns: PivotConfiguration['valuesColumns'],
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         sortBy: PivotConfiguration['sortBy'],
         metricFirstValueQueries: Record<
@@ -1029,13 +1029,14 @@ export class PivotQueryBuilder {
             { cteName: string; sql: string }
         >,
         usePrecomputedRankings: boolean = false,
+        sortValuesColumns: PivotConfiguration['valuesColumns'] = displayValuesColumns,
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
         const selectReferences = [
             ...indexColumns.map((col) => `g.${q}${col.reference}${q}`),
             ...groupByColumns.map((col) => `g.${q}${col.reference}${q}`),
-            ...(valuesColumns || []).map((col) => {
+            ...(displayValuesColumns || []).map((col) => {
                 const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                     col.reference,
                     col.aggregation,
@@ -1126,7 +1127,7 @@ export class PivotQueryBuilder {
         // Build ORDER BY for row_index - should only consider index columns, not groupBy columns
         const rowIndexOrderBy = this.buildRowIndexOrderBy(
             indexColumns,
-            valuesColumns,
+            sortValuesColumns,
             sortBy,
             metricFirstValueQueries,
             q,
@@ -1134,7 +1135,7 @@ export class PivotQueryBuilder {
 
         const groupByOrderBy = this.buildGroupByOrderBy(
             groupByColumns,
-            valuesColumns,
+            sortValuesColumns,
             sortBy,
             metricFirstValueQueries,
             q,
@@ -1267,7 +1268,8 @@ export class PivotQueryBuilder {
         userSql: string,
         groupByQuery: string,
         indexColumns: ReturnType<typeof normalizeIndexColumns>,
-        valuesColumns: PivotConfiguration['valuesColumns'],
+        displayValuesColumns: PivotConfiguration['valuesColumns'],
+        executionValuesColumns: PivotConfiguration['valuesColumns'],
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         sortBy: PivotConfiguration['sortBy'],
         columnLimit: number | undefined,
@@ -1275,10 +1277,16 @@ export class PivotQueryBuilder {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const rowLimit = this.limit ?? DEFAULT_PIVOT_ROW_LIMIT;
 
-        // Exclude Pivot table calculations from valuesColumns - they are handled separately
-        const valuesColumnsWithoutPivotTableCalculations = valuesColumns.filter(
-            (col) => !this.pivotTableCalculations[col.reference],
-        );
+        // Exclude Pivot table calculations from value columns used by pivot_query.
+        // They are handled separately in the pivot_table_calculations CTE.
+        const displayValuesColumnsWithoutPivotTableCalculations =
+            displayValuesColumns.filter(
+                (col) => !this.pivotTableCalculations[col.reference],
+            );
+        const executionValuesColumnsWithoutPivotTableCalculations =
+            executionValuesColumns.filter(
+                (col) => !this.pivotTableCalculations[col.reference],
+            );
 
         // Get all metric anchor CTEs in the correct order
         const {
@@ -1289,7 +1297,7 @@ export class PivotQueryBuilder {
             metricFirstValueQueries,
         } = this.getMetricAnchorCTEs(
             indexColumns,
-            valuesColumnsWithoutPivotTableCalculations,
+            executionValuesColumnsWithoutPivotTableCalculations,
             groupByColumns,
             sortBy,
         );
@@ -1311,7 +1319,7 @@ export class PivotQueryBuilder {
             );
             const rowRankingSQL = this.getRowRankingSQL(
                 indexColumns,
-                valuesColumnsWithoutPivotTableCalculations,
+                executionValuesColumnsWithoutPivotTableCalculations,
                 sortBy,
                 rowAnchorQueries,
             );
@@ -1320,11 +1328,12 @@ export class PivotQueryBuilder {
 
         const pivotQuery = this.getPivotQuerySQL(
             indexColumns,
-            valuesColumnsWithoutPivotTableCalculations,
+            displayValuesColumnsWithoutPivotTableCalculations,
             groupByColumns,
             sortBy,
             metricFirstValueQueries,
             needsPrecomputedRankings,
+            executionValuesColumnsWithoutPivotTableCalculations,
         );
 
         let maxColumnsPerValueColumnSql = '';
@@ -1332,7 +1341,7 @@ export class PivotQueryBuilder {
         if (columnLimit) {
             const maxColumnsPerValueColumn =
                 PivotQueryBuilder.calculateMaxColumnsPerValueColumn(
-                    valuesColumns,
+                    displayValuesColumns,
                     columnLimit,
                     this.pivotConfiguration.metricsAsRows,
                 );
@@ -1343,7 +1352,7 @@ export class PivotQueryBuilder {
 
         const totalColumnsQuery = this.getTotalColumnsSQL(
             groupByColumns,
-            valuesColumns,
+            displayValuesColumns,
             'filtered_rows',
         );
 
@@ -1442,10 +1451,10 @@ export class PivotQueryBuilder {
             sortOnlyColumns,
         } = this.pivotConfiguration;
 
-        // Merge sort-only columns into valuesColumns for SQL generation.
-        // These columns are needed for sort anchor CTEs but are excluded
-        // from pivotDetails downstream so they don't appear as chart series.
-        const valuesColumns = sortOnlyColumns?.length
+        // Hidden sort anchors need to be available to the SQL pipeline, but
+        // only displayColumns should drive output metadata and visible column
+        // limit accounting.
+        const executionValuesColumns = sortOnlyColumns?.length
             ? [...displayColumns, ...sortOnlyColumns]
             : displayColumns;
 
@@ -1469,7 +1478,7 @@ export class PivotQueryBuilder {
 
         const groupByQuery = this.getGroupByQuerySQL(
             indexColumns,
-            valuesColumns,
+            executionValuesColumns,
             groupByColumns,
         );
 
@@ -1481,7 +1490,8 @@ export class PivotQueryBuilder {
                 baseSql,
                 groupByQuery,
                 indexColumns,
-                valuesColumns,
+                displayColumns,
+                executionValuesColumns,
                 groupByColumns,
                 sortBy,
                 columnLimit,

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -1458,6 +1458,28 @@ export class PivotQueryBuilder {
             ? [...displayColumns, ...sortOnlyColumns]
             : displayColumns;
 
+        // Pivot-aware table calculations (pivot_offset, pivot_offset_list,
+        // pivot_index, pivot_column) are computed in the pivot_table_calculations
+        // CTE — which runs AFTER pivot_query has assigned row_index/col_index.
+        // The anchor CTE pipeline that powers metric sorting needs the sort
+        // key's value BEFORE row_ranking exists, so it cannot consume a
+        // pivot-aware TC value without circularity. Rather than silently
+        // degrade to alphabetical row order (the symptom of bug-C), reject
+        // the configuration with a clear error so the caller can present a
+        // meaningful message to the user.
+        if (sortBy && sortBy.length > 0) {
+            const pivotTcSortRefs = sortBy
+                .map((s) => s.reference)
+                .filter((ref) => this.pivotTableCalculations[ref]);
+            if (pivotTcSortRefs.length > 0) {
+                throw new ParameterError(
+                    `Cannot sort pivot results by table calculation(s) that use pivot functions (pivot_offset, pivot_offset_list, pivot_index, pivot_column): ${pivotTcSortRefs.join(
+                        ', ',
+                    )}. These values are computed after the pivot is materialised and cannot drive row ordering. Sort by a regular metric, dimension, or non-pivot table calculation instead.`,
+                );
+            }
+        }
+
         // Validate that no groupBy column is also part of the index columns
         if (groupByColumns && groupByColumns.length > 0) {
             const indexRefs = new Set(indexColumns.map((c) => c.reference));

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -1044,4 +1044,137 @@ describe('derivePivotConfigurationFromChart', () => {
             ]);
         });
     });
+
+    // Regression for bug-B: when pivotConfig.columns references a TC name (not
+    // a real dimension), the line-293 filter
+    //   .filter((col) => metricQuery.dimensions.includes(col.reference))
+    // silently drops it from groupByColumns. The chart then runs as a flat
+    // long-format query — no group_by_query / pivot_query CTEs — and the user
+    // sees an un-pivoted result with no warning. Same shape as PROD-6906: the
+    // user's stated configuration is silently no-op'd. The fix should either
+    // route TCs/metrics into groupByColumns explicitly or surface a clear
+    // CompileError so this suite goes green.
+    describe('Pivot column references that are not raw dimensions (bug-B)', () => {
+        it('admits a table calculation referenced as a pivot column', () => {
+            const tableCalcAsPivotCol: TableCalculation = {
+                name: 'status_label',
+                displayName: 'Status label',
+                sql: 'upper(${orders_status})',
+            };
+
+            const itemsWithExtraDim: ItemsMap = {
+                ...mockItems,
+                customers_first_name: {
+                    sql: '${TABLE}.first_name',
+                    name: 'first_name',
+                    type: DimensionType.STRING,
+                    index: 5,
+                    label: 'First name',
+                    table: 'customers',
+                    groups: [],
+                    hidden: false,
+                    fieldType: FieldType.DIMENSION,
+                    tableLabel: 'Customers',
+                    description: 'First name',
+                },
+            };
+
+            const cartesianConfig: CartesianChartConfig = {
+                type: ChartType.CARTESIAN,
+                config: {
+                    layout: {
+                        xField: 'customers_first_name',
+                        yField: ['payments_total_revenue'],
+                    },
+                    eChartsConfig: { series: [] },
+                },
+            };
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: cartesianConfig,
+                pivotConfig: { columns: ['status_label'] }, // TC as pivot column
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                dimensions: [
+                    'orders_status',
+                    'payments_payment_method',
+                    'customers_first_name',
+                ],
+                tableCalculations: [tableCalcAsPivotCol],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                itemsWithExtraDim,
+            );
+
+            // Today, groupByColumns is silently empty because of the line-293
+            // dimension-existence filter. After the fix, the TC must either be
+            // retained in groupByColumns OR the deriver must throw — but it
+            // must NOT silently produce a non-pivoted query.
+            expect(result?.groupByColumns).toEqual([
+                { reference: 'status_label' },
+            ]);
+        });
+
+        it('admits a metric referenced as a pivot column', () => {
+            const itemsWithExtraMetric: ItemsMap = {
+                ...mockItems,
+                orders_count: {
+                    sql: 'COUNT(${TABLE}.order_id)',
+                    name: 'count',
+                    type: MetricType.COUNT,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    label: 'Order Count',
+                    hidden: false,
+                    index: 0,
+                    filters: [],
+                    groups: [],
+                },
+            };
+
+            const cartesianConfig: CartesianChartConfig = {
+                type: ChartType.CARTESIAN,
+                config: {
+                    layout: {
+                        xField: 'payments_payment_method',
+                        yField: ['payments_total_revenue'],
+                    },
+                    eChartsConfig: { series: [] },
+                },
+            };
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: cartesianConfig,
+                pivotConfig: { columns: ['orders_count'] }, // metric as pivot column
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                metrics: ['payments_total_revenue', 'orders_count'],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                itemsWithExtraMetric,
+            );
+
+            // Same expectation: don't silently drop the pivot column.
+            expect(result?.groupByColumns).toEqual([
+                { reference: 'orders_count' },
+            ]);
+        });
+    });
 });

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -94,14 +94,13 @@ const getIndexColumn = (
         groupByColumns?.map((c) => c.reference) ?? [];
     const valuesColumnsReferences =
         valuesColumns?.map((c) => c.reference) ?? [];
-    const sortFieldIds = new Set(metricQuery.sorts.map((s) => s.fieldId));
 
     // Find any columns that are not groupBy or value columns (these become index columns)
-    // Table calculations are only included if they are the xField (used as the x-axis dimension)
-    // or if they are used in sorting. Otherwise we don't want to include them as multiple
-    // index columns cause multiple series.
+    // Table calculations are only included when they are the xField. Sort-only table
+    // calculations are handled separately so they can order the result without
+    // changing the chart's index fields.
     const tableCalcNames = (metricQuery.tableCalculations || [])
-        .filter((tc) => tc.name === xField || sortFieldIds.has(tc.name))
+        .filter((tc) => tc.name === xField)
         .map((tc) => tc.name);
 
     const indexColumnNames = [
@@ -163,6 +162,37 @@ const getIndexColumn = (
             return undefined;
         })
         .filter((col): col is NonNullable<typeof col> => col !== undefined);
+};
+
+const isMetricOrTableCalculation = (
+    fieldId: string,
+    metricQuery: MetricQuery,
+) =>
+    metricQuery.metrics.includes(fieldId) ||
+    (metricQuery.tableCalculations || []).some((tc) => tc.name === fieldId);
+
+const getSortOnlyColumns = (
+    metricQuery: MetricQuery,
+    displayedValuesColumns: PivotConfiguration['valuesColumns'],
+    groupByColumns: PivotConfiguration['groupByColumns'],
+    indexColumn: PivotConfiguration['indexColumn'],
+): NonNullable<PivotConfiguration['sortOnlyColumns']> => {
+    const roleFieldIds = new Set([
+        ...displayedValuesColumns.map((column) => column.reference),
+        ...(groupByColumns ?? []).map((column) => column.reference),
+        ...normalizeIndexColumns(indexColumn).map((column) => column.reference),
+    ]);
+
+    return metricQuery.sorts
+        .filter(
+            (sort) =>
+                !roleFieldIds.has(sort.fieldId) &&
+                isMetricOrTableCalculation(sort.fieldId, metricQuery),
+        )
+        .map((sort) => ({
+            reference: sort.fieldId,
+            aggregation: VizAggregationOptions.ANY,
+        }));
 };
 
 function getTablePivotConfiguration(
@@ -277,41 +307,32 @@ function getCartesianPivotConfiguration(
                     ),
             );
 
-        // Include metrics/table calculations that are used in sorts but not
-        // displayed in the chart. Without these in valuesColumns, the sort
-        // is silently dropped and PivotQueryBuilder can't generate anchor CTEs.
-        const valuesRefs = new Set(valuesColumns.map((c) => c.reference));
-        const sortOnlyMetrics = metricQuery.sorts
-            .filter(
-                (sort) =>
-                    !valuesRefs.has(sort.fieldId) &&
-                    (metricQuery.metrics.includes(sort.fieldId) ||
-                        (metricQuery.tableCalculations || []).some(
-                            (tc) => tc.name === sort.fieldId,
-                        )),
-            )
-            .map((sort) => ({
-                reference: sort.fieldId,
-                aggregation: VizAggregationOptions.ANY,
-            }));
         // Find columns that are not groupBy or value columns (these become index columns)
-        // Include sortOnlyMetrics in the valuesColumns passed to getIndexColumn
-        // so they aren't incorrectly classified as index columns.
-        const allValuesColumns = [...valuesColumns, ...sortOnlyMetrics];
         const indexColumn = getIndexColumn(
             groupByColumns,
-            allValuesColumns,
+            valuesColumns,
             fields,
             metricQuery,
             xField,
+        );
+
+        // Include metrics/table calculations that are used in sorts but not
+        // displayed in the chart or otherwise represented by the pivot roles.
+        // Without these, PivotQueryBuilder can't generate anchor CTEs for sort keys
+        // that are not part of the chart output.
+        const sortOnlyColumns = getSortOnlyColumns(
+            metricQuery,
+            valuesColumns,
+            groupByColumns,
+            indexColumn,
         );
 
         const partialPivotConfiguration: Omit<PivotConfiguration, 'sortBy'> = {
             indexColumn,
             valuesColumns,
             groupByColumns,
-            ...(sortOnlyMetrics.length > 0 && {
-                sortOnlyColumns: sortOnlyMetrics,
+            ...(sortOnlyColumns.length > 0 && {
+                sortOnlyColumns,
             }),
         };
 

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -285,12 +285,25 @@ function getCartesianPivotConfiguration(
     } = chartConfig.config;
 
     if (pivotConfig?.columns && xField && yField) {
-        // Extract and validate pivot columns
+        // Extract and validate pivot columns. Pivot columns are usually raw
+        // dimensions but the user can also reference a metric or table
+        // calculation — both of which exist as columns in `original_query`
+        // and are valid GROUP BY targets in the downstream PivotQueryBuilder
+        // CTEs. We only drop references that match nothing in the metric
+        // query (typos / stale config) to avoid emitting SQL against
+        // non-existent columns.
         const groupByColumns = pivotConfig.columns
             .map((pv) => ({
                 reference: pv,
             }))
-            .filter((col) => metricQuery.dimensions.includes(col.reference));
+            .filter(
+                (col) =>
+                    metricQuery.dimensions.includes(col.reference) ||
+                    metricQuery.metrics.includes(col.reference) ||
+                    (metricQuery.tableCalculations || []).some(
+                        (tc) => tc.name === col.reference,
+                    ),
+            );
 
         // Extract value columns (metrics and table calculations from yField)
         const valuesColumns = yField

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -28,8 +28,8 @@ export type PivotConfiguration = {
     metricsAsRows?: boolean;
     /**
      * Metrics/table calculations needed for sort anchor CTEs but not for display.
-     * These are merged into valuesColumns for SQL generation in PivotQueryBuilder,
-     * but excluded from pivotDetails so they don't appear as chart series.
+     * These are carried as execution-only values in PivotQueryBuilder, but excluded
+     * from pivotDetails so they don't appear as chart series or exported columns.
      */
     sortOnlyColumns?: ValuesColumn[];
 };

--- a/packages/common/src/utils/chartValidation.test.ts
+++ b/packages/common/src/utils/chartValidation.test.ts
@@ -101,5 +101,45 @@ describe('chartValidation', () => {
 
             expect(unusedDimensions).toEqual(['customers_first_name']);
         });
+
+        // Regression for bug-A: formula table calculations are a third TC
+        // variant (`isFormulaTableCalculation`) alongside SQL and template TCs.
+        // `getTableCalculationReferencedFieldIds` currently only handles SQL +
+        // template branches and returns [] for formula TCs, so any dimension
+        // referenced solely by a formula TC is falsely flagged as "unused" by
+        // the validator and by the in-app "Results may be incorrect" banner.
+        // The fix should walk formula references (e.g. via `extractColumnRefs`
+        // from packages/formula/src/ast.ts) so this test goes green.
+        test('treats dimensions referenced by a chart-used formula table calculation as used', () => {
+            const { unusedDimensions } = getUnusedDimensions({
+                chartType: ChartType.CARTESIAN,
+                chartConfig: cartesianChartConfig({
+                    xField: 'name_label',
+                    yField: ['orders_total_order_amount'],
+                }),
+                // Order-date-week is the pivot dim, so it's already in a role
+                // and not "unused" — keeps the test focused on whether the
+                // formula walker picks up `customers_first_name`.
+                pivotDimensions: ['orders_order_date_week'],
+                queryDimensions: [
+                    'customers_first_name',
+                    'orders_order_date_week',
+                    'customers_email',
+                ],
+                queryTableCalculations: [
+                    {
+                        name: 'name_label',
+                        displayName: 'Name label',
+                        type: TableCalculationType.STRING,
+                        // Formula references `customers_first_name` as a bare identifier
+                        formula: '=CONCAT(customers_first_name, "_label")',
+                    },
+                ],
+            });
+
+            // `customers_first_name` is referenced by the formula TC that
+            // powers xField; only `customers_email` is genuinely unused.
+            expect(unusedDimensions).toEqual(['customers_email']);
+        });
     });
 });

--- a/packages/common/src/utils/chartValidation.test.ts
+++ b/packages/common/src/utils/chartValidation.test.ts
@@ -1,4 +1,7 @@
-import { TableCalculationType } from '../types/field';
+import {
+    TableCalculationTemplateType,
+    TableCalculationType,
+} from '../types/field';
 import { ChartType, type ChartConfig } from '../types/savedCharts';
 import { getUnusedDimensions } from './chartValidation';
 
@@ -31,6 +34,42 @@ describe('chartValidation', () => {
                         displayName: 'Customer label',
                         type: TableCalculationType.STRING,
                         sql: "${customers.first_name} || ' ' || ${customers.last_name}",
+                    },
+                ],
+            });
+
+            expect(unusedDimensions).toEqual(['customers_email']);
+        });
+
+        test('treats dimensions referenced by a chart-used template table calculation as used', () => {
+            const { unusedDimensions } = getUnusedDimensions({
+                chartType: ChartType.CARTESIAN,
+                chartConfig: cartesianChartConfig({
+                    xField: 'orders_running_total',
+                    yField: ['orders_total_order_amount'],
+                }),
+                pivotDimensions: [],
+                queryDimensions: [
+                    'orders_order_date_week',
+                    'orders_status',
+                    'customers_email',
+                ],
+                queryTableCalculations: [
+                    {
+                        name: 'orders_running_total',
+                        displayName: 'Orders running total',
+                        type: TableCalculationType.NUMBER,
+                        template: {
+                            type: TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS,
+                            fieldId: 'orders_total_order_amount',
+                            orderBy: [
+                                {
+                                    fieldId: 'orders_order_date_week',
+                                    order: 'asc',
+                                },
+                            ],
+                            partitionBy: ['orders_status'],
+                        },
                     },
                 ],
             });

--- a/packages/common/src/utils/chartValidation.test.ts
+++ b/packages/common/src/utils/chartValidation.test.ts
@@ -1,0 +1,66 @@
+import { TableCalculationType } from '../types/field';
+import { ChartType, type ChartConfig } from '../types/savedCharts';
+import { getUnusedDimensions } from './chartValidation';
+
+const cartesianChartConfig = (
+    layout: Record<string, unknown>,
+): ChartConfig['config'] =>
+    ({
+        layout,
+    }) as ChartConfig['config'];
+
+describe('chartValidation', () => {
+    describe('getUnusedDimensions', () => {
+        test('treats dimensions referenced by a chart-used table calculation as used', () => {
+            const { unusedDimensions } = getUnusedDimensions({
+                chartType: ChartType.CARTESIAN,
+                chartConfig: cartesianChartConfig({
+                    xField: 'customer_label',
+                    yField: ['orders_total_order_amount'],
+                }),
+                pivotDimensions: ['orders_order_date_week'],
+                queryDimensions: [
+                    'customers_first_name',
+                    'customers_last_name',
+                    'orders_order_date_week',
+                    'customers_email',
+                ],
+                queryTableCalculations: [
+                    {
+                        name: 'customer_label',
+                        displayName: 'Customer label',
+                        type: TableCalculationType.STRING,
+                        sql: "${customers.first_name} || ' ' || ${customers.last_name}",
+                    },
+                ],
+            });
+
+            expect(unusedDimensions).toEqual(['customers_email']);
+        });
+
+        test('does not count dimensions from table calculations that are not used by the chart', () => {
+            const { unusedDimensions } = getUnusedDimensions({
+                chartType: ChartType.CARTESIAN,
+                chartConfig: cartesianChartConfig({
+                    xField: 'orders_order_date_week',
+                    yField: ['orders_total_order_amount'],
+                }),
+                pivotDimensions: [],
+                queryDimensions: [
+                    'orders_order_date_week',
+                    'customers_first_name',
+                ],
+                queryTableCalculations: [
+                    {
+                        name: 'customer_label',
+                        displayName: 'Customer label',
+                        type: TableCalculationType.STRING,
+                        sql: '${customers.first_name}',
+                    },
+                ],
+            });
+
+            expect(unusedDimensions).toEqual(['customers_first_name']);
+        });
+    });
+});

--- a/packages/common/src/utils/chartValidation.ts
+++ b/packages/common/src/utils/chartValidation.ts
@@ -1,5 +1,6 @@
 import {
     convertFieldRefToFieldId,
+    isFormulaTableCalculation,
     isSqlTableCalculation,
     isTemplateTableCalculation,
     type TableCalculation,
@@ -43,11 +44,47 @@ const convertReferenceToFieldId = (reference: string): string => {
     }
 };
 
+// Identifiers that are syntactically valid in a formula but never refer to a
+// user field — keywords, boolean literals, and the operators that the grammar
+// accepts in identifier position. Function names are excluded separately by
+// detecting `<ident>(`, so we don't need to enumerate them here.
+const FORMULA_RESERVED_WORDS = new Set(['TRUE', 'FALSE', 'AND', 'OR', 'NOT']);
+
+const getFormulaReferences = (formula: string): string[] => {
+    // Drop the leading `=` and any double-quoted string literals so identifiers
+    // appearing inside a string aren't mistaken for column references.
+    const stripped = formula
+        .replace(/^=/, '')
+        .replace(/"(?:[^"\\]|\\.)*"/g, '');
+
+    // An identifier immediately followed by `(` is a function call (CONCAT,
+    // SUM, IF, …) and never a column ref.
+    const functionNames = new Set(
+        [...stripped.matchAll(/([A-Za-z_][A-Za-z0-9_]*)\s*\(/g)].map(
+            (match) => match[1],
+        ),
+    );
+
+    return [...stripped.matchAll(/\b([A-Za-z_][A-Za-z0-9_]*)\b/g)]
+        .map((match) => match[1])
+        .filter((identifier) => !functionNames.has(identifier))
+        .filter(
+            (identifier) =>
+                !FORMULA_RESERVED_WORDS.has(identifier.toUpperCase()),
+        );
+};
+
 export const getTableCalculationReferencedFieldIds = (
     tableCalculation: TableCalculation,
 ): string[] => {
     if (isSqlTableCalculation(tableCalculation)) {
         return getLightdashReferences(tableCalculation.sql).map(
+            convertReferenceToFieldId,
+        );
+    }
+
+    if (isFormulaTableCalculation(tableCalculation)) {
+        return getFormulaReferences(tableCalculation.formula).map(
             convertReferenceToFieldId,
         );
     }

--- a/packages/common/src/utils/chartValidation.ts
+++ b/packages/common/src/utils/chartValidation.ts
@@ -1,4 +1,9 @@
 import {
+    convertFieldRefToFieldId,
+    isSqlTableCalculation,
+    type TableCalculation,
+} from '../types/field';
+import {
     ChartType,
     type CartesianChart,
     type ChartConfig,
@@ -16,6 +21,75 @@ export type UnusedDimensionsInput = {
     pivotDimensions: string[];
     /** All dimension field IDs in the metric query */
     queryDimensions: string[];
+    /** Table calculations in the metric query */
+    queryTableCalculations?: TableCalculation[];
+};
+
+const lightdashVariablePattern = /\$\{((?!(lightdash|ld)\.)[a-zA-Z0-9_.]+)\}/g;
+
+const getLightdashReferences = (sql: string): string[] =>
+    [...sql.matchAll(new RegExp(lightdashVariablePattern.source, 'g'))].map(
+        (match) => match[1],
+    );
+
+const convertReferenceToFieldId = (reference: string): string => {
+    try {
+        return reference.includes('.')
+            ? convertFieldRefToFieldId(reference)
+            : reference;
+    } catch {
+        return reference;
+    }
+};
+
+const getDimensionsUsedByTableCalculations = ({
+    queryDimensions,
+    queryTableCalculations,
+    usedTableCalculationNames,
+}: {
+    queryDimensions: string[];
+    queryTableCalculations: TableCalculation[];
+    usedTableCalculationNames: Set<string>;
+}): string[] => {
+    const dimensions = new Set<string>();
+    const queryDimensionsSet = new Set(queryDimensions);
+    const tableCalculationsByName = new Map(
+        queryTableCalculations.map((tableCalculation) => [
+            tableCalculation.name,
+            tableCalculation,
+        ]),
+    );
+    const visitedTableCalculationNames = new Set<string>();
+
+    const visitTableCalculation = (tableCalculationName: string) => {
+        if (visitedTableCalculationNames.has(tableCalculationName)) {
+            return;
+        }
+        visitedTableCalculationNames.add(tableCalculationName);
+
+        const tableCalculation =
+            tableCalculationsByName.get(tableCalculationName);
+        if (!tableCalculation || !isSqlTableCalculation(tableCalculation)) {
+            return;
+        }
+
+        for (const reference of getLightdashReferences(tableCalculation.sql)) {
+            const fieldId = convertReferenceToFieldId(reference);
+            if (queryDimensionsSet.has(fieldId)) {
+                dimensions.add(fieldId);
+            }
+            if (tableCalculationsByName.has(reference)) {
+                visitTableCalculation(reference);
+            }
+            if (tableCalculationsByName.has(fieldId)) {
+                visitTableCalculation(fieldId);
+            }
+        }
+    };
+
+    usedTableCalculationNames.forEach(visitTableCalculation);
+
+    return [...dimensions];
 };
 
 /**
@@ -34,7 +108,13 @@ export type UnusedDimensionsInput = {
 export function getUnusedDimensions(input: UnusedDimensionsInput): {
     unusedDimensions: string[];
 } {
-    const { chartType, chartConfig, pivotDimensions, queryDimensions } = input;
+    const {
+        chartType,
+        chartConfig,
+        pivotDimensions,
+        queryDimensions,
+        queryTableCalculations = [],
+    } = input;
 
     if (chartType !== ChartType.CARTESIAN) {
         return { unusedDimensions: [] };
@@ -45,6 +125,10 @@ export function getUnusedDimensions(input: UnusedDimensionsInput): {
     }
 
     const usedDimensions = new Set<string>();
+    const queryTableCalculationNames = new Set(
+        queryTableCalculations.map((tableCalculation) => tableCalculation.name),
+    );
+    const usedTableCalculationNames = new Set<string>();
 
     // Get layout from cartesian chart config
     // We cast to CartesianChart since we've already verified chartType is CARTESIAN
@@ -55,6 +139,9 @@ export function getUnusedDimensions(input: UnusedDimensionsInput): {
     if (layout?.xField && queryDimensions.includes(layout.xField)) {
         usedDimensions.add(layout.xField);
     }
+    if (layout?.xField && queryTableCalculationNames.has(layout.xField)) {
+        usedTableCalculationNames.add(layout.xField);
+    }
 
     // Add yField items if they're dimensions
     if (layout?.yField) {
@@ -62,12 +149,23 @@ export function getUnusedDimensions(input: UnusedDimensionsInput): {
             if (queryDimensions.includes(field)) {
                 usedDimensions.add(field);
             }
+            if (queryTableCalculationNames.has(field)) {
+                usedTableCalculationNames.add(field);
+            }
         }
     }
 
     // Add all pivot dimensions (these are always dimensions by definition)
     for (const pivotDim of pivotDimensions) {
         usedDimensions.add(pivotDim);
+    }
+
+    for (const dimension of getDimensionsUsedByTableCalculations({
+        queryDimensions,
+        queryTableCalculations,
+        usedTableCalculationNames,
+    })) {
+        usedDimensions.add(dimension);
     }
 
     // Find query dimensions that are not used anywhere

--- a/packages/common/src/utils/chartValidation.ts
+++ b/packages/common/src/utils/chartValidation.ts
@@ -1,6 +1,7 @@
 import {
     convertFieldRefToFieldId,
     isSqlTableCalculation,
+    isTemplateTableCalculation,
     type TableCalculation,
 } from '../types/field';
 import {
@@ -42,6 +43,36 @@ const convertReferenceToFieldId = (reference: string): string => {
     }
 };
 
+export const getTableCalculationReferencedFieldIds = (
+    tableCalculation: TableCalculation,
+): string[] => {
+    if (isSqlTableCalculation(tableCalculation)) {
+        return getLightdashReferences(tableCalculation.sql).map(
+            convertReferenceToFieldId,
+        );
+    }
+
+    if (isTemplateTableCalculation(tableCalculation)) {
+        const { template } = tableCalculation;
+        const fieldIdPart =
+            'fieldId' in template && template.fieldId !== null
+                ? [template.fieldId]
+                : [];
+        const orderByPart =
+            'orderBy' in template
+                ? template.orderBy.map((orderBy) => orderBy.fieldId)
+                : [];
+        const partitionByPart =
+            'partitionBy' in template && template.partitionBy
+                ? template.partitionBy
+                : [];
+
+        return [...fieldIdPart, ...orderByPart, ...partitionByPart];
+    }
+
+    return [];
+};
+
 const getDimensionsUsedByTableCalculations = ({
     queryDimensions,
     queryTableCalculations,
@@ -69,17 +100,15 @@ const getDimensionsUsedByTableCalculations = ({
 
         const tableCalculation =
             tableCalculationsByName.get(tableCalculationName);
-        if (!tableCalculation || !isSqlTableCalculation(tableCalculation)) {
+        if (!tableCalculation) {
             return;
         }
 
-        for (const reference of getLightdashReferences(tableCalculation.sql)) {
-            const fieldId = convertReferenceToFieldId(reference);
+        for (const fieldId of getTableCalculationReferencedFieldIds(
+            tableCalculation,
+        )) {
             if (queryDimensionsSet.has(fieldId)) {
                 dimensions.add(fieldId);
-            }
-            if (tableCalculationsByName.has(reference)) {
-                visitTableCalculation(reference);
             }
             if (tableCalculationsByName.has(fieldId)) {
                 visitTableCalculation(fieldId);

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -1,5 +1,91 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { SEED_PROJECT } from '@lightdash/common';
+import {
+    CartesianSeriesType,
+    ChartType,
+    SEED_PROJECT,
+    TableCalculationType,
+} from '@lightdash/common';
+
+const buildExploreUrl = (chartState: Record<string, unknown>) =>
+    `/projects/${SEED_PROJECT.project_uuid}/tables/orders?create_saved_chart_version=${encodeURIComponent(
+        JSON.stringify(chartState),
+    )}`;
+
+const fieldReference = (fieldId: string) => `\${${fieldId}}`;
+
+const xAxisTableCalculationChartState = {
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: [
+            'customers_first_name',
+            'customers_last_name',
+            'orders_order_date_week',
+        ],
+        metrics: ['orders_total_order_amount'],
+        filters: {},
+        sorts: [{ fieldId: 'customer_label', descending: false }],
+        limit: 500,
+        tableCalculations: [
+            {
+                name: 'customer_label',
+                displayName: 'Customer label',
+                type: TableCalculationType.STRING,
+                sql: `concat(${fieldReference(
+                    'customers.first_name',
+                )}, ' ', ${fieldReference('customers.last_name')})`,
+            },
+        ],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_order_date_week'] },
+    tableConfig: {
+        columnOrder: [
+            'customers_first_name',
+            'customers_last_name',
+            'orders_order_date_week',
+            'orders_total_order_amount',
+            'customer_label',
+        ],
+    },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customer_label',
+                yField: ['orders_total_order_amount'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customer_label' },
+                            yRef: { field: 'orders_total_order_amount' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+};
+
+const waitForReadyPivotRows = (
+    assertRows: (rows: Record<string, any>[]) => void,
+) => {
+    cy.wait('@pivotQueryResults', { timeout: 60000 }).then((interception) => {
+        const results = interception.response?.body?.results;
+
+        if (results?.status !== 'ready') {
+            waitForReadyPivotRows(assertRows);
+            return;
+        }
+
+        assertRows(results.rows);
+    });
+};
 
 describe('Pivot Tables', () => {
     beforeEach(() => {
@@ -45,6 +131,29 @@ describe('Pivot Tables', () => {
 
         cy.get('@chartArea').findByText('Loading chart').should('not.exist');
         cy.get('@chartArea').contains('Is completed'); // Check that the chart updated successfully with the pivot table(containing 'is completed' column)
+    });
+
+    it('Can render a pivoted cartesian chart with x-axis table calculation sorted by itself', () => {
+        cy.intercept('GET', '**/api/v2/projects/*/query/*').as(
+            'pivotQueryResults',
+        );
+
+        cy.visit(buildExploreUrl(xAxisTableCalculationChartState));
+
+        cy.get('button').contains('Run query').click();
+
+        waitForReadyPivotRows((rows) => {
+            const customerLabels = rows
+                .map((row) => row.customer_label?.value.raw)
+                .filter((value) => value !== undefined && value !== null);
+
+            expect(customerLabels.length).to.be.greaterThan(1);
+            expect(new Set(customerLabels).size).to.be.greaterThan(1);
+        });
+
+        cy.get('[data-testid="visualization"]').as('chartArea');
+        cy.get('@chartArea').findByText('Loading chart').should('not.exist');
+        cy.get('@chartArea').find('.echarts-for-react svg').should('exist');
     });
 
     // todo: remove

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -153,7 +153,9 @@ describe('Pivot Tables', () => {
 
         cy.get('[data-testid="visualization"]').as('chartArea');
         cy.get('@chartArea').findByText('Loading chart').should('not.exist');
-        cy.get('@chartArea').find('.echarts-for-react svg').should('exist');
+        cy.get('@chartArea')
+            .find('.echarts-for-react canvas, .echarts-for-react svg')
+            .should('exist');
         cy.findByText('Results may be incorrect').should('not.exist');
     });
 

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -154,6 +154,7 @@ describe('Pivot Tables', () => {
         cy.get('[data-testid="visualization"]').as('chartArea');
         cy.get('@chartArea').findByText('Loading chart').should('not.exist');
         cy.get('@chartArea').find('.echarts-for-react svg').should('exist');
+        cy.findByText('Results may be incorrect').should('not.exist');
     });
 
     // todo: remove

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
@@ -92,9 +92,12 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
             chartConfig: chartConfig.config,
             pivotDimensions: dirtyPivotDimensions,
             queryDimensions: resultsData?.metricQuery?.dimensions ?? [],
+            queryTableCalculations:
+                resultsData?.metricQuery?.tableCalculations ?? [],
         });
     }, [
         resultsData?.metricQuery?.dimensions,
+        resultsData?.metricQuery?.tableCalculations,
         chartConfig?.type,
         chartConfig.config,
         dirtyPivotDimensions,

--- a/packages/frontend/src/components/SortButton/SortItem.tsx
+++ b/packages/frontend/src/components/SortButton/SortItem.tsx
@@ -93,8 +93,10 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
                     <Text fz="xs">{isFirstItem ? 'Sort by' : 'then by'}</Text>
 
                     <Text fz="sm" fw={500}>
-                        {(isField(item) ? item.label : item.name) ||
-                            sort.fieldId}
+                        {(isField(item)
+                            ? item.label
+                            : ('displayName' in item && item.displayName) ||
+                              item.name) || sort.fieldId}
                     </Text>
                 </Group>
 

--- a/packages/frontend/src/components/SortButton/Sorting.tsx
+++ b/packages/frontend/src/components/SortButton/Sorting.tsx
@@ -98,7 +98,8 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
                 label: item
                     ? isField(item)
                         ? item.label || item.name
-                        : item.name
+                        : ('displayName' in item && item.displayName) ||
+                          item.name
                     : c.id,
             };
         })

--- a/packages/frontend/src/components/SortButton/index.tsx
+++ b/packages/frontend/src/components/SortButton/index.tsx
@@ -26,7 +26,10 @@ const SortButton: FC<Props> = ({ sorts, isEditMode }) => {
             const column = columns.find((c) => c.id === sort.fieldId);
             const item = column?.meta?.item;
             if (!item) return '1 field';
-            return isField(item) ? item.label : item.name;
+            if (isField(item)) return item.label;
+            // Table calculations expose `displayName` (human label) alongside
+            // their snake_case `name`; custom dimensions only have `name`.
+            return 'displayName' in item ? item.displayName : item.name;
         }
         return `${sorts.length} fields`;
     };

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -122,6 +122,8 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
             chartConfig: savedData.chartConfig?.config,
             pivotDimensions,
             queryDimensions,
+            queryTableCalculations:
+                savedData.metricQuery?.tableCalculations ?? [],
         });
     }, [savedData]);
 


### PR DESCRIPTION
## Summary

Fixes #22389 — Cartesian charts with a table calculation on the x-axis that
is also used as a sort field were collapsing onto a single x-axis tick. This
was a regression introduced by #22081, which over-broadly captured every
sort field as a "sort-only" value column.

- Preserve pivot index fields when the same metric/table calculation is also
  used for sorting (the #22389 fix).
- Keep sort-only metrics/table calculations available for ordering without
  leaking them into chart or export output (preserves #22081's intent).
- Avoid false unused-dimension validator warnings when a chart-used table
  calculation references hidden dimensions, including window-function and
  formula table calculations (closes the table-calculation half of #10229;
  custom SQL dimensions still pending).
- Add API, Cypress, and common utility coverage for the pivot sorting blast
  radius. Cypress selector now matches both `<svg>` and `<canvas>` echarts
  renderers (canvas became the default in #22422).

## Testing

- pnpm -F common test -- derivePivotConfigFromChart.test.ts
- pnpm -F common test -- chartValidation.test.ts
- pnpm -F common typecheck
- pnpm -F frontend typecheck
- SITE_URL=http://localhost:8100 pnpm -F api-tests test:api tests/pivotSorting.test.ts
- pnpm -F e2e cypress:run --spec cypress/e2e/app/pivotTables.cy.ts --config baseUrl=http://localhost:3020
- Targeted lint/format checks for touched packages