### PR TITLE
feat(db): add primary keys to all tables that lacked one

### DIFF
--- a/packages/backend/src/database/CLAUDE.md
+++ b/packages/backend/src/database/CLAUDE.md
@@ -61,6 +61,7 @@ console.log(`Found ${searchResults.pagination.totalResults} results`);
 <importantToKnow>
 - All entities use composite table types (DbEntity, CreateEntity, UpdateEntity) for type safety
 - UUIDs are used for external API identifiers while internal IDs are auto-incrementing integers
+- **Every table must have a PRIMARY KEY**: PostgreSQL logical replication and CDC tools rely on it for row identity, and PG can otherwise be forced into expensive `REPLICA IDENTITY FULL`. For new tables, prefer a synthetic UUID PK (`<table>_uuid` defaulting to `uuid_generate_v4()`) — this is consistent with the external API and avoids relying on natural keys that can change. A composite natural-key PK is acceptable when every column is already `NOT NULL` and inherently stable. Append-only audit/log tables are no exception.
 - **Foreign key preference**: When referencing other tables, prefer using UUID columns (e.g., `organization_uuid`) over integer IDs (e.g., `organization_id`). This maintains consistency with the external API and simplifies joins.
 - The migration system supports both up/down functions and includes 150+ historical migrations
 - KnexPaginate uses CTEs for efficient counting and supports both paginated and unpaginated modes

