### PR TITLE
chore: enable `DashboardTabsInMemory` flag by default via server flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -90,8 +90,9 @@ export enum FeatureFlags {
 
     /**
      * Keep visited dashboard tabs mounted in the DOM (hidden) for instant
-     * re-switching. Disabled by default because large dashboards can spike
-     * browser memory to 3 GB+ when all tab data stays in memory.
+     * re-switching. Enabled by default; disabled per-org for orgs where
+     * large dashboards spiked browser memory to 3 GB+ from accumulated
+     * tab content.
      */
     DashboardTabsInMemory = 'dashboard-tabs-in-memory',
 

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -32,7 +32,7 @@ import { ScrollToTop } from '../../components/common/ScrollToTop';
 import { StickyWithDetection } from '../../components/common/StickyWithDetection';
 import EmptyStateNoTiles from '../../components/DashboardTiles/EmptyStateNoTiles';
 import useToaster from '../../hooks/toaster/useToaster';
-import { useClientFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import { TrackSection } from '../../providers/Tracking/TrackingProvider';
@@ -239,9 +239,10 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     const { health } = useApp();
     const [, startTabTransition] = useTransition();
 
-    const keepTabsInMemory = useClientFeatureFlag(
+    const { data: dashboardTabsInMemoryFlag } = useServerFeatureFlag(
         FeatureFlags.DashboardTabsInMemory,
     );
+    const keepTabsInMemory = dashboardTabsInMemoryFlag?.enabled ?? false;
 
     const gridWrapperRef = useRef<HTMLDivElement>(null);
     const [isInteracting, setIsInteracting] = useState(false);


### PR DESCRIPTION
Closes:

### Description:
The `DashboardTabsInMemory` feature flag is now enabled by default, with the ability to disable it on a per-org basis for organizations where large dashboards have caused excessive browser memory usage.

To support this, the flag evaluation has been switched from `useClientFeatureFlag` to `useServerFeatureFlag`, allowing the flag to be controlled server-side per organization rather than relying solely on client-side defaults.