### PR TITLE
fix: add legacy env var compat for `ChangeChartExplore`, `ShowHideRows`, and `ShowHideColumns` flags

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -840,6 +840,22 @@ describe('getMultiProjectSetupConfig', () => {
     });
 });
 
+describe('legacy feature-flag env vars (compat repair for trivial-batch)', () => {
+    // The change-chart-explore / show-hide-rows / show-hide-columns env-var
+    // parsers were removed when those flags were migrated to DB-backed
+    // resolution. Re-translating them via the legacy enable list preserves
+    // backward compat for self-hosted deployments that set these vars.
+    test.each([
+        ['CHANGE_CHART_EXPLORE_ENABLED', 'change-chart-explore'],
+        ['SHOW_HIDE_ROWS_ENABLED', 'show-hide-rows'],
+        ['SHOW_HIDE_COLUMNS_ENABLED', 'show-hide-columns'],
+    ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
+        process.env[envVar] = 'true';
+        const config = parseConfig();
+        expect(config.enabledFeatureFlags.has(flagId)).toBe(true);
+    });
+});
+
 describe('feature flag env-var allowlists', () => {
     test('LIGHTDASH_ENABLE_FEATURE_FLAGS populates enabledFeatureFlags', () => {
         process.env.LIGHTDASH_ENABLE_FEATURE_FLAGS = 'foo, bar,baz';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1552,6 +1552,9 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     readonly [envVar: string, flagId: string]
 > = [
     // Add per migration; truthy env value enables the flag.
+    ['CHANGE_CHART_EXPLORE_ENABLED', 'change-chart-explore'],
+    ['SHOW_HIDE_ROWS_ENABLED', 'show-hide-rows'],
+    ['SHOW_HIDE_COLUMNS_ENABLED', 'show-hide-columns'],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<


### PR DESCRIPTION
Closes:

### Description:

Adds backward compatibility for three legacy feature-flag environment variables (`CHANGE_CHART_EXPLORE_ENABLED`, `SHOW_HIDE_ROWS_ENABLED`, `SHOW_HIDE_COLUMNS_ENABLED`) that were previously parsed directly but lost their effect when those flags were migrated to DB-backed resolution.

Self-hosted deployments that already have these environment variables set will now have them automatically translated into the `enabledFeatureFlags` set, preserving existing behavior without requiring any configuration changes.