### PR TITLE
feat: support number metrics with materializable dependencies in pre-aggregates

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -46,6 +46,26 @@ models:
               - average_expression_metric
             time_dimension: order_date
             granularity: day
+          - name: orders_daily_number_metric_refs_demo
+            dimensions:
+              - shipping_method
+              - shipping_cost_tier
+            metrics:
+              - total_non_completed_order_amount
+              - total_order_amount
+              - total_completed_order_amount
+              - completion_percentage
+            time_dimension: order_date
+            granularity: day
+          - name: orders_daily_cross_model_number_metric_refs_demo
+            dimensions:
+              - status
+            metrics:
+              - order_amount_plus_average_customer_age
+              - total_order_amount
+              - customers.average_age
+            time_dimension: order_date
+            granularity: day
           - name: param_dimension_rejected_daily
             dimensions:
               - status
@@ -121,6 +141,14 @@ models:
             description: "Average deduped revenue per order. References a cross-model sum_distinct metric to test PROD-6869."
             format: usd
             round: 2
+          order_amount_plus_average_customer_age:
+            type: number
+            sql: ${total_order_amount} + ${customers.average_age}
+            description: "Example type:number metric that references a joined customers metric."
+            groups: ["pre-aggregations"]
+            drivers:
+              - total_order_amount
+              - customers.average_age
         default_time_dimension:
           field: order_date
           interval: MONTH

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -163,6 +163,11 @@ const sourceExplore = (): Explore => ({
                     table: 'orders',
                     type: MetricType.SUM,
                 }),
+                shipping_total: makeMetric({
+                    name: 'shipping_total',
+                    table: 'orders',
+                    type: MetricType.SUM,
+                }),
                 order_count: makeMetric({
                     name: 'order_count',
                     table: 'orders',
@@ -188,6 +193,18 @@ const sourceExplore = (): Explore => ({
                     table: 'orders',
                     type: MetricType.NUMBER,
                 }),
+                gross_total: makeCustomMetric({
+                    name: 'gross_total',
+                    table: 'orders',
+                    type: MetricType.NUMBER,
+                    sql: '${total_order_amount} + ${shipping_total}',
+                }),
+                total_order_amount_plus_average_customer_age: makeCustomMetric({
+                    name: 'total_order_amount_plus_average_customer_age',
+                    table: 'orders',
+                    type: MetricType.NUMBER,
+                    sql: '${total_order_amount} + ${customers.average_age}',
+                }),
             },
             lineageGraph: {},
         },
@@ -204,6 +221,11 @@ const sourceExplore = (): Explore => ({
                 }),
             },
             metrics: {
+                average_age: makeMetric({
+                    name: 'average_age',
+                    table: 'customers',
+                    type: MetricType.AVERAGE,
+                }),
                 max_customer_age: makeMetric({
                     name: 'max_customer_age',
                     table: 'customers',
@@ -335,6 +357,58 @@ describe('buildPreAggregateExplore', () => {
             }),
         ).toThrow(
             'Pre-aggregate "invalid_rollup" references unsupported metrics: "distinct_customer_count" (count_distinct), "median_order_amount" (median), "custom_sql" (number). Supported metric types: sum, count, min, max, average',
+        );
+    });
+
+    it('requires dependent metrics for supported number metrics', () => {
+        expect(() =>
+            buildPreAggregateExplore(sourceExplore(), {
+                name: 'number_metric_preagg',
+                dimensions: ['status'],
+                metrics: ['gross_total', 'total_order_amount'],
+            }),
+        ).toThrow(
+            'Pre-aggregate "number_metric_preagg" metric "gross_total" requires dependent metrics "shipping_total" to be included in the pre-aggregate definition.',
+        );
+    });
+
+    it('keeps supported number metrics on the pre-aggregate explore and rewrites them to use materialized dependencies', () => {
+        const result = buildPreAggregateExplore(sourceExplore(), {
+            name: 'number_metric_preagg',
+            dimensions: ['status'],
+            metrics: ['gross_total', 'total_order_amount', 'shipping_total'],
+        });
+
+        expect(result.tables.orders.metrics.gross_total.compiledSql).toBe(
+            '(SUM(orders.orders_total_order_amount)) + (SUM(orders.orders_shipping_total))',
+        );
+        expect(
+            result.tables.orders.metrics.total_order_amount.compiledSql,
+        ).toBe('SUM(orders.orders_total_order_amount)');
+        expect(result.tables.orders.metrics.shipping_total.compiledSql).toBe(
+            'SUM(orders.orders_shipping_total)',
+        );
+    });
+
+    it('rewrites supported cross-model number metrics to use materialized dependencies from joined tables', () => {
+        const result = buildPreAggregateExplore(sourceExplore(), {
+            name: 'cross_model_number_metric_preagg',
+            dimensions: ['status'],
+            metrics: [
+                'total_order_amount_plus_average_customer_age',
+                'total_order_amount',
+                'customers.average_age',
+            ],
+        });
+
+        expect(
+            result.tables.orders.metrics
+                .total_order_amount_plus_average_customer_age.compiledSql,
+        ).toBe(
+            '(SUM(orders.orders_total_order_amount)) + (CAST(SUM(orders.customers_average_age__sum) AS DOUBLE) / CAST(NULLIF(SUM(orders.customers_average_age__count), 0) AS DOUBLE))',
+        );
+        expect(result.tables.customers.metrics.average_age.compiledSql).toBe(
+            'CAST(SUM(orders.customers_average_age__sum) AS DOUBLE) / CAST(NULLIF(SUM(orders.customers_average_age__count), 0) AS DOUBLE)',
         );
     });
 

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
@@ -6,6 +6,7 @@ import {
     getPreAggregateMetricColumnName,
     getPreAggregateMetricComponentColumnName,
     getSqlForTruncatedDate,
+    lightdashVariablePattern,
     MetricType,
     PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
     PreAggregateMetricRepresentationKind,
@@ -21,10 +22,13 @@ import {
     type PreAggregateDef,
     type TimeFrames,
 } from '@lightdash/common';
+import { assertDimensionEligibleForDirectMaterialization } from './eligibility';
 import {
-    assertDimensionEligibleForDirectMaterialization,
-    assertMetricEligibleForPreAggregation,
-} from './eligibility';
+    getDimensionsByReference,
+    getMetricReferenceForDef,
+    getSelectedDimension,
+    selectPreAggregateMetrics,
+} from './shared';
 
 const isFinerGranularity = (
     candidateGranularity: TimeFrames,
@@ -37,24 +41,6 @@ const isFinerGranularity = (
     }
     return candidateIndex < targetIndex;
 };
