### PR TITLE
chore: migrate `DashboardComments` feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -321,9 +321,6 @@ export const lightdashConfigMock: LightdashConfig = {
     customRoles: {
         enabled: false,
     },
-    dashboardComments: {
-        enabled: true,
-    },
     echarts6: {
         enabled: false,
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -839,3 +839,39 @@ describe('getMultiProjectSetupConfig', () => {
         );
     });
 });
+
+describe('feature flag env-var allowlists', () => {
+    test('LIGHTDASH_ENABLE_FEATURE_FLAGS populates enabledFeatureFlags', () => {
+        process.env.LIGHTDASH_ENABLE_FEATURE_FLAGS = 'foo, bar,baz';
+        const config = parseConfig();
+        expect([...config.enabledFeatureFlags].sort()).toEqual([
+            'bar',
+            'baz',
+            'foo',
+        ]);
+    });
+
+    test('LIGHTDASH_DISABLE_FEATURE_FLAGS populates disabledFeatureFlags', () => {
+        process.env.LIGHTDASH_DISABLE_FEATURE_FLAGS = 'killed-flag';
+        const config = parseConfig();
+        expect(config.disabledFeatureFlags.has('killed-flag')).toBe(true);
+    });
+
+    test('legacy DISABLE_DASHBOARD_COMMENTS=true translates to disabledFeatureFlags', () => {
+        // Backward-compat for self-hosters who set the legacy env var before
+        // the unified LIGHTDASH_DISABLE_FEATURE_FLAGS pattern was introduced.
+        process.env.DISABLE_DASHBOARD_COMMENTS = 'true';
+        const config = parseConfig();
+        expect(
+            config.disabledFeatureFlags.has('dashboard-comments-enabled'),
+        ).toBe(true);
+    });
+
+    test('legacy DISABLE_DASHBOARD_COMMENTS unset leaves the flag out of disabledFeatureFlags', () => {
+        delete process.env.DISABLE_DASHBOARD_COMMENTS;
+        const config = parseConfig();
+        expect(
+            config.disabledFeatureFlags.has('dashboard-comments-enabled'),
+        ).toBe(false);
+    });
+});

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1233,9 +1233,6 @@ export type LightdashConfig = {
     };
     analyticsEmbedSecret?: string;
 
-    dashboardComments: {
-        enabled: boolean;
-    };
     echarts6: {
         enabled: boolean;
     };
@@ -1561,6 +1558,7 @@ const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
     readonly [envVar: string, flagId: string]
 > = [
     // Add per migration; truthy env value disables the flag.
+    ['DISABLE_DASHBOARD_COMMENTS', 'dashboard-comments-enabled'],
 ];
 
 export const parseConfig = (): LightdashConfig => {
@@ -2259,9 +2257,6 @@ export const parseConfig = (): LightdashConfig => {
             enabled: process.env.CUSTOM_ROLES_ENABLED === 'true',
         },
         analyticsEmbedSecret: process.env.ANALYTICS_EMBED_SECRET,
-        dashboardComments: {
-            enabled: process.env.DISABLE_DASHBOARD_COMMENTS !== 'true',
-        },
         echarts6: {
             enabled: process.env.ECHARTS_V6_ENABLED === 'true',
         },

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -40,8 +40,6 @@ export class FeatureFlagModel {
                 this.getUserGroupsEnabled.bind(this),
             [FeatureFlags.UseSqlPivotResults]:
                 this.getUseSqlPivotResults.bind(this),
-            [FeatureFlags.DashboardComments]:
-                this.getDashboardComments.bind(this),
             [FeatureFlags.EditYamlInUi]: this.getEditYamlInUiEnabled.bind(this),
             [FeatureFlags.ShowExecutionTime]:
                 this.getShowExecutionTimeEnabled.bind(this),
@@ -158,38 +156,6 @@ export class FeatureFlagModel {
                       true,
                   )
                 : true);
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private async getDashboardComments({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        if (!this.lightdashConfig.dashboardComments.enabled) {
-            return {
-                id: featureFlagId,
-                enabled: false,
-            };
-        }
-
-        const enabled = user
-            ? await isFeatureFlagEnabled(
-                  FeatureFlags.DashboardComments,
-                  {
-                      userUuid: user.userUuid,
-                      organizationUuid: user.organizationUuid,
-                  },
-                  {
-                      throwOnTimeout: false,
-                      timeoutMilliseconds: 500,
-                  },
-                  true,
-              )
-            : true;
-
         return {
             id: featureFlagId,
             enabled,


### PR DESCRIPTION
Closes:

### Description:
Removes the `DashboardComments` feature flag and its associated configuration (`DISABLE_DASHBOARD_COMMENTS` env var / `dashboardComments` config block), making dashboard comments permanently enabled without requiring a feature flag check or environment variable override.