### PR TITLE
fix(sql-runner): gate save dropdown items by CASL permissions

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5822,7 +5822,7 @@ export class ProjectService extends BaseService {
         if (
             auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('SqlRunner', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -5875,7 +5875,7 @@ export class ProjectService extends BaseService {
         if (
             auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('SqlRunner', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -5929,7 +5929,7 @@ export class ProjectService extends BaseService {
         if (
             auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('SqlRunner', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -544,14 +544,15 @@ const scopes: Scope[] = [
     },
     {
         name: 'manage:SqlRunner',
-        description: 'Run SQL queries and execute SQL charts',
+        description:
+            'Run SQL queries, execute SQL charts, and browse warehouse schema',
         isEnterprise: false,
         group: ScopeGroup.DATA,
         getConditions: addDefaultUuidCondition,
     },
     {
         name: 'manage:CustomSql',
-        description: 'Save SQL charts and browse warehouse schema',
+        description: 'Save SQL charts',
         isEnterprise: false,
         group: ScopeGroup.DATA,
         getConditions: addDefaultUuidCondition,

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -265,209 +265,224 @@ export const HeaderCreate: FC = () => {
                     </Group>
 
                     <Group spacing="xs">
-                        <Button.Group>
-                            <Button
-                                variant="default"
-                                size="xs"
-                                leftIcon={getCtaIcon(ctaAction)}
-                                disabled={isCtaDisabled}
-                                onClick={handleCtaClick}
-                            >
-                                {getCtaLabels(ctaAction).label}
-                            </Button>
-                            <Menu
-                                withinPortal
-                                disabled={!loadedColumns || !hasAnyAction}
-                                position="bottom-end"
-                                withArrow
-                                shadow="md"
-                                offset={2}
-                                arrowOffset={10}
-                            >
-                                <Menu.Target>
-                                    <Button
-                                        size="xs"
-                                        p={4}
-                                        disabled={
-                                            !loadedColumns || !hasAnyAction
-                                        }
-                                        variant="default"
-                                    >
-                                        <MantineIcon
-                                            icon={IconChevronDown}
-                                            size="sm"
-                                        />
-                                    </Button>
-                                </Menu.Target>
-
-                                <Menu.Dropdown>
-                                    <Tooltip
-                                        label="You don't have permission to save SQL charts in this project."
-                                        multiline
-                                        maw={400}
-                                        position="top"
-                                        withArrow
-                                        withinPortal
-                                        disabled={canSaveChart}
-                                    >
-                                        <Group
-                                            sx={{
-                                                cursor: 'pointer',
-                                            }}
+                        {hasAnyAction && (
+                            <Button.Group>
+                                <Button
+                                    variant="default"
+                                    size="xs"
+                                    leftIcon={getCtaIcon(ctaAction)}
+                                    disabled={isCtaDisabled}
+                                    onClick={handleCtaClick}
+                                >
+                                    {getCtaLabels(ctaAction).label}
+                                </Button>
+                                <Menu
+                                    withinPortal
+                                    disabled={!loadedColumns || !hasAnyAction}
+                                    position="bottom-end"
+                                    withArrow
+                                    shadow="md"
+                                    offset={2}
+                                    arrowOffset={10}
+                                >
+                                    <Menu.Target>
+                                        <Button
+                                            size="xs"
+                                            p={4}
+                                            disabled={
+                                                !loadedColumns || !hasAnyAction
+                                            }
+                                            variant="default"
                                         >
-                                            <Menu.Item
-                                                disabled={!canSaveChart}
-                                                onClick={() => {
-                                                    setCtaAction('save');
+                                            <MantineIcon
+                                                icon={IconChevronDown}
+                                                size="sm"
+                                            />
+                                        </Button>
+                                    </Menu.Target>
+
+                                    <Menu.Dropdown>
+                                        <Tooltip
+                                            label="You don't have permission to save SQL charts in this project."
+                                            multiline
+                                            maw={400}
+                                            position="top"
+                                            withArrow
+                                            withinPortal
+                                            disabled={canSaveChart}
+                                        >
+                                            <Group
+                                                sx={{
+                                                    cursor: 'pointer',
                                                 }}
                                             >
-                                                <Stack spacing="two">
-                                                    <Text
-                                                        fz="xs"
-                                                        fw={600}
-                                                        c={
-                                                            ctaAction ===
-                                                                'save' &&
-                                                            canSaveChart
-                                                                ? 'blue'
-                                                                : undefined
-                                                        }
-                                                    >
-                                                        {
-                                                            getCtaLabels('save')
-                                                                .label
-                                                        }
-                                                    </Text>
-                                                    <Text fz={10} c="ldGray.6">
-                                                        {
-                                                            getCtaLabels('save')
-                                                                .description
-                                                        }
-                                                    </Text>
-                                                </Stack>
-                                            </Menu.Item>
-                                        </Group>
-                                    </Tooltip>
+                                                <Menu.Item
+                                                    disabled={!canSaveChart}
+                                                    onClick={() => {
+                                                        setCtaAction('save');
+                                                    }}
+                                                >
+                                                    <Stack spacing="two">
+                                                        <Text
+                                                            fz="xs"
+                                                            fw={600}
+                                                            c={
+                                                                ctaAction ===
+                                                                    'save' &&
+                                                                canSaveChart
+                                                                    ? 'blue'
+                                                                    : undefined
+                                                            }
+                                                        >
+                                                            {
+                                                                getCtaLabels(
+                                                                    'save',
+                                                                ).label
+                                                            }
+                                                        </Text>
+                                                        <Text
+                                                            fz={10}
+                                                            c="ldGray.6"
+                                                        >
+                                                            {
+                                                                getCtaLabels(
+                                                                    'save',
+                                                                ).description
+                                                            }
+                                                        </Text>
+                                                    </Stack>
+                                                </Menu.Item>
+                                            </Group>
+                                        </Tooltip>
 
-                                    <Tooltip
-                                        label="You don't have permission to create virtual views in this project."
-                                        multiline
-                                        maw={400}
-                                        position="top"
-                                        withArrow
-                                        withinPortal
-                                        disabled={canCreateVirtualView}
-                                    >
-                                        <Group
-                                            sx={{
-                                                cursor: 'pointer',
-                                            }}
+                                        <Tooltip
+                                            label="You don't have permission to create virtual views in this project."
+                                            multiline
+                                            maw={400}
+                                            position="top"
+                                            withArrow
+                                            withinPortal
+                                            disabled={canCreateVirtualView}
                                         >
-                                            <Menu.Item
-                                                disabled={!canCreateVirtualView}
-                                                onClick={() => {
-                                                    setCtaAction(
-                                                        'createVirtualView',
+                                            <Group
+                                                sx={{
+                                                    cursor: 'pointer',
+                                                }}
+                                            >
+                                                <Menu.Item
+                                                    disabled={
+                                                        !canCreateVirtualView
+                                                    }
+                                                    onClick={() => {
+                                                        setCtaAction(
+                                                            'createVirtualView',
+                                                        );
+                                                    }}
+                                                >
+                                                    <Stack spacing="two">
+                                                        <Text
+                                                            fw={600}
+                                                            fz="xs"
+                                                            c={
+                                                                ctaAction ===
+                                                                    'createVirtualView' &&
+                                                                canCreateVirtualView
+                                                                    ? 'blue'
+                                                                    : undefined
+                                                            }
+                                                        >
+                                                            {
+                                                                getCtaLabels(
+                                                                    'createVirtualView',
+                                                                ).label
+                                                            }
+                                                        </Text>
+                                                        <Text
+                                                            fz={10}
+                                                            c="ldGray.6"
+                                                        >
+                                                            {
+                                                                getCtaLabels(
+                                                                    'createVirtualView',
+                                                                ).description
+                                                            }
+                                                        </Text>
+                                                    </Stack>
+                                                </Menu.Item>
+                                            </Group>
+                                        </Tooltip>
+
+                                        <Tooltip
+                                            label={writeBackDisabledMessage}
+                                            multiline
+                                            maw={400}
+                                            position="top"
+                                            withArrow
+                                            withinPortal
+                                            disabled={
+                                                writeBackDisabledMessage ===
+                                                undefined
+                                            }
+                                            onClick={() => {
+                                                if (writeBackOpenUrl)
+                                                    window.open(
+                                                        writeBackOpenUrl,
+                                                        '_blank',
                                                     );
-                                                }}
-                                            >
-                                                <Stack spacing="two">
-                                                    <Text
-                                                        fw={600}
-                                                        fz="xs"
-                                                        c={
-                                                            ctaAction ===
-                                                                'createVirtualView' &&
-                                                            canCreateVirtualView
-                                                                ? 'blue'
-                                                                : undefined
-                                                        }
-                                                    >
-                                                        {
-                                                            getCtaLabels(
-                                                                'createVirtualView',
-                                                            ).label
-                                                        }
-                                                    </Text>
-                                                    <Text fz={10} c="ldGray.6">
-                                                        {
-                                                            getCtaLabels(
-                                                                'createVirtualView',
-                                                            ).description
-                                                        }
-                                                    </Text>
-                                                </Stack>
-                                            </Menu.Item>
-                                        </Group>
-                                    </Tooltip>
-
-                                    <Tooltip
-                                        label={writeBackDisabledMessage}
-                                        multiline
-                                        maw={400}
-                                        position="top"
-                                        withArrow
-                                        withinPortal
-                                        disabled={
-                                            writeBackDisabledMessage ===
-                                            undefined
-                                        }
-                                        onClick={() => {
-                                            if (writeBackOpenUrl)
-                                                window.open(
-                                                    writeBackOpenUrl,
-                                                    '_blank',
-                                                );
-                                        }}
-                                    >
-                                        <Group
-                                            sx={{
-                                                cursor: 'pointer',
                                             }}
                                         >
-                                            <Menu.Item
-                                                disabled={
-                                                    writeBackDisabledMessage !==
-                                                    undefined
-                                                }
-                                                onClick={() => {
-                                                    setCtaAction(
-                                                        'writeBackToDbt',
-                                                    );
+                                            <Group
+                                                sx={{
+                                                    cursor: 'pointer',
                                                 }}
                                             >
-                                                <Stack spacing="two">
-                                                    <Text
-                                                        fw={600}
-                                                        fz="xs"
-                                                        c={
-                                                            ctaAction ===
-                                                                'writeBackToDbt' &&
-                                                            canWriteBackToDbt
-                                                                ? 'blue'
-                                                                : undefined
-                                                        }
-                                                    >
-                                                        {
-                                                            getCtaLabels(
-                                                                'writeBackToDbt',
-                                                            ).label
-                                                        }
-                                                    </Text>
-                                                    <Text fz={10} c="ldGray.6">
-                                                        {
-                                                            getCtaLabels(
-                                                                'writeBackToDbt',
-                                                            ).description
-                                                        }
-                                                    </Text>
-                                                </Stack>
-                                            </Menu.Item>
-                                        </Group>
-                                    </Tooltip>
-                                </Menu.Dropdown>
-                            </Menu>
-                        </Button.Group>
+                                                <Menu.Item
+                                                    disabled={
+                                                        writeBackDisabledMessage !==
+                                                        undefined
+                                                    }
+                                                    onClick={() => {
+                                                        setCtaAction(
+                                                            'writeBackToDbt',
+                                                        );
+                                                    }}
+                                                >
+                                                    <Stack spacing="two">
+                                                        <Text
+                                                            fw={600}
+                                                            fz="xs"
+                                                            c={
+                                                                ctaAction ===
+                                                                    'writeBackToDbt' &&
+                                                                canWriteBackToDbt
+                                                                    ? 'blue'
+                                                                    : undefined
+                                                            }
+                                                        >
+                                                            {
+                                                                getCtaLabels(
+                                                                    'writeBackToDbt',
+                                                                ).label
+                                                            }
+                                                        </Text>
+                                                        <Text
+                                                            fz={10}
+                                                            c="ldGray.6"
+                                                        >
+                                                            {
+                                                                getCtaLabels(
+                                                                    'writeBackToDbt',
+                                                                ).description
+                                                            }
+                                                        </Text>
+                                                    </Stack>
+                                                </Menu.Item>
+                                            </Group>
+                                        </Tooltip>
+                                    </Menu.Dropdown>
+                                </Menu>
+                            </Button.Group>
+                        )}
                         <ActionIcon
                             variant="default"
                             onClick={handleCreateShareUrl}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
 import {
     ActionIcon,
@@ -25,6 +26,7 @@ import { useGitIntegration } from '../../../../hooks/gitIntegration/useGitIntegr
 import useHealth from '../../../../hooks/health/useHealth';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useProject } from '../../../../hooks/useProject';
+import useApp from '../../../../providers/App/useApp';
 import { CreateVirtualViewModal } from '../../../virtualView';
 import { useCreateSqlRunnerShareUrl } from '../../hooks/useSqlRunnerShareUrl';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
@@ -47,6 +49,22 @@ export const HeaderCreate: FC = () => {
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const { data: project } = useProject(projectUuid);
 
+    const { user } = useApp();
+    const organizationUuid = user.data?.organizationUuid;
+
+    const canSaveChart = !!user.data?.ability?.can(
+        'manage',
+        subject('CustomSql', { organizationUuid, projectUuid }),
+    );
+    const canCreateVirtualView = !!user.data?.ability?.can(
+        'create',
+        subject('VirtualView', { organizationUuid, projectUuid }),
+    );
+    const canWriteBackToDbt = !!user.data?.ability?.can(
+        'manage',
+        subject('SourceCode', { organizationUuid, projectUuid }),
+    );
+
     const dispatch = useAppDispatch();
     const name = useAppSelector((state) => state.sqlRunner.name);
     const loadedColumns = useAppSelector((state) => state.sqlRunner.sqlColumns);
@@ -57,6 +75,12 @@ export const HeaderCreate: FC = () => {
     const { data: gitIntegration } = useGitIntegration();
 
     const [writeBackDisabledMessage, writeBackOpenUrl] = useMemo(() => {
+        if (!canWriteBackToDbt) {
+            return [
+                "You don't have permission to write back to dbt in this project.",
+                undefined,
+            ];
+        }
         const hasGithubEnabled = gitIntegration?.enabled;
         const hasGitProject = [
             DbtProjectType.GITHUB,
@@ -91,6 +115,7 @@ export const HeaderCreate: FC = () => {
         }
         return [undefined, undefined];
     }, [
+        canWriteBackToDbt,
         gitIntegration?.enabled,
         health?.data?.hasGithub,
         health?.data?.siteUrl,
@@ -126,7 +151,14 @@ export const HeaderCreate: FC = () => {
             !!cartesianChartSelectors.getErrors(state, selectedChartType),
     );
 
-    const [ctaAction, setCtaAction] = useState<CtaAction>('save');
+    const initialCtaAction: CtaAction = canSaveChart
+        ? 'save'
+        : canCreateVirtualView
+          ? 'createVirtualView'
+          : canWriteBackToDbt
+            ? 'writeBackToDbt'
+            : 'save';
+    const [ctaAction, setCtaAction] = useState<CtaAction>(initialCtaAction);
 
     const handleCtaClick = useCallback(() => {
         switch (ctaAction) {
@@ -194,6 +226,12 @@ export const HeaderCreate: FC = () => {
         showToastSuccess({ title: 'Shared URL copied to clipboard!' });
     }, [createShareUrl, clipboard, showToastSuccess]);
 
+    const isCtaDisabled =
+        !loadedColumns ||
+        (ctaAction === 'save' && !canSaveChart) ||
+        (ctaAction === 'createVirtualView' && !canCreateVirtualView) ||
+        (ctaAction === 'writeBackToDbt' && !canWriteBackToDbt);
+
     return (
         <>
             <Paper
@@ -229,7 +267,7 @@ export const HeaderCreate: FC = () => {
                                 variant="default"
                                 size="xs"
                                 leftIcon={getCtaIcon(ctaAction)}
-                                disabled={!loadedColumns}
+                                disabled={isCtaDisabled}
                                 onClick={handleCtaClick}
                             >
                                 {getCtaLabels(ctaAction).label}
@@ -258,63 +296,102 @@ export const HeaderCreate: FC = () => {
                                 </Menu.Target>
 
                                 <Menu.Dropdown>
-                                    <Menu.Item
-                                        onClick={() => {
-                                            setCtaAction('save');
-                                        }}
+                                    <Tooltip
+                                        label="You don't have permission to save SQL charts in this project."
+                                        multiline
+                                        maw={400}
+                                        position="top"
+                                        withArrow
+                                        withinPortal
+                                        disabled={canSaveChart}
                                     >
-                                        <Stack spacing="two">
-                                            <Text
-                                                fz="xs"
-                                                fw={600}
-                                                c={
-                                                    ctaAction === 'save'
-                                                        ? 'blue'
-                                                        : undefined
-                                                }
+                                        <Group
+                                            sx={{
+                                                cursor: 'pointer',
+                                            }}
+                                        >
+                                            <Menu.Item
+                                                disabled={!canSaveChart}
+                                                onClick={() => {
+                                                    setCtaAction('save');
+                                                }}
                                             >
-                                                {getCtaLabels('save').label}
-                                            </Text>
-                                            <Text fz={10} c="ldGray.6">
-                                                {
-                                                    getCtaLabels('save')
-                                                        .description
-                                                }
-                                            </Text>
-                                        </Stack>
-                                    </Menu.Item>
+                                                <Stack spacing="two">
+                                                    <Text
+                                                        fz="xs"
+                                                        fw={600}
+                                                        c={
+                                                            ctaAction === 'save'
+                                                                ? 'blue'
+                                                                : undefined
+                                                        }
+                                                    >
+                                                        {
+                                                            getCtaLabels('save')
+                                                                .label
+                                                        }
+                                                    </Text>
+                                                    <Text fz={10} c="ldGray.6">
+                                                        {
+                                                            getCtaLabels('save')
+                                                                .description
+                                                        }
+                                                    </Text>
+                                                </Stack>
+                                            </Menu.Item>
+                                        </Group>
+                                    </Tooltip>
 
-                                    <Menu.Item
-                                        onClick={() => {
-                                            setCtaAction('createVirtualView');
-                                        }}
+                                    <Tooltip
+                                        label="You don't have permission to create virtual views in this project."
+                                        multiline
+                                        maw={400}
+                                        position="top"
+                                        withArrow
+                                        withinPortal
+                                        disabled={canCreateVirtualView}
                                     >
-                                        <Stack spacing="two">
-                                            <Text
-                                                fw={600}
-                                                fz="xs"
-                                                c={
-                                                    ctaAction ===
-                                                    'createVirtualView'
-                                                        ? 'blue'
-                                                        : undefined
-                                                }
+                                        <Group
+                                            sx={{
+                                                cursor: 'pointer',
+                                            }}
+                                        >
+                                            <Menu.Item
+                                                disabled={!canCreateVirtualView}
+                                                onClick={() => {
+                                                    setCtaAction(
+                                                        'createVirtualView',
+                                                    );
+                                                }}
                                             >
-                                                {
-                                                    getCtaLabels(
-                                                        'createVirtualView',
-                                                    ).label
-                                                }
-                                            </Text>
-                                            <Text fz={10} c="ldGray.6">
-                                                {
-                                                    getCtaLabels(
-                                                        'createVirtualView',
-                                                    ).description
-                                                }
-                                            </Text>
-                                        </Stack>
-                                    </Menu.Item>
+                                                <Stack spacing="two">
+                                                    <Text
+                                                        fw={600}
+                                                        fz="xs"
+                                                        c={
+                                                            ctaAction ===
+                                                            'createVirtualView'
+                                                                ? 'blue'
+                                                                : undefined
+                                                        }
+                                                    >
+                                                        {
+                                                            getCtaLabels(
+                                                                'createVirtualView',
+                                                            ).label
+                                                        }
+                                                    </Text>
+                                                    <Text fz={10} c="ldGray.6">
+                                                        {
+                                                            getCtaLabels(
+                                                                'createVirtualView',
+                                                            ).description
+                                                        }
+                                                    </Text>
+                                                </Stack>
+                                            </Menu.Item>
+                                        </Group>
+                                    </Tooltip>
 
                                     <Tooltip
                                         label={writeBackDisabledMessage}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -232,6 +232,9 @@ export const HeaderCreate: FC = () => {
         (ctaAction === 'createVirtualView' && !canCreateVirtualView) ||
         (ctaAction === 'writeBackToDbt' && !canWriteBackToDbt);
 
+    const hasAnyAction =
+        canSaveChart || canCreateVirtualView || canWriteBackToDbt;
+
     return (
         <>
             <Paper
@@ -274,7 +277,7 @@ export const HeaderCreate: FC = () => {
                             </Button>
                             <Menu
                                 withinPortal
-                                disabled={!loadedColumns}
+                                disabled={!loadedColumns || !hasAnyAction}
                                 position="bottom-end"
                                 withArrow
                                 shadow="md"
@@ -285,7 +288,9 @@ export const HeaderCreate: FC = () => {
                                     <Button
                                         size="xs"
                                         p={4}
-                                        disabled={!loadedColumns}
+                                        disabled={
+                                            !loadedColumns || !hasAnyAction
+                                        }
                                         variant="default"
                                     >
                                         <MantineIcon
@@ -321,7 +326,9 @@ export const HeaderCreate: FC = () => {
                                                         fz="xs"
                                                         fw={600}
                                                         c={
-                                                            ctaAction === 'save'
+                                                            ctaAction ===
+                                                                'save' &&
+                                                            canSaveChart
                                                                 ? 'blue'
                                                                 : undefined
                                                         }
@@ -370,7 +377,8 @@ export const HeaderCreate: FC = () => {
                                                         fz="xs"
                                                         c={
                                                             ctaAction ===
-                                                            'createVirtualView'
+                                                                'createVirtualView' &&
+                                                            canCreateVirtualView
                                                                 ? 'blue'
                                                                 : undefined
                                                         }
@@ -434,7 +442,8 @@ export const HeaderCreate: FC = () => {
                                                         fz="xs"
                                                         c={
                                                             ctaAction ===
-                                                            'writeBackToDbt'
+                                                                'writeBackToDbt' &&
+                                                            canWriteBackToDbt
                                                                 ? 'blue'
                                                                 : undefined
                                                         }

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -252,17 +252,19 @@ export const HeaderCreate: FC = () => {
                 })}
             >
                 <Group position="apart">
-                    <Group spacing="two">
-                        <EditableText
-                            size="md"
-                            w={400}
-                            placeholder={untitledName}
-                            value={name}
-                            onChange={(e) =>
-                                dispatch(updateName(e.currentTarget.value))
-                            }
-                        />
-                    </Group>
+                    {hasAnyAction && (
+                        <Group spacing="two">
+                            <EditableText
+                                size="md"
+                                w={400}
+                                placeholder={untitledName}
+                                value={name}
+                                onChange={(e) =>
+                                    dispatch(updateName(e.currentTarget.value))
+                                }
+                            />
+                        </Group>
+                    )}
 
                     <Group spacing="xs">
                         {hasAnyAction && (

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -252,8 +252,8 @@ export const HeaderCreate: FC = () => {
                 })}
             >
                 <Group position="apart">
-                    {hasAnyAction && (
-                        <Group spacing="two">
+                    <Group spacing="two">
+                        {hasAnyAction && (
                             <EditableText
                                 size="md"
                                 w={400}
@@ -263,8 +263,8 @@ export const HeaderCreate: FC = () => {
                                     dispatch(updateName(e.currentTarget.value))
                                 }
                             />
-                        </Group>
-                    )}
+                        )}
+                    </Group>
 
                     <Group spacing="xs">
                         {hasAnyAction && (


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/22425
Closes: https://linear.app/lightdash/issue/PROD-7171/assign-different-permissions-for-each-action-in-sql-runner-page

## Summary

Two related fixes in the SQL Runner permission flow.

### Frontend: gate save dropdown items by CASL permissions

The "Save chart" dropdown showed all three options (Save chart, Create virtual view, Write back to dbt) regardless of permissions. Users without the corresponding scopes could click an option and hit a backend Forbidden — confusing UX.

Each menu item is now disabled with an explanatory tooltip when the user lacks the corresponding scope, mirroring the existing write-back-disabled pattern in the same component:

- `Save chart` → gated by `manage:CustomSql`
- `Create virtual view` → gated by `create:VirtualView`
- `Write back to dbt` → gated by `manage:SourceCode` (permission message takes precedence over GitHub-integration messages)

The initial `ctaAction` defaults to the first action the user can perform; the main CTA disables when the current action lacks permission, but the chevron stays reachable so the user can switch.

### Backend: warehouse schema browsing should use `manage:SqlRunner`, not `manage:CustomSql`

`getWarehouseTables`, `getWarehouseFields`, and `populateWarehouseTablesCache` (all three only consumed by `sqlRunnerController`) were checking `manage:CustomSql`, which conflated "save SQL charts" with "browse warehouse schema". A user who could run SQL via `manage:SqlRunner` but lacked save permission could not see the schema tree they were querying.

These three endpoints now check `manage:SqlRunner`. The scope descriptions in `scopes.ts` are updated to reflect the new boundaries.

## Test Plan

- [ ] As Admin (`demo@lightdash.com`): all three menu items enabled, schema sidebar populates
- [ ] As a custom-role user with `manage:SqlRunner` but missing `manage:CustomSql`: schema sidebar populates, "Save chart" menu item disabled with permission tooltip
- [ ] As a custom-role user missing `create:VirtualView`: "Create virtual view" greyed with tooltip
- [ ] As a custom-role user missing `manage:SourceCode`: "Write back to dbt" greyed with permission tooltip
- [ ] User with `manage:SourceCode` but project not connected to GitHub still sees the existing integration tooltip (precedence ordering)
- [ ] As Editor / Interactive Viewer (built-in roles lacking these scopes): all three items disabled with permission tooltips
- [ ] Verify `pnpm -F common test --testPathPattern=authorization` passes (parity tests, scope abilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)