-
-const getDimensionsByReference = (sourceExplore: Explore) =>
-    Object.values(sourceExplore.tables).reduce<
-        Map<string, CompiledDimension[]>
-    >((acc, table) => {
-        Object.values(table.dimensions).forEach((dimension) => {
-            preAggregateUtils
-                .getDimensionReferences({
-                    dimension,
-                    baseTable: sourceExplore.baseTable,
-                })
-                .forEach((reference) => {
-                    const existingDimensions = acc.get(reference) || [];
-                    acc.set(reference, [...existingDimensions, dimension]);
-                });
-        });
-        return acc;
-    }, new Map<string, CompiledDimension[]>());
 
 const getMetricAggregateSql = (
     metricType: MetricType.SUM | MetricType.MIN | MetricType.MAX,
@@ -135,6 +121,63 @@ const getMetricSqlForPreAggregateExplore = ({
                 `Unsupported pre-aggregate metric representation`,
             );
     }
+};
+
+const getNumberMetricSqlForPreAggregateExplore = ({
+    sourceExplore,
+    metric,
+    metricsByReference,
+    cache,
+}: {
+    sourceExplore: Explore;
+    metric: CompiledMetric;
+    metricsByReference: ReturnType<
+        typeof preAggregateUtils.getMetricsByReference
+    >;
+    cache: Map<FieldId, string>;
+}): string => {
+    const metricFieldId = getItemId(metric);
+    const cachedSql = cache.get(metricFieldId);
+    if (cachedSql) {
+        return cachedSql;
+    }
+
+    const compiledSql = metric.sql.replace(
+        lightdashVariablePattern,
+        (_, ref) => {
+            const metricLookup = metricsByReference.get(ref);
+            if (!metricLookup) {
+                throw new Error(
+                    `Pre-aggregate explore rewrite for metric "${getMetricReferenceForDef(
+                        {
+                            metric,
+                            baseTable: sourceExplore.baseTable,
+                        },
+                    )}" cannot resolve metric reference "${ref}"`,
+                );
+            }
+
+            if (metricLookup.metric.type === MetricType.NUMBER) {
+                return `(${getNumberMetricSqlForPreAggregateExplore({
+                    sourceExplore,
+                    metric: metricLookup.metric,
+                    metricsByReference,
+                    cache,
+                })})`;
+            }
+
+            return `(${
+                getMetricSqlForPreAggregateExplore({
+                    metricType: metricLookup.metric.type,
+                    tableName: sourceExplore.baseTable,
+                    fieldId: metricLookup.fieldId,
+                }).compiledSql
+            })`;
+        },
+    );
+
+    cache.set(metricFieldId, compiledSql);
+    return compiledSql;
 };
 
 const getMaterializedDimensionColumnName = ({
@@ -223,54 +266,6 @@ const buildDimensionSql = ({
     );
 };
 
-const getSelectedDimension = ({
-    dimensionsByReference,
-    preAggregateDef,
-    dimensionReference,
-}: {
-    dimensionsByReference: Map<string, CompiledDimension[]>;
-    preAggregateDef: PreAggregateDef;
-    dimensionReference: string;
-}): CompiledDimension => {
-    const candidates = dimensionsByReference.get(dimensionReference) || [];
-
-    if (candidates.length === 0) {
-        throw new Error(
-            `Pre-aggregate "${preAggregateDef.name}" references unknown dimension "${dimensionReference}"`,
-        );
-    }
-
-    const isTimeDimensionReference =
-        !!preAggregateDef.timeDimension &&
-        preAggregateUtils.getDimensionBaseName(candidates[0]) ===
-            preAggregateDef.timeDimension;
-
-    if (
-        isTimeDimensionReference &&
-        preAggregateDef.granularity &&
-        preAggregateDef.timeDimension
-    ) {
-        const timeGranularityDimension = candidates.find(
-            (dimension) =>
-                preAggregateUtils.getDimensionBaseName(dimension) ===
-                    preAggregateDef.timeDimension &&
-                dimension.timeInterval === preAggregateDef.granularity,
-        );
-
-        if (!timeGranularityDimension) {
-            throw new Error(
-                `Pre-aggregate "${preAggregateDef.name}" is missing time granularity field "${preAggregateDef.timeDimension}_${preAggregateDef.granularity.toLowerCase()}"`,
-            );
-        }
-
-        return timeGranularityDimension;
-    }
-
-    return (
-        candidates.find((dimension) => !dimension.timeInterval) ?? candidates[0]
-    );
-};
-
 const getIncludedDimensions = (
     sourceExplore: Explore,
     preAggregateDef: PreAggregateDef,
@@ -355,69 +350,6 @@ const getIncludedDimensions = (
     });
 };
 
-const getIncludedMetrics = (
-    sourceExplore: Explore,
-    preAggregateDef: PreAggregateDef,
-): Array<{ fieldId: FieldId; metric: CompiledMetric }> => {
-    const metricsByReference = preAggregateUtils.getMetricsByReference({
-        tables: sourceExplore.tables,
-        baseTable: sourceExplore.baseTable,
-    });
-    const unsupportedMetrics: Array<{
-        reference: string;
-        metricType: MetricType;
-    }> = [];
-
-    const includedMetrics = preAggregateDef.metrics.reduce<
-        Array<{ fieldId: FieldId; metric: CompiledMetric }>
-    >((acc, metricReference) => {
-        const metricLookup = metricsByReference.get(metricReference);
-        if (!metricLookup) {
-            throw new Error(
-                `Pre-aggregate "${preAggregateDef.name}" references unknown metric "${metricReference}"`,
-            );
-        }
-
-        const { fieldId, metric } = metricLookup;
-
-        assertMetricEligibleForPreAggregation({
-            sourceExplore,
-            preAggregateDef,
-            metricReference,
-            metric,
-        });
-
-        if (!preAggregateUtils.isSupportedMetricType(metric.type)) {
-            unsupportedMetrics.push({
-                reference: metricReference,
-                metricType: metric.type,
-            });
-            return acc;
-        }
-
-        return [...acc, { fieldId, metric }];
-    }, []);
-
-    if (unsupportedMetrics.length > 0) {
-        throw new Error(
-            `Pre-aggregate "${
-                preAggregateDef.name
-            }" references unsupported metrics: ${unsupportedMetrics
-                .map(
-                    ({ reference, metricType }) =>
-                        `"${reference}" (${metricType})`,
-                )
-                .join(
-                    ', ',
-                )}. Supported metric types: ${preAggregateUtils.supportedMetricTypes.join(
-                ', ',
-            )}`,
-        );
-    }
-
-    return includedMetrics;
-};
-
 const getEmptyTable = (
     sourceTable: CompiledTable,
     sqlTable: string,
@@ -436,12 +368,17 @@ export const buildPreAggregateExplore = (
         sourceExplore,
         preAggregateDef,
     );
-    const includedMetrics = getIncludedMetrics(sourceExplore, preAggregateDef);
+    const { materializedMetrics, derivedNumberMetrics, metricsByReference } =
+        selectPreAggregateMetrics({
+            sourceExplore,
+            preAggregateDef,
+        });
 
     const includedTableNames = new Set<string>([
         sourceExplore.baseTable,
         ...includedDimensions.map((dimension) => dimension.table),
-        ...includedMetrics.map(({ metric }) => metric.table),
+        ...materializedMetrics.map(({ metric }) => metric.table),
+        ...derivedNumberMetrics.map(({ metric }) => metric.table),
     ]);
 
     const tables = Array.from(includedTableNames).reduce<
@@ -475,7 +412,7 @@ export const buildPreAggregateExplore = (
         };
     });
 
