### PR TITLE
fix: metric tree canvas only shows first page of metrics

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/MetricsSidebar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/MetricsSidebar/index.tsx
@@ -2,6 +2,7 @@ import { friendlyName } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
+    Button,
     Group,
     Paper,
     ScrollArea,
@@ -23,6 +24,9 @@ import classes from './MetricsSidebar.module.css';
 
 type MetricsSidebarProps = {
     nodes: ExpandedNodeData[];
+    hasMore?: boolean;
+    isLoadingMore?: boolean;
+    onLoadMore?: () => void;
 };
 
 type DraggableMetricItemProps = {
@@ -92,93 +96,116 @@ const DraggableMetricItem: FC<DraggableMetricItemProps> = React.memo(
     },
 );
 
-const MetricsSidebar: FC<MetricsSidebarProps> = React.memo(({ nodes }) => {
-    const handleDragStart = useCallback(
-        (event: DragEvent<HTMLDivElement>, node: ExpandedNodeData) => {
-            event.dataTransfer.setData(
-                'application/reactflow',
-                JSON.stringify({
-                    catalogSearchUuid: node.id,
-                    name: node.data.label,
-                    tableName: node.data.tableName,
-                }),
-            );
-            event.dataTransfer.effectAllowed = 'move';
-        },
-        [],
-    );
+const MetricsSidebar: FC<MetricsSidebarProps> = React.memo(
+    ({ nodes, hasMore, isLoadingMore, onLoadMore }) => {
+        const handleDragStart = useCallback(
+            (event: DragEvent<HTMLDivElement>, node: ExpandedNodeData) => {
+                event.dataTransfer.setData(
+                    'application/reactflow',
+                    JSON.stringify({
+                        catalogSearchUuid: node.id,
+                        name: node.data.label,
+                        tableName: node.data.tableName,
+                    }),
+                );
+                event.dataTransfer.effectAllowed = 'move';
+            },
+            [],
+        );
 
-    return (
-        <>
-            <Panel
-                id="metrics-sidebar"
-                order={1}
-                defaultSize={20}
-                minSize={15}
-                maxSize={40}
-            >
-                <Paper
-                    h="100%"
-                    p="xs"
-                    className={classes.sidebar}
-                    radius={0}
-                    pr={0}
+        return (
+            <>
+                <Panel
+                    id="metrics-sidebar"
+                    order={1}
+                    defaultSize={20}
+                    minSize={15}
+                    maxSize={40}
                 >
-                    <Stack gap="sm" h="100%">
-                        <Group
-                            gap="sm"
-                            justify="space-between"
-                            px="xs"
-                            wrap="nowrap"
-                        >
-                            {nodes.length > 0 && (
-                                <Text fz="xs" c="dimmed">
-                                    {nodes.length} metric
-                                    {nodes.length !== 1 ? 's' : ''} not on
-                                    canvas
-                                </Text>
-                            )}
-                            <ActionIcon
-                                title="Documentation"
-                                component="a"
-                                href="https://docs.lightdash.com/guides/metrics-catalog/canvas"
-                                target="_blank"
-                                variant="transparent"
-                                size="xs"
+                    <Paper
+                        h="100%"
+                        p="xs"
+                        className={classes.sidebar}
+                        radius={0}
+                        pr={0}
+                    >
+                        <Stack gap="sm" h="100%">
+                            <Group
+                                gap="sm"
+                                justify="space-between"
+                                px="xs"
+                                wrap="nowrap"
                             >
-                                <MantineIcon icon={IconBook} color="ldGray.5" />
-                            </ActionIcon>
-                        </Group>
+                                {nodes.length > 0 && (
+                                    <Text fz="xs" c="dimmed">
+                                        {nodes.length} metric
+                                        {nodes.length !== 1 ? 's' : ''} not on
+                                        canvas
+                                    </Text>
+                                )}
+                                <ActionIcon
+                                    title="Documentation"
+                                    component="a"
+                                    href="https://docs.lightdash.com/guides/metrics-catalog/canvas"
+                                    target="_blank"
+                                    variant="transparent"
+                                    size="xs"
+                                >
+                                    <MantineIcon
+                                        icon={IconBook}
+                                        color="ldGray.5"
+                                    />
+                                </ActionIcon>
+                            </Group>
 
-                        <ScrollArea style={{ flex: 1 }} offsetScrollbars>
-                            {nodes.length > 0 ? (
+                            <ScrollArea style={{ flex: 1 }} offsetScrollbars>
                                 <Stack gap="xs">
-                                    {nodes.map((node) => (
-                                        <DraggableMetricItem
-                                            key={node.id}
-                                            node={node}
-                                            onDragStart={handleDragStart}
-                                        />
-                                    ))}
+                                    {nodes.length > 0
+                                        ? nodes.map((node) => (
+                                              <DraggableMetricItem
+                                                  key={node.id}
+                                                  node={node}
+                                                  onDragStart={handleDragStart}
+                                              />
+                                          ))
+                                        : !hasMore && (
+                                              <Text
+                                                  fz="xs"
+                                                  c="dimmed"
+                                                  ta="center"
+                                                  mt="md"
+                                              >
+                                                  All metrics are on the canvas
+                                              </Text>
+                                          )}
+                                    {hasMore && (
+                                        <Button
+                                            variant="subtle"
+                                            size="xs"
+                                            onClick={onLoadMore}
+                                            loading={isLoadingMore}
+                                        >
+                                            Load more
+                                        </Button>
+                                    )}
                                 </Stack>
-                            ) : (
-                                <Text fz="xs" c="dimmed" ta="center" mt="md">
-                                    All metrics are on the canvas
-                                </Text>
-                            )}
-                        </ScrollArea>
-                    </Stack>
-                </Paper>
-            </Panel>
-            <Box component={PanelResizeHandle} className={classes.resizeHandle}>
-                <MantineIcon
-                    icon={IconGripVertical}
-                    size={12}
-                    color="ldGray.5"
-                />
-            </Box>
-        </>
-    );
-});
+                            </ScrollArea>
+                        </Stack>
+                    </Paper>
+                </Panel>
+                <Box
+                    component={PanelResizeHandle}
+                    className={classes.resizeHandle}
+                >
+                    <MantineIcon
+                        icon={IconGripVertical}
+                        size={12}
+                        color="ldGray.5"
+                    />
+                </Box>
+            </>
+        );
+    },
+);
 
 export default MetricsSidebar;

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
@@ -36,6 +36,9 @@ type Props = {
     sidebarFilter?: (node: ExpandedNodeData) => boolean;
     /** All YAML edges for the project — used to inject YAML edges reactively in edit mode */
     allProjectYamlEdges?: CatalogMetricsTreeEdge[];
+    hasMoreMetrics?: boolean;
+    isLoadingMoreMetrics?: boolean;
+    onLoadMoreMetrics?: () => void;
 };
 
 const SavedTreeCanvasFlow: FC<Props> = ({
@@ -45,6 +48,9 @@ const SavedTreeCanvasFlow: FC<Props> = ({
     onCanvasStateChange,
     sidebarFilter,
     allProjectYamlEdges,
+    hasMoreMetrics,
+    isLoadingMoreMetrics,
+    onLoadMoreMetrics,
 }) => {
     const theme = useMantineTheme();
 
@@ -61,7 +67,14 @@ const SavedTreeCanvasFlow: FC<Props> = ({
 
     return (
         <PanelGroup direction="horizontal" style={{ height: '100%' }}>
-            {!viewOnly && <MetricsSidebar nodes={flow.sidebarNodes} />}
+            {!viewOnly && (
+                <MetricsSidebar
+                    nodes={flow.sidebarNodes}
+                    hasMore={hasMoreMetrics}
+                    isLoadingMore={isLoadingMoreMetrics}
+                    onLoadMore={onLoadMoreMetrics}
+                />
+            )}
             <Panel id="metrics-canvas" order={2}>
                 <Box h="100%">
                     <ReactFlow

--- a/packages/frontend/src/features/metricsCatalog/components/SavedTrees/SavedTreeCanvas.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/SavedTrees/SavedTreeCanvas.tsx
@@ -98,14 +98,26 @@ const SavedTreeCanvas: FC<SavedTreeCanvasProps> = ({ mode, treeUuid }) => {
         useMetricsTreeDetails(projectUuid, treeUuid);
 
     const isEditMode = mode === SavedTreeEditMode.EDIT;
-    const { data: metricsData } = useMetricsCatalog({
+    const {
+        data: metricsData,
+        hasNextPage: hasNextMetricsPage,
+        fetchNextPage: fetchNextMetricsPage,
+        isFetchingNextPage: isFetchingNextMetricsPage,
+    } = useMetricsCatalog({
         projectUuid: isEditMode ? projectUuid : undefined,
-        pageSize: 50,
+        pageSize: 300,
         categories: categoryFilters,
         categoriesFilterMode: categoryFilterMode,
         tables: tableFilters,
         ownerUserUuids: ownerFilters,
     });
+
+    const handleLoadMoreMetrics = useCallback(() => {
+        if (hasNextMetricsPage && !isFetchingNextMetricsPage) {
+            void fetchNextMetricsPage();
+        }
+    }, [hasNextMetricsPage, isFetchingNextMetricsPage, fetchNextMetricsPage]);
+
     const allMetrics = useMemo(
         () => metricsData?.pages.flatMap((page) => page.data) ?? [],
         [metricsData],
@@ -428,6 +440,9 @@ const SavedTreeCanvas: FC<SavedTreeCanvasProps> = ({ mode, treeUuid }) => {
                         onCanvasStateChange={handleCanvasStateChange}
                         sidebarFilter={sidebarFilter}
                         allProjectYamlEdges={allProjectYamlEdges}
+                        hasMoreMetrics={hasNextMetricsPage ?? false}
+                        isLoadingMoreMetrics={isFetchingNextMetricsPage}
+                        onLoadMoreMetrics={handleLoadMoreMetrics}
                     />
                 </Box>
                 <MantineModal


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  ZAP-344<!-- reference the related issue e.g. #150 -->

Closes #22370

### Description:

Add Load more behavior to metrics tree canvas to load more than the initial page.

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->