### PR TITLE
feat: add `disabledFeatureFlags` kill-switch to `FeatureFlagModel`

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -376,4 +376,5 @@ export const lightdashConfigMock: LightdashConfig = {
         e2bApiKey: null,
     },
     enabledFeatureFlags: new Set<string>(),
+    disabledFeatureFlags: new Set<string>(),
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1276,6 +1276,7 @@ export type LightdashConfig = {
     };
     appRuntime: AppRuntimeConfig;
     enabledFeatureFlags: Set<string>;
+    disabledFeatureFlags: Set<string>;
 };
 
 export type SlackConfig = {
@@ -1541,6 +1542,27 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
         e2bApiKey: process.env.E2B_API_KEY || null,
     };
 };
+
+/**
+ * Map of legacy per-flag env vars to their feature-flag IDs. Deprecated —
+ * operators should migrate to LIGHTDASH_ENABLE_FEATURE_FLAGS /
+ * LIGHTDASH_DISABLE_FEATURE_FLAGS. Entries here translate the legacy var into
+ * the unified allowlists for backward compatibility, so self-hosted
+ * deployments don't regress when a per-flag handler is removed during
+ * PostHog migration. Once an entry has soaked for ~6 months after the
+ * unified pattern is documented, delete it.
+ */
+const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
+    readonly [envVar: string, flagId: string]
+> = [
+    // Add per migration; truthy env value enables the flag.
+];
+
+const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
+    readonly [envVar: string, flagId: string]
+> = [
+    // Add per migration; truthy env value disables the flag.
+];
 
 export const parseConfig = (): LightdashConfig => {
     const lightdashSecret = process.env.LIGHTDASH_SECRET;
@@ -2291,11 +2313,23 @@ export const parseConfig = (): LightdashConfig => {
                 : undefined,
         },
         appRuntime: parseAppRuntimeConfig(siteUrl),
-        enabledFeatureFlags: new Set(
-            (process.env.LIGHTDASH_ENABLE_FEATURE_FLAGS ?? '')
+        enabledFeatureFlags: new Set([
+            ...(process.env.LIGHTDASH_ENABLE_FEATURE_FLAGS ?? '')
                 .split(',')
                 .map((s) => s.trim())
                 .filter(Boolean),
-        ),
+            ...LEGACY_ENABLE_ENV_VARS.filter(
+                ([envVar]) => process.env[envVar] === 'true',
+            ).map(([, flagId]) => flagId),
+        ]),
+        disabledFeatureFlags: new Set([
+            ...(process.env.LIGHTDASH_DISABLE_FEATURE_FLAGS ?? '')
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean),
+            ...LEGACY_DISABLE_ENV_VARS.filter(
+                ([envVar]) => process.env[envVar] === 'true',
+            ).map(([, flagId]) => flagId),
+        ]),
     };
 };

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -50,6 +50,47 @@ describe('FeatureFlagModel', () => {
 
             expect(result.enabled).toBe(true);
         });
+
+        it('returns disabled for any flag listed in LIGHTDASH_DISABLE_FEATURE_FLAGS', async () => {
+            const model = buildModel({
+                disabledFeatureFlags: new Set(['killed-flag']),
+            });
+
+            const result = await model.get({
+                featureFlagId: 'killed-flag',
+            });
+
+            expect(result).toEqual({ id: 'killed-flag', enabled: false });
+        });
+
+        it('disable-allowlist forces off even when a config handler would enable', async () => {
+            // Self-hoster kill switch wins over default-on flags.
+            const model = buildModel({
+                disabledFeatureFlags: new Set([FeatureFlags.EditYamlInUi]),
+                editYamlInUi: { enabled: true },
+            });
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EditYamlInUi,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('enable-allowlist takes precedence over disable-allowlist if both set', async () => {
+            // If a flag is in both lists (operator misconfig), enable wins —
+            // matches the order of checks in get().
+            const model = buildModel({
+                enabledFeatureFlags: new Set(['conflicting-flag']),
+                disabledFeatureFlags: new Set(['conflicting-flag']),
+            });
+
+            const result = await model.get({
+                featureFlagId: 'conflicting-flag',
+            });
+
+            expect(result.enabled).toBe(true);
+        });
     });
 
     describe('resolution priority', () => {

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -61,9 +61,14 @@ export class FeatureFlagModel {
     }
 
     public async get(args: FeatureFlagLogicArgs): Promise<FeatureFlag> {
-        // 1. Check env var override (self-hosted escape hatch, enable-only)
+        // 1a. Check env var enable-allowlist (self-hosted escape hatch)
         if (this.lightdashConfig.enabledFeatureFlags.has(args.featureFlagId)) {
             return { id: args.featureFlagId, enabled: true };
+        }
+
+        // 1b. Check env var disable-allowlist (self-hosted kill switch)
+        if (this.lightdashConfig.disabledFeatureFlags.has(args.featureFlagId)) {
+            return { id: args.featureFlagId, enabled: false };
         }
 
         // 2. Check per-flag config handlers


### PR DESCRIPTION
Closes:

### Description:

Adds a `LIGHTDASH_DISABLE_FEATURE_FLAGS` environment variable that allows self-hosted operators to force-disable specific feature flags, complementing the existing `LIGHTDASH_ENABLE_FEATURE_FLAGS` enable allowlist.

The disable allowlist acts as a kill switch — if a flag appears in `LIGHTDASH_DISABLE_FEATURE_FLAGS`, it will be returned as disabled regardless of what any per-flag config handler would otherwise resolve. If a flag appears in both the enable and disable lists (operator misconfiguration), the enable allowlist takes precedence.

A `LEGACY_ENABLE_ENV_VARS` / `LEGACY_DISABLE_ENV_VARS` mapping table is also introduced to support backward-compatible migration of per-flag environment variables into the unified allowlist pattern as flags are moved to PostHog. Entries in these tables translate legacy per-flag env vars into the unified lists so self-hosted deployments don't regress when individual handlers are removed.