-    includedMetrics.forEach(({ fieldId, metric }) => {
+    materializedMetrics.forEach(({ fieldId, metric }) => {
         const { sql, compiledSql } = getMetricSqlForPreAggregateExplore({
             metricType: metric.type,
             tableName: sourceExplore.baseTable,
@@ -485,6 +422,24 @@ export const buildPreAggregateExplore = (
         tables[metric.table].metrics[metric.name] = {
             ...metric,
             sql,
+            compiledSql,
+            tablesReferences: [sourceExplore.baseTable],
+        };
+    });
+
+    const numberMetricSqlCache = new Map<FieldId, string>();
+
+    derivedNumberMetrics.forEach(({ metric }) => {
+        const compiledSql = getNumberMetricSqlForPreAggregateExplore({
+            sourceExplore,
+            metric,
+            metricsByReference,
+            cache: numberMetricSqlCache,
+        });
+
+        tables[metric.table].metrics[metric.name] = {
+            ...metric,
+            sql: compiledSql,
             compiledSql,
             tablesReferences: [sourceExplore.baseTable],
         };

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -110,6 +110,10 @@ const baseExplore = (): Explore => ({
                     name: 'total_order_amount',
                     type: MetricType.SUM,
                 }),
+                shipping_total: makeMetric({
+                    name: 'shipping_total',
+                    type: MetricType.SUM,
+                }),
                 order_count: makeMetric({
                     name: 'order_count',
                     type: MetricType.COUNT,
@@ -122,6 +126,14 @@ const baseExplore = (): Explore => ({
                     name: 'custom_metric',
                     type: MetricType.NUMBER,
                 }),
+                gross_total: {
+                    ...makeMetric({
+                        name: 'gross_total',
+                        type: MetricType.NUMBER,
+                    }),
+                    sql: '${total_order_amount} + ${shipping_total}',
+                    compiledSql: '(SUM(x)) + (SUM(y))',
+                },
                 avg_order_amount: makeMetric({
                     name: 'avg_order_amount',
                     type: MetricType.AVERAGE,
@@ -254,6 +266,37 @@ describe('findMatch', () => {
             makeMetricQuery({
                 dimensions: ['orders_status', 'orders_order_date_month'],
                 metrics: ['orders_order_count'],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_daily',
+            miss: null,
+        });
+    });
+
+    it('returns hit for eligible number metrics when the pre-aggregate explicitly includes their dependencies', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_daily',
+                    dimensions: ['status'],
+                    metrics: [
+                        'gross_total',
+                        'total_order_amount',
+                        'shipping_total',
+                    ],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_gross_total'],
             }),
             explore,
         );
@@ -986,7 +1029,7 @@ describe('findMatch', () => {
         });
     });
 
-    it('returns custom_sql_metric for type:number metrics', () => {
+    it('allows type:number metrics when they are explicitly included in the pre-aggregate definition', () => {
         const explore = {
             ...baseExplore(),
             preAggregates: [
@@ -1006,9 +1049,10 @@ describe('findMatch', () => {
             explore,
         );
 
-        expect(result.miss).toStrictEqual({
-            reason: PreAggregateMissReason.CUSTOM_SQL_METRIC,
-            fieldId: 'orders_custom_metric',
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
         });
     });
 

--- a/packages/backend/src/ee/preAggregates/postProcessor.test.ts
+++ b/packages/backend/src/ee/preAggregates/postProcessor.test.ts
@@ -401,7 +401,7 @@ describe('pre-aggregate virtual explore generation', () => {
         expect((explores[0] as Explore).warnings).toContainEqual({
             type: InlineErrorType.FIELD_ERROR,
             message:
-                'Pre-aggregate "broken_rollup" references unsupported metrics: "myTable_user_count" (count_distinct). Supported metric types: sum, count, min, max, average',
+                'Pre-aggregate "broken_rollup" references unsupported metrics: "user_count" (count_distinct). Supported metric types: sum, count, min, max, average',
         });
     });
 

--- a/packages/backend/src/ee/preAggregates/shared.ts
+++ b/packages/backend/src/ee/preAggregates/shared.ts
@@ -1,0 +1,260 @@
+import {
+    MetricType,
+    preAggregateUtils,
+    type CompiledDimension,
+    type CompiledMetric,
+    type Explore,
+    type FieldId,
+    type PreAggregateDef,
+} from '@lightdash/common';
+import { assertMetricEligibleForPreAggregation } from './eligibility';
+
+export const getDimensionsByReference = (sourceExplore: Explore) =>
+    Object.values(sourceExplore.tables).reduce<
+        Map<string, CompiledDimension[]>
+    >((acc, table) => {
+        Object.values(table.dimensions).forEach((dimension) => {
+            preAggregateUtils
+                .getDimensionReferences({
+                    dimension,
+                    baseTable: sourceExplore.baseTable,
+                })
+                .forEach((reference) => {
+                    const existingDimensions = acc.get(reference) || [];
+                    acc.set(reference, [...existingDimensions, dimension]);
+                });
+        });
+        return acc;
+    }, new Map<string, CompiledDimension[]>());
+
+export const getSelectedDimension = ({
+    dimensionsByReference,
+    preAggregateDef,
+    dimensionReference,
+}: {
+    dimensionsByReference: Map<string, CompiledDimension[]>;
+    preAggregateDef: PreAggregateDef;
+    dimensionReference: string;
+}): CompiledDimension => {
+    const candidates = dimensionsByReference.get(dimensionReference) || [];
+
+    if (candidates.length === 0) {
+        throw new Error(
+            `Pre-aggregate "${preAggregateDef.name}" references unknown dimension "${dimensionReference}"`,
+        );
+    }
+
+    const isTimeDimensionReference =
+        !!preAggregateDef.timeDimension &&
+        preAggregateUtils.getDimensionBaseName(candidates[0]) ===
+            preAggregateDef.timeDimension;
+
+    if (
+        isTimeDimensionReference &&
+        preAggregateDef.granularity &&
+        preAggregateDef.timeDimension
+    ) {
+        const timeGranularityDimension = candidates.find(
+            (dimension) =>
+                preAggregateUtils.getDimensionBaseName(dimension) ===
+                    preAggregateDef.timeDimension &&
+                dimension.timeInterval === preAggregateDef.granularity,
+        );
+
+        if (!timeGranularityDimension) {
+            throw new Error(
+                `Pre-aggregate "${preAggregateDef.name}" is missing time granularity field "${preAggregateDef.timeDimension}_${preAggregateDef.granularity.toLowerCase()}"`,
+            );
+        }
+
+        return timeGranularityDimension;
+    }
+
+    return (
+        candidates.find((dimension) => !dimension.timeInterval) ?? candidates[0]
+    );
+};
+
+export const getMetricReferenceForDef = ({
+    metric,
+    baseTable,
+}: {
+    metric: CompiledMetric;
+    baseTable: string;
+}): string =>
+    metric.table === baseTable ? metric.name : `${metric.table}.${metric.name}`;
+
+const formatMissingDependentMetricsError = ({
+    preAggregateName,
+    metric,
+    missingMetrics,
+    baseTable,
+}: {
+    preAggregateName: string;
+    metric: CompiledMetric;
+    missingMetrics: CompiledMetric[];
+    baseTable: string;
+}): string =>
+    `Pre-aggregate "${preAggregateName}" metric "${getMetricReferenceForDef({
+        metric,
+        baseTable,
+    })}" requires dependent metrics ${missingMetrics
+        .map(
+            (missingMetric) =>
+                `"${getMetricReferenceForDef({
+                    metric: missingMetric,
+                    baseTable,
+                })}"`,
+        )
+        .join(', ')} to be included in the pre-aggregate definition.`;
+
+type SelectedPreAggregateMetric = {
+    fieldId: FieldId;
+    metric: CompiledMetric;
+};
+
+export const selectPreAggregateMetrics = ({
+    sourceExplore,
+    preAggregateDef,
+}: {
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
+}): {
+    metricsByReference: ReturnType<
+        typeof preAggregateUtils.getMetricsByReference
+    >;
+    materializedMetrics: SelectedPreAggregateMetric[];
+    derivedNumberMetrics: SelectedPreAggregateMetric[];
+} => {
+    const metricsByReference = preAggregateUtils.getMetricsByReference({
+        tables: sourceExplore.tables,
+        baseTable: sourceExplore.baseTable,
+    });
+    const allMetricsByFieldId = new Map<FieldId, CompiledMetric>(
+        Array.from(metricsByReference.values()).map(({ fieldId, metric }) => [
+            fieldId,
+            metric,
+        ]),
+    );
+    const selectedMetrics = Array.from(
+        preAggregateDef.metrics
+            .reduce<Map<FieldId, SelectedPreAggregateMetric>>(
+                (acc, metricReference) => {
+                    const metricLookup =
+                        metricsByReference.get(metricReference);
+                    if (!metricLookup) {
+                        throw new Error(
+                            `Pre-aggregate "${preAggregateDef.name}" references unknown metric "${metricReference}"`,
+                        );
+                    }
+
+                    assertMetricEligibleForPreAggregation({
+                        sourceExplore,
+                        preAggregateDef,
+                        metricReference,
+                        metric: metricLookup.metric,
+                    });
+
+                    acc.set(metricLookup.fieldId, metricLookup);
+                    return acc;
+                },
+                new Map<FieldId, SelectedPreAggregateMetric>(),
+            )
+            .values(),
+    );
+    const selectedMetricFieldIds = new Set(
+        selectedMetrics.map(({ fieldId }) => fieldId),
+    );
+    const unsupportedMetrics: Array<{
+        reference: string;
+        metricType: MetricType;
+    }> = [];
+    const materializedMetrics: SelectedPreAggregateMetric[] = [];
+    const derivedNumberMetrics: SelectedPreAggregateMetric[] = [];
+
+    selectedMetrics.forEach(({ fieldId, metric }) => {
+        const metricReference = getMetricReferenceForDef({
+            metric,
+            baseTable: sourceExplore.baseTable,
+        });
+
+        if (metric.type === MetricType.NUMBER) {
+            const dependencies =
+                preAggregateUtils.analyzePreAggregateNumberMetricDependencies({
+                    metric,
+                    tables: sourceExplore.tables,
+                });
+
+            if (!dependencies.isValid) {
+                unsupportedMetrics.push({
+                    reference: metricReference,
+                    metricType: metric.type,
+                });
+                return;
+            }
+
+            const missingMetrics =
+                dependencies.transitiveReferencedMetricFieldIds
+                    .filter(
+                        (dependencyFieldId) =>
+                            !selectedMetricFieldIds.has(dependencyFieldId),
+                    )
+                    .map((dependencyFieldId) =>
+                        allMetricsByFieldId.get(dependencyFieldId),
+                    )
+                    .filter(
+                        (
+                            dependencyMetric,
+                        ): dependencyMetric is CompiledMetric =>
+                            dependencyMetric !== undefined,
+                    );
+
+            if (missingMetrics.length > 0) {
+                throw new Error(
+                    formatMissingDependentMetricsError({
+                        preAggregateName: preAggregateDef.name,
+                        metric,
+                        missingMetrics,
+                        baseTable: sourceExplore.baseTable,
+                    }),
+                );
+            }
+
+            derivedNumberMetrics.push({ fieldId, metric });
+            return;
+        }
+
+        if (!preAggregateUtils.isSupportedMetricType(metric.type)) {
+            unsupportedMetrics.push({
+                reference: metricReference,
+                metricType: metric.type,
+            });
+            return;
+        }
+
+        materializedMetrics.push({ fieldId, metric });
+    });
+
+    if (unsupportedMetrics.length > 0) {
+        throw new Error(
+            `Pre-aggregate "${
+                preAggregateDef.name
+            }" references unsupported metrics: ${unsupportedMetrics
+                .map(
+                    ({ reference, metricType }) =>
+                        `"${reference}" (${metricType})`,
+                )
+                .join(
+                    ', ',
+                )}. Supported metric types: ${preAggregateUtils.supportedMetricTypes.join(
+                ', ',
+            )}`,
+        );
+    }
+
+    return {
+        metricsByReference,
+        materializedMetrics,
+        derivedNumberMetrics,
+    };
+};

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -16,6 +16,8 @@ import { buildMaterializationMetricQuery } from './buildMaterializationMetricQue
 
 const makeDimension = ({
     name,
+    table = 'orders',
+    tableLabel,
     type = DimensionType.STRING,
     sql,
     compiledSql,
@@ -23,6 +25,8 @@ const makeDimension = ({
     compilationError,
 }: {
     name: string;
+    table?: string;
+    tableLabel?: string;
     type?: DimensionType;
     sql?: string;
     compiledSql?: string;
@@ -33,20 +37,22 @@ const makeDimension = ({
     type,
     name,
     label: name,
-    table: 'orders',
-    tableLabel: 'Orders',
+    table,
+    tableLabel: tableLabel ?? table,
     sql: sql ?? '${TABLE}.id',
     hidden: false,
     compiledSql: compiledSql ?? sql ?? '"orders".id',
     parameterReferences:
         parameterReferences ??
         getParameterReferencesFromSqlAndFormat(sql ?? '${TABLE}.id'),
-    tablesReferences: ['orders'],
+    tablesReferences: [table],
     ...(compilationError ? { compilationError } : {}),
 });
 
 const makeMetric = ({
     name,
+    table = 'orders',
+    tableLabel,
     type,
     sql,
     compiledSql,
@@ -55,6 +61,8 @@ const makeMetric = ({
     filters,
 }: {
     name: string;
+    table?: string;
+    tableLabel?: string;
     type: MetricType;
     sql?: string;
     compiledSql?: string;
@@ -66,15 +74,15 @@ const makeMetric = ({
     type,
     name,
     label: name,
-    table: 'orders',
-    tableLabel: 'Orders',
+    table,
+    tableLabel: tableLabel ?? table,
     sql: sql ?? 'count(*)',
     hidden: false,
     compiledSql: compiledSql ?? sql ?? 'count(*)',
     parameterReferences:
         parameterReferences ??
         getParameterReferencesFromSqlAndFormat(sql ?? 'count(*)'),
-    tablesReferences: ['orders'],
+    tablesReferences: [table],
     ...(filters ? { filters } : {}),
     ...(compilationError ? { compilationError } : {}),
 });
@@ -85,7 +93,13 @@ const getSourceExplore = (): Explore =>
         label: 'Orders',
         tags: [],
         baseTable: 'orders',
-        joinedTables: [],
+        joinedTables: [
+            {
+                table: 'customers',
+                sqlOn: '${orders.customer_id} = ${customers.customer_id}',
+                compiledSqlOn: '"orders".customer_id = "customers".customer_id',
+            },
+        ],
         targetDatabase: SupportedDbtAdapter.POSTGRES,
         tables: {
             orders: {
@@ -147,6 +161,56 @@ const getSourceExplore = (): Explore =>
                         compiledSql: 'count(*)',
                         tablesReferences: ['orders'],
                     },
+                    total_order_amount: {
+                        fieldType: FieldType.METRIC,
+                        type: MetricType.SUM,
+                        name: 'total_order_amount',
+                        label: 'Total order amount',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        sql: '${TABLE}.amount',
+                        hidden: false,
+                        compiledSql: 'SUM("orders".amount)',
+                        tablesReferences: ['orders'],
+                    },
+                    shipping_total: {
+                        fieldType: FieldType.METRIC,
+                        type: MetricType.SUM,
+                        name: 'shipping_total',
+                        label: 'Shipping total',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        sql: '${TABLE}.shipping_cost',
+                        hidden: false,
+                        compiledSql: 'SUM("orders".shipping_cost)',
+                        tablesReferences: ['orders'],
+                    },
+                    gross_total: {
+                        fieldType: FieldType.METRIC,
+                        type: MetricType.NUMBER,
+                        name: 'gross_total',
+                        label: 'Gross total',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        sql: '${total_order_amount} + ${shipping_total}',
+                        hidden: false,
+                        compiledSql:
+                            '(SUM("orders".amount)) + (SUM("orders".shipping_cost))',
+                        tablesReferences: ['orders'],
+                    },
+                    total_order_amount_plus_average_customer_age: {
+                        fieldType: FieldType.METRIC,
+                        type: MetricType.NUMBER,
+                        name: 'total_order_amount_plus_average_customer_age',
+                        label: 'Total order amount plus average customer age',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        sql: '${total_order_amount} + ${customers.average_age}',
+                        hidden: false,
+                        compiledSql:
+                            '(SUM("orders".amount)) + (AVG("customers".age))',
+                        tablesReferences: ['orders', 'customers'],
+                    },
                     avg_order_amount: {
                         fieldType: FieldType.METRIC,
                         type: MetricType.AVERAGE,
@@ -181,6 +245,29 @@ const getSourceExplore = (): Explore =>
                         compiledSql: 'SUM("orders".amount)',
                         tablesReferences: ['orders'],
                     },
+                },
+                lineageGraph: {},
+            },
+            customers: {
+                name: 'customers',
+                label: 'Customers',
+                database: 'analytics',
+                schema: 'public',
+                sqlTable: 'public.customers',
+                dimensions: {
+                    first_name: makeDimension({
+                        name: 'first_name',
+                        table: 'customers',
+                    }),
+                },
+                metrics: {
+                    average_age: makeMetric({
+                        name: 'average_age',
+                        table: 'customers',
+                        type: MetricType.AVERAGE,
+                        sql: '${TABLE}.age',
+                        compiledSql: 'AVG("customers".age)',
+                    }),
                 },
                 lineageGraph: {},
             },
@@ -542,6 +629,97 @@ describe('buildMaterializationMetricQuery', () => {
             orders_order_revenue: [
                 {
                     componentFieldId: 'orders_order_revenue',
+                    aggregation: MetricType.SUM,
+                },
+            ],
+        });
+    });
+
+    it('requires dependent metrics for supported number metrics', () => {
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore: getSourceExplore(),
+                preAggregateDef: {
+                    name: 'orders_number_metric_preagg',
+                    dimensions: ['status'],
+                    metrics: ['gross_total', 'total_order_amount'],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_number_metric_preagg" metric "gross_total" requires dependent metrics "shipping_total" to be included in the pre-aggregate definition.',
+        );
+    });
+
+    it('materializes only the leaf dependencies for supported number metrics', () => {
+        const result = buildMaterializationMetricQuery({
+            sourceExplore: getSourceExplore(),
+            preAggregateDef: {
+                name: 'orders_number_metric_preagg',
+                dimensions: ['status'],
+                metrics: [
+                    'gross_total',
+                    'total_order_amount',
+                    'shipping_total',
+                ],
+            },
+            materializationConfig: { maxRows: null },
+        });
+
+        expect(result.metricQuery.metrics).toEqual([
+            'orders_total_order_amount',
+            'orders_shipping_total',
+        ]);
+        expect(result.metricComponents).toEqual({
+            orders_total_order_amount: [
+                {
+                    componentFieldId: 'orders_total_order_amount',
+                    aggregation: MetricType.SUM,
+                },
+            ],
+            orders_shipping_total: [
+                {
+                    componentFieldId: 'orders_shipping_total',
+                    aggregation: MetricType.SUM,
+                },
+            ],
+        });
+    });
+
+    it('materializes cross-model dependencies for supported number metrics', () => {
+        const result = buildMaterializationMetricQuery({
+            sourceExplore: getSourceExplore(),
+            preAggregateDef: {
+                name: 'orders_cross_model_number_metric_preagg',
+                dimensions: ['status'],
+                metrics: [
+                    'total_order_amount_plus_average_customer_age',
+                    'total_order_amount',
+                    'customers.average_age',
+                ],
+            },
+            materializationConfig: { maxRows: null },
+        });
+
+        expect(result.metricQuery.metrics).toEqual([
+            'orders_total_order_amount',
+            'customers_average_age__sum',
+            'customers_average_age__count',
+        ]);
+        expect(result.metricComponents).toEqual({
+            orders_total_order_amount: [
+                {
+                    componentFieldId: 'orders_total_order_amount',
+                    aggregation: MetricType.SUM,
+                },
+            ],
+            customers_average_age: [
+                {
+                    componentFieldId: 'customers_average_age__sum',
+                    aggregation: MetricType.SUM,
+                },
+                {
+                    componentFieldId: 'customers_average_age__count',
                     aggregation: MetricType.SUM,
                 },
             ],

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
@@ -17,29 +17,12 @@ import {
     type MetricQuery,
     type PreAggregateDef,
 } from '@lightdash/common';
+import { assertDimensionEligibleForDirectMaterialization } from '../../preAggregates/eligibility';
 import {
-    assertDimensionEligibleForDirectMaterialization,
-    assertMetricEligibleForPreAggregation,
-} from '../../preAggregates/eligibility';
-
-const getDimensionsByReference = (sourceExplore: Explore) =>
-    Object.values(sourceExplore.tables).reduce<
-        Map<string, CompiledDimension[]>
-    >((acc, table) => {
-        Object.values(table.dimensions).forEach((dimension) => {
-            preAggregateUtils
-                .getDimensionReferences({
-                    dimension,
-                    baseTable: sourceExplore.baseTable,
-                })
-                .forEach((reference) => {
-                    const existingDimensions = acc.get(reference) || [];
-                    acc.set(reference, [...existingDimensions, dimension]);
-                });
-        });
-
-        return acc;
-    }, new Map<string, CompiledDimension[]>());
+    getDimensionsByReference,
+    getSelectedDimension,
+    selectPreAggregateMetrics,
+} from '../../preAggregates/shared';
 
 const getAverageMetricComponents = (
     metric: CompiledMetric,
@@ -85,56 +68,6 @@ const getDimensionFieldId = ({
 }: {
     dimension: CompiledDimension;
 }): FieldId => getItemId(dimension);
-
-const getSelectedDimension = ({
-    dimensionsByReference,
-    preAggregateDef,
-    dimensionReference,
-}: {
-    dimensionsByReference: Map<string, CompiledDimension[]>;
-    preAggregateDef: PreAggregateDef;
-    dimensionReference: string;
-}): CompiledDimension => {
-    const candidates = dimensionsByReference.get(dimensionReference) || [];
-
-    if (candidates.length === 0) {
-        throw new Error(
-            `Pre-aggregate "${preAggregateDef.name}" references unknown dimension "${dimensionReference}"`,
-        );
-    }
-
-    const isTimeDimensionReference =
-        !!preAggregateDef.timeDimension &&
-        preAggregateUtils.getDimensionBaseName(candidates[0]) ===
-            preAggregateDef.timeDimension;
-
-    if (
-        isTimeDimensionReference &&
-        preAggregateDef.granularity &&
-        preAggregateDef.timeDimension
-    ) {
-        const timeGranularityDimension = candidates.find(
-            (dimension) =>
-                preAggregateUtils.getDimensionBaseName(dimension) ===
-                    preAggregateDef.timeDimension &&
-                dimension.timeInterval === preAggregateDef.granularity,
-        );
-
-        if (!timeGranularityDimension) {
-            throw new Error(
-                `Pre-aggregate "${preAggregateDef.name}" is missing time granularity field "${preAggregateDef.timeDimension}_${preAggregateDef.granularity.toLowerCase()}"`,
-            );
-        }
-
-        return timeGranularityDimension;
-    }
-
-    const exactBaseDimension = candidates.find(
-        (dimension) => !dimension.timeInterval,
-    );
-
-    return exactBaseDimension ?? candidates[0];
-};
 
 const hasTimeDimensionReference = ({
     sourceExplore,
@@ -207,12 +140,12 @@ export const buildMaterializationMetricQuery = ({
     preAggregateDef: PreAggregateDef;
     materializationConfig: MaterializationConfig;
 }): MaterializationMetricQueryPayload => {
-    const metricsByReference = preAggregateUtils.getMetricsByReference({
-        tables: sourceExplore.tables,
-        baseTable: sourceExplore.baseTable,
-    });
     const dimensionsByReference = getDimensionsByReference(sourceExplore);
     const dimensionReferences = [...preAggregateDef.dimensions];
+    const { materializedMetrics } = selectPreAggregateMetrics({
+        sourceExplore,
+        preAggregateDef,
+    });
 
     if (
         preAggregateDef.timeDimension &&
@@ -269,39 +202,20 @@ export const buildMaterializationMetricQuery = ({
               })
             : null;
 
-    const metricsByFieldId = preAggregateDef.metrics.reduce<
-        Map<FieldId, CompiledMetric>
-    >((acc, metricReference) => {
-        const metricLookup = metricsByReference.get(metricReference);
-
-        if (!metricLookup) {
-            throw new Error(
-                `Pre-aggregate "${preAggregateDef.name}" references unknown metric "${metricReference}"`,
-            );
-        }
-
-        assertMetricEligibleForPreAggregation({
-            sourceExplore,
-            preAggregateDef,
-            metricReference,
-            metric: metricLookup.metric,
-        });
-
-        acc.set(metricLookup.fieldId, metricLookup.metric);
-
-        return acc;
-    }, new Map<FieldId, CompiledMetric>());
-
     const selectedMetricFieldIds = new Set<FieldId>();
     const additionalMetrics: AdditionalMetric[] = [];
-    const metricComponents = Array.from(metricsByFieldId.entries()).reduce<
+    const metricComponents = materializedMetrics.reduce<
         Record<string, MaterializationMetricComponent[]>
-    >((acc, [metricFieldId, metric]) => {
+    >((acc, { fieldId: metricFieldId, metric }) => {
         const representation = preAggregateUtils.getMetricRepresentation(
             metric.type,
         );
 
         switch (representation.kind) {
+            case PreAggregateMetricRepresentationKind.UNSUPPORTED:
+                throw new Error(
+                    `Unsupported metric type "${metric.type}" for pre-aggregate materialization`,
+                );
             case PreAggregateMetricRepresentationKind.DECOMPOSED: {
                 const [sumMetric, countMetric] =
                     getAverageMetricComponents(metric);
@@ -364,10 +278,6 @@ export const buildMaterializationMetricQuery = ({
                 ];
 
                 return acc;
-            case PreAggregateMetricRepresentationKind.UNSUPPORTED:
-                throw new Error(
-                    `Unsupported metric type "${metric.type}" for pre-aggregate materialization`,
-                );
             default:
                 return assertUnreachable(
                     representation,

--- a/packages/common/src/ee/preAggregates/index.ts
+++ b/packages/common/src/ee/preAggregates/index.ts
@@ -9,3 +9,8 @@ export {
     PreAggregateDerivedMetricIneligibilityReason,
     type PreAggregateDerivedMetricEligibility,
 } from './metricEligibility';
+export {
+    analyzePreAggregateNumberMetricDependencies,
+    PreAggregateNumberMetricDependencyIneligibilityReason,
+    type PreAggregateNumberMetricDependencies,
+} from './numberMetricDependencies';

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -848,10 +848,8 @@ const getMissForDef = ({
         }
 
         if (metric.type === MetricType.NUMBER) {
-            return {
-                reason: PreAggregateMissReason.CUSTOM_SQL_METRIC,
-                fieldId: metricFieldId,
-            };
+            // eslint-disable-next-line no-continue
+            continue;
         }
         if (!isCompatible(metric.type)) {
             return {

--- a/packages/common/src/ee/preAggregates/metricEligibility.ts
+++ b/packages/common/src/ee/preAggregates/metricEligibility.ts
@@ -1,18 +1,5 @@
-import {
-    getAllReferences,
-    getParsedReference,
-} from '../../compiler/exploreCompiler';
-import {
-    getReferencedDimension,
-    getReferencedDimensionCaseInsensitive,
-    getReferencedMetric,
-} from '../../compiler/referenceLookup';
-import type { CompiledTable } from '../../types/explore';
-import type {
-    CompiledDimension,
-    CompiledMetric,
-    FieldId,
-} from '../../types/field';
+import { getAllReferences } from '../../compiler/exploreCompiler';
+import type { CompiledMetric, FieldId } from '../../types/field';
 import { getItemId } from '../../utils/item';
 import { hasLightdashUserContextVariableReference } from '../../utils/lightdashSqlVariables';
 import {
@@ -20,6 +7,12 @@ import {
     type PreAggregateDerivedDimensionEligibility,
     type PreAggregateDerivedDimensionIneligibilityReason,
 } from './dimensionEligibility';
+import {
+    getReferencedDimensionForPreAggregation,
+    getReferencedFilterDimensionForPreAggregation,
+    getReferencedMetricForPreAggregation,
+    type PreAggregateReferenceLookup,
+} from './referenceLookup';
 
 export enum PreAggregateDerivedMetricIneligibilityReason {
     CIRCULAR_DEPENDENCY = 'circular_dependency',
@@ -31,11 +24,6 @@ export enum PreAggregateDerivedMetricIneligibilityReason {
     PARAMETER_REFERENCES = 'parameter_references',
     USER_ATTRIBUTES = 'user_attributes',
 }
-
-type PreAggregateMetricLookup = Record<
-    string,
-    Pick<CompiledTable, 'name' | 'originalName' | 'dimensions' | 'metrics'>
->;
 
 type PreAggregateDerivedMetricEligibilityBase = {
     referencedDimensionFieldIds: FieldId[];
@@ -67,53 +55,6 @@ const hasParameterReferences = (metric: CompiledMetric): boolean =>
 
 const hasExplicitUserAttributeReference = (sql: string): boolean =>
     hasLightdashUserContextVariableReference(sql);
-
-const getReferencedDimensionForEligibility = ({
-    metric,
-    ref,
-    tables,
-}: {
-    metric: CompiledMetric;
-    ref: string;
-    tables: PreAggregateMetricLookup;
-}): CompiledDimension | undefined => {
-    if (ref === 'TABLE') {
-        return undefined;
-    }
-
-    const { refTable, refName } = getParsedReference(ref, metric.table);
-    return getReferencedDimension(refTable, refName, tables);
-};
-
-const getReferencedMetricForEligibility = ({
-    metric,
-    ref,
-    tables,
-}: {
-    metric: CompiledMetric;
-    ref: string;
-    tables: PreAggregateMetricLookup;
-}): CompiledMetric | undefined => {
-    if (ref === 'TABLE') {
-        return undefined;
-    }
-
-    const { refTable, refName } = getParsedReference(ref, metric.table);
-    return getReferencedMetric(refTable, refName, tables);
-};
-
-const getReferencedFilterDimension = ({
-    metric,
-    fieldRef,
-    tables,
-}: {
-    metric: CompiledMetric;
-    fieldRef: string;
-    tables: PreAggregateMetricLookup;
-}): CompiledDimension | undefined => {
-    const { refTable, refName } = getParsedReference(fieldRef, metric.table);
-    return getReferencedDimensionCaseInsensitive(refTable, refName, tables);
-};
 
 const getIneligibleMetricResult = ({
     metricFieldId,
@@ -159,7 +100,7 @@ const analyzeMetricEligibility = ({
     state,
 }: {
     metric: CompiledMetric;
-    tables: PreAggregateMetricLookup;
+    tables: PreAggregateReferenceLookup;
     state: EligibilityTraversalState;
 }): PreAggregateDerivedMetricEligibility => {
     const currentFieldId = getItemId(metric);
@@ -222,11 +163,13 @@ const analyzeMetricEligibility = ({
                 continue;
             }
 
-            const referencedDimension = getReferencedDimensionForEligibility({
-                metric,
-                ref,
-                tables,
-            });
+            const referencedDimension = getReferencedDimensionForPreAggregation(
+                {
+                    metric,
+                    ref,
+                    tables,
+                },
+            );
 
             if (referencedDimension) {
                 const dimensionEligibility =
@@ -265,7 +208,7 @@ const analyzeMetricEligibility = ({
                 continue;
             }
 
-            const referencedMetric = getReferencedMetricForEligibility({
+            const referencedMetric = getReferencedMetricForPreAggregation({
                 metric,
                 ref,
                 tables,
@@ -328,11 +271,12 @@ const analyzeMetricEligibility = ({
                     // @ts-expect-error This fallback is to support old metric filters in yml. We can delete this after a few months since we can assume all projects have been redeployed
                     (filter.target.fieldRef || filter.target.fieldId) as string;
 
-                const referencedDimension = getReferencedFilterDimension({
-                    metric,
-                    fieldRef,
-                    tables,
-                });
+                const referencedDimension =
+                    getReferencedFilterDimensionForPreAggregation({
+                        metric,
+                        fieldRef,
+                        tables,
+                    });
 
                 if (!referencedDimension) {
                     result = getIneligibleMetricResult({
@@ -393,7 +337,7 @@ export const analyzePreAggregateDerivedMetricEligibility = ({
     tables,
 }: {
     metric: CompiledMetric;
-    tables: PreAggregateMetricLookup;
+    tables: PreAggregateReferenceLookup;
 }): PreAggregateDerivedMetricEligibility =>
     analyzeMetricEligibility({
         metric,

--- a/packages/common/src/ee/preAggregates/numberMetricDependencies.test.ts
+++ b/packages/common/src/ee/preAggregates/numberMetricDependencies.test.ts
@@ -1,0 +1,143 @@
+import type { CompiledTable } from '../../types/explore';
+import { FieldType, MetricType, type CompiledMetric } from '../../types/field';
+import { getItemId } from '../../utils/item';
+import {
+    analyzePreAggregateNumberMetricDependencies,
+    PreAggregateNumberMetricDependencyIneligibilityReason,
+} from './numberMetricDependencies';
+
+const makeMetric = (
+    overrides: Partial<CompiledMetric> & Pick<CompiledMetric, 'name' | 'type'>,
+): CompiledMetric => ({
+    ...overrides,
+    fieldType: FieldType.METRIC,
+    type: overrides.type,
+    name: overrides.name,
+    label: overrides.label ?? overrides.name,
+    table: overrides.table ?? 'orders',
+    tableLabel: overrides.tableLabel ?? 'Orders',
+    sql: overrides.sql ?? 'count(*)',
+    compiledSql: overrides.compiledSql ?? overrides.sql ?? 'count(*)',
+    tablesReferences: overrides.tablesReferences ?? ['orders'],
+    hidden: overrides.hidden ?? false,
+});
+
+const makeTables = (
+    metrics: CompiledMetric[],
+): Record<
+    string,
+    Pick<CompiledTable, 'name' | 'originalName' | 'dimensions' | 'metrics'>
+> =>
+    metrics.reduce<
+        Record<
+            string,
+            Pick<
+                CompiledTable,
+                'name' | 'originalName' | 'dimensions' | 'metrics'
+            >
+        >
+    >((acc, metric) => {
+        acc[metric.table] = acc[metric.table] ?? {
+            name: metric.table,
+            dimensions: {},
+            metrics: {},
+        };
+
+        acc[metric.table].metrics[metric.name] = metric;
+        return acc;
+    }, {});
+
+describe('analyzePreAggregateNumberMetricDependencies', () => {
+    it('collects direct, transitive, and leaf metric dependencies', () => {
+        const revenue = makeMetric({
+            name: 'revenue',
+            type: MetricType.SUM,
+            sql: '${TABLE}.amount',
+        });
+        const cogs = makeMetric({
+            name: 'cogs',
+            type: MetricType.SUM,
+            sql: '${TABLE}.cost',
+        });
+        const grossProfit = makeMetric({
+            name: 'gross_profit',
+            type: MetricType.NUMBER,
+            sql: '${revenue} - ${cogs}',
+        });
+        const margin = makeMetric({
+            name: 'margin',
+            type: MetricType.NUMBER,
+            sql: '${gross_profit} / NULLIF(${revenue}, 0)',
+        });
+
+        expect(
+            analyzePreAggregateNumberMetricDependencies({
+                metric: margin,
+                tables: makeTables([revenue, cogs, grossProfit, margin]),
+            }),
+        ).toEqual({
+            isValid: true,
+            directReferencedMetricFieldIds: [
+                getItemId(grossProfit),
+                getItemId(revenue),
+            ],
+            transitiveReferencedMetricFieldIds: [
+                getItemId(grossProfit),
+                getItemId(revenue),
+                getItemId(cogs),
+            ],
+            leafMetricFieldIds: [getItemId(revenue), getItemId(cogs)],
+        });
+    });
+
+    it('rejects number metrics that aggregate over metric references', () => {
+        const maxValue = makeMetric({
+            name: 'max_value',
+            type: MetricType.MAX,
+            sql: '${TABLE}.value',
+        });
+        const sumOfMaxValue = makeMetric({
+            name: 'sum_of_max_value',
+            type: MetricType.NUMBER,
+            sql: 'sum(${max_value})',
+        });
+
+        expect(
+            analyzePreAggregateNumberMetricDependencies({
+                metric: sumOfMaxValue,
+                tables: makeTables([maxValue, sumOfMaxValue]),
+            }),
+        ).toEqual(
+            expect.objectContaining({
+                isValid: false,
+                reason: PreAggregateNumberMetricDependencyIneligibilityReason.NESTED_AGGREGATE_METRIC_REFERENCE,
+            }),
+        );
+    });
+
+    it('rejects number metrics whose leaf dependencies are not materializable', () => {
+        const distinctCustomerCount = makeMetric({
+            name: 'distinct_customer_count',
+            type: MetricType.COUNT_DISTINCT,
+            sql: '${TABLE}.customer_id',
+        });
+        const customerDelta = makeMetric({
+            name: 'customer_delta',
+            type: MetricType.NUMBER,
+            sql: '${distinct_customer_count} - 1',
+        });
+
+        expect(
+            analyzePreAggregateNumberMetricDependencies({
+                metric: customerDelta,
+                tables: makeTables([distinctCustomerCount, customerDelta]),
+            }),
+        ).toEqual(
+            expect.objectContaining({
+                isValid: false,
+                reason: PreAggregateNumberMetricDependencyIneligibilityReason.UNSUPPORTED_LEAF_METRIC_TYPE,
+                ineligibleMetricFieldId: getItemId(distinctCustomerCount),
+            }),
+        );
+    });
+});

--- a/packages/common/src/ee/preAggregates/numberMetricDependencies.ts
+++ b/packages/common/src/ee/preAggregates/numberMetricDependencies.ts
@@ -1,0 +1,240 @@
+import {
+    getAllReferences,
+    sqlAggregationWrapsReferences,
+} from '../../compiler/exploreCompiler';
+import {
+    MetricType,
+    type CompiledMetric,
+    type FieldId,
+} from '../../types/field';
+import { getItemId } from '../../utils/item';
+import { isSupportedMetricType } from './metricRepresentation';
+import {
+    getReferencedMetricForPreAggregation,
+    type PreAggregateReferenceLookup,
+} from './referenceLookup';
+
+export enum PreAggregateNumberMetricDependencyIneligibilityReason {
+    CIRCULAR_DEPENDENCY = 'circular_dependency',
+    NESTED_AGGREGATE_METRIC_REFERENCE = 'nested_aggregate_metric_reference',
+    NO_METRIC_REFERENCES = 'no_metric_references',
+    UNSUPPORTED_LEAF_METRIC_TYPE = 'unsupported_leaf_metric_type',
+}
+
+type PreAggregateNumberMetricDependencyBase = {
+    directReferencedMetricFieldIds: FieldId[];
+    transitiveReferencedMetricFieldIds: FieldId[];
+    leafMetricFieldIds: FieldId[];
+};
+
+export type PreAggregateNumberMetricDependencies =
+    | ({
+          isValid: true;
+      } & PreAggregateNumberMetricDependencyBase)
+    | ({
+          isValid: false;
+          reason: PreAggregateNumberMetricDependencyIneligibilityReason;
+          ineligibleMetricFieldId: FieldId;
+      } & PreAggregateNumberMetricDependencyBase);
+
+type TraversalState = {
+    activeMetricFieldIds: Set<FieldId>;
+    cache: Map<FieldId, PreAggregateNumberMetricDependencies>;
+};
+
+const mergeFieldIds = (current: FieldId[], next: FieldId[]): FieldId[] =>
+    Array.from(new Set([...current, ...next]));
+
+const getIneligibleResult = ({
+    reason,
+    ineligibleMetricFieldId,
+    directReferencedMetricFieldIds,
+    transitiveReferencedMetricFieldIds,
+    leafMetricFieldIds,
+}: {
+    reason: PreAggregateNumberMetricDependencyIneligibilityReason;
+    ineligibleMetricFieldId: FieldId;
+} & PreAggregateNumberMetricDependencyBase): PreAggregateNumberMetricDependencies => ({
+    isValid: false,
+    reason,
+    ineligibleMetricFieldId,
+    directReferencedMetricFieldIds,
+    transitiveReferencedMetricFieldIds,
+    leafMetricFieldIds,
+});
+
+const analyzeNumberMetricDependencies = ({
+    metric,
+    tables,
+    state,
+}: {
+    metric: CompiledMetric;
+    tables: PreAggregateReferenceLookup;
+    state: TraversalState;
+}): PreAggregateNumberMetricDependencies => {
+    const currentFieldId = getItemId(metric);
+    const cachedResult = state.cache.get(currentFieldId);
+    if (cachedResult) {
+        return cachedResult;
+    }
+
+    if (state.activeMetricFieldIds.has(currentFieldId)) {
+        return getIneligibleResult({
+            reason: PreAggregateNumberMetricDependencyIneligibilityReason.CIRCULAR_DEPENDENCY,
+            ineligibleMetricFieldId: currentFieldId,
+            directReferencedMetricFieldIds: [],
+            transitiveReferencedMetricFieldIds: [],
+            leafMetricFieldIds: [],
+        });
+    }
+
+    state.activeMetricFieldIds.add(currentFieldId);
+
+    let result: PreAggregateNumberMetricDependencies = {
+        isValid: true,
+        directReferencedMetricFieldIds: [],
+        transitiveReferencedMetricFieldIds: [],
+        leafMetricFieldIds: [],
+    };
+
+    try {
+        const directMetricReferences = getAllReferences(metric.sql)
+            .map((ref) => ({
+                ref,
+                referencedMetric: getReferencedMetricForPreAggregation({
+                    metric,
+                    ref,
+                    tables,
+                }),
+            }))
+            .filter(
+                (
+                    candidate,
+                ): candidate is {
+                    ref: string;
+                    referencedMetric: CompiledMetric;
+                } => candidate.referencedMetric !== undefined,
+            );
+
+        if (directMetricReferences.length === 0) {
+            result = getIneligibleResult({
+                reason: PreAggregateNumberMetricDependencyIneligibilityReason.NO_METRIC_REFERENCES,
+                ineligibleMetricFieldId: currentFieldId,
+                directReferencedMetricFieldIds: [],
+                transitiveReferencedMetricFieldIds: [],
+                leafMetricFieldIds: [],
+            });
+            return result;
+        }
+
+        if (
+            sqlAggregationWrapsReferences(
+                metric.sql,
+                directMetricReferences.map(({ ref }) => ref),
+            )
+        ) {
+            result = getIneligibleResult({
+                reason: PreAggregateNumberMetricDependencyIneligibilityReason.NESTED_AGGREGATE_METRIC_REFERENCE,
+                ineligibleMetricFieldId: currentFieldId,
+                directReferencedMetricFieldIds: directMetricReferences.map(
+                    ({ referencedMetric }) => getItemId(referencedMetric),
+                ),
+                transitiveReferencedMetricFieldIds: directMetricReferences.map(
+                    ({ referencedMetric }) => getItemId(referencedMetric),
+                ),
+                leafMetricFieldIds: [],
+            });
+            return result;
+        }
+
+        let directReferencedMetricFieldIds: FieldId[] = [];
+        let transitiveReferencedMetricFieldIds: FieldId[] = [];
+        let leafMetricFieldIds: FieldId[] = [];
+
+        for (const { referencedMetric } of directMetricReferences) {
+            const referencedMetricFieldId = getItemId(referencedMetric);
+            directReferencedMetricFieldIds = mergeFieldIds(
+                directReferencedMetricFieldIds,
+                [referencedMetricFieldId],
+            );
+            transitiveReferencedMetricFieldIds = mergeFieldIds(
+                transitiveReferencedMetricFieldIds,
+                [referencedMetricFieldId],
+            );
+
+            if (referencedMetric.type === MetricType.NUMBER) {
+                const nestedResult = analyzeNumberMetricDependencies({
+                    metric: referencedMetric,
+                    tables,
+                    state,
+                });
+
+                transitiveReferencedMetricFieldIds = mergeFieldIds(
+                    transitiveReferencedMetricFieldIds,
+                    nestedResult.transitiveReferencedMetricFieldIds,
+                );
+                leafMetricFieldIds = mergeFieldIds(
+                    leafMetricFieldIds,
+                    nestedResult.leafMetricFieldIds,
+                );
+
+                if (!nestedResult.isValid) {
+                    result = getIneligibleResult({
+                        reason: nestedResult.reason,
+                        ineligibleMetricFieldId:
+                            nestedResult.ineligibleMetricFieldId,
+                        directReferencedMetricFieldIds,
+                        transitiveReferencedMetricFieldIds,
+                        leafMetricFieldIds,
+                    });
+                    return result;
+                }
+
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            if (!isSupportedMetricType(referencedMetric.type)) {
+                result = getIneligibleResult({
+                    reason: PreAggregateNumberMetricDependencyIneligibilityReason.UNSUPPORTED_LEAF_METRIC_TYPE,
+                    ineligibleMetricFieldId: referencedMetricFieldId,
+                    directReferencedMetricFieldIds,
+                    transitiveReferencedMetricFieldIds,
+                    leafMetricFieldIds,
+                });
+                return result;
+            }
+
+            leafMetricFieldIds = mergeFieldIds(leafMetricFieldIds, [
+                referencedMetricFieldId,
+            ]);
+        }
+
+        result = {
+            isValid: true,
+            directReferencedMetricFieldIds,
+            transitiveReferencedMetricFieldIds,
+            leafMetricFieldIds,
+        };
+        return result;
+    } finally {
+        state.activeMetricFieldIds.delete(currentFieldId);
+        state.cache.set(currentFieldId, result);
+    }
+};
+
+export const analyzePreAggregateNumberMetricDependencies = ({
+    metric,
+    tables,
+}: {
+    metric: CompiledMetric;
+    tables: PreAggregateReferenceLookup;
+}): PreAggregateNumberMetricDependencies =>
+    analyzeNumberMetricDependencies({
+        metric,
+        tables,
+        state: {
+            activeMetricFieldIds: new Set<FieldId>(),
+            cache: new Map<FieldId, PreAggregateNumberMetricDependencies>(),
+        },
+    });

--- a/packages/common/src/ee/preAggregates/referenceLookup.ts
+++ b/packages/common/src/ee/preAggregates/referenceLookup.ts
@@ -1,0 +1,82 @@
+import { getParsedReference } from '../../compiler/exploreCompiler';
+import {
+    getReferencedDimension,
+    getReferencedDimensionCaseInsensitive,
+    getReferencedMetric,
+} from '../../compiler/referenceLookup';
+import type { CompiledTable } from '../../types/explore';
+import type { CompiledDimension, CompiledMetric } from '../../types/field';
+
+export type PreAggregateReferenceLookup = Record<
+    string,
+    Pick<CompiledTable, 'name' | 'originalName' | 'dimensions' | 'metrics'>
+>;
+
+const getParsedMetricReference = ({
+    metric,
+    ref,
+}: {
+    metric: CompiledMetric;
+    ref: string;
+}) => {
+    if (ref === 'TABLE') {
+        return undefined;
+    }
+
+    return getParsedReference(ref, metric.table);
+};
+
+export const getReferencedDimensionForPreAggregation = ({
+    metric,
+    ref,
+    tables,
+}: {
+    metric: CompiledMetric;
+    ref: string;
+    tables: PreAggregateReferenceLookup;
+}): CompiledDimension | undefined => {
+    const parsedReference = getParsedMetricReference({ metric, ref });
+    if (!parsedReference) {
+        return undefined;
+    }
+
+    return getReferencedDimension(
+        parsedReference.refTable,
+        parsedReference.refName,
+        tables,
+    );
+};
+
+export const getReferencedMetricForPreAggregation = ({
+    metric,
+    ref,
+    tables,
+}: {
+    metric: CompiledMetric;
+    ref: string;
+    tables: PreAggregateReferenceLookup;
+}): CompiledMetric | undefined => {
+    const parsedReference = getParsedMetricReference({ metric, ref });
+    if (!parsedReference) {
+        return undefined;
+    }
+
+    return getReferencedMetric(
+        parsedReference.refTable,
+        parsedReference.refName,
+        tables,
+    );
+};
+
+export const getReferencedFilterDimensionForPreAggregation = ({
+    metric,
+    fieldRef,
+    tables,
+}: {
+    metric: CompiledMetric;
+    fieldRef: string;
+    tables: PreAggregateReferenceLookup;
+}): CompiledDimension | undefined => {
+    const { refTable, refName } = getParsedReference(fieldRef, metric.table);
+    return getReferencedDimensionCaseInsensitive(refTable, refName, tables);
+};

--- a/packages/common/src/ee/preAggregates/utils.ts
+++ b/packages/common/src/ee/preAggregates/utils.ts
@@ -9,6 +9,11 @@ export {
     PreAggregateDerivedMetricIneligibilityReason,
     type PreAggregateDerivedMetricEligibility,
 } from './metricEligibility';
+export {
+    analyzePreAggregateNumberMetricDependencies,
+    PreAggregateNumberMetricDependencyIneligibilityReason,
+    type PreAggregateNumberMetricDependencies,
+} from './numberMetricDependencies';
 export { applyUserBypass, findMatch } from './matcher';
 export {
     getMetricRepresentation,


### PR DESCRIPTION
[PROD-6664: Pre-aggregates: support custom SQL metrics referencing supported metric types](https://linear.app/lightdash/issue/PROD-6664/pre-aggregates-support-custom-sql-metrics-referencing-supported-metric)<!-- reference the related issue e.g. #150 -->

### Description:

Adds support for `type: number` metrics in pre-aggregates when their metric dependencies are explicitly included in the pre-aggregate definition.

Previously, any `type: number` metric would immediately result in a `CUSTOM_SQL_METRIC` miss, preventing pre-aggregate matching. Now, the matcher allows `type: number` metrics to pass through, and the pre-aggregate build and materialization pipelines handle them by:

- Analyzing the transitive metric dependency graph of each `type: number` metric to determine if all leaf dependencies are materializable (i.e., `SUM`, `MIN`, `MAX`, `COUNT`, or `AVERAGE`)
- Throwing an error if any required dependency metrics are missing from the pre-aggregate definition
- Rewriting the SQL of `type: number` metrics to reference the materialized column expressions of their dependencies rather than the original source SQL
- Only materializing the leaf (non-`NUMBER`) dependency metrics, with derived `NUMBER` metrics computed on top of them at query time

A new `analyzePreAggregateNumberMetricDependencies` utility handles the dependency graph traversal, detecting circular dependencies, nested aggregations wrapping metric references, missing metric references, and unsupported leaf metric types.

Shared logic for dimension/metric selection and reference lookup has been extracted into `shared.ts` and `referenceLookup.ts` to avoid duplication between `buildPreAggregateExplore` and `buildMaterializationMetricQuery`.

A demo pre-aggregate (`orders_daily_number_metric_refs_demo`) has been added to the full jaffle shop example to exercise this new capability end-to-end.