### PR TITLE
chore: add variable to specify data app template

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -33,9 +33,9 @@ flowchart LR
 1. **App creation** — The API creates a `DbApp` record and a v1 `DbAppVersion` with `status='building'`, then returns
    immediately with `{ appUuid, version }`. The pipeline runs asynchronously in the background.
 
-2. **Sandbox setup** — An [E2B](https://e2b.dev/) sandbox is created from the `lightdash-data-app` template. The
-   template contains a pre-configured React + Vite project with the Lightdash App SDK, plus a system prompt
-   (`/app/skill.md`) that teaches Claude how to build data apps.
+2. **Sandbox setup** — An [E2B](https://e2b.dev/) sandbox is created from the `lightdash-data-app` template (override
+   with `E2B_TEMPLATE_NAME` for development). The template contains a pre-configured React + Vite project with the
+   Lightdash App SDK, plus a system prompt (`/app/skill.md`) that teaches Claude how to build data apps.
 
 3. **Catalog injection** — The project's dbt catalog (tables, dimensions, metrics) is fetched via `CatalogModel` and
    written as YAML into the sandbox at `/tmp/dbt-repo/models/schema.yml`. This gives Claude full context on the
@@ -316,6 +316,7 @@ notification via `useBuildNotification`.
 ```
 APP_RUNTIME_ENABLED=true                           # Master feature flag
 E2B_API_KEY=...                                    # E2B sandbox API key
+E2B_TEMPLATE_NAME=lightdash-data-app               # Optional E2B template override (for dev)
 APP_RUNTIME_LIGHTDASH_ORIGIN=https://app.example   # Origin for CORS/CSP (defaults to SITE_URL)
 APP_RUNTIME_CDN_ORIGIN=https://cdn.example.com     # Optional CDN for CSP
 APP_RUNTIME_PREVIEW_ORIGIN=https://preview.example # Optional Separate domain for preview serving

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -383,6 +383,7 @@ export const lightdashConfigMock: LightdashConfig = {
         previewOrigin: null,
         s3: null,
         e2bApiKey: null,
+        e2bTemplateName: 'lightdash-data-app',
     },
     enabledFeatureFlags: new Set<string>(),
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1341,6 +1341,7 @@ export type AppRuntimeConfig = {
     previewOrigin: string | null;
     s3: S3Config | null;
     e2bApiKey: string | null;
+    e2bTemplateName: string;
 };
 
 export type IntercomConfig = {
@@ -1548,6 +1549,7 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
         previewOrigin: process.env.APP_RUNTIME_PREVIEW_ORIGIN || null,
         s3,
         e2bApiKey: process.env.E2B_API_KEY || null,
+        e2bTemplateName: process.env.E2B_TEMPLATE_NAME || 'lightdash-data-app',
     };
 };
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -647,15 +647,18 @@ export class AppGenerateService extends BaseService {
         e2bApiKey: string,
     ): Promise<{ sandbox: Sandbox; durationMs: number }> {
         const start = performance.now();
-        const sandbox = await Sandbox.create('lightdash-data-app', {
-            timeoutMs: 60 * 60 * 1000,
-            apiKey: e2bApiKey,
-            lifecycle: { onTimeout: 'pause' },
-            network: {
-                allowOut: ['api.anthropic.com'],
-                denyOut: [ALL_TRAFFIC],
+        const sandbox = await Sandbox.create(
+            this.lightdashConfig.appRuntime.e2bTemplateName,
+            {
+                timeoutMs: 60 * 60 * 1000,
+                apiKey: e2bApiKey,
+                lifecycle: { onTimeout: 'pause' },
+                network: {
+                    allowOut: ['api.anthropic.com'],
+                    denyOut: [ALL_TRAFFIC],
+                },
             },
-        });
+        );
         const durationMs = AppGenerateService.elapsed(start);
         this.logger.info(
             `App ${appUuid}: E2B sandbox created (sandboxId=${sandbox.sandboxId}, ${durationMs}ms)`,

--- a/sandboxes/data-apps/README.md
+++ b/sandboxes/data-apps/README.md
@@ -57,6 +57,24 @@ pnpm run dev
 pnpm run build
 ```
 
+## E2B template name
+
+The build script (`build-sandbox.ts`) and the backend (`AppGenerateService`) both target the
+`lightdash-data-app` E2B template by default — this is the production template.
+
+During development, set `E2B_TEMPLATE_NAME` to a different name to build and use a personal/dev
+template instead. Both `build-sandbox.ts` and the backend read the same env var, so as long as
+they share it, the backend will spin up sandboxes from your dev template.
+
+```bash
+# Build to a dev template
+E2B_TEMPLATE_NAME=lightdash-data-app-dev pnpm run build
+
+# Backend will use the same template when this env var is set
+```
+
+When `E2B_TEMPLATE_NAME` is unset, both sides fall back to the prod `lightdash-data-app` template.
+
 ## Related
 
 - **GLITCH-270** — E2B sandbox that runs this scaffold in production

--- a/sandboxes/data-apps/build-sandbox.ts
+++ b/sandboxes/data-apps/build-sandbox.ts
@@ -53,13 +53,17 @@ async function main() {
             fileContextPath: path.resolve('.'),
         }).fromDockerfile(dockerfile);
 
-        console.log('Submitting sandbox template build...\n');
+        const templateName =
+            process.env.E2B_TEMPLATE_NAME || 'lightdash-data-app';
+        console.log(
+            `Submitting sandbox template build (template: ${templateName})...\n`,
+        );
 
         const skipCache = process.argv.includes('--no-cache');
 
         const info = await Template.buildInBackground(
             template,
-            'lightdash-data-app',
+            templateName,
             {
                 cpuCount: 2,
                 memoryMB: 2048,

--- a/sandboxes/data-apps/test-generate.ts
+++ b/sandboxes/data-apps/test-generate.ts
@@ -61,9 +61,10 @@ if (!process.env.E2B_API_KEY) {
 // ---------------------------------------------------------------------------
 // Create sandbox
 // ---------------------------------------------------------------------------
-console.log('Creating sandbox from lightdash-data-app template...');
+const templateName = process.env.E2B_TEMPLATE_NAME || 'lightdash-data-app';
+console.log(`Creating sandbox from ${templateName} template...`);
 
-const sandbox = await Sandbox.create('lightdash-data-app', {
+const sandbox = await Sandbox.create(templateName, {
     timeoutMs: 10 * 60 * 1000, // 10 min TTL
     envs: {
         ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,


### PR DESCRIPTION

### Description:

- Add E2B_TEMPLATE_NAME env var to override the E2B template used for data apps during development
- Wired through AppRuntimeConfig so both the sandbox build script (sandboxes/data-apps/build-sandbox.ts) and the backend (AppGenerateService) target the same template
- Defaults to the prod lightdash-data-app template when unset — no change in production behavior
- Updated sandboxes/data-apps/README.md and docs/data-apps.md with usage notes
