### PR TITLE
feat(service-account): make fallback admin selection deterministic [SPK-397]

### DIFF
--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -111,6 +111,35 @@ export class OrganizationMemberProfileModel {
         };
     }
 
+    async findOldestAdminUserUuid(
+        organizationUuid: string,
+    ): Promise<string | undefined> {
+        const row = await this.database(OrganizationMembershipsTableName)
+            .innerJoin(
+                UserTableName,
+                `${OrganizationMembershipsTableName}.user_id`,
+                `${UserTableName}.user_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationMembershipsTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(
+                `${OrganizationMembershipsTableName}.role`,
+                OrganizationMemberRole.ADMIN,
+            )
+            .orderBy(`${UserTableName}.created_at`, 'asc')
+            .orderBy(`${UserTableName}.user_uuid`, 'asc')
+            .select<{ user_uuid: string }[]>(`${UserTableName}.user_uuid`)
+            .first();
+        return row?.user_uuid;
+    }
+
     async getOrganizationMembers({
         organizationUuid,
         paginateArgs,

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -864,4 +864,130 @@ describe('UserService', () => {
             );
         });
     });
+
+    describe('getAdminUser', () => {
+        const orgUuid = 'org-uuid';
+        const creatorUuid = 'creator-uuid';
+        const oldestAdminUuid = 'oldest-admin-uuid';
+
+        const buildService = (overrides: {
+            findSessionUserAndOrgByUuid: jest.Mock;
+            findOldestAdminUserUuid: jest.Mock;
+        }) => {
+            const userModelOverride = {
+                ...userModel,
+                findSessionUserAndOrgByUuid:
+                    overrides.findSessionUserAndOrgByUuid,
+            } as unknown as UserModel;
+            const orgMemberModelOverride = {
+                findOldestAdminUserUuid: overrides.findOldestAdminUserUuid,
+            } as unknown as OrganizationMemberProfileModel;
+            return new UserService({
+                analytics: analyticsMock,
+                lightdashConfig: lightdashConfigMock,
+                inviteLinkModel: inviteLinkModel as unknown as InviteLinkModel,
+                userModel: userModelOverride,
+                groupsModel: {} as GroupsModel,
+                sessionModel: {} as SessionModel,
+                emailModel: emailModel as unknown as EmailModel,
+                openIdIdentityModel:
+                    openIdIdentityModel as unknown as OpenIdIdentityModel,
+                passwordResetLinkModel: {} as PasswordResetLinkModel,
+                emailClient: emailClient as unknown as EmailClient,
+                organizationMemberProfileModel: orgMemberModelOverride,
+                organizationModel:
+                    organizationModel as unknown as OrganizationModel,
+                personalAccessTokenModel: {} as PersonalAccessTokenModel,
+                organizationAllowedEmailDomainsModel:
+                    {} as OrganizationAllowedEmailDomainsModel,
+                userWarehouseCredentialsModel:
+                    {} as UserWarehouseCredentialsModel,
+                warehouseAvailableTablesModel:
+                    {} as WarehouseAvailableTablesModel,
+                projectModel: projectModel as unknown as ProjectModel,
+            });
+        };
+
+        test('returns the creator when it still exists (no fallback)', async () => {
+            const findSessionUserAndOrgByUuid = jest
+                .fn()
+                .mockResolvedValueOnce(sessionUser);
+            const findOldestAdminUserUuid = jest.fn();
+            const service = buildService({
+                findSessionUserAndOrgByUuid,
+                findOldestAdminUserUuid,
+            });
+
+            const result = await service.getAdminUser(creatorUuid, orgUuid);
+
+            expect(result).toBe(sessionUser);
+            expect(findSessionUserAndOrgByUuid).toHaveBeenCalledWith(
+                creatorUuid,
+                orgUuid,
+            );
+            expect(findOldestAdminUserUuid).not.toHaveBeenCalled();
+        });
+
+        test('falls back to the oldest admin when the creator no longer exists', async () => {
+            const findSessionUserAndOrgByUuid = jest
+                .fn()
+                .mockRejectedValueOnce(new Error('not found'))
+                .mockResolvedValueOnce(sessionUser);
+            const findOldestAdminUserUuid = jest
+                .fn()
+                .mockResolvedValueOnce(oldestAdminUuid);
+            const service = buildService({
+                findSessionUserAndOrgByUuid,
+                findOldestAdminUserUuid,
+            });
+
+            const result = await service.getAdminUser(creatorUuid, orgUuid);
+
+            expect(result).toBe(sessionUser);
+            expect(findOldestAdminUserUuid).toHaveBeenCalledWith(orgUuid);
+            expect(findSessionUserAndOrgByUuid).toHaveBeenLastCalledWith(
+                oldestAdminUuid,
+                orgUuid,
+            );
+        });
+
+        test('falls back when the creator uuid is null', async () => {
+            const findSessionUserAndOrgByUuid = jest
+                .fn()
+                .mockResolvedValueOnce(sessionUser);
+            const findOldestAdminUserUuid = jest
+                .fn()
+                .mockResolvedValueOnce(oldestAdminUuid);
+            const service = buildService({
+                findSessionUserAndOrgByUuid,
+                findOldestAdminUserUuid,
+            });
+
+            const result = await service.getAdminUser(null, orgUuid);
+
+            expect(result).toBe(sessionUser);
+            expect(findOldestAdminUserUuid).toHaveBeenCalledWith(orgUuid);
+            expect(findSessionUserAndOrgByUuid).toHaveBeenCalledWith(
+                oldestAdminUuid,
+                orgUuid,
+            );
+        });
+
+        test('throws when no admin exists in the organization', async () => {
+            const findSessionUserAndOrgByUuid = jest
+                .fn()
+                .mockRejectedValueOnce(new Error('not found'));
+            const findOldestAdminUserUuid = jest
+                .fn()
+                .mockResolvedValueOnce(undefined);
+            const service = buildService({
+                findSessionUserAndOrgByUuid,
+                findOldestAdminUserUuid,
+            });
+
+            await expect(
+                service.getAdminUser(creatorUuid, orgUuid),
+            ).rejects.toThrow('No admin user found');
+        });
+    });
 });

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2461,7 +2461,9 @@ export class UserService extends BaseService {
 
     /*
     For service accounts, we get the admin user from the userUuid who created the user
-    if this user no longer exist, then we will get another admin user from the org
+    if this user no longer exist, then we fall back to the oldest admin in the org
+    (ordered by created_at asc, user_uuid asc as tie-breaker) so the same service
+    account always resolves to the same fallback admin.
     */
     async getAdminUser(userUuid: string | null, organizationUuid: string) {
         try {
@@ -2473,24 +2475,17 @@ export class UserService extends BaseService {
                 organizationUuid,
             );
         } catch (error) {
-            const members =
-                await this.organizationMemberProfileModel.getOrganizationMembers(
-                    {
-                        organizationUuid,
-                        searchQuery: 'admin', // Filtering by role
-                    },
-                );
-
-            const adminUser = members.data.find(
-                (member) => member.role === 'admin',
-            );
-            if (adminUser) {
-                return this.userModel.findSessionUserAndOrgByUuid(
-                    adminUser.userUuid,
+            const adminUserUuid =
+                await this.organizationMemberProfileModel.findOldestAdminUserUuid(
                     organizationUuid,
                 );
+            if (!adminUserUuid) {
+                throw new Error('No admin user found');
             }
-            throw new Error('No admin user found');
+            return this.userModel.findSessionUserAndOrgByUuid(
+                adminUserUuid,
+                organizationUuid,
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Implements [SPK-397](https://linear.app/lightdash/issue/SPK-397) — makes the service-account fallback admin selection deterministic.

When a service account's creator user has been deleted, we previously fell back to "any admin" via a fragile string search:

```ts
getOrganizationMembers({ organizationUuid, searchQuery: 'admin' })
  .data.find((m) => m.role === 'admin')
```

`searchQuery: 'admin'` is a regex match across `first_name` / `last_name` / `email` / `role` (so it'd also match a user named "Adminah"), and `find` returns whichever row Postgres happens to return first — non-deterministic. The same service account could have its actions attributed to different admins over time.

## Change

Add `OrganizationMemberProfileModel.findOldestAdminUserUuid(organizationUuid)`:

- `WHERE role = 'admin' AND organization_uuid = ?`
- `ORDER BY users.created_at ASC, users.user_uuid ASC LIMIT 1`
- Returns `string | undefined`

`UserService.getAdminUser` calls it instead of the search hack. Same service account → same fallback admin (until that admin is also deleted), with a stable tie-breaker by `user_uuid` for the unlikely case of equal `created_at`.

## Acceptance criteria

- [x] Creator-exists path unchanged
- [x] Fallback consistently picks the oldest admin
- [x] Selection stable across requests
- [x] Tie-breaking by `user_uuid` ascending

## Test plan

- [x] `pnpm jest src/services/UserService.test.ts` — 33 tests pass, including 4 new `getAdminUser` cases (creator exists / creator missing / null creator / no admins → throws)
- [x] Manual SQL verification on local dev DB — query returns admins in stable order
- [ ] Backend typecheck passes in CI
