### PR TITLE
feat(permissions): gate SQL table calcs and add saved-version exemption

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -171,6 +171,7 @@ export class QueryController extends BaseController {
                 dateZoom: body.dateZoom,
                 parameters: body.parameters,
                 pivotConfiguration: body.pivotConfiguration,
+                savedChartUuid: body.savedChartUuid,
             });
 
         return {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8879,11 +8879,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8898,11 +8898,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8917,11 +8917,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8952,29 +8952,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 chartUsage:
                                                                                                     {
                                                                                                         dataType:
@@ -8998,6 +8975,35 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -9009,12 +9015,6 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                fieldType:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9130,11 +9130,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9210,29 +9210,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     chartUsage:
                                                                                                         {
                                                                                                             dataType:
@@ -9256,6 +9233,35 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
+                                                                                                    searchRank:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                        },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -9267,12 +9273,6 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    fieldType:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
-                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9304,11 +9304,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9323,11 +9323,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6802,6 +6802,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                savedChartUuid: { dataType: 'string' },
                 invalidateCache: { dataType: 'boolean' },
                 parameters: { ref: 'ParametersValuesMap' },
                 explore: { dataType: 'string', required: true },
@@ -27750,6 +27751,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        savedChartUuid: { dataType: 'string' },
                         pivotConfiguration: { ref: 'PivotConfiguration' },
                         dateZoom: { ref: 'DateZoom' },
                         query: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8177,6 +8177,10 @@
             },
             "CalculateTotalFromQuery": {
                 "properties": {
+                    "savedChartUuid": {
+                        "type": "string",
+                        "description": "UUID of the saved chart this query was loaded from, when applicable."
+                    },
                     "invalidateCache": {
                         "type": "boolean"
                     },
@@ -22333,22 +22337,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -22703,22 +22707,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -28919,6 +28923,10 @@
                     },
                     {
                         "properties": {
+                            "savedChartUuid": {
+                                "type": "string",
+                                "description": "UUID of the saved chart this query was loaded from, when applicable.\nUsed by permission checks to exempt unchanged SQL-authored fields\nfrom the `manage:CustomFields` gate."
+                            },
                             "pivotConfiguration": {
                                 "$ref": "#/components/schemas/PivotConfiguration"
                             },
@@ -31185,7 +31193,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2825.1",
+        "version": "0.2825.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -47172,7 +47180,6 @@
                 "description": "Create an edge in the metrics tree",
                 "summary": "Create metrics tree edge",
                 "tags": ["Catalog"],
-                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -47662,7 +47669,6 @@
                 "description": "Get the metrics tree structure",
                 "summary": "Get metrics tree",
                 "tags": ["Catalog"],
-                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -47714,7 +47720,6 @@
                 "description": "Delete an edge from the metrics tree",
                 "summary": "Delete metrics tree edge",
                 "tags": ["Catalog"],
-                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10331,20 +10331,36 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "error",
+                                                            "success"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
+                                                                        "fieldType": {
+                                                                            "type": "string"
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10352,17 +10368,14 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
-                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10411,8 +10424,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -10456,15 +10469,18 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
+                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10472,17 +10488,14 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
-                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10510,8 +10523,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -22337,22 +22350,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -22707,22 +22720,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -31193,7 +31206,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2825.0",
+        "version": "0.2828.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -47180,6 +47193,7 @@
                 "description": "Create an edge in the metrics tree",
                 "summary": "Create metrics tree edge",
                 "tags": ["Catalog"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -47669,6 +47683,7 @@
                 "description": "Get the metrics tree structure",
                 "summary": "Get metrics tree",
                 "tags": ["Catalog"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {
@@ -47720,6 +47735,7 @@
                 "description": "Delete an edge from the metrics tree",
                 "summary": "Delete metrics tree edge",
                 "tags": ["Catalog"],
+                "deprecated": true,
                 "security": [],
                 "parameters": [
                     {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -47,10 +47,10 @@ import {
     getMetricOverridesWithPopInheritance,
     getMetrics,
     getMetricsWithValidParameters,
+    hasModifiedSqlAuthoredFields,
     isCartesianChartConfig,
     isCustomBinDimension,
     isCustomDimension,
-    isCustomSqlDimension,
     isDateItem,
     isExploreError,
     isField,
@@ -3537,6 +3537,71 @@ export class AsyncQueryService extends ProjectService {
         );
     }
 
+    /**
+     * Throws if the incoming query contains SQL-authored fields (custom SQL
+     * dimensions or SQL table calculations) that are new or modified compared
+     * to the saved chart, and the user lacks `manage:CustomFields`.
+     *
+     * If `savedChartUuid` is provided, the saved chart's metricQuery is loaded
+     * so we only gate fields that differ from what was saved — letting users
+     * without the scope still run/explore charts that already contain SQL
+     * fields someone else authored.
+     */
+    private async assertCanRunSqlAuthoredFields({
+        auditedAbility,
+        organizationUuid,
+        projectUuid,
+        exploreName,
+        metricQuery,
+        savedChartUuid,
+    }: {
+        auditedAbility: ReturnType<AsyncQueryService['createAuditedAbility']>;
+        organizationUuid: string;
+        projectUuid: string;
+        exploreName: string;
+        metricQuery: Pick<
+            MetricQuery,
+            'customDimensions' | 'tableCalculations'
+        >;
+        savedChartUuid?: string;
+    }): Promise<void> {
+        let savedMetricQuery: Pick<
+            MetricQuery,
+            'customDimensions' | 'tableCalculations'
+        > | null = null;
+
+        if (savedChartUuid) {
+            try {
+                const savedChart = await this.savedChartModel.get(
+                    savedChartUuid,
+                    undefined,
+                    { projectUuid },
+                );
+                savedMetricQuery = savedChart.metricQuery;
+            } catch {
+                // If the saved chart can't be loaded, treat the incoming
+                // query as fresh authoring — the gate below decides.
+            }
+        }
+
+        if (!hasModifiedSqlAuthoredFields(metricQuery, savedMetricQuery)) {
+            return;
+        }
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('CustomFields', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { exploreName },
+                }),
+            )
+        ) {
+            throw new CustomSqlQueryForbiddenError();
+        }
+    }
+
     // execute
     async executeAsyncMetricQuery({
         account,
@@ -3550,6 +3615,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration,
         userAttributeOverrides,
         materializationRole,
+        savedChartUuid,
     }: ExecuteAsyncMetricQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
         assertIsAccountWithOrg(account);
 
@@ -3585,21 +3651,14 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        if (
-            metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            auditedAbility.cannot(
-                'manage',
-                subject('CustomFields', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: {
-                        exploreName: metricQuery.exploreName,
-                    },
-                }),
-            )
-        ) {
-            throw new CustomSqlQueryForbiddenError();
-        }
+        await this.assertCanRunSqlAuthoredFields({
+            auditedAbility,
+            organizationUuid,
+            projectUuid,
+            exploreName: metricQuery.exploreName,
+            metricQuery,
+            savedChartUuid,
+        });
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
@@ -6006,21 +6065,14 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        if (
-            data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            auditedAbility.cannot(
-                'manage',
-                subject('CustomFields', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: {
-                        exploreName: data.explore,
-                    },
-                }),
-            )
-        ) {
-            throw new CustomSqlQueryForbiddenError();
-        }
+        await this.assertCanRunSqlAuthoredFields({
+            auditedAbility,
+            organizationUuid,
+            projectUuid,
+            exploreName: data.explore,
+            metricQuery: data.metricQuery,
+            savedChartUuid: data.savedChartUuid,
+        });
 
         const explore = await this.getExplore(
             account,
@@ -6088,21 +6140,14 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        if (
-            data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            auditedAbility.cannot(
-                'manage',
-                subject('CustomFields', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: {
-                        exploreName: data.explore,
-                    },
-                }),
-            )
-        ) {
-            throw new CustomSqlQueryForbiddenError();
-        }
+        await this.assertCanRunSqlAuthoredFields({
+            auditedAbility,
+            organizationUuid,
+            projectUuid,
+            exploreName: data.explore,
+            metricQuery: data.metricQuery,
+            savedChartUuid: data.savedChartUuid,
+        });
 
         const explore = await this.getExplore(
             account,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3578,9 +3578,17 @@ export class AsyncQueryService extends ProjectService {
                     { projectUuid },
                 );
                 savedMetricQuery = savedChart.metricQuery;
-            } catch {
-                // If the saved chart can't be loaded, treat the incoming
-                // query as fresh authoring — the gate below decides.
+            } catch (e) {
+                this.logger.warn(
+                    'Failed to load saved chart for SQL-authored fields exemption; falling back to strict gate',
+                    {
+                        savedChartUuid,
+                        projectUuid,
+                        organizationUuid,
+                        exploreName,
+                        error: getErrorMessage(e),
+                    },
+                );
             }
         }
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -75,6 +75,8 @@ export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
     dateZoom?: DateZoom;
     pivotConfiguration?: PivotConfiguration;
     materializationRole?: UserAccessControls;
+    /** UUID of the saved chart this query was loaded from, when applicable. */
+    savedChartUuid?: string;
 };
 
 export type ExecuteAsyncSavedChartQueryArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -2,7 +2,7 @@ import { subject } from '@casl/ability';
 import {
     CustomSqlQueryForbiddenError,
     ForbiddenError,
-    isCustomSqlDimension,
+    hasSqlAuthoredFields,
     SessionUser,
     UploadMetricGsheet,
     UploadMetricGsheetPayload,
@@ -100,9 +100,7 @@ export class GdriveService extends BaseService {
         }
 
         if (
-            gsheetOptions.metricQuery.customDimensions?.some(
-                isCustomSqlDimension,
-            ) &&
+            hasSqlAuthoredFields(gsheetOptions.metricQuery) &&
             auditedAbility.cannot(
                 'manage',
                 subject('CustomFields', {

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -58,6 +58,7 @@ export const user: SessionUser = {
         { subject: 'Job', action: ['view'] },
         { subject: 'SqlRunner', action: ['manage'] },
         { subject: 'Explore', action: ['manage'] },
+        { subject: 'CustomFields', action: ['manage'] },
     ]),
     isActive: true,
     abilityRules: [],

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -79,10 +79,10 @@ import {
     getTimezoneLabel,
     hasConnectionChanges,
     hasIntersection,
+    hasSqlAuthoredFields,
     hasWarehouseCredentials,
     IntrinsicUserAttributes,
     isCartesianChartConfig,
-    isCustomSqlDimension,
     isDateItem,
     isExploreError,
     isFilterableDimension,
@@ -3155,7 +3155,7 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError();
         }
         if (
-            metricQuery.customDimensions?.some(isCustomSqlDimension) &&
+            hasSqlAuthoredFields(metricQuery) &&
             auditedAbility.cannot(
                 'manage',
                 subject('CustomFields', { organizationUuid, projectUuid }),
@@ -3485,7 +3485,7 @@ export class ProjectService extends BaseService {
         }
 
         if (
-            metricQuery.customDimensions?.some(isCustomSqlDimension) &&
+            hasSqlAuthoredFields(metricQuery) &&
             auditedAbility.cannot(
                 'manage',
                 subject('CustomFields', { organizationUuid, projectUuid }),
@@ -3808,7 +3808,7 @@ export class ProjectService extends BaseService {
         }
 
         if (
-            metricQuery.customDimensions?.some(isCustomSqlDimension) &&
+            hasSqlAuthoredFields(metricQuery) &&
             auditedAbility.cannot(
                 'manage',
                 subject('CustomFields', { organizationUuid, projectUuid }),

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -29,6 +29,7 @@ import {
     isFormulaTableCalculation,
     isJwtUser,
     isSchedulerGsheetsOptions,
+    isSqlTableCalculation,
     isUserWithOrg,
     isValidFrequency,
     isValidTimezone,
@@ -521,6 +522,22 @@ export class SavedChartService
         ) {
             throw new ForbiddenError(
                 'User cannot save queries with custom SQL dimensions',
+            );
+        }
+
+        if (
+            data.metricQuery.tableCalculations.some(isSqlTableCalculation) &&
+            auditedAbility.cannot(
+                'manage',
+                subject('CustomFields', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { savedChartUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'User cannot save queries with custom SQL table calculations',
             );
         }
 
@@ -1220,6 +1237,23 @@ export class SavedChartService
             )
         ) {
             throw new ForbiddenError();
+        }
+
+        if (
+            savedChart.metricQuery.tableCalculations.some(
+                isSqlTableCalculation,
+            ) &&
+            auditedAbility.cannot(
+                'manage',
+                subject('CustomFields', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'User cannot save queries with custom SQL table calculations',
+            );
         }
 
         if (!resolvedSpaceUuid && !savedChart.dashboardUuid) {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -215,6 +215,7 @@ export * from './utils/searchParams';
 export * from './utils/slack';
 export * from './utils/sleep';
 export * from './utils/slugs';
+export * from './utils/sqlAuthoredFields';
 export * from './utils/sqlDialect';
 export * from './utils/subtotals';
 export * from './utils/dateZoom';

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -23,6 +23,12 @@ export type ExecuteAsyncMetricQueryRequestParams =
         query: Omit<MetricQueryRequest, 'csvLimit'>;
         dateZoom?: DateZoom;
         pivotConfiguration?: PivotConfiguration;
+        /**
+         * UUID of the saved chart this query was loaded from, when applicable.
+         * Used by permission checks to exempt unchanged SQL-authored fields
+         * from the `manage:CustomFields` gate.
+         */
+        savedChartUuid?: string;
     };
 
 export type ExecuteAsyncSavedChartRequestParams =

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -1188,6 +1188,8 @@ export type CalculateTotalFromQuery = {
     explore: string;
     parameters?: ParametersValuesMap;
     invalidateCache?: boolean;
+    /** UUID of the saved chart this query was loaded from, when applicable. */
+    savedChartUuid?: string;
 };
 
 export type ApiCalculateTotalResponse = {

--- a/packages/common/src/utils/sqlAuthoredFields.test.ts
+++ b/packages/common/src/utils/sqlAuthoredFields.test.ts
@@ -1,0 +1,297 @@
+import {
+    CustomDimensionType,
+    DimensionType,
+    type CustomDimension,
+    type CustomSqlDimension,
+    type FormulaTableCalculation,
+    type SqlTableCalculation,
+    type TemplateTableCalculation,
+} from '../types/field';
+import { type MetricQuery } from '../types/metricQuery';
+import {
+    getModifiedSqlAuthoredFields,
+    hasModifiedSqlAuthoredFields,
+    hasSqlAuthoredFields,
+} from './sqlAuthoredFields';
+
+const sqlDim = (id: string, sql: string, name = id): CustomSqlDimension => ({
+    id,
+    name,
+    table: 'orders',
+    type: CustomDimensionType.SQL,
+    sql,
+    dimensionType: DimensionType.STRING,
+});
+
+const binDim = (id: string): CustomDimension =>
+    ({
+        id,
+        name: id,
+        table: 'orders',
+        type: CustomDimensionType.BIN,
+    }) as unknown as CustomDimension;
+
+const sqlCalc = (name: string, sql: string): SqlTableCalculation => ({
+    name,
+    displayName: name,
+    sql,
+});
+
+const templateCalc = (name: string): TemplateTableCalculation => ({
+    name,
+    displayName: name,
+    template: {
+        type: 'percent_change_from_previous',
+    } as TemplateTableCalculation['template'],
+});
+
+const formulaCalc = (
+    name: string,
+    formula: string,
+): FormulaTableCalculation => ({
+    name,
+    displayName: name,
+    formula,
+});
+
+const mq = (
+    overrides: Partial<MetricQuery> = {},
+): Pick<MetricQuery, 'customDimensions' | 'tableCalculations'> => ({
+    customDimensions: overrides.customDimensions ?? [],
+    tableCalculations: overrides.tableCalculations ?? [],
+});
+
+describe('getModifiedSqlAuthoredFields', () => {
+    describe('saved baseline absent', () => {
+        it('treats every incoming SQL field as modified when there is no saved version', () => {
+            const incoming = mq({
+                customDimensions: [sqlDim('d1', 'a + 1')],
+                tableCalculations: [sqlCalc('c1', 'sum(x)')],
+            });
+
+            const result = getModifiedSqlAuthoredFields(incoming, null);
+
+            expect(result.customDimensions).toHaveLength(1);
+            expect(result.tableCalculations).toHaveLength(1);
+        });
+
+        it('returns empty result when incoming has no SQL fields and saved is missing', () => {
+            const incoming = mq({
+                customDimensions: [binDim('b1')],
+                tableCalculations: [
+                    templateCalc('t1'),
+                    formulaCalc('f1', 'SUM(x)'),
+                ],
+            });
+
+            const result = getModifiedSqlAuthoredFields(incoming, undefined);
+
+            expect(result.customDimensions).toHaveLength(0);
+            expect(result.tableCalculations).toHaveLength(0);
+        });
+    });
+
+    describe('custom SQL dimensions', () => {
+        it('returns nothing when SQL is identical', () => {
+            const dim = sqlDim('d1', 'a + 1');
+            const result = getModifiedSqlAuthoredFields(
+                mq({ customDimensions: [dim] }),
+                mq({ customDimensions: [dim] }),
+            );
+            expect(result.customDimensions).toHaveLength(0);
+        });
+
+        it('flags a dim whose SQL body changed', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({ customDimensions: [sqlDim('d1', 'a + 2')] }),
+                mq({ customDimensions: [sqlDim('d1', 'a + 1')] }),
+            );
+            expect(result.customDimensions).toEqual([sqlDim('d1', 'a + 2')]);
+        });
+
+        it('flags a brand-new dim added on top of a saved query', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({
+                    customDimensions: [
+                        sqlDim('d1', 'a + 1'),
+                        sqlDim('d2', 'b + 1'),
+                    ],
+                }),
+                mq({ customDimensions: [sqlDim('d1', 'a + 1')] }),
+            );
+            expect(result.customDimensions).toEqual([sqlDim('d2', 'b + 1')]);
+        });
+
+        it('does not flag a removed dim (removal is not authoring)', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({ customDimensions: [] }),
+                mq({ customDimensions: [sqlDim('d1', 'a + 1')] }),
+            );
+            expect(result.customDimensions).toHaveLength(0);
+        });
+
+        it('does not flag a name-only change when SQL is unchanged', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({
+                    customDimensions: [sqlDim('d1', 'a + 1', 'New Display')],
+                }),
+                mq({
+                    customDimensions: [sqlDim('d1', 'a + 1', 'Old Display')],
+                }),
+            );
+            expect(result.customDimensions).toHaveLength(0);
+        });
+
+        it('ignores bin custom dimensions entirely', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({ customDimensions: [binDim('b1')] }),
+                mq({ customDimensions: [] }),
+            );
+            expect(result.customDimensions).toHaveLength(0);
+        });
+    });
+
+    describe('SQL table calculations', () => {
+        it('returns nothing when SQL is identical', () => {
+            const calc = sqlCalc('c1', 'sum(x)');
+            const result = getModifiedSqlAuthoredFields(
+                mq({ tableCalculations: [calc] }),
+                mq({ tableCalculations: [calc] }),
+            );
+            expect(result.tableCalculations).toHaveLength(0);
+        });
+
+        it('flags a calc whose SQL body changed', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({ tableCalculations: [sqlCalc('c1', 'avg(x)')] }),
+                mq({ tableCalculations: [sqlCalc('c1', 'sum(x)')] }),
+            );
+            expect(result.tableCalculations).toEqual([sqlCalc('c1', 'avg(x)')]);
+        });
+
+        it('flags a newly added calc', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({
+                    tableCalculations: [
+                        sqlCalc('c1', 'sum(x)'),
+                        sqlCalc('c2', 'count(*)'),
+                    ],
+                }),
+                mq({ tableCalculations: [sqlCalc('c1', 'sum(x)')] }),
+            );
+            expect(result.tableCalculations).toEqual([
+                sqlCalc('c2', 'count(*)'),
+            ]);
+        });
+
+        it('does not flag a removed calc', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({ tableCalculations: [] }),
+                mq({ tableCalculations: [sqlCalc('c1', 'sum(x)')] }),
+            );
+            expect(result.tableCalculations).toHaveLength(0);
+        });
+
+        it('does not flag a display-name-only change', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({
+                    tableCalculations: [
+                        {
+                            ...sqlCalc('c1', 'sum(x)'),
+                            displayName: 'New label',
+                        },
+                    ],
+                }),
+                mq({
+                    tableCalculations: [
+                        {
+                            ...sqlCalc('c1', 'sum(x)'),
+                            displayName: 'Old label',
+                        },
+                    ],
+                }),
+            );
+            expect(result.tableCalculations).toHaveLength(0);
+        });
+
+        it('ignores template and formula calcs entirely (added or removed)', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({
+                    tableCalculations: [
+                        templateCalc('t1'),
+                        formulaCalc('f1', 'SUM(x) / SUM(y)'),
+                    ],
+                }),
+                mq({ tableCalculations: [] }),
+            );
+            expect(result.tableCalculations).toHaveLength(0);
+        });
+
+        it('treats SQL→formula conversion as a non-modification (the SQL is gone, formula is ungated)', () => {
+            const result = getModifiedSqlAuthoredFields(
+                mq({ tableCalculations: [formulaCalc('c1', 'SUM(x)')] }),
+                mq({ tableCalculations: [sqlCalc('c1', 'sum(x)')] }),
+            );
+            expect(result.tableCalculations).toHaveLength(0);
+        });
+    });
+});
+
+describe('hasSqlAuthoredFields', () => {
+    it('returns false for null/undefined input', () => {
+        expect(hasSqlAuthoredFields(null)).toBe(false);
+        expect(hasSqlAuthoredFields(undefined)).toBe(false);
+    });
+
+    it('returns false when only non-SQL fields are present', () => {
+        expect(
+            hasSqlAuthoredFields(
+                mq({
+                    customDimensions: [binDim('b1')],
+                    tableCalculations: [
+                        templateCalc('t1'),
+                        formulaCalc('f1', 'SUM(x)'),
+                    ],
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it('returns true if any SQL custom dim is present', () => {
+        expect(
+            hasSqlAuthoredFields(
+                mq({ customDimensions: [sqlDim('d1', 'a + 1')] }),
+            ),
+        ).toBe(true);
+    });
+
+    it('returns true if any SQL table calc is present', () => {
+        expect(
+            hasSqlAuthoredFields(
+                mq({ tableCalculations: [sqlCalc('c1', 'sum(x)')] }),
+            ),
+        ).toBe(true);
+    });
+});
+
+describe('hasModifiedSqlAuthoredFields', () => {
+    it('returns true when there is any modification', () => {
+        expect(
+            hasModifiedSqlAuthoredFields(
+                mq({ tableCalculations: [sqlCalc('c1', 'avg(x)')] }),
+                mq({ tableCalculations: [sqlCalc('c1', 'sum(x)')] }),
+            ),
+        ).toBe(true);
+    });
+
+    it('returns false when nothing changed', () => {
+        const dim = sqlDim('d1', 'a + 1');
+        const calc = sqlCalc('c1', 'sum(x)');
+        expect(
+            hasModifiedSqlAuthoredFields(
+                mq({ customDimensions: [dim], tableCalculations: [calc] }),
+                mq({ customDimensions: [dim], tableCalculations: [calc] }),
+            ),
+        ).toBe(false);
+    });
+});

--- a/packages/common/src/utils/sqlAuthoredFields.ts
+++ b/packages/common/src/utils/sqlAuthoredFields.ts
@@ -1,0 +1,82 @@
+import {
+    isCustomSqlDimension,
+    isSqlTableCalculation,
+    type CustomSqlDimension,
+    type SqlTableCalculation,
+} from '../types/field';
+import { type MetricQuery } from '../types/metricQuery';
+
+export type SqlAuthoredFields = {
+    customDimensions: CustomSqlDimension[];
+    tableCalculations: SqlTableCalculation[];
+};
+
+const getSqlCustomDimensions = (
+    metricQuery: Pick<MetricQuery, 'customDimensions'> | null | undefined,
+): CustomSqlDimension[] =>
+    (metricQuery?.customDimensions ?? []).filter(isCustomSqlDimension);
+
+const getSqlTableCalculations = (
+    metricQuery: Pick<MetricQuery, 'tableCalculations'> | null | undefined,
+): SqlTableCalculation[] =>
+    (metricQuery?.tableCalculations ?? []).filter(isSqlTableCalculation);
+
+export const hasSqlAuthoredFields = (
+    metricQuery:
+        | Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>
+        | null
+        | undefined,
+): boolean =>
+    getSqlCustomDimensions(metricQuery).length > 0 ||
+    getSqlTableCalculations(metricQuery).length > 0;
+
+export const getModifiedSqlAuthoredFields = (
+    incoming:
+        | Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>
+        | null
+        | undefined,
+    saved:
+        | Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>
+        | null
+        | undefined,
+): SqlAuthoredFields => {
+    const incomingDims = getSqlCustomDimensions(incoming);
+    const savedDimsById = new Map(
+        getSqlCustomDimensions(saved).map((dim) => [dim.id, dim]),
+    );
+    const modifiedCustomDimensions = incomingDims.filter((dim) => {
+        const savedDim = savedDimsById.get(dim.id);
+        return !savedDim || savedDim.sql !== dim.sql;
+    });
+
+    const incomingCalcs = getSqlTableCalculations(incoming);
+    const savedCalcsByName = new Map(
+        getSqlTableCalculations(saved).map((calc) => [calc.name, calc]),
+    );
+    const modifiedTableCalculations = incomingCalcs.filter((calc) => {
+        const savedCalc = savedCalcsByName.get(calc.name);
+        return !savedCalc || savedCalc.sql !== calc.sql;
+    });
+
+    return {
+        customDimensions: modifiedCustomDimensions,
+        tableCalculations: modifiedTableCalculations,
+    };
+};
+
+export const hasModifiedSqlAuthoredFields = (
+    incoming:
+        | Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>
+        | null
+        | undefined,
+    saved:
+        | Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>
+        | null
+        | undefined,
+): boolean => {
+    const modified = getModifiedSqlAuthoredFields(incoming, saved);
+    return (
+        modified.customDimensions.length > 0 ||
+        modified.tableCalculations.length > 0
+    );
+};

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -295,7 +295,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                 columnOrder={unsavedChartVersion.tableConfig.columnOrder}
                 onSeriesContextMenu={onSeriesContextMenu}
                 pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
-                savedChartUuid={isEditMode ? undefined : savedChart?.uuid}
+                savedChartUuid={savedChart?.uuid}
                 onChartConfigChange={handleSetChartConfig}
                 onChartTypeChange={handleSetChartType}
                 onPivotDimensionsChange={handleSetPivotFields}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTable.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTable.tsx
@@ -17,6 +17,7 @@ const VisualizationTableConfig: FC<VisualizationTableConfigProps> = ({
     invalidateCache,
     parameters,
     dateZoom,
+    isEditMode,
 }) => {
     const tableConfig = useTableConfig(
         initialChartConfig,
@@ -30,6 +31,7 @@ const VisualizationTableConfig: FC<VisualizationTableConfigProps> = ({
         invalidateCache,
         parameters,
         dateZoom,
+        isEditMode,
     );
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTreemap.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTreemap.tsx
@@ -17,6 +17,7 @@ const VisualizationConfigTreemap: FC<VisualizationConfigTreemapProps> = ({
     tableCalculationsMetadata,
     children,
     parameters,
+    savedChartUuid,
 }) => {
     const { dimensions, numericMetrics } = useMemo(() => {
         const metrics = getMetricsFromItemsMap(itemsMap ?? {}, isNumericItem);
@@ -35,6 +36,7 @@ const VisualizationConfigTreemap: FC<VisualizationConfigTreemapProps> = ({
         numericMetrics,
         tableCalculationsMetadata,
         parameters,
+        savedChartUuid,
     );
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -526,6 +526,7 @@ const VisualizationProvider: FC<
                     invalidateCache={invalidateCache}
                     parameters={parameters}
                     dateZoom={dateZoom}
+                    isEditMode={isEditMode}
                 >
                     {({ visualizationConfig }) => (
                         <Context.Provider

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -465,6 +465,7 @@ const VisualizationProvider: FC<
                     initialChartConfig={chartConfig.config}
                     onChartConfigChange={handleChartConfigChange}
                     parameters={parameters}
+                    savedChartUuid={savedChartUuid}
                 >
                     {({ visualizationConfig }) => (
                         <Context.Provider

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -180,6 +180,7 @@ export type VisualizationConfigTreemapProps =
         itemsMap: ItemsMap | undefined;
         tableCalculationsMetadata?: TableCalculationMetadata[];
         parameters?: ParametersValuesMap;
+        savedChartUuid?: string;
     };
 
 // Custom

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -157,6 +157,7 @@ export type VisualizationTableConfigProps =
         invalidateCache: boolean | undefined;
         parameters?: ParametersValuesMap;
         dateZoom?: DateZoom;
+        isEditMode?: boolean;
     };
 
 // Treemap

--- a/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
+++ b/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
@@ -33,6 +33,7 @@ export function buildQueryArgs(options: {
     minimal: boolean;
     usePreAggregateCache?: boolean;
     savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>;
+    savedChartUuid?: string;
 }): QueryResultsProps | null {
     const {
         activeFields,
@@ -46,6 +47,7 @@ export function buildQueryArgs(options: {
         viewModeQueryArgs,
         dateZoomGranularity,
         minimal,
+        savedChartUuid,
     } = options;
 
     const hasFields = activeFields.size > 0;
@@ -80,6 +82,7 @@ export function buildQueryArgs(options: {
             pivotDimensions,
         },
         ...savedChartArgs,
+        savedChartUuid,
         dateZoomGranularity,
         invalidateCache: savedChartArgs ? minimal : true,
         usePreAggregateCache: options.usePreAggregateCache,

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -52,6 +52,7 @@ const useTableConfig = (
     invalidateCache?: boolean,
     parameters?: ParametersValuesMap,
     dateZoom?: DateZoom,
+    isEditMode?: boolean,
 ) => {
     const { embedToken } = useEmbed();
 
@@ -213,31 +214,19 @@ const useTableConfig = (
             setShowSubtotals(false);
     }, [dimensions.length, numUnpivotedDimensions]);
 
-    const { data: totalCalculations } = useCalculateTotal(
-        savedChartUuid
-            ? {
-                  savedChartUuid,
-                  fieldIds: selectedItemIds,
-                  dashboardFilters,
-                  invalidateCache,
-                  itemsMap,
-                  showColumnCalculation:
-                      tableChartConfig?.showColumnCalculation,
-                  embedToken,
-                  parameters,
-              }
-            : {
-                  metricQuery: resultsData?.metricQuery,
-                  explore: resultsData?.metricQuery?.exploreName,
-                  fieldIds: selectedItemIds,
-                  itemsMap,
-                  invalidateCache,
-                  showColumnCalculation:
-                      tableChartConfig?.showColumnCalculation,
-                  embedToken,
-                  parameters,
-              },
-    );
+    const { data: totalCalculations } = useCalculateTotal({
+        metricQuery: resultsData?.metricQuery,
+        explore: resultsData?.metricQuery?.exploreName,
+        savedChartUuid,
+        isEditMode,
+        fieldIds: selectedItemIds,
+        dashboardFilters,
+        invalidateCache,
+        itemsMap,
+        showColumnCalculation: tableChartConfig?.showColumnCalculation,
+        embedToken,
+        parameters,
+    });
 
     const { data: groupedSubtotals } = useCalculateSubtotals(
         embedToken && savedChartUuid
@@ -254,6 +243,7 @@ const useTableConfig = (
             : {
                   metricQuery: resultsData?.metricQuery,
                   explore: resultsData?.metricQuery?.exploreName,
+                  savedChartUuid,
                   showSubtotals,
                   columnOrder,
                   pivotDimensions,

--- a/packages/frontend/src/hooks/useCalculateSubtotals.ts
+++ b/packages/frontend/src/hooks/useCalculateSubtotals.ts
@@ -24,6 +24,7 @@ const calculateSubtotalsFromQuery = async (
     parameters?: ParametersValuesMap,
     dateZoom?: DateZoom,
     invalidateCache?: boolean,
+    savedChartUuid?: string,
 ): Promise<ApiCalculateSubtotalsResponse['results']> => {
     const timezoneFixPayload: CalculateSubtotalsFromQuery = {
         explore: explore,
@@ -36,6 +37,7 @@ const calculateSubtotalsFromQuery = async (
         parameters,
         dateZoom,
         invalidateCache,
+        savedChartUuid,
     };
     return lightdashApi<ApiCalculateSubtotalsResponse['results']>({
         url: `/projects/${projectUuid}/calculate-subtotals`,
@@ -188,6 +190,7 @@ export const useCalculateSubtotals = ({
                           parameters,
                           dateZoom,
                           invalidateCache,
+                          savedChartUuid,
                       )
                     : Promise.reject(),
         {

--- a/packages/frontend/src/hooks/useCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useCalculateTotal.ts
@@ -26,12 +26,14 @@ const calculateTotalFromQuery = async ({
     explore,
     invalidateCache,
     parameters,
+    savedChartUuid,
 }: {
     projectUuid: string;
     metricQuery?: MetricQuery;
     explore?: string;
     invalidateCache?: boolean;
     parameters?: ParametersValuesMap;
+    savedChartUuid?: string;
 }): Promise<ApiCalculateTotalResponse['results']> => {
     if (!metricQuery || !explore) {
         throw new Error(
@@ -47,6 +49,7 @@ const calculateTotalFromQuery = async ({
         },
         parameters,
         invalidateCache,
+        savedChartUuid,
     };
     return lightdashApi<ApiCalculateTotalResponse['results']>({
         url: `/projects/${projectUuid}/calculate-total`,
@@ -176,6 +179,7 @@ export const useCalculateTotal = ({
     showColumnCalculation,
     embedToken,
     parameters,
+    isEditMode,
 }: {
     metricQuery?: MetricQueryRequest;
     explore?: string;
@@ -187,6 +191,7 @@ export const useCalculateTotal = ({
     showColumnCalculation?: boolean;
     embedToken: string | undefined;
     parameters?: ParametersValuesMap;
+    isEditMode?: boolean;
 }) => {
     const metricsWithTotals = useMemo(() => {
         if (!fieldIds || !itemsMap) return [];
@@ -195,8 +200,9 @@ export const useCalculateTotal = ({
     }, [fieldIds, itemsMap, showColumnCalculation]);
     const projectUuid = useProjectUuid();
 
-    // only add relevant fields to the key (filters, metrics)
-    const queryKey = savedChartUuid
+    const useSavedChartEndpoint = Boolean(savedChartUuid && !isEditMode);
+
+    const queryKey = useSavedChartEndpoint
         ? { savedChartUuid, dashboardFilters, invalidateCache, parameters }
         : {
               filters: metricQuery?.filters,
@@ -204,6 +210,7 @@ export const useCalculateTotal = ({
               additionalMetrics: metricQuery?.additionalMetrics,
               invalidateCache,
               parameters,
+              savedChartUuid,
           };
 
     return useQuery<ApiCalculateTotalResponse['results'], ApiError>({
@@ -228,15 +235,15 @@ export const useCalculateTotal = ({
                         invalidateCache,
                         parameters,
                     })
-                  : // Regular mode with saved chart
-                    savedChartUuid
+                  : // Regular mode with saved chart (view)
+                    useSavedChartEndpoint && savedChartUuid
                     ? calculateTotalFromSavedChart({
                           savedChartUuid,
                           dashboardFilters,
                           invalidateCache,
                           parameters,
                       })
-                    : // Regular mode with raw query
+                    : // Regular mode with raw query (explore / edit)
                       projectUuid
                       ? calculateTotalFromQuery({
                             projectUuid,
@@ -244,6 +251,7 @@ export const useCalculateTotal = ({
                             explore,
                             invalidateCache,
                             parameters,
+                            savedChartUuid,
                         })
                       : Promise.reject(),
         retry: false,

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -52,8 +52,10 @@ import useEmbed from '../ee/providers/Embed/useEmbed';
 import {
     selectAdditionalMetrics,
     selectCustomDimensions,
+    selectIsEditMode,
     selectMetricOverrides,
     selectParameters,
+    selectSavedChart,
     selectSorts,
     selectTableCalculations,
     selectTableName,
@@ -395,6 +397,8 @@ export const useColumns = (): TableColumn[] => {
     const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
     const sorts = useExplorerSelector(selectSorts);
     const metricOverrides = useExplorerSelector(selectMetricOverrides);
+    const savedChart = useExplorerSelector(selectSavedChart);
+    const isEditMode = useExplorerSelector(selectIsEditMode);
 
     const { activeFields, query, validQueryArgs } = useExplorerQuery();
     const resultsMetricQuery = query.data?.metricQuery;
@@ -508,6 +512,8 @@ export const useColumns = (): TableColumn[] => {
     const { data: totals } = useCalculateTotal({
         metricQuery: resultsMetricQuery,
         explore: exploreData?.baseTable,
+        savedChartUuid: savedChart?.uuid,
+        isEditMode,
         fieldIds: resultsMetricQuery
             ? itemsInMetricQuery(resultsMetricQuery)
             : undefined,

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -169,6 +169,7 @@ export const useExplorerQueryManager = () => {
             minimal,
             usePreAggregateCache: preAggCacheEnabled,
             savedChart: chartConfigForQuery,
+            savedChartUuid: savedQueryUuid,
         });
 
         if (mainQueryArgs) {
@@ -188,6 +189,7 @@ export const useExplorerQueryManager = () => {
         minimal,
         preAggCacheEnabled,
         chartConfigForQuery,
+        savedQueryUuid,
         dispatch,
     ]);
 

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -38,6 +38,12 @@ export type QueryResultsProps = {
     csvLimit?: number | null; //giving null returns all results (no limit)
     chartUuid?: string;
     chartVersionUuid?: string;
+    /**
+     * UUID of the saved chart this query was loaded from. Set on the
+     * edit-mode (metric-query) path so the backend can exempt unchanged
+     * SQL-authored fields from the `manage:CustomFields` gate.
+     */
+    savedChartUuid?: string;
     dateZoomGranularity?: DateGranularity | string;
     context?: QueryExecutionContext;
     invalidateCache?: boolean;
@@ -168,6 +174,7 @@ const executeAsyncQuery = (
                 usePreAggregateCache: data.usePreAggregateCache,
                 parameters: data.parameters,
                 pivotConfiguration: data.pivotConfiguration,
+                savedChartUuid: data.savedChartUuid,
             },
             { signal },
         );

--- a/packages/frontend/src/hooks/useTreemapChartConfig.ts
+++ b/packages/frontend/src/hooks/useTreemapChartConfig.ts
@@ -77,6 +77,7 @@ export type TreemapChartConfigFn = (
     numericMetrics: Record<string, Metric | TableCalculation>,
     tableCalculationsMetadata?: TableCalculationMetadata[],
     parameters?: ParametersValuesMap,
+    savedChartUuid?: string,
 ) => TreemapChartConfig;
 
 const useTreemapChartConfig: TreemapChartConfigFn = (
@@ -87,6 +88,7 @@ const useTreemapChartConfig: TreemapChartConfigFn = (
     numericMetrics,
     tableCalculationsMetadata,
     parameters,
+    savedChartUuid,
 ) => {
     const { embedToken } = useEmbed();
 
@@ -218,6 +220,7 @@ const useTreemapChartConfig: TreemapChartConfigFn = (
     const { data: groupedSubtotals } = useCalculateSubtotals({
         metricQuery: resultsData?.metricQuery,
         explore: resultsData?.metricQuery?.exploreName,
+        savedChartUuid,
         showSubtotals: true,
         columnOrder: groupFieldIds,
         pivotDimensions: undefined,


### PR DESCRIPTION
### Summary

Adds a `manage:CustomFields` gate for **SQL table calculations** at every backend execution and persistence site, mirroring the gate that already existed for custom SQL dimensions, and introduces a **saved-version exemption** so users without the scope can still run a saved chart whose authored SQL fields are unchanged from what's persisted.

Refs: [PROD-7028](https://linear.app/lightdash/issue/PROD-7028) (over-zealous run-time gate sub-bug). Builds on the scope split landed in [PROD-5990](https://linear.app/lightdash/issue/PROD-5990).

### What changed

**`@lightdash/common`** — new helpers (`packages/common/src/utils/sqlAuthoredFields.ts`):
- `hasSqlAuthoredFields(metricQuery)` — any custom SQL dim or SQL table calc present.
- `getModifiedSqlAuthoredFields(incoming, saved)` — returns only fields that are new or whose `sql` body differs from the saved version.
- `hasModifiedSqlAuthoredFields(incoming, saved)` — boolean wrapper.

297 lines of unit tests cover the diff matrix from the audit doc (added/removed/edited dim, edited cosmetic-only, formula/template ungated, etc.).

**Backend gating sites:**
- `AsyncQueryService.assertCanRunSqlAuthoredFields()` — new private helper. Loads the saved chart when `savedChartUuid` is provided, computes the modified-fields diff, and throws `CustomSqlQueryForbiddenError` only if the diff is non-empty *and* the user lacks `manage:CustomFields`. Wired into `executeAsyncMetricQuery`, `calculateTotalFromQuery`, `calculateSubtotalsFromQuery`.
- `SavedChartService.create` and `.createVersion` — now also reject when `tableCalculations.some(isSqlTableCalculation)` and the user lacks the scope (matches the existing custom-dim check).
- `ProjectService.runQuery` / `runUnderlyingDataResults` / `runExploreQuery` and `GdriveService` — switched the existing custom-dim check to the new `hasSqlAuthoredFields()` helper so SQL table calcs are gated there too. These sites do **not** apply the saved-version exemption (still strict) — see [PROD-7177](https://linear.app/lightdash/issue/PROD-7177) for the SQL-panel symptom.

**Request type:** `ExecuteAsyncMetricQueryRequestParams` and `CalculateTotalFromQuery` gain optional `savedChartUuid` so the explorer can declare the originating saved chart.

**Frontend wiring:** `useExplorerQueryManager` / `buildQueryArgs` / `useQueryResults` propagate `savedChartUuid` into every metric-query call. Totals/subtotals were trickier — `VisualizationCard` was nullifying `savedChartUuid` in edit mode (forcing the raw-query endpoint, which was the desired behaviour). The fix plumbs `isEditMode` from `VisualizationProvider` → `VisualizationConfigTable` → `useTableConfig` → `useCalculateTotal`, so the saved-chart endpoint is used only in view mode and the raw endpoint always gets `savedChartUuid` in its body for the gate exemption.

### Out of scope (tracked separately)

- Frontend gating of custom-dim modal/menu affordances → [#22453](https://github.com/lightdash/lightdash/pull/22453) (closes [PROD-7178](https://linear.app/lightdash/issue/PROD-7178))
- Frontend gating of the table-calc modal → [#22456](https://github.com/lightdash/lightdash/pull/22456)
- SQL panel still surfaces the strict gate from `ProjectService.compileQuery` → [PROD-7177](https://linear.app/lightdash/issue/PROD-7177)
- Explore-from-here URL leaks SQL bodies + drops `savedChartUuid` → [PROD-7180](https://linear.app/lightdash/issue/PROD-7180) (implementation plan in the issue's comment)
- Write-side bypasses (`SavedChartService.create` for custom dims, `CoderService`, `PromoteService`) and read-side info disclosure → [PROD-7028](https://linear.app/lightdash/issue/PROD-7028) follow-ups

### Test plan

- [ ] As an Editor (no `manage:CustomFields`), open a saved chart authored by an Admin containing a custom SQL dim → click Run → rows + totals + subtotals all succeed.
- [ ] Same chart, change a filter → query reruns, no 403.
- [ ] Same chart, modify the SQL body of the custom dim → 403 (`CustomSqlQueryForbiddenError`).
- [ ] Same chart, add a *new* SQL custom dim → 403.
- [ ] Repeat the four cases above with a SQL table calculation instead of a custom SQL dim.
- [ ] Add a Formula or Template table calc as the Editor → succeeds (these aren't gated).
- [ ] As Admin: full author/edit/save flow on both SQL custom dims and SQL table calcs continues to work.
- [ ] Charts containing no SQL-authored fields are unaffected for any role.
