### PR TITLE
feat(table-calc): drop Beta badge from formula input

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
@@ -73,15 +73,6 @@
     height: 100%;
 }
 
-.inputModeBadge {
-    height: 16px;
-    padding-inline: 5px;
-    font-size: 10px;
-    letter-spacing: 0;
-    line-height: 16px;
-    text-transform: none;
-}
-
 .sqlEditorBorder {
     border: 1px solid var(--mantine-color-ldGray-3);
     border-radius: var(--mantine-radius-md);

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -16,7 +16,6 @@ import { SUPPORTED_DIALECTS, type Dialect } from '@lightdash/formula';
 import {
     ActionIcon,
     Anchor,
-    Badge,
     Box,
     Button,
     Group,
@@ -545,22 +544,9 @@ const TableCalculationModal: FC<Props> = ({
             <Stack gap="xs">
                 <Stack gap={2}>
                     <Group className={classes.inputModeHeader}>
-                        <Group gap={6} align="center">
-                            <Text fz="sm" fw={600}>
-                                {editorLabel}
-                            </Text>
-                            {editMode === EditMode.FORMULA && (
-                                <Tooltip label="This feature is currently in beta. It might cause unexpected results and is subject to change.">
-                                    <Badge
-                                        color="indigo"
-                                        radius="sm"
-                                        className={classes.inputModeBadge}
-                                    >
-                                        Beta
-                                    </Badge>
-                                </Tooltip>
-                            )}
-                        </Group>
+                        <Text fz="sm" fw={600}>
+                            {editorLabel}
+                        </Text>
                         {canSwitchEditMode && (
                             <Anchor
                                 size="xs"


### PR DESCRIPTION
## Summary
- Formula table calculations are GA — the Beta badge next to the "Formula" label in the create/edit modal is now stale.
- Removes the badge, its tooltip, and the associated CSS class / `Badge` import that no longer have any consumers.

## Test plan
- [ ] Open the Create Table Calculation modal, switch to Formula mode, confirm no "Beta" badge appears next to the label.
- [ ] Switch back to SQL mode and confirm nothing else regressed in the input-mode header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)