--- a/packages/backend/src/database/entities/analytics.ts
+++ b/packages/backend/src/database/entities/analytics.ts
@@ -7,18 +7,21 @@ export const AnalyticsSqlChartViewsTableName = 'analytics_sql_chart_views';
 export const AnalyticsAppViewsTableName = 'analytics_app_views';
 
 export type DbAnalyticsChartViews = {
+    analytics_chart_view_uuid: string;
     chart_uuid: string;
     user_uuid: string | null;
     timestamp: Date;
     context: Record<string, AnyType> | null;
 };
 export type DbAnalyticsDashboardViews = {
+    analytics_dashboard_view_uuid: string;
     dashboard_uuid: string;
     user_uuid: string | null;
     timestamp: Date;
     context: Record<string, AnyType> | null;
 };
 export type DbAnalyticsAppViews = {
+    analytics_app_view_uuid: string;
     app_id: string;
     user_uuid: string | null;
     timestamp: Date;

--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -153,6 +153,7 @@ export type SchedulerEmailTargetTable = Knex.CompositeTableType<
 >;
 
 export type SchedulerLogDb = {
+    scheduler_log_uuid: string;
     task: string;
     scheduler_uuid?: string;
     job_id: string;
@@ -167,7 +168,7 @@ export type SchedulerLogDb = {
 
 export type SchedulerLogTable = Knex.CompositeTableType<
     SchedulerLogDb,
-    Omit<SchedulerLogDb, 'created_at'>
+    Omit<SchedulerLogDb, 'created_at' | 'scheduler_log_uuid'>
 >;
 
 export const getSchedulerTargetType = (

--- a/packages/backend/src/database/entities/warehouseAvailableTables.ts
+++ b/packages/backend/src/database/entities/warehouseAvailableTables.ts
@@ -2,6 +2,7 @@ import { PartitionColumn } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export type DbWarehouseAvailableTables = {
+    warehouse_credentials_available_table_uuid: string;
     database: string;
     schema: string;
     table: string;
@@ -12,5 +13,10 @@ export type DbWarehouseAvailableTables = {
 
 export const WarehouseAvailableTablesTableName =
     'warehouse_credentials_available_tables';
-export type WarehouseAvailableTablesTable =
-    Knex.CompositeTableType<DbWarehouseAvailableTables>;
+export type WarehouseAvailableTablesTable = Knex.CompositeTableType<
+    DbWarehouseAvailableTables,
+    Omit<
+        DbWarehouseAvailableTables,
+        'warehouse_credentials_available_table_uuid'
+    >
+>;

--- a/packages/backend/src/database/migrations/20260428153355_add_primary_keys_to_analytics_and_scheduler_log.ts
+++ b/packages/backend/src/database/migrations/20260428153355_add_primary_keys_to_analytics_and_scheduler_log.ts
@@ -88,7 +88,18 @@ async function addPrimaryKey(
         checkName,
     ]);
 
-    // 7. Build the unique index without blocking writes.
+    // 7. Build the unique index without blocking writes. If a previous run
+    //    crashed mid-build, PG may have left an INVALID index behind —
+    //    `IF NOT EXISTS` matches by name only, so drop it first if present.
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_class c
+         JOIN pg_index i ON i.indexrelid = c.oid
+         WHERE c.relname = ? AND NOT i.indisvalid`,
+        [pkName],
+    );
+    if ((invalidIndex.rowCount ?? 0) > 0) {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [pkName]);
+    }
     await knex.raw(
         `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (??)`,
         [pkName, table, column],

--- a/packages/backend/src/database/migrations/20260428153355_add_primary_keys_to_analytics_and_scheduler_log.ts
+++ b/packages/backend/src/database/migrations/20260428153355_add_primary_keys_to_analytics_and_scheduler_log.ts
@@ -1,0 +1,141 @@
+import { Knex } from 'knex';
+
+// Disable transaction wrapping so CREATE INDEX CONCURRENTLY can be used and
+// the long-running batched backfill is not held in a single transaction.
+// Each statement runs in its own implicit transaction. The migration is
+// idempotent so a partial run can be safely resumed by re-running.
+export const config = { transaction: false };
+
+const TABLES: ReadonlyArray<{ table: string; column: string }> = [
+    { table: 'analytics_chart_views', column: 'analytics_chart_view_uuid' },
+    {
+        table: 'analytics_dashboard_views',
+        column: 'analytics_dashboard_view_uuid',
+    },
+    { table: 'analytics_app_views', column: 'analytics_app_view_uuid' },
+    { table: 'scheduler_log', column: 'scheduler_log_uuid' },
+];
+
+const BATCH_SIZE = 10000;
+
+async function addPrimaryKey(
+    knex: Knex,
+    table: string,
+    column: string,
+): Promise<void> {
+    const pkName = `${table}_pkey`;
+    const checkName = `${column}_not_null`;
+
+    // 1. Add nullable column without default. PG records the default in the
+    //    catalog only; this is instant regardless of table size.
+    await knex.raw(`ALTER TABLE ?? ADD COLUMN IF NOT EXISTS ?? uuid`, [
+        table,
+        column,
+    ]);
+
+    // 2. Attach the default so any new INSERTs auto-populate the column while
+    //    the backfill is running.
+    await knex.raw(
+        `ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT uuid_generate_v4()`,
+        [table, column],
+    );
+
+    // 3. Backfill existing rows in bounded batches so we never hold a long
+    //    write lock and never bloat the WAL with one giant UPDATE.
+    let totalUpdated = 0;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await knex.raw<{ rowCount: number }>(
+            `UPDATE ?? SET ?? = uuid_generate_v4()
+             WHERE ctid IN (
+                 SELECT ctid FROM ?? WHERE ?? IS NULL LIMIT ${BATCH_SIZE}
+             )`,
+            [table, column, table, column],
+        );
+        const updated = result.rowCount ?? 0;
+        if (updated === 0) break;
+        totalUpdated += updated;
+        // eslint-disable-next-line no-console
+        console.log(`  ${table}: backfilled ${totalUpdated} rows`);
+    }
+
+    // 4. Add a CHECK (col IS NOT NULL) NOT VALID, then VALIDATE it. VALIDATE
+    //    only takes SHARE UPDATE EXCLUSIVE — concurrent reads and writes
+    //    continue. PG12+ uses this validated CHECK to skip the full table
+    //    scan that SET NOT NULL would otherwise require.
+    const existingCheck = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_constraint
+         WHERE conname = ? AND conrelid = ?::regclass`,
+        [checkName, table],
+    );
+    if ((existingCheck.rowCount ?? 0) === 0) {
+        await knex.raw(
+            `ALTER TABLE ?? ADD CONSTRAINT ?? CHECK (?? IS NOT NULL) NOT VALID`,
+            [table, checkName, column],
+        );
+    }
+    await knex.raw(`ALTER TABLE ?? VALIDATE CONSTRAINT ??`, [table, checkName]);
+
+    // 5. SET NOT NULL — fast on PG12+ thanks to the validated CHECK above.
+    await knex.raw(`ALTER TABLE ?? ALTER COLUMN ?? SET NOT NULL`, [
+        table,
+        column,
+    ]);
+
+    // 6. The CHECK is now redundant with the column-level NOT NULL.
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+        table,
+        checkName,
+    ]);
+
+    // 7. Build the unique index without blocking writes.
+    await knex.raw(
+        `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (??)`,
+        [pkName, table, column],
+    );
+
+    // 8. Promote the existing unique index to PRIMARY KEY. This briefly
+    //    takes ACCESS EXCLUSIVE but does no scanning and finishes in ms.
+    const existingPk = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_constraint
+         WHERE conname = ? AND conrelid = ?::regclass AND contype = 'p'`,
+        [pkName, table],
+    );
+    if ((existingPk.rowCount ?? 0) === 0) {
+        await knex.raw(
+            `ALTER TABLE ?? ADD CONSTRAINT ?? PRIMARY KEY USING INDEX ??`,
+            [table, pkName, pkName],
+        );
+    }
+}
+
+export async function up(knex: Knex): Promise<void> {
+    for (const { table, column } of TABLES) {
+        // eslint-disable-next-line no-console
+        console.log(`Adding primary key ${column} to ${table}`);
+        // eslint-disable-next-line no-await-in-loop
+        await addPrimaryKey(knex, table, column);
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    for (const { table, column } of TABLES) {
+        const pkName = `${table}_pkey`;
+        const checkName = `${column}_not_null`;
+        // eslint-disable-next-line no-await-in-loop
+        await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+            table,
+            pkName,
+        ]);
+        // eslint-disable-next-line no-await-in-loop
+        await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+            table,
+            checkName,
+        ]);
+        // eslint-disable-next-line no-await-in-loop
+        await knex.raw(`ALTER TABLE ?? DROP COLUMN IF EXISTS ??`, [
+            table,
+            column,
+        ]);
+    }
+}

--- a/packages/backend/src/database/migrations/20260429102145_promote_unique_constraints_to_primary_keys.ts
+++ b/packages/backend/src/database/migrations/20260429102145_promote_unique_constraints_to_primary_keys.ts
@@ -1,0 +1,146 @@
+import { Knex } from 'knex';
+
+// Disable transaction wrapping so CREATE INDEX CONCURRENTLY can be used.
+// Each statement runs in its own implicit transaction. The migration is
+// idempotent — a partial run can be safely resumed by re-running.
+export const config = { transaction: false };
+
+// Tables that already have a UNIQUE constraint on NOT NULL columns. We can
+// build a fresh unique index, promote it to PRIMARY KEY, and drop the old
+// UNIQUE constraint — no rewrite, no backfill, no long-held write lock.
+const TABLES: ReadonlyArray<{
+    table: string;
+    columns: readonly string[];
+    oldConstraint: string;
+}> = [
+    {
+        table: 'download_files',
+        columns: ['nanoid'],
+        oldConstraint: 'download_files_nanoid_unique',
+    },
+    {
+        table: 'project_memberships',
+        columns: ['user_id', 'project_id'],
+        oldConstraint: 'project_memberships_project_id_user_id_unique',
+    },
+    {
+        table: 'project_group_access',
+        columns: ['project_uuid', 'group_uuid'],
+        oldConstraint: 'project_group_access_project_uuid_group_uuid_unique',
+    },
+    {
+        table: 'project_user_warehouse_credentials_preference',
+        columns: ['user_uuid', 'project_uuid'],
+        // The constraint name was truncated to 63 chars by PG.
+        oldConstraint:
+            'project_user_warehouse_credentials_preference_user_uuid_project',
+    },
+    {
+        table: 'saved_queries_version_custom_sql_dimensions',
+        columns: ['saved_queries_version_id', 'id'],
+        oldConstraint:
+            'saved_queries_version_custom_sql_dimensions_version_id_unique',
+    },
+    {
+        table: 'space_group_access',
+        columns: ['group_uuid', 'space_uuid'],
+        oldConstraint: 'space_group_access_group_uuid_space_uuid_unique',
+    },
+    {
+        table: 'space_user_access',
+        columns: ['user_uuid', 'space_uuid'],
+        oldConstraint: 'space_user_access_user_uuid_space_uuid_unique',
+    },
+];
+
+async function promoteToPrimaryKey(
+    knex: Knex,
+    table: string,
+    columns: readonly string[],
+    oldConstraint: string,
+): Promise<void> {
+    const pkName = `${table}_pkey`;
+
+    // If the PK already exists (idempotent re-run), there's nothing to do —
+    // but make sure the old UNIQUE constraint is dropped.
+    const existingPk = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_constraint
+         WHERE conname = ? AND conrelid = ?::regclass AND contype = 'p'`,
+        [pkName, table],
+    );
+    if ((existingPk.rowCount ?? 0) > 0) {
+        await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+            table,
+            oldConstraint,
+        ]);
+        return;
+    }
+
+    // If a previous run crashed mid-build, drop the leftover INVALID index.
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_class c
+         JOIN pg_index i ON i.indexrelid = c.oid
+         WHERE c.relname = ? AND NOT i.indisvalid`,
+        [pkName],
+    );
+    if ((invalidIndex.rowCount ?? 0) > 0) {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [pkName]);
+    }
+
+    // Build the new unique index without blocking writes. We use a fresh
+    // index rather than reusing the one behind the existing UNIQUE
+    // constraint because PG won't let two constraints share a single index.
+    const columnList = columns.map(() => '??').join(', ');
+    await knex.raw(
+        `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (${columnList})`,
+        [pkName, table, ...columns],
+    );
+
+    // Promote the new index to PRIMARY KEY (brief lock, no scan).
+    await knex.raw(
+        `ALTER TABLE ?? ADD CONSTRAINT ?? PRIMARY KEY USING INDEX ??`,
+        [table, pkName, pkName],
+    );
+
+    // Drop the now-redundant UNIQUE constraint (this also drops its index).
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+        table,
+        oldConstraint,
+    ]);
+}
+
+export async function up(knex: Knex): Promise<void> {
+    for (const { table, columns, oldConstraint } of TABLES) {
+        // eslint-disable-next-line no-console
+        console.log(`Promoting UNIQUE on ${table} to PRIMARY KEY`);
+        // eslint-disable-next-line no-await-in-loop
+        await promoteToPrimaryKey(knex, table, columns, oldConstraint);
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    for (const { table, columns, oldConstraint } of TABLES) {
+        const pkName = `${table}_pkey`;
+        // Recreate the UNIQUE constraint first so we never leave the table
+        // without row identity, then drop the PRIMARY KEY.
+        const columnList = columns.map(() => '??').join(', ');
+        // eslint-disable-next-line no-await-in-loop
+        const existingUnique = await knex.raw<{ rowCount: number }>(
+            `SELECT 1 FROM pg_constraint
+             WHERE conname = ? AND conrelid = ?::regclass AND contype = 'u'`,
+            [oldConstraint, table],
+        );
+        if ((existingUnique.rowCount ?? 0) === 0) {
+            // eslint-disable-next-line no-await-in-loop
+            await knex.raw(
+                `ALTER TABLE ?? ADD CONSTRAINT ?? UNIQUE (${columnList})`,
+                [table, oldConstraint, ...columns],
+            );
+        }
+        // eslint-disable-next-line no-await-in-loop
+        await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+            table,
+            pkName,
+        ]);
+    }
+}

--- a/packages/backend/src/database/migrations/20260429102146_add_primary_keys_to_remaining_tables.ts
+++ b/packages/backend/src/database/migrations/20260429102146_add_primary_keys_to_remaining_tables.ts
@@ -1,0 +1,158 @@
+import { Knex } from 'knex';
+
+// Disable transaction wrapping so CREATE INDEX CONCURRENTLY can be used and
+// the long-running batched backfill is not held in a single transaction.
+// Each statement runs in its own implicit transaction. The migration is
+// idempotent — a partial run can be safely resumed by re-running.
+export const config = { transaction: false };
+
+// Tables that have no row identity at all and need a synthetic UUID PK.
+// pre_aggregate_daily_stats has a unique INDEX (not constraint) using
+// COALESCE expressions, which can't back a PRIMARY KEY — so it gets a
+// synthetic key here too.
+const TABLES: ReadonlyArray<{ table: string; column: string }> = [
+    {
+        table: 'pre_aggregate_daily_stats',
+        column: 'pre_aggregate_daily_stat_uuid',
+    },
+    { table: 'preview_content', column: 'preview_content_uuid' },
+    {
+        table: 'warehouse_credentials_available_tables',
+        column: 'warehouse_credentials_available_table_uuid',
+    },
+];
+
+const BATCH_SIZE = 10000;
+
+async function addPrimaryKey(
+    knex: Knex,
+    table: string,
+    column: string,
+): Promise<void> {
+    const pkName = `${table}_pkey`;
+    const checkName = `${column}_not_null`;
+
+    // 1. Add nullable column without default. PG records the default in the
+    //    catalog only; this is instant regardless of table size.
+    await knex.raw(`ALTER TABLE ?? ADD COLUMN IF NOT EXISTS ?? uuid`, [
+        table,
+        column,
+    ]);
+
+    // 2. Attach the default so any new INSERTs auto-populate the column while
+    //    the backfill is running.
+    await knex.raw(
+        `ALTER TABLE ?? ALTER COLUMN ?? SET DEFAULT uuid_generate_v4()`,
+        [table, column],
+    );
+
+    // 3. Backfill existing rows in bounded batches so we never hold a long
+    //    write lock and never bloat the WAL with one giant UPDATE.
+    let totalUpdated = 0;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await knex.raw<{ rowCount: number }>(
+            `UPDATE ?? SET ?? = uuid_generate_v4()
+             WHERE ctid IN (
+                 SELECT ctid FROM ?? WHERE ?? IS NULL LIMIT ${BATCH_SIZE}
+             )`,
+            [table, column, table, column],
+        );
+        const updated = result.rowCount ?? 0;
+        if (updated === 0) break;
+        totalUpdated += updated;
+        // eslint-disable-next-line no-console
+        console.log(`  ${table}: backfilled ${totalUpdated} rows`);
+    }
+
+    // 4. Add a CHECK (col IS NOT NULL) NOT VALID, then VALIDATE it. VALIDATE
+    //    only takes SHARE UPDATE EXCLUSIVE — concurrent reads and writes
+    //    continue. PG12+ uses this validated CHECK to skip the full table
+    //    scan that SET NOT NULL would otherwise require.
+    const existingCheck = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_constraint
+         WHERE conname = ? AND conrelid = ?::regclass`,
+        [checkName, table],
+    );
+    if ((existingCheck.rowCount ?? 0) === 0) {
+        await knex.raw(
+            `ALTER TABLE ?? ADD CONSTRAINT ?? CHECK (?? IS NOT NULL) NOT VALID`,
+            [table, checkName, column],
+        );
+    }
+    await knex.raw(`ALTER TABLE ?? VALIDATE CONSTRAINT ??`, [table, checkName]);
+
+    // 5. SET NOT NULL — fast on PG12+ thanks to the validated CHECK above.
+    await knex.raw(`ALTER TABLE ?? ALTER COLUMN ?? SET NOT NULL`, [
+        table,
+        column,
+    ]);
+
+    // 6. The CHECK is now redundant with the column-level NOT NULL.
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+        table,
+        checkName,
+    ]);
+
+    // 7. Build the unique index without blocking writes. If a previous run
+    //    crashed mid-build, PG may have left an INVALID index behind —
+    //    `IF NOT EXISTS` matches by name only, so drop it first if present.
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_class c
+         JOIN pg_index i ON i.indexrelid = c.oid
+         WHERE c.relname = ? AND NOT i.indisvalid`,
+        [pkName],
+    );
+    if ((invalidIndex.rowCount ?? 0) > 0) {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [pkName]);
+    }
+    await knex.raw(
+        `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (??)`,
+        [pkName, table, column],
+    );
+
+    // 8. Promote the existing unique index to PRIMARY KEY. This briefly
+    //    takes ACCESS EXCLUSIVE but does no scanning and finishes in ms.
+    const existingPk = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_constraint
+         WHERE conname = ? AND conrelid = ?::regclass AND contype = 'p'`,
+        [pkName, table],
+    );
+    if ((existingPk.rowCount ?? 0) === 0) {
+        await knex.raw(
+            `ALTER TABLE ?? ADD CONSTRAINT ?? PRIMARY KEY USING INDEX ??`,
+            [table, pkName, pkName],
+        );
+    }
+}
+
+export async function up(knex: Knex): Promise<void> {
+    for (const { table, column } of TABLES) {
+        // eslint-disable-next-line no-console
+        console.log(`Adding primary key ${column} to ${table}`);
+        // eslint-disable-next-line no-await-in-loop
+        await addPrimaryKey(knex, table, column);
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    for (const { table, column } of TABLES) {
+        const pkName = `${table}_pkey`;
+        const checkName = `${column}_not_null`;
+        // eslint-disable-next-line no-await-in-loop
+        await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+            table,
+            pkName,
+        ]);
+        // eslint-disable-next-line no-await-in-loop
+        await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+            table,
+            checkName,
+        ]);
+        // eslint-disable-next-line no-await-in-loop
+        await knex.raw(`ALTER TABLE ?? DROP COLUMN IF EXISTS ??`, [
+            table,
+            column,
+        ]);
+    }
+}

