### PR TITLE
chore: remove rejected saved query test cases from jaffle shop demo

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -66,43 +66,6 @@ models:
               - customers.average_age
             time_dimension: order_date
             granularity: day
-          - name: param_dimension_rejected_daily
-            dimensions:
-              - status
-              - date_dim_param_test
-            metrics:
-              - total_order_amount
-            time_dimension: order_date
-            granularity: day
-          - name: user_attribute_email_rejected_daily
-            dimensions:
-              - status
-              - user_attribute_email_test
-            metrics:
-              - total_order_amount
-            time_dimension: order_date
-            granularity: day
-          - name: param_metric_rejected_daily
-            dimensions:
-              - status
-            metrics:
-              - parameterized_metric_test
-            time_dimension: order_date
-            granularity: day
-          - name: user_attribute_metric_rejected_daily
-            dimensions:
-              - status
-            metrics:
-              - user_attribute_email_metric_test
-            time_dimension: order_date
-            granularity: day
-          - name: param_filter_metric_rejected_daily
-            dimensions:
-              - status
-            metrics:
-              - param_filter_metric_test
-            time_dimension: order_date
-            granularity: day
         primary_key: order_id
         spotlight:
           categories:

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -363,18 +363,18 @@ describe('buildPreAggregateExplore', () => {
     it('requires dependent metrics for supported number metrics', () => {
         expect(() =>
             buildPreAggregateExplore(sourceExplore(), {
-                name: 'number_metric_rollup',
+                name: 'number_metric_preagg',
                 dimensions: ['status'],
                 metrics: ['gross_total', 'total_order_amount'],
             }),
         ).toThrow(
-            'Pre-aggregate "number_metric_rollup" metric "gross_total" requires dependent metrics "shipping_total" to be included in the pre-aggregate definition.',
+            'Pre-aggregate "number_metric_preagg" metric "gross_total" requires dependent metrics "shipping_total" to be included in the pre-aggregate definition.',
         );
     });
 
     it('keeps supported number metrics on the pre-aggregate explore and rewrites them to use materialized dependencies', () => {
         const result = buildPreAggregateExplore(sourceExplore(), {
-            name: 'number_metric_rollup',
+            name: 'number_metric_preagg',
             dimensions: ['status'],
             metrics: ['gross_total', 'total_order_amount', 'shipping_total'],
         });
@@ -392,7 +392,7 @@ describe('buildPreAggregateExplore', () => {
 
     it('rewrites supported cross-model number metrics to use materialized dependencies from joined tables', () => {
         const result = buildPreAggregateExplore(sourceExplore(), {
-            name: 'cross_model_number_metric_rollup',
+            name: 'cross_model_number_metric_preagg',
             dimensions: ['status'],
             metrics: [
                 'total_order_amount_plus_average_customer_age',

--- a/packages/backend/src/ee/preAggregates/postProcessor.test.ts
+++ b/packages/backend/src/ee/preAggregates/postProcessor.test.ts
@@ -401,7 +401,7 @@ describe('pre-aggregate virtual explore generation', () => {
         expect((explores[0] as Explore).warnings).toContainEqual({
             type: InlineErrorType.FIELD_ERROR,
             message:
-                'Pre-aggregate "broken_rollup" references unsupported metrics: "myTable_user_count" (count_distinct). Supported metric types: sum, count, min, max, average',
+                'Pre-aggregate "broken_rollup" references unsupported metrics: "user_count" (count_distinct). Supported metric types: sum, count, min, max, average',
         });
     });
 

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -640,14 +640,14 @@ describe('buildMaterializationMetricQuery', () => {
             buildMaterializationMetricQuery({
                 sourceExplore: getSourceExplore(),
                 preAggregateDef: {
-                    name: 'orders_rollup',
+                    name: 'orders_number_metric_preagg',
                     dimensions: ['status'],
                     metrics: ['gross_total', 'total_order_amount'],
                 },
                 materializationConfig: { maxRows: null },
             }),
         ).toThrow(
-            'Pre-aggregate "orders_rollup" metric "gross_total" requires dependent metrics "shipping_total" to be included in the pre-aggregate definition.',
+            'Pre-aggregate "orders_number_metric_preagg" metric "gross_total" requires dependent metrics "shipping_total" to be included in the pre-aggregate definition.',
         );
     });
 
@@ -655,7 +655,7 @@ describe('buildMaterializationMetricQuery', () => {
         const result = buildMaterializationMetricQuery({
             sourceExplore: getSourceExplore(),
             preAggregateDef: {
-                name: 'orders_rollup',
+                name: 'orders_number_metric_preagg',
                 dimensions: ['status'],
                 metrics: [
                     'gross_total',
@@ -690,7 +690,7 @@ describe('buildMaterializationMetricQuery', () => {
         const result = buildMaterializationMetricQuery({
             sourceExplore: getSourceExplore(),
             preAggregateDef: {
-                name: 'orders_rollup',
+                name: 'orders_cross_model_number_metric_preagg',
                 dimensions: ['status'],
                 metrics: [
                     'total_order_amount_plus_average_customer_age',


### PR DESCRIPTION
Closes:

### Description:
Removes several saved queries from the `orders.yml` model in the full Jaffle Shop demo that were related to parameterized dimensions, user attribute dimensions, parameterized metrics, user attribute metrics, and parameterized filter metrics. These queries (`param_dimension_rejected_daily`, `user_attribute_email_rejected_daily`, `param_metric_rejected_daily`, `user_attribute_metric_rejected_daily`, and `param_filter_metric_rejected_daily`) have been cleaned up from the demo configuration.