### PR TITLE
fix: hide pivot table "Drill into" for non-metric cells (PROD-7179)

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -2,6 +2,8 @@ import {
     createDashboardFilterRuleFromField,
     isDimension,
     isDimensionValueInvalidDate,
+    isField,
+    isMetric,
     type ItemsMap,
     type ResultValue,
 } from '@lightdash/common';
@@ -94,7 +96,8 @@ const ValueCellMenuDropdownContent: FC<{
     const { track } = tracking;
 
     const hasUnderlyingData = getUnderlyingFieldValues && item;
-    const hasDrillInto = getUnderlyingFieldValues && item;
+    const hasDrillInto =
+        getUnderlyingFieldValues && item && isField(item) && isMetric(item);
 
     const handleOpenUnderlyingDataModal = () => {
         if (


### PR DESCRIPTION
## Summary

- The pivot table's `ValueCellMenu` was showing the "Drill into" option for all cells, including dimensions, table calculations, and custom dimensions. Clicking it on a dimension produced an invalid drill-down query (dimension in the `metrics` array) and errored.
- Adds the same `isField(item) && isMetric(item)` guard already used by the shared `DrillDownMenuItem` (regular tables, charts, dashboard tiles).

Linear: https://linear.app/lightdash/issue/PROD-7179

## Test plan

- [x] Open an explore with at least one dimension and one metric, run a query, switch to Pivot Table.
- [x] Right-click a dimension cell — "Drill into" no longer appears.
- [x] Right-click a metric cell — "Drill into" appears; clicking it opens the modal as before.
- [x] Regular (non-pivoted) table behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)