--- a/packages/backend/src/ee/database/entities/preAggregateDailyStats.ts
+++ b/packages/backend/src/ee/database/entities/preAggregateDailyStats.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex';
 export const PreAggregateDailyStatsTableName = 'pre_aggregate_daily_stats';
 
 export type DbPreAggregateDailyStat = {
+    pre_aggregate_daily_stat_uuid: string;
     project_uuid: string;
     explore_name: string;
     date: Date;
@@ -19,7 +20,7 @@ export type DbPreAggregateDailyStat = {
 
 export type DbPreAggregateDailyStatIn = Omit<
     DbPreAggregateDailyStat,
-    'created_at' | 'updated_at'
+    'pre_aggregate_daily_stat_uuid' | 'created_at' | 'updated_at'
 >;
 
 export type PreAggregateDailyStatsTable = Knex.CompositeTableType<

--- a/packages/backend/src/ee/database/migrations/20260429105241_promote_unique_constraints_to_primary_keys.ts
+++ b/packages/backend/src/ee/database/migrations/20260429105241_promote_unique_constraints_to_primary_keys.ts
@@ -1,0 +1,123 @@
+import { Knex } from 'knex';
+
+// Disable transaction wrapping so CREATE INDEX CONCURRENTLY can be used.
+// Each statement runs in its own implicit transaction. The migration is
+// idempotent — a partial run can be safely resumed by re-running.
+export const config = { transaction: false };
+
+// EE tables that already have a UNIQUE constraint on NOT NULL columns. We
+// build a fresh unique index, promote it to PRIMARY KEY, and drop the old
+// UNIQUE constraint — no rewrite, no backfill, no long-held write lock.
+const TABLES: ReadonlyArray<{
+    table: string;
+    columns: readonly string[];
+    oldConstraint: string;
+}> = [
+    {
+        table: 'ai_agent_group_access',
+        columns: ['group_uuid', 'ai_agent_uuid'],
+        oldConstraint: 'ai_agent_group_access_group_uuid_ai_agent_uuid_unique',
+    },
+    {
+        table: 'ai_agent_user_access',
+        columns: ['user_uuid', 'ai_agent_uuid'],
+        oldConstraint: 'ai_agent_user_access_user_uuid_ai_agent_uuid_unique',
+    },
+    {
+        table: 'embedding',
+        columns: ['project_uuid'],
+        oldConstraint: 'embedding_project_uuid_unique',
+    },
+];
+
+async function promoteToPrimaryKey(
+    knex: Knex,
+    table: string,
+    columns: readonly string[],
+    oldConstraint: string,
+): Promise<void> {
+    const pkName = `${table}_pkey`;
+
+    // If the PK already exists (idempotent re-run), make sure the old
+    // UNIQUE constraint is dropped and exit.
+    const existingPk = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_constraint
+         WHERE conname = ? AND conrelid = ?::regclass AND contype = 'p'`,
+        [pkName, table],
+    );
+    if ((existingPk.rowCount ?? 0) > 0) {
+        await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+            table,
+            oldConstraint,
+        ]);
+        return;
+    }
+
+    // If a previous run crashed mid-build, drop the leftover INVALID index.
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_class c
+         JOIN pg_index i ON i.indexrelid = c.oid
+         WHERE c.relname = ? AND NOT i.indisvalid`,
+        [pkName],
+    );
+    if ((invalidIndex.rowCount ?? 0) > 0) {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [pkName]);
+    }
+
+    // Build the new unique index without blocking writes. We use a fresh
+    // index rather than reusing the one behind the existing UNIQUE
+    // constraint because PG won't let two constraints share a single index.
+    const columnList = columns.map(() => '??').join(', ');
+    await knex.raw(
+        `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (${columnList})`,
+        [pkName, table, ...columns],
+    );
+
+    // Promote the new index to PRIMARY KEY (brief lock, no scan).
+    await knex.raw(
+        `ALTER TABLE ?? ADD CONSTRAINT ?? PRIMARY KEY USING INDEX ??`,
+        [table, pkName, pkName],
+    );
+
+    // Drop the now-redundant UNIQUE constraint (this also drops its index).
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+        table,
+        oldConstraint,
+    ]);
+}
+
+export async function up(knex: Knex): Promise<void> {
+    for (const { table, columns, oldConstraint } of TABLES) {
+        // eslint-disable-next-line no-console
+        console.log(`Promoting UNIQUE on ${table} to PRIMARY KEY`);
+        // eslint-disable-next-line no-await-in-loop
+        await promoteToPrimaryKey(knex, table, columns, oldConstraint);
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    for (const { table, columns, oldConstraint } of TABLES) {
+        const pkName = `${table}_pkey`;
+        // Recreate the UNIQUE constraint first so the table never lacks
+        // row identity, then drop the PRIMARY KEY.
+        const columnList = columns.map(() => '??').join(', ');
+        // eslint-disable-next-line no-await-in-loop
+        const existingUnique = await knex.raw<{ rowCount: number }>(
+            `SELECT 1 FROM pg_constraint
+             WHERE conname = ? AND conrelid = ?::regclass AND contype = 'u'`,
+            [oldConstraint, table],
+        );
+        if ((existingUnique.rowCount ?? 0) === 0) {
+            // eslint-disable-next-line no-await-in-loop
+            await knex.raw(
+                `ALTER TABLE ?? ADD CONSTRAINT ?? UNIQUE (${columnList})`,
+                [table, oldConstraint, ...columns],
+            );
+        }
+        // eslint-disable-next-line no-await-in-loop
+        await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+            table,
+            pkName,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `PRIMARY KEY` to every table in the Lightdash app DB that lacked one — both OSS and EE. Originally scoped to the four called out in [PROD-7181](https://linear.app/lightdash/issue/PROD-7181) / #22446 (`analytics_chart_views`, `analytics_dashboard_views`, `analytics_app_views`, `scheduler_log`); expanded to cover the remaining 10 OSS tables and 3 EE tables once they were uncovered.

Missing primary keys cause issues with PostgreSQL logical replication, CDC tools, and general database management — and they're a common point of pain in operational tooling.

test-frontend

## What changed

### Migrations

| Migration | Strategy | Tables |
|-----------|----------|--------|
| OSS `20260428153355_add_primary_keys_to_analytics_and_scheduler_log` | Synthetic UUID PK + staged backfill | `analytics_chart_views`, `analytics_dashboard_views`, `analytics_app_views`, `scheduler_log` |
| OSS `20260429102145_promote_unique_constraints_to_primary_keys` | Promote existing `UNIQUE(NOT NULL …)` → `PRIMARY KEY` | `download_files`, `project_memberships`, `project_group_access`, `project_user_warehouse_credentials_preference`, `saved_queries_version_custom_sql_dimensions`, `space_group_access`, `space_user_access` |
| OSS `20260429102146_add_primary_keys_to_remaining_tables` | Synthetic UUID PK + staged backfill (no usable existing UNIQUE) | `pre_aggregate_daily_stats`, `preview_content`, `warehouse_credentials_available_tables` |
| EE `20260429105241_promote_unique_constraints_to_primary_keys` | Promote existing `UNIQUE(NOT NULL …)` → `PRIMARY KEY` | `ai_agent_group_access`, `ai_agent_user_access`, `embedding` |

### Entity files touched

- `packages/backend/src/database/entities/analytics.ts`
- `packages/backend/src/database/entities/scheduler.ts`
- `packages/backend/src/database/entities/warehouseAvailableTables.ts`
- `packages/backend/src/ee/database/entities/preAggregateDailyStats.ts` — entity for an OSS-created table that happens to live in the EE tree

The EE UNIQUE-promotion migration adds no columns, so no entity type updates are needed for the AI agent / embedding tables.

All four migrations use `config = { transaction: false }` so `CREATE INDEX CONCURRENTLY` works and the long-running backfills don't hold a single transaction. Every step is idempotent — a partial run can be resumed by re-running.

### Staged synthetic-PK approach (OSS migrations 1 & 3)

A naïve `ALTER TABLE … ADD COLUMN … PRIMARY KEY DEFAULT uuid_generate_v4()` would hold `ACCESS EXCLUSIVE` for a full table rewrite. Instead each table gets:

1. `ADD COLUMN … uuid` (nullable, no default) — instant.
2. `ALTER COLUMN … SET DEFAULT uuid_generate_v4()` — new INSERTs auto-populate.
3. Backfill in 10k-row batches via `ctid`.
4. `ADD CONSTRAINT … CHECK (col IS NOT NULL) NOT VALID` then `VALIDATE CONSTRAINT` — only takes `SHARE UPDATE EXCLUSIVE`.
5. `SET NOT NULL` — fast on PG12+ thanks to the validated CHECK.
6. `CREATE UNIQUE INDEX CONCURRENTLY` (with leftover-INVALID-index recovery, per Graphite review feedback).
7. `ADD CONSTRAINT … PRIMARY KEY USING INDEX` — brief lock, no scan.

### UNIQUE-promotion approach (OSS migration 2 & EE migration)

For tables that already have a UNIQUE on NOT NULL columns: build a fresh unique index CONCURRENTLY, promote it to PRIMARY KEY via `ADD PRIMARY KEY USING INDEX`, then drop the now-redundant UNIQUE constraint. No backfill, no rewrite, no long lock.

### Documentation

`packages/backend/src/database/CLAUDE.md` now states that every table must have a PRIMARY KEY and explains the trade-off between synthetic UUID PKs and natural-key composites — so future tables don't end up in the same situation.

## Test plan

- [x] `pnpm -F backend typecheck` passes
- [x] `pnpm -F backend lint` passes
- [x] All four migrations verified end-to-end on fresh PG16 databases seeded with realistic row counts (incl. 25k+ for analytics_chart_views, 12k for pre_aggregate_daily_stats): `up` adds PKs, backfills cleanly, no NULL UUIDs remain, batches as expected
- [x] Idempotent re-run (`up` after `up`): no-op
- [x] Up→down→up cycle works for all four migrations; UNIQUE-promotion `down` restores the original UNIQUE constraint before dropping the PK so the table never lacks row identity
- [x] Invalid-index recovery path verified (forced `pg_index.indisvalid = false`, confirmed `ADD PK USING INDEX` errors, confirmed the recovery branch fixes it)
- [ ] Reviewer to spot-check that no consumer code relies on the old UNIQUE constraint *names* (e.g., catching errors by `constraint_name` text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)