### PR TITLE
feat(table-calc): redesign Create/Edit Table Calculation modal

### DIFF
--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -850,6 +850,28 @@ export function formatItemValue(
 
         if (isCustomSqlDimension(item) || 'type' in item) {
             const type = getItemType(item);
+
+            // Date/Timestamp table calculations may carry a CUSTOM format
+            // expression (e.g. "mmmm d, yyyy"). The default switch path
+            // hardwires formatDate/formatTimestamp and would silently drop
+            // it, so honour the custom expression first.
+            if (
+                (type === TableCalculationType.DATE ||
+                    type === TableCalculationType.TIMESTAMP) &&
+                customFormat?.type === CustomFormatType.CUSTOM &&
+                customFormat.custom &&
+                isMomentInput(value)
+            ) {
+                try {
+                    return formatValueWithExpression(
+                        customFormat.custom,
+                        value,
+                    );
+                } catch {
+                    // Fall through to the default date/timestamp render.
+                }
+            }
+
             switch (type) {
                 case TableCalculationType.STRING:
                 case DimensionType.STRING:

--- a/packages/frontend/src/components/Explorer/FormatForm/getFormatSummary.ts
+++ b/packages/frontend/src/components/Explorer/FormatForm/getFormatSummary.ts
@@ -1,8 +1,4 @@
-import {
-    CustomFormatType,
-    findCompactConfig,
-    type CustomFormat,
-} from '@lightdash/common';
+import { CustomFormatType } from '@lightdash/common';
 
 export const getFormatTypeLabel = (type: CustomFormatType): string => {
     switch (type) {
@@ -27,52 +23,4 @@ export const getFormatTypeLabel = (type: CustomFormatType): string => {
         default:
             return type;
     }
-};
-
-export const getFormatSummary = (format: CustomFormat): string => {
-    const type = format.type ?? CustomFormatType.DEFAULT;
-
-    if (type === CustomFormatType.DEFAULT) {
-        return 'Default';
-    }
-
-    const parts: string[] = [];
-
-    if (type === CustomFormatType.CURRENCY && format.currency) {
-        parts.push(format.currency);
-    } else {
-        parts.push(getFormatTypeLabel(type));
-    }
-
-    const supportsRound =
-        type === CustomFormatType.PERCENT ||
-        type === CustomFormatType.CURRENCY ||
-        type === CustomFormatType.NUMBER ||
-        type === CustomFormatType.BYTES_SI ||
-        type === CustomFormatType.BYTES_IEC;
-
-    if (supportsRound && format.round !== undefined && format.round !== null) {
-        parts.push(`${format.round} decimal${format.round === 1 ? '' : 's'}`);
-    }
-
-    if (format.compact) {
-        const compactConfig = findCompactConfig(format.compact);
-        if (compactConfig) parts.push(compactConfig.label.toLowerCase());
-    }
-
-    if (type === CustomFormatType.NUMBER) {
-        if (format.prefix) parts.push(`prefix "${format.prefix}"`);
-        if (format.suffix) parts.push(`suffix "${format.suffix}"`);
-    }
-
-    if (
-        (type === CustomFormatType.CUSTOM ||
-            type === CustomFormatType.DATE ||
-            type === CustomFormatType.TIMESTAMP) &&
-        format.custom
-    ) {
-        parts.push(format.custom);
-    }
-
-    return parts.join(' · ');
 };

--- a/packages/frontend/src/components/Explorer/FormatForm/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatForm/index.tsx
@@ -48,6 +48,7 @@ type Props = {
         value: ValueOf<CustomFormat>,
     ) => void;
     itemType?: DimensionType | MetricType | TableCalculationType;
+    compact?: boolean;
 };
 
 const numericFormatTypeOptions = [
@@ -128,13 +129,18 @@ export const FormatForm: FC<Props> = ({
     format,
 
     itemType,
+    compact = false,
 }) => {
     const formatType = format.type;
 
     const isDateField = useMemo(() => {
         return (
             itemType === DimensionType.DATE ||
-            itemType === DimensionType.TIMESTAMP
+            itemType === DimensionType.TIMESTAMP ||
+            itemType === MetricType.DATE ||
+            itemType === MetricType.TIMESTAMP ||
+            itemType === TableCalculationType.DATE ||
+            itemType === TableCalculationType.TIMESTAMP
         );
     }, [itemType]);
 
@@ -231,7 +237,7 @@ export const FormatForm: FC<Props> = ({
                     </Stack>
                 </Grid.Col>
             ) : (
-                <Grid.Col span={4}>
+                <Grid.Col span={compact ? 12 : 4}>
                     <Select
                         label="Format type"
                         data={formatTypeOptions.map((type) => ({
@@ -268,10 +274,14 @@ export const FormatForm: FC<Props> = ({
             {isDateType && (
                 <Grid.Col span={12}>
                     <Stack gap="md">
-                        <Flex align="flex-end" gap="md">
+                        <Flex
+                            align={compact ? 'stretch' : 'flex-end'}
+                            direction={compact ? 'column' : 'row'}
+                            gap="md"
+                        >
                             <TextInput
                                 flex={1}
-                                maw={400}
+                                maw={compact ? undefined : 400}
                                 leftSection={
                                     <MantineIcon
                                         icon={
@@ -409,7 +419,7 @@ export const FormatForm: FC<Props> = ({
             ].includes(formatType) && (
                 <>
                     {formatType === CustomFormatType.CURRENCY && (
-                        <Grid.Col span={4}>
+                        <Grid.Col span={compact ? 12 : 4}>
                             <Select
                                 searchable
                                 label="Currency"
@@ -418,7 +428,7 @@ export const FormatForm: FC<Props> = ({
                             />
                         </Grid.Col>
                     )}
-                    <Grid.Col span={4}>
+                    <Grid.Col span={compact ? 12 : 4}>
                         <NumberInput
                             type="number"
                             min={0}
@@ -436,7 +446,7 @@ export const FormatForm: FC<Props> = ({
                             }}
                         />
                     </Grid.Col>
-                    <Grid.Col span={4}>
+                    <Grid.Col span={compact ? 12 : 4}>
                         <Select
                             label="Separator style"
                             data={formatSeparatorOptions}
@@ -488,14 +498,14 @@ export const FormatForm: FC<Props> = ({
 
                     {formatType === CustomFormatType.NUMBER && (
                         <>
-                            <Grid.Col span={4}>
+                            <Grid.Col span={compact ? 12 : 4}>
                                 <TextInput
                                     label="Prefix"
                                     placeholder="e.g. $"
                                     {...formatInputProps('prefix')}
                                 />
                             </Grid.Col>
-                            <Grid.Col span={4}>
+                            <Grid.Col span={compact ? 12 : 4}>
                                 <TextInput
                                     label="Suffix"
                                     placeholder="e.g. km/h"

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -170,6 +170,13 @@ export type MantineModalProps = {
     modalHeaderProps?: Partial<ModalHeaderProps>;
     modalBodyProps?: Partial<ModalBodyProps>;
     modalActionsProps?: Partial<FlexProps>;
+    /**
+     * Max-height for the body's ScrollArea in standard (non-fullscreen) mode.
+     * Use this to grow the modal vertically when the content needs more room.
+     * Ignored when `fullScreen` is true.
+     * @default 'calc(80vh - 140px)'
+     */
+    bodyScrollAreaMaxHeight?: string;
 };
 
 const MantineModal: React.FC<MantineModalProps> = ({
@@ -200,6 +207,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
     modalHeaderProps,
     modalBodyProps,
     modalActionsProps,
+    bodyScrollAreaMaxHeight = 'calc(80vh - 140px)',
 }) => {
     const [
         isConfirmCloseOpen,
@@ -254,7 +262,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
         // Standard mode: ScrollArea with max height
         return (
             <Modal.Body p={0} className={classes.body}>
-                <ScrollArea.Autosize mah="calc(80vh - 140px)">
+                <ScrollArea.Autosize mah={bodyScrollAreaMaxHeight}>
                     <Stack
                         gap="md"
                         px={modalBodyProps?.px ?? 'xl'}

--- a/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.module.css
@@ -1,0 +1,231 @@
+.root {
+    padding: var(--mantine-spacing-md);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-ldGray-0);
+
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-2);
+        border-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--mantine-spacing-sm);
+    margin-bottom: var(--mantine-spacing-sm);
+}
+
+.headerLabel {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    color: var(--mantine-color-ldGray-7);
+
+    @mixin dark {
+        color: var(--mantine-color-ldDark-9);
+    }
+}
+
+.dataTypeSelect {
+    width: 160px;
+}
+
+.pillRow {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-sm);
+    flex-wrap: wrap;
+}
+
+.previewPill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    min-height: 28px;
+    color: var(--mantine-color-ldGray-7);
+    background-color: var(--mantine-color-white);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-sm);
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+
+    @mixin dark {
+        color: var(--mantine-color-ldDark-9);
+        background-color: var(--mantine-color-ldDark-3);
+        border-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.previewIcon {
+    color: var(--mantine-color-ldGray-5);
+
+    @mixin dark {
+        color: var(--mantine-color-ldDark-7);
+    }
+}
+
+.divider {
+    width: 1px;
+    align-self: stretch;
+    background-color: var(--mantine-color-ldGray-2);
+
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.pillsControl {
+    background: transparent;
+    padding: 0;
+    gap: 4px;
+}
+
+.pillsControlIndicator {
+    background-color: var(--mantine-color-blue-6);
+    box-shadow: none;
+}
+
+.pillsControlItem {
+    border-radius: 999px;
+}
+
+.pillsControlLabel {
+    padding-inline: var(--mantine-spacing-sm);
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    line-height: 24px;
+    color: var(--mantine-color-ldGray-7);
+    border-radius: 999px;
+
+    &[data-active] {
+        color: var(--mantine-color-white);
+    }
+
+    @mixin dark {
+        color: var(--mantine-color-ldDark-9);
+    }
+}
+
+.subRow {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--mantine-spacing-md);
+    margin-top: var(--mantine-spacing-sm);
+    padding-top: var(--mantine-spacing-sm);
+    border-top: 1px dashed var(--mantine-color-ldGray-2);
+    flex-wrap: wrap;
+
+    @mixin dark {
+        border-top-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.subRowField {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+}
+
+.subRowFieldLabel {
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-6);
+    white-space: nowrap;
+
+    @mixin dark {
+        color: var(--mantine-color-ldDark-8);
+    }
+}
+
+.subRowInput {
+    width: 84px;
+}
+
+.subRowSelect {
+    width: 130px;
+}
+
+.subRowCurrencySelect {
+    width: 160px;
+}
+
+.subRowText {
+    width: 110px;
+}
+
+.customExpression {
+    margin-top: var(--mantine-spacing-sm);
+    padding-top: var(--mantine-spacing-sm);
+    border-top: 1px dashed var(--mantine-color-ldGray-2);
+
+    @mixin dark {
+        border-top-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.dateBody {
+    margin-top: var(--mantine-spacing-sm);
+    padding-top: var(--mantine-spacing-sm);
+    border-top: 1px dashed var(--mantine-color-ldGray-2);
+
+    @mixin dark {
+        border-top-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.dateExamplesRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--mantine-spacing-xs);
+    margin-top: var(--mantine-spacing-xs);
+}
+
+.headerIcon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    color: var(--mantine-color-blue-6);
+    background-color: var(--mantine-color-blue-0);
+    border: 1px solid var(--mantine-color-blue-1);
+    border-radius: var(--mantine-radius-sm);
+
+    @mixin dark {
+        color: var(--mantine-color-blue-3);
+        background-color: var(--mantine-color-blue-9);
+        border-color: var(--mantine-color-blue-8);
+    }
+}
+
+@media (max-width: 48em) {
+    .pillRow {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .divider {
+        display: none;
+    }
+
+    .subRow {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .subRowField {
+        justify-content: space-between;
+    }
+
+    .subRowInput,
+    .subRowSelect,
+    .subRowCurrencySelect,
+    .subRowText {
+        width: 100%;
+    }
+}

--- a/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.module.css
@@ -1,8 +1,8 @@
-.root {
-    padding: var(--mantine-spacing-md);
+.card {
+    padding: 6px var(--mantine-spacing-sm) var(--mantine-spacing-xs);
     border: 1px solid var(--mantine-color-ldGray-2);
     border-radius: var(--mantine-radius-md);
-    background-color: var(--mantine-color-ldGray-0);
+    background-color: var(--mantine-color-white);
 
     @mixin dark {
         background-color: var(--mantine-color-ldDark-2);
@@ -10,58 +10,39 @@
     }
 }
 
-.header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--mantine-spacing-sm);
-    margin-bottom: var(--mantine-spacing-sm);
+.cardEmpty {
+    padding: 6px var(--mantine-spacing-sm);
 }
 
-.headerLabel {
-    display: flex;
-    align-items: center;
-    gap: var(--mantine-spacing-xs);
-    color: var(--mantine-color-ldGray-7);
-
-    @mixin dark {
-        color: var(--mantine-color-ldDark-9);
-    }
-}
-
-.dataTypeSelect {
-    width: 160px;
-}
-
-.pillRow {
+.topRow {
     display: flex;
     align-items: center;
     gap: var(--mantine-spacing-sm);
+    min-height: 26px;
     flex-wrap: wrap;
 }
 
-.previewPill {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 10px;
-    min-height: 28px;
-    color: var(--mantine-color-ldGray-7);
-    background-color: var(--mantine-color-white);
-    border: 1px solid var(--mantine-color-ldGray-2);
-    border-radius: var(--mantine-radius-sm);
-    font-size: var(--mantine-font-size-sm);
-    font-weight: 500;
-    font-variant-numeric: tabular-nums;
-
-    @mixin dark {
-        color: var(--mantine-color-ldDark-9);
-        background-color: var(--mantine-color-ldDark-3);
-        border-color: var(--mantine-color-ldDark-4);
-    }
+.dataTypeSelect {
+    width: 132px;
+    flex-shrink: 0;
 }
 
-.previewIcon {
+.pillsGroup {
+    flex-shrink: 0;
+}
+
+.pillButton {
+    font-weight: 500;
+    letter-spacing: 0;
+}
+
+.preview {
+    margin-left: auto;
+    flex-shrink: 0;
+    padding-left: var(--mantine-spacing-sm);
+}
+
+.previewArrow {
     color: var(--mantine-color-ldGray-5);
 
     @mixin dark {
@@ -69,112 +50,94 @@
     }
 }
 
-.divider {
-    width: 1px;
-    align-self: stretch;
-    background-color: var(--mantine-color-ldGray-2);
+.previewValue {
+    font-size: var(--mantine-font-size-md);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--mantine-color-ldDark-9);
 
     @mixin dark {
-        background-color: var(--mantine-color-ldDark-4);
-    }
-}
-
-.pillsControl {
-    background: transparent;
-    padding: 0;
-    gap: 4px;
-}
-
-.pillsControlIndicator {
-    background-color: var(--mantine-color-blue-6);
-    box-shadow: none;
-}
-
-.pillsControlItem {
-    border-radius: 999px;
-}
-
-.pillsControlLabel {
-    padding-inline: var(--mantine-spacing-sm);
-    font-size: var(--mantine-font-size-xs);
-    font-weight: 500;
-    line-height: 24px;
-    color: var(--mantine-color-ldGray-7);
-    border-radius: 999px;
-
-    &[data-active] {
         color: var(--mantine-color-white);
     }
-
-    @mixin dark {
-        color: var(--mantine-color-ldDark-9);
-    }
 }
 
-.subRow {
-    display: flex;
-    align-items: flex-end;
-    gap: var(--mantine-spacing-md);
-    margin-top: var(--mantine-spacing-sm);
-    padding-top: var(--mantine-spacing-sm);
+.divider {
+    height: 1px;
+    margin: 6px 0;
     border-top: 1px dashed var(--mantine-color-ldGray-2);
-    flex-wrap: wrap;
 
     @mixin dark {
         border-top-color: var(--mantine-color-ldDark-4);
     }
 }
 
-.subRowField {
+.subBody {
+    /* Matches a labeled input row (label ~16 + input 28 + gap) so switching
+       between Plain (no inputs) and other pills doesn't jump the modal. */
+    min-height: 50px;
     display: flex;
-    align-items: center;
-    gap: var(--mantine-spacing-xs);
+    flex-direction: column;
+    justify-content: center;
 }
 
-.subRowFieldLabel {
-    font-size: var(--mantine-font-size-xs);
-    font-weight: 500;
-    color: var(--mantine-color-ldGray-6);
-    white-space: nowrap;
+.emptyBody {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    color: var(--mantine-color-ldGray-5);
 
     @mixin dark {
-        color: var(--mantine-color-ldDark-8);
+        color: var(--mantine-color-ldDark-7);
     }
 }
 
-.subRowInput {
-    width: 84px;
+.subFieldInput {
+    width: 100px;
 }
 
-.subRowSelect {
+.subFieldInputNarrow {
+    width: 80px;
+}
+
+.subFieldSelect {
+    width: 150px;
+}
+
+.subFieldSelectNarrow {
     width: 130px;
 }
 
-.subRowCurrencySelect {
+.subFieldSeparator {
     width: 160px;
 }
 
-.subRowText {
-    width: 110px;
+.subFieldSelectWide {
+    width: 180px;
 }
 
-.customExpression {
-    margin-top: var(--mantine-spacing-sm);
-    padding-top: var(--mantine-spacing-sm);
-    border-top: 1px dashed var(--mantine-color-ldGray-2);
-
-    @mixin dark {
-        border-top-color: var(--mantine-color-ldDark-4);
-    }
+.subFieldText {
+    width: 130px;
 }
 
-.dateBody {
-    margin-top: var(--mantine-spacing-sm);
-    padding-top: var(--mantine-spacing-sm);
-    border-top: 1px dashed var(--mantine-color-ldGray-2);
+.subFieldTextNarrow {
+    width: 100px;
+}
+
+.subFieldCurrency {
+    width: 200px;
+}
+
+.fullWidthLabel {
+    width: 100%;
+    display: block;
+}
+
+.labelLink {
+    color: var(--mantine-color-blue-6);
+    font-weight: 500;
 
     @mixin dark {
-        border-top-color: var(--mantine-color-ldDark-4);
+        color: var(--mantine-color-blue-3);
     }
 }
 
@@ -182,50 +145,38 @@
     display: flex;
     flex-wrap: wrap;
     gap: var(--mantine-spacing-xs);
-    margin-top: var(--mantine-spacing-xs);
-}
-
-.headerIcon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
-    color: var(--mantine-color-blue-6);
-    background-color: var(--mantine-color-blue-0);
-    border: 1px solid var(--mantine-color-blue-1);
-    border-radius: var(--mantine-radius-sm);
-
-    @mixin dark {
-        color: var(--mantine-color-blue-3);
-        background-color: var(--mantine-color-blue-9);
-        border-color: var(--mantine-color-blue-8);
-    }
 }
 
 @media (max-width: 48em) {
-    .pillRow {
+    .topRow {
         flex-direction: column;
         align-items: stretch;
     }
 
-    .divider {
-        display: none;
+    .preview {
+        margin-left: 0;
+        padding-left: 0;
+        justify-content: flex-end;
     }
 
-    .subRow {
-        flex-direction: column;
-        align-items: stretch;
+    .pillsGroup {
+        flex-wrap: wrap;
     }
 
-    .subRowField {
-        justify-content: space-between;
+    .subFieldInput,
+    .subFieldInputNarrow,
+    .subFieldSelect,
+    .subFieldSelectNarrow,
+    .subFieldSelectWide,
+    .subFieldSeparator,
+    .subFieldText,
+    .subFieldTextNarrow,
+    .subFieldCurrency {
+        flex: 1;
+        width: auto;
     }
 
-    .subRowInput,
-    .subRowSelect,
-    .subRowCurrencySelect,
-    .subRowText {
+    .dataTypeSelect {
         width: 100%;
     }
 }

--- a/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
@@ -5,6 +5,8 @@ import {
     currencies,
     CustomFormatType,
     findCompactConfig,
+    formatDate,
+    formatTimestamp,
     formatValueWithExpression,
     getCompactOptionsForFormatType,
     NumberSeparator,
@@ -202,10 +204,12 @@ const getPreviewValue = (
             ) {
                 return formatValueWithExpression(format.custom, sample);
             }
-            // Default Date / Timestamp rendering
+            // Default Date / Timestamp rendering — match what the explore
+            // results table renders for these types (formatDate /
+            // formatTimestamp from @lightdash/common), not toLocaleString.
             return dataType === TableCalculationType.TIMESTAMP
-                ? sample.toLocaleString()
-                : sample.toLocaleDateString();
+                ? formatTimestamp(sample)
+                : formatDate(sample);
         }
 
         const expression = convertCustomFormatToFormatExpression(format);

--- a/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
@@ -1,0 +1,790 @@
+import {
+    assertUnreachable,
+    CompactConfigMap,
+    convertCustomFormatToFormatExpression,
+    currencies,
+    CustomFormatType,
+    findCompactConfig,
+    formatValueWithExpression,
+    getCompactOptionsForFormatType,
+    NumberSeparator,
+    TableCalculationType,
+    type CustomFormat,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Box,
+    Group,
+    SegmentedControl,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+    type ComboboxItem,
+} from '@mantine-8/core';
+import { NumberInput } from '@mantine/core';
+import { type UseFormReturnType } from '@mantine/form';
+import {
+    Icon123,
+    IconAbc,
+    IconArrowBackUp,
+    IconCalendar,
+    IconClockHour4,
+    IconExternalLink,
+    IconPalette,
+    IconToggleLeft,
+} from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import { type ValueOf } from 'type-fest';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { PolymorphicPaperButton } from '../../../../components/common/PolymorphicPaperButton';
+import classes from './FormatRow.module.css';
+
+type Props = {
+    format: CustomFormat;
+    setFormatFieldValue: (
+        path: keyof CustomFormat,
+        value: ValueOf<CustomFormat>,
+    ) => void;
+    formatInputProps: (
+        path: keyof CustomFormat,
+    ) => ReturnType<UseFormReturnType<CustomFormat>['getInputProps']>;
+    dataType: TableCalculationType;
+    onDataTypeChange: (value: TableCalculationType) => void;
+};
+
+type NumericPill =
+    | CustomFormatType.DEFAULT
+    | CustomFormatType.NUMBER
+    | CustomFormatType.CURRENCY
+    | CustomFormatType.PERCENT
+    | 'bytes'
+    | CustomFormatType.CUSTOM;
+
+type DatePill = CustomFormatType.DEFAULT | CustomFormatType.CUSTOM;
+
+const NUMERIC_SAMPLE = 1234.5678;
+
+const dataTypeMeta = {
+    [TableCalculationType.NUMBER]: { label: 'Number', icon: Icon123 },
+    [TableCalculationType.STRING]: { label: 'String', icon: IconAbc },
+    [TableCalculationType.DATE]: { label: 'Date', icon: IconCalendar },
+    [TableCalculationType.TIMESTAMP]: {
+        label: 'Timestamp',
+        icon: IconClockHour4,
+    },
+    [TableCalculationType.BOOLEAN]: {
+        label: 'Boolean',
+        icon: IconToggleLeft,
+    },
+} as const satisfies Record<
+    TableCalculationType,
+    { label: string; icon: typeof Icon123 }
+>;
+
+const numericPills: { value: NumericPill; label: string }[] = [
+    { value: CustomFormatType.DEFAULT, label: 'Plain' },
+    { value: CustomFormatType.NUMBER, label: 'Number' },
+    { value: CustomFormatType.CURRENCY, label: 'Currency' },
+    { value: CustomFormatType.PERCENT, label: 'Percent' },
+    { value: 'bytes', label: 'Bytes' },
+    { value: CustomFormatType.CUSTOM, label: 'Custom' },
+];
+
+const datePills: { value: DatePill; label: string }[] = [
+    { value: CustomFormatType.DEFAULT, label: 'Default' },
+    { value: CustomFormatType.CUSTOM, label: 'Custom' },
+];
+
+const separatorOptions: ComboboxItem[] = [
+    { value: NumberSeparator.DEFAULT, label: 'Default separator' },
+    { value: NumberSeparator.COMMA_PERIOD, label: '100,000.00' },
+    { value: NumberSeparator.SPACE_PERIOD, label: '100 000.00' },
+    { value: NumberSeparator.PERIOD_COMMA, label: '100.000,00' },
+    { value: NumberSeparator.NO_SEPARATOR_PERIOD, label: '100000.00' },
+];
+
+const bytesUnitOptions: { value: 'si' | 'iec'; label: string }[] = [
+    { value: 'si', label: 'SI (KB, MB, GB)' },
+    { value: 'iec', label: 'IEC (KiB, MiB, GiB)' },
+];
+
+const currencyOptions: ComboboxItem[] = currencies.map((c) => {
+    const formatter = Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: c,
+    });
+    return {
+        value: c,
+        label: `${c} (${formatter.format(1234.56).replace(/\u00A0/, ' ')})`,
+    };
+});
+
+const DATE_FORMATS = [
+    'dd/mm/yyyy',
+    'mm-dd-yyyy',
+    'd mmm yyyy',
+    'mmmm d, yyyy',
+    'yyyy-mm-dd',
+    'ddd, MMM d, yyyy',
+];
+
+const TIMESTAMP_FORMATS = [
+    'yyyy-mm-dd HH:mm:ss',
+    'dd/mm/yyyy HH:mm',
+    'mmmm d, yyyy h:mm AM/PM',
+    'ddd, MMM d, yyyy HH:mm',
+    'HH:mm:ss',
+    'h:mm:ss AM/PM',
+];
+
+const isDateLike = (dataType: TableCalculationType) =>
+    dataType === TableCalculationType.DATE ||
+    dataType === TableCalculationType.TIMESTAMP;
+
+const isFormatRowVisible = (dataType: TableCalculationType) =>
+    dataType === TableCalculationType.NUMBER || isDateLike(dataType);
+
+const getNumericPillValue = (formatType: CustomFormatType): NumericPill => {
+    if (
+        formatType === CustomFormatType.BYTES_SI ||
+        formatType === CustomFormatType.BYTES_IEC
+    ) {
+        return 'bytes';
+    }
+    switch (formatType) {
+        case CustomFormatType.DEFAULT:
+        case CustomFormatType.NUMBER:
+        case CustomFormatType.CURRENCY:
+        case CustomFormatType.PERCENT:
+        case CustomFormatType.CUSTOM:
+            return formatType;
+        // ID/DATE/TIMESTAMP can't be reached through this UI for a NUMBER
+        // data type, but stale records may carry them — fall back to Plain.
+        case CustomFormatType.ID:
+        case CustomFormatType.DATE:
+        case CustomFormatType.TIMESTAMP:
+            return CustomFormatType.DEFAULT;
+        default:
+            return assertUnreachable(formatType, 'Unknown format type');
+    }
+};
+
+const getDatePillValue = (
+    formatType: CustomFormatType,
+    dataType: TableCalculationType,
+): DatePill => {
+    const matchesType =
+        (dataType === TableCalculationType.DATE &&
+            formatType === CustomFormatType.DATE) ||
+        (dataType === TableCalculationType.TIMESTAMP &&
+            formatType === CustomFormatType.TIMESTAMP) ||
+        formatType === CustomFormatType.CUSTOM;
+    return matchesType ? CustomFormatType.CUSTOM : CustomFormatType.DEFAULT;
+};
+
+const getPreviewValue = (
+    format: CustomFormat,
+    dataType: TableCalculationType,
+): string | null => {
+    try {
+        if (isDateLike(dataType)) {
+            if (
+                format.type === CustomFormatType.CUSTOM &&
+                format.custom &&
+                format.custom.trim().length > 0
+            ) {
+                return formatValueWithExpression(format.custom, new Date());
+            }
+            return null;
+        }
+
+        const expression = convertCustomFormatToFormatExpression(format);
+        if (!expression) return String(NUMERIC_SAMPLE);
+        return formatValueWithExpression(expression, NUMERIC_SAMPLE);
+    } catch {
+        return 'Invalid format';
+    }
+};
+
+const renderDataTypeOption = ({ option }: { option: ComboboxItem }) => {
+    const meta = dataTypeMeta[option.value as TableCalculationType];
+    return (
+        <Group gap="xs" wrap="nowrap">
+            <MantineIcon icon={meta.icon} size="sm" />
+            <Text size="sm" fw={500}>
+                {meta.label}
+            </Text>
+        </Group>
+    );
+};
+
+export const FormatRow: FC<Props> = ({
+    format,
+    setFormatFieldValue,
+    formatInputProps,
+    dataType,
+    onDataTypeChange,
+}) => {
+    const dataTypeOptions = useMemo(
+        () =>
+            (Object.keys(dataTypeMeta) as TableCalculationType[]).map(
+                (value) => ({
+                    value,
+                    label: dataTypeMeta[value].label,
+                }),
+            ),
+        [],
+    );
+
+    const selectedDataTypeMeta = dataTypeMeta[dataType];
+
+    const isBytes =
+        format.type === CustomFormatType.BYTES_SI ||
+        format.type === CustomFormatType.BYTES_IEC;
+
+    const numericPill = useMemo(
+        () => getNumericPillValue(format.type),
+        [format.type],
+    );
+
+    const datePill = useMemo(
+        () => getDatePillValue(format.type, dataType),
+        [format.type, dataType],
+    );
+
+    const previewValue = useMemo(
+        () => getPreviewValue(format, dataType),
+        [format, dataType],
+    );
+
+    const compactValidValue = useMemo(() => {
+        if (!format.compact) return null;
+        const allowed = getCompactOptionsForFormatType(format.type);
+        const config = findCompactConfig(format.compact);
+        return config && allowed.includes(config.compact)
+            ? format.compact
+            : null;
+    }, [format.compact, format.type]);
+
+    const compactSelectData = useMemo(
+        () =>
+            getCompactOptionsForFormatType(format.type).map((c) => ({
+                value: c,
+                label: CompactConfigMap[c].label,
+            })),
+        [format.type],
+    );
+
+    const handleNumericPillChange = (next: NumericPill) => {
+        // Format-type changes always reset compact, since allowed values differ
+        // per type. Reset `custom` whenever the new type can't use it.
+        setFormatFieldValue('compact', undefined);
+
+        if (next === 'bytes') {
+            // Default to SI; user can flip to IEC via the unit sub-select.
+            setFormatFieldValue('type', CustomFormatType.BYTES_SI);
+            setFormatFieldValue('custom', undefined);
+            return;
+        }
+
+        setFormatFieldValue('type', next);
+
+        if (next !== CustomFormatType.CUSTOM) {
+            setFormatFieldValue('custom', undefined);
+        }
+        if (
+            next !== CustomFormatType.NUMBER &&
+            next !== CustomFormatType.CURRENCY &&
+            next !== CustomFormatType.PERCENT
+        ) {
+            // Drop number-only fields when leaving a numeric pill.
+            setFormatFieldValue('round', undefined);
+            setFormatFieldValue('separator', NumberSeparator.DEFAULT);
+            setFormatFieldValue('prefix', undefined);
+            setFormatFieldValue('suffix', undefined);
+        }
+        if (next !== CustomFormatType.CURRENCY) {
+            setFormatFieldValue('currency', undefined);
+        }
+    };
+
+    const handleDatePillChange = (next: DatePill) => {
+        if (next === CustomFormatType.DEFAULT) {
+            setFormatFieldValue('type', CustomFormatType.DEFAULT);
+            setFormatFieldValue('custom', undefined);
+        } else {
+            setFormatFieldValue('type', CustomFormatType.CUSTOM);
+        }
+    };
+
+    const handleBytesUnitChange = (value: 'si' | 'iec' | null) => {
+        if (!value) return;
+        setFormatFieldValue(
+            'type',
+            value === 'si'
+                ? CustomFormatType.BYTES_SI
+                : CustomFormatType.BYTES_IEC,
+        );
+        // Clear compact since SI/IEC compact values aren't interchangeable.
+        setFormatFieldValue('compact', undefined);
+    };
+
+    if (!isFormatRowVisible(dataType)) {
+        // String / Boolean — no format row, but keep the data-type Select so
+        // the user can still switch back to a numeric/date type.
+        return (
+            <Stack gap="xs">
+                <Group justify="space-between" align="center">
+                    <Group gap="xs" className={classes.headerLabel}>
+                        <Box className={classes.headerIcon}>
+                            <MantineIcon icon={IconPalette} size="sm" />
+                        </Box>
+                        <Text size="sm" fw={600}>
+                            Format
+                        </Text>
+                    </Group>
+                    <Select
+                        className={classes.dataTypeSelect}
+                        value={dataType}
+                        onChange={(value) =>
+                            value &&
+                            onDataTypeChange(value as TableCalculationType)
+                        }
+                        data={dataTypeOptions}
+                        allowDeselect={false}
+                        leftSection={
+                            <MantineIcon
+                                icon={selectedDataTypeMeta.icon}
+                                size="sm"
+                            />
+                        }
+                        renderOption={renderDataTypeOption}
+                        checkIconPosition="right"
+                        size="xs"
+                    />
+                </Group>
+                <Text size="xs" c="dimmed">
+                    {dataType === TableCalculationType.STRING
+                        ? 'Strings render as-is.'
+                        : 'Booleans render as true / false.'}
+                </Text>
+            </Stack>
+        );
+    }
+
+    const isNumeric = dataType === TableCalculationType.NUMBER;
+
+    return (
+        <Box className={classes.root}>
+            <Box className={classes.header}>
+                <Group gap="xs" className={classes.headerLabel}>
+                    <Box className={classes.headerIcon}>
+                        <MantineIcon icon={IconPalette} size="sm" />
+                    </Box>
+                    <Text size="sm" fw={600}>
+                        Format
+                    </Text>
+                </Group>
+                <Select
+                    className={classes.dataTypeSelect}
+                    value={dataType}
+                    onChange={(value) =>
+                        value && onDataTypeChange(value as TableCalculationType)
+                    }
+                    data={dataTypeOptions}
+                    allowDeselect={false}
+                    leftSection={
+                        <MantineIcon
+                            icon={selectedDataTypeMeta.icon}
+                            size="sm"
+                        />
+                    }
+                    renderOption={renderDataTypeOption}
+                    checkIconPosition="right"
+                    size="xs"
+                />
+            </Box>
+
+            <Box className={classes.pillRow}>
+                {previewValue !== null && (
+                    <Box className={classes.previewPill}>
+                        <MantineIcon
+                            icon={IconArrowBackUp}
+                            size="sm"
+                            className={classes.previewIcon}
+                        />
+                        <Text component="span" inherit>
+                            {previewValue}
+                        </Text>
+                    </Box>
+                )}
+                {previewValue !== null && <Box className={classes.divider} />}
+                {isNumeric ? (
+                    <SegmentedControl
+                        value={numericPill}
+                        onChange={(value) =>
+                            handleNumericPillChange(value as NumericPill)
+                        }
+                        data={numericPills}
+                        size="xs"
+                        classNames={{
+                            root: classes.pillsControl,
+                            indicator: classes.pillsControlIndicator,
+                            label: classes.pillsControlLabel,
+                            control: classes.pillsControlItem,
+                        }}
+                    />
+                ) : (
+                    <SegmentedControl
+                        value={datePill}
+                        onChange={(value) =>
+                            handleDatePillChange(value as DatePill)
+                        }
+                        data={datePills}
+                        size="xs"
+                        classNames={{
+                            root: classes.pillsControl,
+                            indicator: classes.pillsControlIndicator,
+                            label: classes.pillsControlLabel,
+                            control: classes.pillsControlItem,
+                        }}
+                    />
+                )}
+            </Box>
+
+            {isNumeric && format.type === CustomFormatType.NUMBER && (
+                <>
+                    <Box className={classes.subRow}>
+                        <Box className={classes.subRowField}>
+                            <Text className={classes.subRowFieldLabel}>
+                                Decimals
+                            </Text>
+                            <NumberInput
+                                className={classes.subRowInput}
+                                size="xs"
+                                min={0}
+                                placeholder="Auto"
+                                {...{
+                                    ...formatInputProps('round'),
+                                    onChange: (value) =>
+                                        setFormatFieldValue(
+                                            'round',
+                                            value === '' ? undefined : value,
+                                        ),
+                                }}
+                            />
+                        </Box>
+                        <Box className={classes.subRowField}>
+                            <Text className={classes.subRowFieldLabel}>
+                                Compact
+                            </Text>
+                            <Select
+                                className={classes.subRowSelect}
+                                size="xs"
+                                clearable
+                                placeholder="None"
+                                data={compactSelectData}
+                                value={compactValidValue}
+                                onChange={(value) =>
+                                    setFormatFieldValue(
+                                        'compact',
+                                        !value || !(value in CompactConfigMap)
+                                            ? undefined
+                                            : value,
+                                    )
+                                }
+                            />
+                        </Box>
+                    </Box>
+                    <Box className={classes.subRow}>
+                        <Box className={classes.subRowField}>
+                            <Text className={classes.subRowFieldLabel}>
+                                Prefix
+                            </Text>
+                            <TextInput
+                                className={classes.subRowText}
+                                size="xs"
+                                placeholder="e.g. $"
+                                {...formatInputProps('prefix')}
+                            />
+                        </Box>
+                        <Box className={classes.subRowField}>
+                            <Text className={classes.subRowFieldLabel}>
+                                Suffix
+                            </Text>
+                            <TextInput
+                                className={classes.subRowText}
+                                size="xs"
+                                placeholder="e.g. km/h"
+                                {...formatInputProps('suffix')}
+                            />
+                        </Box>
+                        <Box className={classes.subRowField}>
+                            <Text className={classes.subRowFieldLabel}>
+                                Separator
+                            </Text>
+                            <Select
+                                className={classes.subRowSelect}
+                                size="xs"
+                                data={separatorOptions}
+                                {...formatInputProps('separator')}
+                            />
+                        </Box>
+                    </Box>
+                </>
+            )}
+
+            {isNumeric && format.type === CustomFormatType.CURRENCY && (
+                <Box className={classes.subRow}>
+                    <Box className={classes.subRowField}>
+                        <Text className={classes.subRowFieldLabel}>
+                            Currency
+                        </Text>
+                        <Select
+                            className={classes.subRowCurrencySelect}
+                            size="xs"
+                            searchable
+                            data={currencyOptions}
+                            {...formatInputProps('currency')}
+                        />
+                    </Box>
+                    <Box className={classes.subRowField}>
+                        <Text className={classes.subRowFieldLabel}>
+                            Decimals
+                        </Text>
+                        <NumberInput
+                            className={classes.subRowInput}
+                            size="xs"
+                            min={0}
+                            placeholder="Auto"
+                            {...{
+                                ...formatInputProps('round'),
+                                onChange: (value) =>
+                                    setFormatFieldValue(
+                                        'round',
+                                        value === '' ? undefined : value,
+                                    ),
+                            }}
+                        />
+                    </Box>
+                    <Box className={classes.subRowField}>
+                        <Text className={classes.subRowFieldLabel}>
+                            Compact
+                        </Text>
+                        <Select
+                            className={classes.subRowSelect}
+                            size="xs"
+                            clearable
+                            placeholder="None"
+                            data={compactSelectData}
+                            value={compactValidValue}
+                            onChange={(value) =>
+                                setFormatFieldValue(
+                                    'compact',
+                                    !value || !(value in CompactConfigMap)
+                                        ? undefined
+                                        : value,
+                                )
+                            }
+                        />
+                    </Box>
+                </Box>
+            )}
+
+            {isNumeric && format.type === CustomFormatType.PERCENT && (
+                <Box className={classes.subRow}>
+                    <Box className={classes.subRowField}>
+                        <Text className={classes.subRowFieldLabel}>
+                            Decimals
+                        </Text>
+                        <NumberInput
+                            className={classes.subRowInput}
+                            size="xs"
+                            min={0}
+                            placeholder="Auto"
+                            {...{
+                                ...formatInputProps('round'),
+                                onChange: (value) =>
+                                    setFormatFieldValue(
+                                        'round',
+                                        value === '' ? undefined : value,
+                                    ),
+                            }}
+                        />
+                    </Box>
+                </Box>
+            )}
+
+            {isNumeric && isBytes && (
+                <Box className={classes.subRow}>
+                    <Box className={classes.subRowField}>
+                        <Text className={classes.subRowFieldLabel}>
+                            Unit system
+                        </Text>
+                        <Select
+                            className={classes.subRowSelect}
+                            size="xs"
+                            data={bytesUnitOptions}
+                            value={
+                                format.type === CustomFormatType.BYTES_IEC
+                                    ? 'iec'
+                                    : 'si'
+                            }
+                            onChange={(value) =>
+                                handleBytesUnitChange(value as 'si' | 'iec')
+                            }
+                            allowDeselect={false}
+                        />
+                    </Box>
+                    <Box className={classes.subRowField}>
+                        <Text className={classes.subRowFieldLabel}>
+                            Compact
+                        </Text>
+                        <Select
+                            className={classes.subRowSelect}
+                            size="xs"
+                            clearable
+                            placeholder="None"
+                            data={compactSelectData}
+                            value={compactValidValue}
+                            onChange={(value) =>
+                                setFormatFieldValue(
+                                    'compact',
+                                    !value || !(value in CompactConfigMap)
+                                        ? undefined
+                                        : value,
+                                )
+                            }
+                        />
+                    </Box>
+                </Box>
+            )}
+
+            {isNumeric && format.type === CustomFormatType.CUSTOM && (
+                <Box className={classes.customExpression}>
+                    <TextInput
+                        size="xs"
+                        label="Format expression"
+                        placeholder="e.g. #,##0.00"
+                        description={
+                            <Group gap="two">
+                                <MantineIcon
+                                    icon={IconExternalLink}
+                                    size="sm"
+                                    color="blue.6"
+                                />
+                                <Anchor
+                                    href="https://customformats.com"
+                                    target="_blank"
+                                    size="xs"
+                                >
+                                    Build your format at customformats.com
+                                </Anchor>
+                            </Group>
+                        }
+                        {...formatInputProps('custom')}
+                    />
+                </Box>
+            )}
+
+            {!isNumeric && datePill === CustomFormatType.CUSTOM && (
+                <DateFormatBody
+                    format={format}
+                    formatInputProps={formatInputProps}
+                    setFormatFieldValue={setFormatFieldValue}
+                    isTimestamp={dataType === TableCalculationType.TIMESTAMP}
+                />
+            )}
+        </Box>
+    );
+};
+
+const DateFormatBody: FC<{
+    format: CustomFormat;
+    formatInputProps: Props['formatInputProps'];
+    setFormatFieldValue: Props['setFormatFieldValue'];
+    isTimestamp: boolean;
+}> = ({ format, formatInputProps, setFormatFieldValue, isTimestamp }) => {
+    const presets = isTimestamp ? TIMESTAMP_FORMATS : DATE_FORMATS;
+    const sample = useMemo(() => new Date(), []);
+    const examples = useMemo(
+        () =>
+            presets.map((fmt) => ({
+                format: fmt,
+                example: formatValueWithExpression(fmt, sample),
+            })),
+        [presets, sample],
+    );
+
+    return (
+        <Box className={classes.dateBody}>
+            <TextInput
+                size="xs"
+                label="Custom format"
+                placeholder="e.g. dd/mm/yyyy or mmmm d, yyyy"
+                leftSection={
+                    <MantineIcon
+                        icon={isTimestamp ? IconClockHour4 : IconCalendar}
+                        size="sm"
+                    />
+                }
+                {...formatInputProps('custom')}
+            />
+            <Stack gap={4} mt="xs">
+                <Group gap="xs">
+                    <Text size="xs" c="ldGray.6" fw={500}>
+                        Common formats
+                    </Text>
+                    <Anchor
+                        href="https://customformats.com"
+                        target="_blank"
+                        size="xs"
+                    >
+                        <MantineIcon
+                            icon={IconExternalLink}
+                            size="sm"
+                            color="blue.6"
+                        />
+                    </Anchor>
+                </Group>
+                <Box className={classes.dateExamplesRow}>
+                    {examples.map(({ format: fmt, example }) => (
+                        <PolymorphicPaperButton
+                            key={fmt}
+                            withBorder
+                            p="xs"
+                            shadow="none"
+                            radius="md"
+                            onClick={() => setFormatFieldValue('custom', fmt)}
+                        >
+                            <Text size="xs" c="ldDark.8" fw={500}>
+                                {example}
+                            </Text>
+                            <Text size="xs" c="ldGray.5">
+                                {fmt}
+                            </Text>
+                        </PolymorphicPaperButton>
+                    ))}
+                </Box>
+            </Stack>
+            {format.custom && (
+                <Text size="xs" c="ldGray.6" mt="xs">
+                    Preview:{' '}
+                    <Text span fw={600} c="inherit">
+                        {(() => {
+                            try {
+                                return formatValueWithExpression(
+                                    format.custom,
+                                    sample,
+                                );
+                            } catch {
+                                return 'Invalid format';
+                            }
+                        })()}
+                    </Text>
+                </Text>
+            )}
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
@@ -12,14 +12,17 @@ import {
     type CustomFormat,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Anchor,
     Box,
+    Button,
     Group,
-    SegmentedControl,
+    Menu,
     Select,
     Stack,
     Text,
     TextInput,
+    Tooltip,
     type ComboboxItem,
 } from '@mantine-8/core';
 import { NumberInput } from '@mantine/core';
@@ -27,17 +30,16 @@ import { type UseFormReturnType } from '@mantine/form';
 import {
     Icon123,
     IconAbc,
-    IconArrowBackUp,
+    IconArrowRight,
     IconCalendar,
+    IconChevronDown,
     IconClockHour4,
     IconExternalLink,
-    IconPalette,
     IconToggleLeft,
 } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import { type ValueOf } from 'type-fest';
 import MantineIcon from '../../../../components/common/MantineIcon';
-import { PolymorphicPaperButton } from '../../../../components/common/PolymorphicPaperButton';
 import classes from './FormatRow.module.css';
 
 type Props = {
@@ -116,7 +118,7 @@ const currencyOptions: ComboboxItem[] = currencies.map((c) => {
     });
     return {
         value: c,
-        label: `${c} (${formatter.format(1234.56).replace(/\u00A0/, ' ')})`,
+        label: `${c} (${formatter.format(1234.56).replace(/ /, ' ')})`,
     };
 });
 
@@ -141,9 +143,6 @@ const TIMESTAMP_FORMATS = [
 const isDateLike = (dataType: TableCalculationType) =>
     dataType === TableCalculationType.DATE ||
     dataType === TableCalculationType.TIMESTAMP;
-
-const isFormatRowVisible = (dataType: TableCalculationType) =>
-    dataType === TableCalculationType.NUMBER || isDateLike(dataType);
 
 const getNumericPillValue = (formatType: CustomFormatType): NumericPill => {
     if (
@@ -188,19 +187,34 @@ const getPreviewValue = (
     dataType: TableCalculationType,
 ): string | null => {
     try {
+        if (dataType === TableCalculationType.BOOLEAN) {
+            return 'true';
+        }
+        if (dataType === TableCalculationType.STRING) {
+            return 'Sample text';
+        }
         if (isDateLike(dataType)) {
+            const sample = new Date();
             if (
                 format.type === CustomFormatType.CUSTOM &&
                 format.custom &&
                 format.custom.trim().length > 0
             ) {
-                return formatValueWithExpression(format.custom, new Date());
+                return formatValueWithExpression(format.custom, sample);
             }
-            return null;
+            // Default Date / Timestamp rendering
+            return dataType === TableCalculationType.TIMESTAMP
+                ? sample.toLocaleString()
+                : sample.toLocaleDateString();
         }
 
         const expression = convertCustomFormatToFormatExpression(format);
-        if (!expression) return String(NUMERIC_SAMPLE);
+        if (!expression) {
+            // Plain — show the raw sample with grouping so it reads cleanly.
+            return new Intl.NumberFormat(undefined, {
+                maximumFractionDigits: 12,
+            }).format(NUMERIC_SAMPLE);
+        }
         return formatValueWithExpression(expression, NUMERIC_SAMPLE);
     } catch {
         return 'Invalid format';
@@ -330,140 +344,121 @@ export const FormatRow: FC<Props> = ({
         setFormatFieldValue('compact', undefined);
     };
 
-    if (!isFormatRowVisible(dataType)) {
-        // String / Boolean — no format row, but keep the data-type Select so
-        // the user can still switch back to a numeric/date type.
-        return (
-            <Stack gap="xs">
-                <Group justify="space-between" align="center">
-                    <Group gap="xs" className={classes.headerLabel}>
-                        <Box className={classes.headerIcon}>
-                            <MantineIcon icon={IconPalette} size="sm" />
-                        </Box>
-                        <Text size="sm" fw={600}>
-                            Format
-                        </Text>
-                    </Group>
-                    <Select
-                        className={classes.dataTypeSelect}
-                        value={dataType}
-                        onChange={(value) =>
-                            value &&
-                            onDataTypeChange(value as TableCalculationType)
-                        }
-                        data={dataTypeOptions}
-                        allowDeselect={false}
-                        leftSection={
-                            <MantineIcon
-                                icon={selectedDataTypeMeta.icon}
-                                size="sm"
-                            />
-                        }
-                        renderOption={renderDataTypeOption}
-                        checkIconPosition="right"
-                        size="xs"
-                    />
-                </Group>
-                <Text size="xs" c="dimmed">
-                    {dataType === TableCalculationType.STRING
-                        ? 'Strings render as-is.'
-                        : 'Booleans render as true / false.'}
+    const dataTypeSelect = (
+        <Select
+            className={classes.dataTypeSelect}
+            value={dataType}
+            onChange={(value) =>
+                value && onDataTypeChange(value as TableCalculationType)
+            }
+            data={dataTypeOptions}
+            allowDeselect={false}
+            leftSection={
+                <MantineIcon icon={selectedDataTypeMeta.icon} size="sm" />
+            }
+            renderOption={renderDataTypeOption}
+            checkIconPosition="right"
+            size="xs"
+        />
+    );
+
+    const isNumeric = dataType === TableCalculationType.NUMBER;
+    const isPlainNumeric =
+        isNumeric && numericPill === CustomFormatType.DEFAULT;
+
+    const headerRow = (
+        <Group justify="space-between" align="center" wrap="nowrap">
+            <Group gap="md" align="center" wrap="nowrap">
+                <Text size="sm" fw={600}>
+                    Format
                 </Text>
+                {dataTypeSelect}
+            </Group>
+            {previewValue !== null && (
+                <Group gap={6} wrap="nowrap" className={classes.preview}>
+                    <MantineIcon
+                        icon={IconArrowRight}
+                        size="sm"
+                        className={classes.previewArrow}
+                    />
+                    <Text className={classes.previewValue}>{previewValue}</Text>
+                </Group>
+            )}
+        </Group>
+    );
+
+    if (
+        dataType === TableCalculationType.STRING ||
+        dataType === TableCalculationType.BOOLEAN
+    ) {
+        // Strings / Booleans render as-is. Slim card — no pills/divider —
+        // since there's nothing to choose.
+        return (
+            <Stack gap={2}>
+                {headerRow}
+                <Box className={`${classes.card} ${classes.cardEmpty}`}>
+                    <Box className={classes.emptyBody}>
+                        <Text size="xs" c="dimmed" fs="italic">
+                            No formatting options for this type
+                        </Text>
+                    </Box>
+                </Box>
             </Stack>
         );
     }
 
-    const isNumeric = dataType === TableCalculationType.NUMBER;
+    const pills = isNumeric ? numericPills : datePills;
+    const activePillValue: string = isNumeric ? numericPill : datePill;
+    const onPillClick = (value: string) => {
+        if (isNumeric) {
+            handleNumericPillChange(value as NumericPill);
+        } else {
+            handleDatePillChange(value as DatePill);
+        }
+    };
 
     return (
-        <Box className={classes.root}>
-            <Box className={classes.header}>
-                <Group gap="xs" className={classes.headerLabel}>
-                    <Box className={classes.headerIcon}>
-                        <MantineIcon icon={IconPalette} size="sm" />
-                    </Box>
-                    <Text size="sm" fw={600}>
-                        Format
-                    </Text>
-                </Group>
-                <Select
-                    className={classes.dataTypeSelect}
-                    value={dataType}
-                    onChange={(value) =>
-                        value && onDataTypeChange(value as TableCalculationType)
-                    }
-                    data={dataTypeOptions}
-                    allowDeselect={false}
-                    leftSection={
-                        <MantineIcon
-                            icon={selectedDataTypeMeta.icon}
-                            size="sm"
-                        />
-                    }
-                    renderOption={renderDataTypeOption}
-                    checkIconPosition="right"
-                    size="xs"
-                />
-            </Box>
+        <Stack gap={2}>
+            {headerRow}
+            <Box className={classes.card}>
+                <Box className={classes.topRow}>
+                    <Group gap={6} wrap="wrap" className={classes.pillsGroup}>
+                        {pills.map((p) => {
+                            const isActive = activePillValue === p.value;
+                            return (
+                                <Button
+                                    key={p.value}
+                                    size="compact-xs"
+                                    radius="md"
+                                    variant={isActive ? 'filled' : 'default'}
+                                    color={isActive ? 'blue' : undefined}
+                                    onClick={() => onPillClick(p.value)}
+                                    className={classes.pillButton}
+                                >
+                                    {p.label}
+                                </Button>
+                            );
+                        })}
+                    </Group>
+                </Box>
 
-            <Box className={classes.pillRow}>
-                {previewValue !== null && (
-                    <Box className={classes.previewPill}>
-                        <MantineIcon
-                            icon={IconArrowBackUp}
-                            size="sm"
-                            className={classes.previewIcon}
-                        />
-                        <Text component="span" inherit>
-                            {previewValue}
+                <Box className={classes.divider} />
+
+                <Box className={classes.subBody}>
+                    {isPlainNumeric && (
+                        <Text size="xs" c="dimmed" fs="italic">
+                            No further options for this preset
                         </Text>
-                    </Box>
-                )}
-                {previewValue !== null && <Box className={classes.divider} />}
-                {isNumeric ? (
-                    <SegmentedControl
-                        value={numericPill}
-                        onChange={(value) =>
-                            handleNumericPillChange(value as NumericPill)
-                        }
-                        data={numericPills}
-                        size="xs"
-                        classNames={{
-                            root: classes.pillsControl,
-                            indicator: classes.pillsControlIndicator,
-                            label: classes.pillsControlLabel,
-                            control: classes.pillsControlItem,
-                        }}
-                    />
-                ) : (
-                    <SegmentedControl
-                        value={datePill}
-                        onChange={(value) =>
-                            handleDatePillChange(value as DatePill)
-                        }
-                        data={datePills}
-                        size="xs"
-                        classNames={{
-                            root: classes.pillsControl,
-                            indicator: classes.pillsControlIndicator,
-                            label: classes.pillsControlLabel,
-                            control: classes.pillsControlItem,
-                        }}
-                    />
-                )}
-            </Box>
+                    )}
 
-            {isNumeric && format.type === CustomFormatType.NUMBER && (
-                <>
-                    <Box className={classes.subRow}>
-                        <Box className={classes.subRowField}>
-                            <Text className={classes.subRowFieldLabel}>
-                                Decimals
-                            </Text>
+                    {isNumeric && format.type === CustomFormatType.NUMBER && (
+                        <Group gap="md" wrap="wrap" align="flex-end">
                             <NumberInput
-                                className={classes.subRowInput}
+                                className={classes.subFieldInputNarrow}
                                 size="xs"
+                                radius="md"
                                 min={0}
+                                label="Decimals"
                                 placeholder="Auto"
                                 {...{
                                     ...formatInputProps('round'),
@@ -474,15 +469,11 @@ export const FormatRow: FC<Props> = ({
                                         ),
                                 }}
                             />
-                        </Box>
-                        <Box className={classes.subRowField}>
-                            <Text className={classes.subRowFieldLabel}>
-                                Compact
-                            </Text>
                             <Select
-                                className={classes.subRowSelect}
+                                className={classes.subFieldSelectNarrow}
                                 size="xs"
                                 clearable
+                                label="Compact"
                                 placeholder="None"
                                 data={compactSelectData}
                                 value={compactValidValue}
@@ -495,68 +486,84 @@ export const FormatRow: FC<Props> = ({
                                     )
                                 }
                             />
-                        </Box>
-                    </Box>
-                    <Box className={classes.subRow}>
-                        <Box className={classes.subRowField}>
-                            <Text className={classes.subRowFieldLabel}>
-                                Prefix
-                            </Text>
                             <TextInput
-                                className={classes.subRowText}
+                                className={classes.subFieldTextNarrow}
                                 size="xs"
-                                placeholder="e.g. $"
+                                label="Prefix"
+                                placeholder="$"
                                 {...formatInputProps('prefix')}
                             />
-                        </Box>
-                        <Box className={classes.subRowField}>
-                            <Text className={classes.subRowFieldLabel}>
-                                Suffix
-                            </Text>
                             <TextInput
-                                className={classes.subRowText}
+                                className={classes.subFieldTextNarrow}
                                 size="xs"
-                                placeholder="e.g. km/h"
+                                label="Suffix"
+                                placeholder="km/h"
                                 {...formatInputProps('suffix')}
                             />
-                        </Box>
-                        <Box className={classes.subRowField}>
-                            <Text className={classes.subRowFieldLabel}>
-                                Separator
-                            </Text>
                             <Select
-                                className={classes.subRowSelect}
+                                className={classes.subFieldSeparator}
                                 size="xs"
+                                label="Separator"
                                 data={separatorOptions}
                                 {...formatInputProps('separator')}
                             />
-                        </Box>
-                    </Box>
-                </>
-            )}
+                        </Group>
+                    )}
 
-            {isNumeric && format.type === CustomFormatType.CURRENCY && (
-                <Box className={classes.subRow}>
-                    <Box className={classes.subRowField}>
-                        <Text className={classes.subRowFieldLabel}>
-                            Currency
-                        </Text>
-                        <Select
-                            className={classes.subRowCurrencySelect}
-                            size="xs"
-                            searchable
-                            data={currencyOptions}
-                            {...formatInputProps('currency')}
-                        />
-                    </Box>
-                    <Box className={classes.subRowField}>
-                        <Text className={classes.subRowFieldLabel}>
-                            Decimals
-                        </Text>
+                    {isNumeric && format.type === CustomFormatType.CURRENCY && (
+                        <Group gap="md" wrap="wrap" align="flex-end">
+                            <Select
+                                className={classes.subFieldCurrency}
+                                size="xs"
+                                searchable
+                                label="Currency"
+                                placeholder="Pick a currency"
+                                data={currencyOptions}
+                                {...formatInputProps('currency')}
+                            />
+                            <NumberInput
+                                className={classes.subFieldInput}
+                                size="xs"
+                                radius="md"
+                                min={0}
+                                label="Decimals"
+                                placeholder="Auto"
+                                {...{
+                                    ...formatInputProps('round'),
+                                    onChange: (value) =>
+                                        setFormatFieldValue(
+                                            'round',
+                                            value === '' ? undefined : value,
+                                        ),
+                                }}
+                            />
+                            <Select
+                                className={classes.subFieldSelect}
+                                size="xs"
+                                clearable
+                                label="Compact"
+                                placeholder="None"
+                                data={compactSelectData}
+                                value={compactValidValue}
+                                onChange={(value) =>
+                                    setFormatFieldValue(
+                                        'compact',
+                                        !value || !(value in CompactConfigMap)
+                                            ? undefined
+                                            : value,
+                                    )
+                                }
+                            />
+                        </Group>
+                    )}
+
+                    {isNumeric && format.type === CustomFormatType.PERCENT && (
                         <NumberInput
-                            className={classes.subRowInput}
+                            className={classes.subFieldInput}
                             size="xs"
+                            radius="md"
                             min={0}
+                            label="Decimals"
                             placeholder="Auto"
                             {...{
                                 ...formatInputProps('round'),
@@ -567,145 +574,107 @@ export const FormatRow: FC<Props> = ({
                                     ),
                             }}
                         />
-                    </Box>
-                    <Box className={classes.subRowField}>
-                        <Text className={classes.subRowFieldLabel}>
-                            Compact
-                        </Text>
-                        <Select
-                            className={classes.subRowSelect}
-                            size="xs"
-                            clearable
-                            placeholder="None"
-                            data={compactSelectData}
-                            value={compactValidValue}
-                            onChange={(value) =>
-                                setFormatFieldValue(
-                                    'compact',
-                                    !value || !(value in CompactConfigMap)
-                                        ? undefined
-                                        : value,
-                                )
-                            }
-                        />
-                    </Box>
-                </Box>
-            )}
+                    )}
 
-            {isNumeric && format.type === CustomFormatType.PERCENT && (
-                <Box className={classes.subRow}>
-                    <Box className={classes.subRowField}>
-                        <Text className={classes.subRowFieldLabel}>
-                            Decimals
-                        </Text>
-                        <NumberInput
-                            className={classes.subRowInput}
-                            size="xs"
-                            min={0}
-                            placeholder="Auto"
-                            {...{
-                                ...formatInputProps('round'),
-                                onChange: (value) =>
+                    {isNumeric && isBytes && (
+                        <Group gap="md" wrap="wrap" align="flex-end">
+                            <Select
+                                className={classes.subFieldSelect}
+                                size="xs"
+                                label="Unit system"
+                                data={bytesUnitOptions}
+                                value={
+                                    format.type === CustomFormatType.BYTES_IEC
+                                        ? 'iec'
+                                        : 'si'
+                                }
+                                onChange={(value) =>
+                                    handleBytesUnitChange(value as 'si' | 'iec')
+                                }
+                                allowDeselect={false}
+                            />
+                            <Select
+                                className={classes.subFieldSelect}
+                                size="xs"
+                                clearable
+                                label="Compact"
+                                placeholder="None"
+                                data={compactSelectData}
+                                value={compactValidValue}
+                                onChange={(value) =>
                                     setFormatFieldValue(
-                                        'round',
-                                        value === '' ? undefined : value,
-                                    ),
-                            }}
-                        />
-                    </Box>
-                </Box>
-            )}
+                                        'compact',
+                                        !value || !(value in CompactConfigMap)
+                                            ? undefined
+                                            : value,
+                                    )
+                                }
+                            />
+                        </Group>
+                    )}
 
-            {isNumeric && isBytes && (
-                <Box className={classes.subRow}>
-                    <Box className={classes.subRowField}>
-                        <Text className={classes.subRowFieldLabel}>
-                            Unit system
-                        </Text>
-                        <Select
-                            className={classes.subRowSelect}
+                    {isNumeric && format.type === CustomFormatType.CUSTOM && (
+                        <TextInput
                             size="xs"
-                            data={bytesUnitOptions}
-                            value={
-                                format.type === CustomFormatType.BYTES_IEC
-                                    ? 'iec'
-                                    : 'si'
-                            }
-                            onChange={(value) =>
-                                handleBytesUnitChange(value as 'si' | 'iec')
-                            }
-                            allowDeselect={false}
-                        />
-                    </Box>
-                    <Box className={classes.subRowField}>
-                        <Text className={classes.subRowFieldLabel}>
-                            Compact
-                        </Text>
-                        <Select
-                            className={classes.subRowSelect}
-                            size="xs"
-                            clearable
-                            placeholder="None"
-                            data={compactSelectData}
-                            value={compactValidValue}
-                            onChange={(value) =>
-                                setFormatFieldValue(
-                                    'compact',
-                                    !value || !(value in CompactConfigMap)
-                                        ? undefined
-                                        : value,
-                                )
-                            }
-                        />
-                    </Box>
-                </Box>
-            )}
-
-            {isNumeric && format.type === CustomFormatType.CUSTOM && (
-                <Box className={classes.customExpression}>
-                    <TextInput
-                        size="xs"
-                        label="Format expression"
-                        placeholder="e.g. #,##0.00"
-                        description={
-                            <Group gap="two">
-                                <MantineIcon
-                                    icon={IconExternalLink}
-                                    size="sm"
-                                    color="blue.6"
-                                />
-                                <Anchor
-                                    href="https://customformats.com"
-                                    target="_blank"
-                                    size="xs"
+                            radius="md"
+                            placeholder="e.g. #,##0.00"
+                            label={
+                                <Group
+                                    justify="space-between"
+                                    align="baseline"
+                                    w="100%"
+                                    gap={6}
                                 >
-                                    Build your format at customformats.com
-                                </Anchor>
-                            </Group>
-                        }
-                        {...formatInputProps('custom')}
-                    />
-                </Box>
-            )}
+                                    <Text size="xs" fw={500} c="ldGray.7">
+                                        Format expression
+                                    </Text>
+                                    <Anchor
+                                        href="https://customformats.com"
+                                        target="_blank"
+                                        size="xs"
+                                        className={classes.labelLink}
+                                    >
+                                        <Group gap={4} wrap="nowrap">
+                                            <MantineIcon
+                                                icon={IconExternalLink}
+                                                size="sm"
+                                            />
+                                            Build at customformats.com
+                                        </Group>
+                                    </Anchor>
+                                </Group>
+                            }
+                            classNames={{ label: classes.fullWidthLabel }}
+                            {...formatInputProps('custom')}
+                        />
+                    )}
 
-            {!isNumeric && datePill === CustomFormatType.CUSTOM && (
-                <DateFormatBody
-                    format={format}
-                    formatInputProps={formatInputProps}
-                    setFormatFieldValue={setFormatFieldValue}
-                    isTimestamp={dataType === TableCalculationType.TIMESTAMP}
-                />
-            )}
-        </Box>
+                    {!isNumeric && datePill === CustomFormatType.DEFAULT && (
+                        <Text size="xs" c="dimmed" fs="italic">
+                            No further options for this preset
+                        </Text>
+                    )}
+
+                    {!isNumeric && datePill === CustomFormatType.CUSTOM && (
+                        <DateFormatBody
+                            formatInputProps={formatInputProps}
+                            setFormatFieldValue={setFormatFieldValue}
+                            isTimestamp={
+                                dataType === TableCalculationType.TIMESTAMP
+                            }
+                        />
+                    )}
+                </Box>
+            </Box>
+        </Stack>
     );
 };
 
 const DateFormatBody: FC<{
-    format: CustomFormat;
     formatInputProps: Props['formatInputProps'];
     setFormatFieldValue: Props['setFormatFieldValue'];
     isTimestamp: boolean;
-}> = ({ format, formatInputProps, setFormatFieldValue, isTimestamp }) => {
+}> = ({ formatInputProps, setFormatFieldValue, isTimestamp }) => {
     const presets = isTimestamp ? TIMESTAMP_FORMATS : DATE_FORMATS;
     const sample = useMemo(() => new Date(), []);
     const examples = useMemo(
@@ -718,73 +687,76 @@ const DateFormatBody: FC<{
     );
 
     return (
-        <Box className={classes.dateBody}>
-            <TextInput
-                size="xs"
-                label="Custom format"
-                placeholder="e.g. dd/mm/yyyy or mmmm d, yyyy"
-                leftSection={
-                    <MantineIcon
-                        icon={isTimestamp ? IconClockHour4 : IconCalendar}
-                        size="sm"
-                    />
-                }
-                {...formatInputProps('custom')}
-            />
-            <Stack gap={4} mt="xs">
-                <Group gap="xs">
-                    <Text size="xs" c="ldGray.6" fw={500}>
-                        Common formats
+        <TextInput
+            size="xs"
+            radius="md"
+            placeholder="e.g. dd/mm/yyyy or mmmm d, yyyy"
+            label={
+                <Group
+                    justify="space-between"
+                    align="baseline"
+                    w="100%"
+                    gap={6}
+                >
+                    <Text size="xs" fw={500} c="ldGray.7">
+                        {isTimestamp ? 'Timestamp format' : 'Date format'}
                     </Text>
                     <Anchor
                         href="https://customformats.com"
                         target="_blank"
                         size="xs"
+                        className={classes.labelLink}
                     >
-                        <MantineIcon
-                            icon={IconExternalLink}
-                            size="sm"
-                            color="blue.6"
-                        />
+                        <Group gap={4} wrap="nowrap">
+                            <MantineIcon icon={IconExternalLink} size="sm" />
+                            Build at customformats.com
+                        </Group>
                     </Anchor>
                 </Group>
-                <Box className={classes.dateExamplesRow}>
-                    {examples.map(({ format: fmt, example }) => (
-                        <PolymorphicPaperButton
-                            key={fmt}
-                            withBorder
-                            p="xs"
-                            shadow="none"
-                            radius="md"
-                            onClick={() => setFormatFieldValue('custom', fmt)}
-                        >
-                            <Text size="xs" c="ldDark.8" fw={500}>
-                                {example}
-                            </Text>
-                            <Text size="xs" c="ldGray.5">
-                                {fmt}
-                            </Text>
-                        </PolymorphicPaperButton>
-                    ))}
-                </Box>
-            </Stack>
-            {format.custom && (
-                <Text size="xs" c="ldGray.6" mt="xs">
-                    Preview:{' '}
-                    <Text span fw={600} c="inherit">
-                        {(() => {
-                            try {
-                                return formatValueWithExpression(
-                                    format.custom,
-                                    sample,
-                                );
-                            } catch {
-                                return 'Invalid format';
-                            }
-                        })()}
-                    </Text>
-                </Text>
-            )}
-        </Box>
+            }
+            classNames={{ label: classes.fullWidthLabel }}
+            leftSection={
+                <MantineIcon
+                    icon={isTimestamp ? IconClockHour4 : IconCalendar}
+                    size="sm"
+                />
+            }
+            rightSection={
+                <Menu shadow="md" position="bottom-end" width={240}>
+                    <Menu.Target>
+                        <Tooltip label="Pick a preset" withArrow>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                size="sm"
+                                aria-label="Pick a preset"
+                            >
+                                <MantineIcon icon={IconChevronDown} size="sm" />
+                            </ActionIcon>
+                        </Tooltip>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        {examples.map(({ format: fmt, example }) => (
+                            <Menu.Item
+                                key={fmt}
+                                onClick={() =>
+                                    setFormatFieldValue('custom', fmt)
+                                }
+                            >
+                                <Stack gap={0}>
+                                    <Text size="xs" fw={600} c="ldDark.8">
+                                        {example}
+                                    </Text>
+                                    <Text size="xs" c="ldGray.5">
+                                        {fmt}
+                                    </Text>
+                                </Stack>
+                            </Menu.Item>
+                        ))}
+                    </Menu.Dropdown>
+                </Menu>
+            }
+            {...formatInputProps('custom')}
+        />
     );
 };

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
@@ -82,32 +82,6 @@
     text-transform: none;
 }
 
-.typeOptionIcon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
-    color: var(--mantine-color-ldGray-6);
-    background-color: var(--mantine-color-ldGray-0);
-    border: 1px solid var(--mantine-color-ldGray-2);
-    border-radius: var(--mantine-radius-sm);
-
-    @mixin dark {
-        color: var(--mantine-color-ldDark-8);
-        background-color: var(--mantine-color-ldDark-3);
-        border-color: var(--mantine-color-ldDark-4);
-    }
-}
-
-.typeInputIcon {
-    color: var(--mantine-color-ldGray-6);
-
-    @mixin dark {
-        color: var(--mantine-color-ldDark-8);
-    }
-}
-
 .sqlEditorBorder {
     border: 1px solid var(--mantine-color-ldGray-3);
     border-radius: var(--mantine-radius-md);
@@ -128,62 +102,6 @@
     gap: var(--mantine-spacing-sm);
 }
 
-.calculationLayout {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(300px, 340px);
-    align-items: stretch;
-    gap: var(--mantine-spacing-md);
-}
-
-.editorColumn {
-    min-width: 0;
-}
-
-.formatPanel {
-    min-width: 0;
-    padding: var(--mantine-spacing-md);
-    border: 1px solid var(--mantine-color-ldGray-2);
-    border-radius: var(--mantine-radius-md);
-    background-color: var(--mantine-color-ldGray-0);
-
-    @mixin dark {
-        background-color: var(--mantine-color-ldDark-2);
-        border-color: var(--mantine-color-ldDark-4);
-    }
-}
-
-.formatPanelIcon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    color: var(--mantine-color-blue-6);
-    background-color: var(--mantine-color-blue-0);
-    border: 1px solid var(--mantine-color-blue-1);
-    border-radius: var(--mantine-radius-sm);
-
-    @mixin dark {
-        color: var(--mantine-color-blue-3);
-        background-color: var(--mantine-color-blue-9);
-        border-color: var(--mantine-color-blue-8);
-    }
-}
-
-.formatStatusBadge {
-    flex-shrink: 0;
-    text-transform: none;
-}
-
-.formatPanelBody {
-    overflow: auto;
-    padding-right: 2px;
-}
-
-.minWidth0 {
-    min-width: 0;
-}
-
 @media (max-width: 48em) {
     .inputModeHeader {
         align-items: flex-start;
@@ -196,13 +114,5 @@
 
     .inputModeControlItem {
         min-width: 0;
-    }
-
-    .calculationLayout {
-        grid-template-columns: 1fr;
-    }
-
-    .formatPanel {
-        padding: var(--mantine-spacing-sm);
     }
 }

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
@@ -7,7 +7,7 @@
 .editorContainerExpanded {
     display: flex;
     flex-direction: column;
-    height: calc(85vh - 400px);
+    height: calc(95vh - 480px);
     min-height: 280px;
 }
 

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
@@ -128,26 +128,60 @@
     gap: var(--mantine-spacing-sm);
 }
 
-.formatAccordionItem {
+.calculationLayout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(300px, 340px);
+    align-items: stretch;
+    gap: var(--mantine-spacing-md);
+}
+
+.editorColumn {
+    min-width: 0;
+}
+
+.formatPanel {
+    min-width: 0;
+    padding: var(--mantine-spacing-md);
     border: 1px solid var(--mantine-color-ldGray-2);
     border-radius: var(--mantine-radius-md);
-    background-color: transparent;
+    background-color: var(--mantine-color-ldGray-0);
 
     @mixin dark {
+        background-color: var(--mantine-color-ldDark-2);
         border-color: var(--mantine-color-ldDark-4);
     }
 }
 
-.formatAccordionControl {
-    padding-block: var(--mantine-spacing-xs);
-    padding-inline: var(--mantine-spacing-md);
-    border-radius: var(--mantine-radius-md);
+.formatPanelIcon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    color: var(--mantine-color-blue-6);
+    background-color: var(--mantine-color-blue-0);
+    border: 1px solid var(--mantine-color-blue-1);
+    border-radius: var(--mantine-radius-sm);
+
+    @mixin dark {
+        color: var(--mantine-color-blue-3);
+        background-color: var(--mantine-color-blue-9);
+        border-color: var(--mantine-color-blue-8);
+    }
 }
 
-.formatAccordionContent {
-    padding-block-start: var(--mantine-spacing-md);
-    padding-inline: var(--mantine-spacing-md);
-    padding-block-end: var(--mantine-spacing-md);
+.formatStatusBadge {
+    flex-shrink: 0;
+    text-transform: none;
+}
+
+.formatPanelBody {
+    overflow: auto;
+    padding-right: 2px;
+}
+
+.minWidth0 {
+    min-width: 0;
 }
 
 @media (max-width: 48em) {
@@ -162,5 +196,13 @@
 
     .inputModeControlItem {
         min-width: 0;
+    }
+
+    .calculationLayout {
+        grid-template-columns: 1fr;
+    }
+
+    .formatPanel {
+        padding: var(--mantine-spacing-sm);
     }
 }

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -198,7 +198,7 @@ const TableCalculationModal: FC<Props> = ({
 
     const validateName = useCallback(
         (label: string) => {
-            if (!label) return null;
+            if (!label || !label.trim()) return 'Name is required';
 
             if (tableCalculation && tableCalculation.displayName === label) {
                 return null;
@@ -228,6 +228,7 @@ const TableCalculationModal: FC<Props> = ({
 
     const form = useForm<TableCalculationFormInputs>({
         initialValues,
+        validateInputOnBlur: true,
         validate: {
             name: validateName,
         },
@@ -346,13 +347,6 @@ const TableCalculationModal: FC<Props> = ({
         if (validation.hasErrors) return;
 
         const { name, sql, formula, format, type } = form.values;
-        if (name.length === 0) {
-            addToastError({
-                title: 'Name cannot be empty',
-                key: 'table-calculation-modal',
-            });
-            return;
-        }
         try {
             const isNewCalculation = !tableCalculation;
             const nameChanged =
@@ -534,20 +528,21 @@ const TableCalculationModal: FC<Props> = ({
                 </Button>
             }
             cancelLabel="Cancel"
+            bodyScrollAreaMaxHeight={
+                isExpanded ? 'calc(95vh - 140px)' : 'calc(78vh - 140px)'
+            }
             modalRootProps={{
                 closeOnClickOutside: false,
                 styles: isExpanded
                     ? {
                           content: {
                               minWidth: '90vw',
-                              height: '92vh',
-                              maxHeight: '95vh',
                           },
                       }
                     : undefined,
             }}
         >
-            <Stack gap="lg" mih={isExpanded ? undefined : 520}>
+            <Stack gap="xs">
                 <Stack gap={2}>
                     <Group className={classes.inputModeHeader}>
                         <Group gap={6} align="center">

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -14,13 +14,13 @@ import {
 } from '@lightdash/common';
 import { SUPPORTED_DIALECTS, type Dialect } from '@lightdash/formula';
 import {
-    Accordion,
     ActionIcon,
     Badge,
     Box,
     Button,
     Group,
     Loader,
+    Paper,
     SegmentedControl,
     Select,
     Stack,
@@ -38,6 +38,7 @@ import {
     IconClockHour4,
     IconMaximize,
     IconMinimize,
+    IconPalette,
     IconToggleLeft,
     IconWand,
 } from '@tabler/icons-react';
@@ -579,6 +580,9 @@ const TableCalculationModal: FC<Props> = ({
         : editMode === EditMode.FORMULA
           ? 'Create formula'
           : 'Create SQL calculation';
+    const formatSummary = getFormatSummary(form.values.format);
+    const hasCustomFormat =
+        form.values.format.type !== CustomFormatType.DEFAULT;
 
     return (
         <MantineModal
@@ -656,172 +660,185 @@ const TableCalculationModal: FC<Props> = ({
                     />
                 </Group>
 
-                <Stack gap="xs">
-                    <Group className={classes.inputModeHeader}>
-                        <Text fz="sm" fw={600}>
-                            Input mode
-                        </Text>
-                        {isNewCalculation && isFormulaSupported && (
-                            <SegmentedControl
-                                classNames={{
-                                    root: classes.inputModeControl,
-                                    indicator:
-                                        classes.inputModeControlIndicator,
-                                    control: classes.inputModeControlItem,
-                                    label: classes.inputModeControlLabel,
-                                }}
-                                value={editMode}
-                                onChange={(value) =>
-                                    setEditMode(value as EditMode)
-                                }
-                                data={editModeOptions}
-                                size="xs"
-                            />
-                        )}
-                        {showConvertToFormulaButton && (
-                            <Tooltip
-                                label="Use AI to suggest a formula equivalent of your SQL. You can review and edit it before saving."
-                                withArrow
-                                multiline
-                                w={260}
-                                disabled={showConversionPreview}
-                            >
-                                <Button
-                                    variant="light"
-                                    color="indigo"
+                <Box className={classes.calculationLayout}>
+                    <Stack gap="xs" className={classes.editorColumn}>
+                        <Group className={classes.inputModeHeader}>
+                            <Text fz="sm" fw={600}>
+                                Input mode
+                            </Text>
+                            {isNewCalculation && isFormulaSupported && (
+                                <SegmentedControl
+                                    classNames={{
+                                        root: classes.inputModeControl,
+                                        indicator:
+                                            classes.inputModeControlIndicator,
+                                        control: classes.inputModeControlItem,
+                                        label: classes.inputModeControlLabel,
+                                    }}
+                                    value={editMode}
+                                    onChange={(value) =>
+                                        setEditMode(value as EditMode)
+                                    }
+                                    data={editModeOptions}
                                     size="xs"
-                                    leftSection={
+                                />
+                            )}
+                            {showConvertToFormulaButton && (
+                                <Tooltip
+                                    label="Use AI to suggest a formula equivalent of your SQL. You can review and edit it before saving."
+                                    withArrow
+                                    multiline
+                                    w={260}
+                                    disabled={showConversionPreview}
+                                >
+                                    <Button
+                                        variant="light"
+                                        color="indigo"
+                                        size="xs"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconWand}
+                                                size="sm"
+                                            />
+                                        }
+                                        onClick={handleConvertClick}
+                                        loading={isConvertingSql}
+                                        disabled={
+                                            !form.values.sql ||
+                                            form.values.sql.trim().length === 0
+                                        }
+                                        style={{
+                                            visibility: showConversionPreview
+                                                ? 'hidden'
+                                                : 'visible',
+                                        }}
+                                    >
+                                        Convert to formula
+                                    </Button>
+                                </Tooltip>
+                            )}
+                        </Group>
+
+                        <Box
+                            key={editMode}
+                            className={
+                                isExpanded
+                                    ? classes.editorContainerExpanded
+                                    : classes.editorContainer
+                            }
+                        >
+                            {editMode === EditMode.TEMPLATE &&
+                            tableCalculation &&
+                            isTemplateTableCalculation(tableCalculation) ? (
+                                <TemplateViewer
+                                    template={editedTemplate ?? template}
+                                    readOnly={false}
+                                    onTemplateChange={handleTemplateChange}
+                                />
+                            ) : editMode === EditMode.FORMULA ? (
+                                <FormulaForm
+                                    explore={explore}
+                                    metricQuery={metricQuery}
+                                    formula={form.values.formula}
+                                    initialFormula={
+                                        form.values.formula || undefined
+                                    }
+                                    onChange={(text) =>
+                                        form.setFieldValue('formula', text)
+                                    }
+                                    onAiApply={handleFormulaAiApply}
+                                    onValidationChange={setFormulaParseError}
+                                    isFullScreen={isExpanded}
+                                />
+                            ) : (
+                                <Box className={classes.sqlEditorBorder}>
+                                    <Suspense
+                                        fallback={
+                                            <Box
+                                                className={
+                                                    classes.loadingFallback
+                                                }
+                                            >
+                                                <Loader size="sm" />
+                                                <Text c="dimmed" size="sm">
+                                                    Loading SQL editor...
+                                                </Text>
+                                            </Box>
+                                        }
+                                    >
+                                        <SqlForm
+                                            form={form}
+                                            isFullScreen={isExpanded}
+                                            focusOnRender={true}
+                                            onCmdEnter={handleConfirm}
+                                            onAiApplied={handleSqlAiApplied}
+                                            conversionState={
+                                                showConversionPreview
+                                                    ? {
+                                                          isLoading:
+                                                              isConvertingSql,
+                                                          error: conversionError,
+                                                          result: conversionResult,
+                                                          onApply:
+                                                              handleConvertApply,
+                                                          onDiscard:
+                                                              handleConvertDiscard,
+                                                          onRetry:
+                                                              handleConvertRetry,
+                                                      }
+                                                    : undefined
+                                            }
+                                        />
+                                    </Suspense>
+                                </Box>
+                            )}
+                        </Box>
+                    </Stack>
+
+                    <Paper withBorder className={classes.formatPanel}>
+                        <Stack gap="md" h="100%">
+                            <Group justify="space-between" align="flex-start">
+                                <Group gap="xs" wrap="nowrap" flex={1}>
+                                    <Box className={classes.formatPanelIcon}>
                                         <MantineIcon
-                                            icon={IconWand}
+                                            icon={IconPalette}
                                             size="sm"
                                         />
-                                    }
-                                    onClick={handleConvertClick}
-                                    loading={isConvertingSql}
-                                    disabled={
-                                        !form.values.sql ||
-                                        form.values.sql.trim().length === 0
-                                    }
-                                    style={{
-                                        visibility: showConversionPreview
-                                            ? 'hidden'
-                                            : 'visible',
-                                    }}
-                                >
-                                    Convert to formula
-                                </Button>
-                            </Tooltip>
-                        )}
-                    </Group>
-
-                    <Box
-                        key={editMode}
-                        className={
-                            isExpanded
-                                ? classes.editorContainerExpanded
-                                : classes.editorContainer
-                        }
-                    >
-                        {editMode === EditMode.TEMPLATE &&
-                        tableCalculation &&
-                        isTemplateTableCalculation(tableCalculation) ? (
-                            <TemplateViewer
-                                template={editedTemplate ?? template}
-                                readOnly={false}
-                                onTemplateChange={handleTemplateChange}
-                            />
-                        ) : editMode === EditMode.FORMULA ? (
-                            <FormulaForm
-                                explore={explore}
-                                metricQuery={metricQuery}
-                                formula={form.values.formula}
-                                initialFormula={
-                                    form.values.formula || undefined
-                                }
-                                onChange={(text) =>
-                                    form.setFieldValue('formula', text)
-                                }
-                                onAiApply={handleFormulaAiApply}
-                                onValidationChange={setFormulaParseError}
-                                isFullScreen={isExpanded}
-                            />
-                        ) : (
-                            <Box className={classes.sqlEditorBorder}>
-                                <Suspense
-                                    fallback={
-                                        <Box
-                                            className={classes.loadingFallback}
-                                        >
-                                            <Loader size="sm" />
-                                            <Text c="dimmed" size="sm">
-                                                Loading SQL editor...
-                                            </Text>
-                                        </Box>
-                                    }
-                                >
-                                    <SqlForm
-                                        form={form}
-                                        isFullScreen={isExpanded}
-                                        focusOnRender={true}
-                                        onCmdEnter={handleConfirm}
-                                        onAiApplied={handleSqlAiApplied}
-                                        conversionState={
-                                            showConversionPreview
-                                                ? {
-                                                      isLoading:
-                                                          isConvertingSql,
-                                                      error: conversionError,
-                                                      result: conversionResult,
-                                                      onApply:
-                                                          handleConvertApply,
-                                                      onDiscard:
-                                                          handleConvertDiscard,
-                                                      onRetry:
-                                                          handleConvertRetry,
-                                                  }
-                                                : undefined
-                                        }
-                                    />
-                                </Suspense>
-                            </Box>
-                        )}
-                    </Box>
-                </Stack>
-
-                <Accordion
-                    variant="default"
-                    chevronPosition="right"
-                    defaultValue={
-                        form.values.format.type !== CustomFormatType.DEFAULT
-                            ? 'format'
-                            : null
-                    }
-                    classNames={{
-                        item: classes.formatAccordionItem,
-                        control: classes.formatAccordionControl,
-                        content: classes.formatAccordionContent,
-                    }}
-                >
-                    <Accordion.Item value="format">
-                        <Accordion.Control>
-                            <Group gap="md" wrap="nowrap">
-                                <Text size="sm" fw={500}>
-                                    Formatting
-                                </Text>
-                                <Text size="xs" c="dimmed" truncate>
-                                    {getFormatSummary(form.values.format)}
-                                </Text>
+                                    </Box>
+                                    <Box flex={1} className={classes.minWidth0}>
+                                        <Text size="sm" fw={600}>
+                                            Result format
+                                        </Text>
+                                        <Text size="xs" c="dimmed" truncate>
+                                            {formatSummary}
+                                        </Text>
+                                    </Box>
+                                </Group>
+                                {hasCustomFormat && (
+                                    <Badge
+                                        size="sm"
+                                        radius="sm"
+                                        color="blue"
+                                        variant="light"
+                                        className={classes.formatStatusBadge}
+                                    >
+                                        Custom
+                                    </Badge>
+                                )}
                             </Group>
-                        </Accordion.Control>
-                        <Accordion.Panel>
-                            <FormatForm
-                                formatInputProps={getFormatInputProps}
-                                setFormatFieldValue={setFormatFieldValue}
-                                format={form.values.format}
-                            />
-                        </Accordion.Panel>
-                    </Accordion.Item>
-                </Accordion>
+
+                            <Box className={classes.formatPanelBody}>
+                                <FormatForm
+                                    compact
+                                    itemType={selectedTableCalculationType}
+                                    formatInputProps={getFormatInputProps}
+                                    setFormatFieldValue={setFormatFieldValue}
+                                    format={form.values.format}
+                                />
+                            </Box>
+                        </Stack>
+                    </Paper>
+                </Box>
             </Stack>
         </MantineModal>
     );

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -20,26 +20,17 @@ import {
     Button,
     Group,
     Loader,
-    Paper,
     SegmentedControl,
-    Select,
     Stack,
     Text,
     TextInput,
     Tooltip,
-    type ComboboxItem,
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import {
-    Icon123,
-    IconAbc,
-    IconCalendar,
     IconCalculator,
-    IconClockHour4,
     IconMaximize,
     IconMinimize,
-    IconPalette,
-    IconToggleLeft,
     IconWand,
 } from '@tabler/icons-react';
 import {
@@ -56,8 +47,6 @@ import { useToggle } from 'react-use';
 import { type ValueOf } from 'type-fest';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
-import { FormatForm } from '../../../components/Explorer/FormatForm';
-import { getFormatSummary } from '../../../components/Explorer/FormatForm/getFormatSummary';
 import {
     selectCustomDimensions,
     selectMetricQuery,
@@ -71,6 +60,7 @@ import { useConvertSqlToFormula } from '../../../hooks/useConvertSqlToFormula';
 import { useExplore } from '../../../hooks/useExplore';
 import { useProject } from '../../../hooks/useProject';
 import { getUniqueTableCalculationName } from '../utils';
+import { FormatRow } from './FormatRow/FormatRow';
 import { FormulaForm } from './FormulaForm/FormulaForm';
 import classes from './TableCalculationModal.module.css';
 import { TemplateViewer } from './TemplateViewer/TemplateViewer';
@@ -107,32 +97,6 @@ enum EditMode {
     TEMPLATE = 'template',
     FORMULA = 'formula',
 }
-
-const tableCalculationTypeMeta = {
-    [TableCalculationType.NUMBER]: {
-        label: 'Number',
-        icon: Icon123,
-    },
-    [TableCalculationType.STRING]: {
-        label: 'String',
-        icon: IconAbc,
-    },
-    [TableCalculationType.DATE]: {
-        label: 'Date',
-        icon: IconCalendar,
-    },
-    [TableCalculationType.TIMESTAMP]: {
-        label: 'Timestamp',
-        icon: IconClockHour4,
-    },
-    [TableCalculationType.BOOLEAN]: {
-        label: 'Boolean',
-        icon: IconToggleLeft,
-    },
-} as const satisfies Record<
-    TableCalculationType,
-    { label: string; icon: typeof Icon123 }
->;
 
 const TableCalculationModal: FC<Props> = ({
     opened,
@@ -492,56 +456,30 @@ const TableCalculationModal: FC<Props> = ({
         [],
     );
 
-    const tableCalculationTypeValues = useMemo(
-        () => Object.values(TableCalculationType),
-        [],
-    );
-
-    const tableCalculationTypeOptions = useMemo(
-        () =>
-            tableCalculationTypeValues.map((value) => ({
-                value,
-                label: tableCalculationTypeMeta[value].label,
-            })),
-        [tableCalculationTypeValues],
-    );
-
     const selectedTableCalculationType =
         form.values.type ?? TableCalculationType.NUMBER;
-    const selectedTypeMeta =
-        tableCalculationTypeMeta[selectedTableCalculationType];
 
-    const renderTypeOption = useCallback(
-        ({ option }: { option: ComboboxItem }) => {
-            const meta =
-                tableCalculationTypeMeta[option.value as TableCalculationType];
-
-            return (
-                <Group gap="xs" wrap="nowrap">
-                    <Box className={classes.typeOptionIcon}>
-                        <MantineIcon icon={meta.icon} size="sm" />
-                    </Box>
-                    <Text size="sm" fw={500}>
-                        {meta.label}
-                    </Text>
-                </Group>
-            );
-        },
-        [],
-    );
-
-    const handleTypeChange = useCallback(
-        (value: string | null) => {
-            if (
-                value &&
-                tableCalculationTypeValues.includes(
-                    value as TableCalculationType,
-                )
-            ) {
-                form.setFieldValue('type', value as TableCalculationType);
+    const handleDataTypeChange = useCallback(
+        (next: TableCalculationType) => {
+            const prev = form.values.type ?? TableCalculationType.NUMBER;
+            // Switching to a different "format family" wipes format state —
+            // a date format expression makes no sense for a number value, etc.
+            const familyOf = (t: TableCalculationType) =>
+                t === TableCalculationType.DATE ||
+                t === TableCalculationType.TIMESTAMP
+                    ? 'date'
+                    : t === TableCalculationType.NUMBER
+                      ? 'numeric'
+                      : 'plain';
+            if (familyOf(prev) !== familyOf(next)) {
+                form.setFieldValue('format', {
+                    type: CustomFormatType.DEFAULT,
+                    separator: NumberSeparator.DEFAULT,
+                });
             }
+            form.setFieldValue('type', next);
         },
-        [form, tableCalculationTypeValues],
+        [form],
     );
 
     const editModeOptions = useMemo(
@@ -580,9 +518,6 @@ const TableCalculationModal: FC<Props> = ({
         : editMode === EditMode.FORMULA
           ? 'Create formula'
           : 'Create SQL calculation';
-    const formatSummary = getFormatSummary(form.values.format);
-    const hasCustomFormat =
-        form.values.format.type !== CustomFormatType.DEFAULT;
 
     return (
         <MantineModal
@@ -632,213 +567,153 @@ const TableCalculationModal: FC<Props> = ({
             }}
         >
             <Stack gap="lg">
-                <Group gap="md" align="flex-start">
-                    <TextInput
-                        label="Name"
-                        required
-                        placeholder="E.g. Cumulative order count"
-                        data-testid="table-calculation-name-input"
-                        flex={2}
-                        {...form.getInputProps('name')}
-                    />
-                    <Select
-                        label="Data type"
-                        flex={1}
-                        {...form.getInputProps('type')}
-                        onChange={handleTypeChange}
-                        data={tableCalculationTypeOptions}
-                        allowDeselect={false}
-                        leftSection={
-                            <MantineIcon
-                                icon={selectedTypeMeta.icon}
-                                size="sm"
-                                className={classes.typeInputIcon}
+                <Stack gap="xs">
+                    <Group className={classes.inputModeHeader}>
+                        <Text fz="sm" fw={600}>
+                            Input mode
+                        </Text>
+                        {isNewCalculation && isFormulaSupported && (
+                            <SegmentedControl
+                                classNames={{
+                                    root: classes.inputModeControl,
+                                    indicator:
+                                        classes.inputModeControlIndicator,
+                                    control: classes.inputModeControlItem,
+                                    label: classes.inputModeControlLabel,
+                                }}
+                                value={editMode}
+                                onChange={(value) =>
+                                    setEditMode(value as EditMode)
+                                }
+                                data={editModeOptions}
+                                size="xs"
                             />
-                        }
-                        renderOption={renderTypeOption}
-                        checkIconPosition="right"
-                    />
-                </Group>
-
-                <Box className={classes.calculationLayout}>
-                    <Stack gap="xs" className={classes.editorColumn}>
-                        <Group className={classes.inputModeHeader}>
-                            <Text fz="sm" fw={600}>
-                                Input mode
-                            </Text>
-                            {isNewCalculation && isFormulaSupported && (
-                                <SegmentedControl
-                                    classNames={{
-                                        root: classes.inputModeControl,
-                                        indicator:
-                                            classes.inputModeControlIndicator,
-                                        control: classes.inputModeControlItem,
-                                        label: classes.inputModeControlLabel,
-                                    }}
-                                    value={editMode}
-                                    onChange={(value) =>
-                                        setEditMode(value as EditMode)
-                                    }
-                                    data={editModeOptions}
+                        )}
+                        {showConvertToFormulaButton && (
+                            <Tooltip
+                                label="Use AI to suggest a formula equivalent of your SQL. You can review and edit it before saving."
+                                withArrow
+                                multiline
+                                w={260}
+                                disabled={showConversionPreview}
+                            >
+                                <Button
+                                    variant="light"
+                                    color="indigo"
                                     size="xs"
-                                />
-                            )}
-                            {showConvertToFormulaButton && (
-                                <Tooltip
-                                    label="Use AI to suggest a formula equivalent of your SQL. You can review and edit it before saving."
-                                    withArrow
-                                    multiline
-                                    w={260}
-                                    disabled={showConversionPreview}
-                                >
-                                    <Button
-                                        variant="light"
-                                        color="indigo"
-                                        size="xs"
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={IconWand}
-                                                size="sm"
-                                            />
-                                        }
-                                        onClick={handleConvertClick}
-                                        loading={isConvertingSql}
-                                        disabled={
-                                            !form.values.sql ||
-                                            form.values.sql.trim().length === 0
-                                        }
-                                        style={{
-                                            visibility: showConversionPreview
-                                                ? 'hidden'
-                                                : 'visible',
-                                        }}
-                                    >
-                                        Convert to formula
-                                    </Button>
-                                </Tooltip>
-                            )}
-                        </Group>
-
-                        <Box
-                            key={editMode}
-                            className={
-                                isExpanded
-                                    ? classes.editorContainerExpanded
-                                    : classes.editorContainer
-                            }
-                        >
-                            {editMode === EditMode.TEMPLATE &&
-                            tableCalculation &&
-                            isTemplateTableCalculation(tableCalculation) ? (
-                                <TemplateViewer
-                                    template={editedTemplate ?? template}
-                                    readOnly={false}
-                                    onTemplateChange={handleTemplateChange}
-                                />
-                            ) : editMode === EditMode.FORMULA ? (
-                                <FormulaForm
-                                    explore={explore}
-                                    metricQuery={metricQuery}
-                                    formula={form.values.formula}
-                                    initialFormula={
-                                        form.values.formula || undefined
-                                    }
-                                    onChange={(text) =>
-                                        form.setFieldValue('formula', text)
-                                    }
-                                    onAiApply={handleFormulaAiApply}
-                                    onValidationChange={setFormulaParseError}
-                                    isFullScreen={isExpanded}
-                                />
-                            ) : (
-                                <Box className={classes.sqlEditorBorder}>
-                                    <Suspense
-                                        fallback={
-                                            <Box
-                                                className={
-                                                    classes.loadingFallback
-                                                }
-                                            >
-                                                <Loader size="sm" />
-                                                <Text c="dimmed" size="sm">
-                                                    Loading SQL editor...
-                                                </Text>
-                                            </Box>
-                                        }
-                                    >
-                                        <SqlForm
-                                            form={form}
-                                            isFullScreen={isExpanded}
-                                            focusOnRender={true}
-                                            onCmdEnter={handleConfirm}
-                                            onAiApplied={handleSqlAiApplied}
-                                            conversionState={
-                                                showConversionPreview
-                                                    ? {
-                                                          isLoading:
-                                                              isConvertingSql,
-                                                          error: conversionError,
-                                                          result: conversionResult,
-                                                          onApply:
-                                                              handleConvertApply,
-                                                          onDiscard:
-                                                              handleConvertDiscard,
-                                                          onRetry:
-                                                              handleConvertRetry,
-                                                      }
-                                                    : undefined
-                                            }
-                                        />
-                                    </Suspense>
-                                </Box>
-                            )}
-                        </Box>
-                    </Stack>
-
-                    <Paper withBorder className={classes.formatPanel}>
-                        <Stack gap="md" h="100%">
-                            <Group justify="space-between" align="flex-start">
-                                <Group gap="xs" wrap="nowrap" flex={1}>
-                                    <Box className={classes.formatPanelIcon}>
+                                    leftSection={
                                         <MantineIcon
-                                            icon={IconPalette}
+                                            icon={IconWand}
                                             size="sm"
                                         />
-                                    </Box>
-                                    <Box flex={1} className={classes.minWidth0}>
-                                        <Text size="sm" fw={600}>
-                                            Result format
-                                        </Text>
-                                        <Text size="xs" c="dimmed" truncate>
-                                            {formatSummary}
-                                        </Text>
-                                    </Box>
-                                </Group>
-                                {hasCustomFormat && (
-                                    <Badge
-                                        size="sm"
-                                        radius="sm"
-                                        color="blue"
-                                        variant="light"
-                                        className={classes.formatStatusBadge}
-                                    >
-                                        Custom
-                                    </Badge>
-                                )}
-                            </Group>
+                                    }
+                                    onClick={handleConvertClick}
+                                    loading={isConvertingSql}
+                                    disabled={
+                                        !form.values.sql ||
+                                        form.values.sql.trim().length === 0
+                                    }
+                                    style={{
+                                        visibility: showConversionPreview
+                                            ? 'hidden'
+                                            : 'visible',
+                                    }}
+                                >
+                                    Convert to formula
+                                </Button>
+                            </Tooltip>
+                        )}
+                    </Group>
 
-                            <Box className={classes.formatPanelBody}>
-                                <FormatForm
-                                    compact
-                                    itemType={selectedTableCalculationType}
-                                    formatInputProps={getFormatInputProps}
-                                    setFormatFieldValue={setFormatFieldValue}
-                                    format={form.values.format}
-                                />
+                    <Box
+                        key={editMode}
+                        className={
+                            isExpanded
+                                ? classes.editorContainerExpanded
+                                : classes.editorContainer
+                        }
+                    >
+                        {editMode === EditMode.TEMPLATE &&
+                        tableCalculation &&
+                        isTemplateTableCalculation(tableCalculation) ? (
+                            <TemplateViewer
+                                template={editedTemplate ?? template}
+                                readOnly={false}
+                                onTemplateChange={handleTemplateChange}
+                            />
+                        ) : editMode === EditMode.FORMULA ? (
+                            <FormulaForm
+                                explore={explore}
+                                metricQuery={metricQuery}
+                                formula={form.values.formula}
+                                initialFormula={
+                                    form.values.formula || undefined
+                                }
+                                onChange={(text) =>
+                                    form.setFieldValue('formula', text)
+                                }
+                                onAiApply={handleFormulaAiApply}
+                                onValidationChange={setFormulaParseError}
+                                isFullScreen={isExpanded}
+                            />
+                        ) : (
+                            <Box className={classes.sqlEditorBorder}>
+                                <Suspense
+                                    fallback={
+                                        <Box
+                                            className={classes.loadingFallback}
+                                        >
+                                            <Loader size="sm" />
+                                            <Text c="dimmed" size="sm">
+                                                Loading SQL editor...
+                                            </Text>
+                                        </Box>
+                                    }
+                                >
+                                    <SqlForm
+                                        form={form}
+                                        isFullScreen={isExpanded}
+                                        focusOnRender={true}
+                                        onCmdEnter={handleConfirm}
+                                        onAiApplied={handleSqlAiApplied}
+                                        conversionState={
+                                            showConversionPreview
+                                                ? {
+                                                      isLoading:
+                                                          isConvertingSql,
+                                                      error: conversionError,
+                                                      result: conversionResult,
+                                                      onApply:
+                                                          handleConvertApply,
+                                                      onDiscard:
+                                                          handleConvertDiscard,
+                                                      onRetry:
+                                                          handleConvertRetry,
+                                                  }
+                                                : undefined
+                                        }
+                                    />
+                                </Suspense>
                             </Box>
-                        </Stack>
-                    </Paper>
-                </Box>
+                        )}
+                    </Box>
+                </Stack>
+
+                <FormatRow
+                    format={form.values.format}
+                    formatInputProps={getFormatInputProps}
+                    setFormatFieldValue={setFormatFieldValue}
+                    dataType={selectedTableCalculationType}
+                    onDataTypeChange={handleDataTypeChange}
+                />
+
+                <TextInput
+                    label="Name"
+                    required
+                    placeholder="E.g. Cumulative order count"
+                    data-testid="table-calculation-name-input"
+                    {...form.getInputProps('name')}
+                />
             </Stack>
         </MantineModal>
     );

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -15,12 +15,12 @@ import {
 import { SUPPORTED_DIALECTS, type Dialect } from '@lightdash/formula';
 import {
     ActionIcon,
+    Anchor,
     Badge,
     Box,
     Button,
     Group,
     Loader,
-    SegmentedControl,
     Stack,
     Text,
     TextInput,
@@ -482,36 +482,17 @@ const TableCalculationModal: FC<Props> = ({
         [form],
     );
 
-    const editModeOptions = useMemo(
-        () => [
-            {
-                value: EditMode.FORMULA,
-                label: (
-                    <Group
-                        gap={4}
-                        wrap="nowrap"
-                        justify="center"
-                        className={classes.inputModeFormulaLabel}
-                    >
-                        <Text span inherit>
-                            Formula
-                        </Text>
-                        <Tooltip label="This feature is currently in beta. It might cause unexpected results and is subject to change.">
-                            <Badge
-                                color="indigo"
-                                radius="sm"
-                                className={classes.inputModeBadge}
-                            >
-                                Beta
-                            </Badge>
-                        </Tooltip>
-                    </Group>
-                ),
-            },
-            { value: EditMode.SQL, label: 'SQL' },
-        ],
-        [],
-    );
+    const canSwitchEditMode = isNewCalculation && isFormulaSupported;
+    const editorLabel = editMode === EditMode.FORMULA ? 'Formula' : 'SQL';
+    const switchEditModeLabel =
+        editMode === EditMode.FORMULA
+            ? 'Use SQL instead'
+            : 'Use formula instead';
+    const handleSwitchEditMode = useCallback(() => {
+        setEditMode(
+            editMode === EditMode.FORMULA ? EditMode.SQL : EditMode.FORMULA,
+        );
+    }, [editMode]);
 
     const saveButtonLabel = tableCalculation
         ? 'Save changes'
@@ -559,35 +540,41 @@ const TableCalculationModal: FC<Props> = ({
                     ? {
                           content: {
                               minWidth: '90vw',
-                              height: '80vh',
-                              maxHeight: '90vh',
+                              height: '92vh',
+                              maxHeight: '95vh',
                           },
                       }
                     : undefined,
             }}
         >
-            <Stack gap="lg">
-                <Stack gap="xs">
+            <Stack gap="lg" mih={isExpanded ? undefined : 520}>
+                <Stack gap={2}>
                     <Group className={classes.inputModeHeader}>
-                        <Text fz="sm" fw={600}>
-                            Input mode
-                        </Text>
-                        {isNewCalculation && isFormulaSupported && (
-                            <SegmentedControl
-                                classNames={{
-                                    root: classes.inputModeControl,
-                                    indicator:
-                                        classes.inputModeControlIndicator,
-                                    control: classes.inputModeControlItem,
-                                    label: classes.inputModeControlLabel,
-                                }}
-                                value={editMode}
-                                onChange={(value) =>
-                                    setEditMode(value as EditMode)
-                                }
-                                data={editModeOptions}
+                        <Group gap={6} align="center">
+                            <Text fz="sm" fw={600}>
+                                {editorLabel}
+                            </Text>
+                            {editMode === EditMode.FORMULA && (
+                                <Tooltip label="This feature is currently in beta. It might cause unexpected results and is subject to change.">
+                                    <Badge
+                                        color="indigo"
+                                        radius="sm"
+                                        className={classes.inputModeBadge}
+                                    >
+                                        Beta
+                                    </Badge>
+                                </Tooltip>
+                            )}
+                        </Group>
+                        {canSwitchEditMode && (
+                            <Anchor
                                 size="xs"
-                            />
+                                c="dimmed"
+                                onClick={handleSwitchEditMode}
+                                className={classes.switchEditModeLink}
+                            >
+                                {switchEditModeLabel}
+                            </Anchor>
                         )}
                         {showConvertToFormulaButton && (
                             <Tooltip


### PR DESCRIPTION
## Summary

- **Variant A inline format row** replaces the old split layout: the data-type Select sits next to the Format heading, the live preview moves to the right of the heading, and the per-pill sub-options live in a single card below. Numeric pills (Plain / Number / Currency / Percent / Bytes / Custom) collapse onto a single row; Date and Timestamp expose Default / Custom with a Date-format input that opens the preset library from a chevron in the right section. String / Boolean show a slim card with no fake divider.
- **TableCalculationModal restructure**: the top \"Name + Data type\" group is gone (data type lives in the Format row), the input-mode SegmentedControl is replaced by a subtle \"Use SQL/formula instead\" Anchor, and the right-side Paper format panel is removed. AmbientAI gating and per-warehouse formula support (\`SUPPORTED_DIALECTS\`) are unchanged.
- **Modal height now stable**: the body's ScrollArea cap was hardcoded at \`calc(80vh - 140px)\` which silently capped any \`Modal.Content\` height override. \`MantineModal\` now exposes \`bodyScrollAreaMaxHeight\`; the table-calc modal uses \`calc(95vh - 140px)\` in fullscreen and \`calc(78vh - 140px)\` otherwise so the Name input below the Format card is always reachable.
- **Name field validates inline** (\"Name is required\" on blur and on submit) instead of only firing a toast at submit time.
- **Renderer fix in @lightdash/common**: \`formatItemValue\` now honours a \`CUSTOM\` format expression on \`TableCalculationType.DATE / TIMESTAMP\` table calcs. The previous switch short-circuited to \`formatDate\` / \`formatTimestamp\` before reaching the custom-expression branch, silently dropping any \`mmmm d, yyyy\`-style expression the user picked.

## Test plan

- [ ] Open the Create Table Calculation modal on Number → confirm Plain/Number/Currency/Percent/Bytes/Custom pills swap sub-options without layout shift, preview reflects every change.
- [ ] Switch data type to String / Boolean → card collapses to the \"no formatting options\" message, preview shows \"Sample text\" / \"true\".
- [ ] Switch to Date → Default and Custom; for Custom, type a \`mmmm d, yyyy\` expression, save, and verify the column renders \`April 28, 2026\` in the explore results table.
- [ ] Same for Timestamp with a \`mmmm d, yyyy h:MM:ss tt\` expression.
- [ ] Open a calc with the modal in fullscreen mode → confirm the Name input at the bottom is fully visible (no scroll required) at typical viewport heights.
- [ ] Empty-name on save → inline \"Name is required\" error shows on the field; toast does not fire.
- [ ] AmbientAI off (or unsupported warehouse) → \"Convert to formula\" button hidden; AI affordances inside SqlForm / FormulaForm hidden.
- [ ] AmbientAI on → \"Improve with AI\" / \"Convert to formula\" / formula generation populate name, body, type, and format end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)