### PR TITLE
fix(pivot): respect explicit sortBy order over groupByColumns declaration

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -754,6 +754,44 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('ORDER BY "date" ASC, "event" DESC');
         });
 
+        test('Should lead column_index ORDER BY with the sorted group-by column, not declaration order (PROD-7154)', () => {
+            // Frontend sends both `status` and `status_priority` as group-by
+            // columns and a sort on `status_priority`. Without this fix the
+            // ORDER BY follows declaration order, so columns end up sorted
+            // alphabetically by `status` with priority only as tiebreaker.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'event_id',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'status' },
+                    { reference: 'status_priority' },
+                ],
+                sortBy: [
+                    {
+                        reference: 'status_priority',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            expect(result.toLowerCase()).toContain(
+                'dense_rank() over (order by g."status_priority" asc, g."status" asc) as "column_index"',
+            );
+        });
+
         test('Should use index column sort for row_index in pivot queries', () => {
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -754,11 +754,10 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('ORDER BY "date" ASC, "event" DESC');
         });
 
-        test('Should lead column_index ORDER BY with the sorted group-by column, not declaration order (PROD-7154)', () => {
-            // Frontend sends both `status` and `status_priority` as group-by
-            // columns and a sort on `status_priority`. Without this fix the
-            // ORDER BY follows declaration order, so columns end up sorted
-            // alphabetically by `status` with priority only as tiebreaker.
+        test('Should lead column_index ORDER BY with the sorted group-by column, not declaration order', () => {
+            // Without this, DENSE_RANK orders columns by the first declared
+            // group-by alphabetically, with the user-sorted column only
+            // acting as a tiebreaker.
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -518,20 +518,45 @@ export class PivotQueryBuilder {
                     return acc;
                 }, []);
 
-            // Create groups order parts. Note that groups parts should follow the groupsByColumns order rather than sortBy order.
-            const groupsOrderByParts = groupByColumns.map((col) => {
-                const sort = sortBy.find((s) => s.reference === col.reference);
+            // Group-by parts: first, emit any group-by columns referenced in
+            // sortBy in the order the user specified them (so the user's sort
+            // intent drives column_index). Then append remaining group-by
+            // columns in declaration order with default ASC. This is what
+            // makes `group by status, status_priority` + `sort by status_priority`
+            // produce columns ordered by priority instead of alphabetical status.
+            const sortedGroupBys = sortBy.filter(isGroupByColumn);
+            const sortedGroupByRefs = new Set(
+                sortedGroupBys.map((s) => s.reference),
+            );
+            const sortedGroupByParts = sortedGroupBys.map((sort) => {
                 const sortExpr = this.resolveSortField(
-                    col.reference,
-                    sort?.direction === SortByDirection.DESC,
-                    sort?.nullsFirst,
+                    sort.reference,
+                    sort.direction === SortByDirection.DESC,
+                    sort.nullsFirst,
                 );
                 return this.prefixSortExprWithAlias(
                     sortExpr,
-                    col.reference,
+                    sort.reference,
                     'g',
                 );
             });
+            const remainingGroupByParts = groupByColumns
+                .filter((col) => !sortedGroupByRefs.has(col.reference))
+                .map((col) => {
+                    const sortExpr = this.resolveSortField(
+                        col.reference,
+                        false,
+                    );
+                    return this.prefixSortExprWithAlias(
+                        sortExpr,
+                        col.reference,
+                        'g',
+                    );
+                });
+            const groupsOrderByParts = [
+                ...sortedGroupByParts,
+                ...remainingGroupByParts,
+            ];
 
             // Order parts cannot have values and groups interleaved. We have to ensure they are together by type
             const sortByValuesFirst = isValueColumn(

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -459,9 +459,11 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Builds ORDER BY clause for groupBy columns with their sort directions.
-     * Respects sortBy order and uses column anchor values for value columns when available.
-     * Appends any missing group by columns at the end.
+     * Builds the ORDER BY clause used to rank pivot columns (column_index).
+     * Group-by columns referenced in sortBy lead in user-specified order; any
+     * remaining group-bys follow in declaration order. Value columns sorted
+     * by an anchor CTE are prepended or appended depending on whether the
+     * first sort entry is a value or a group-by.
      * @param groupByColumns - Group by columns to order by
      * @param valuesColumns - Value columns configuration
      * @param sortBy - Sort configuration for columns
@@ -518,12 +520,8 @@ export class PivotQueryBuilder {
                     return acc;
                 }, []);
 
-            // Group-by parts: first, emit any group-by columns referenced in
-            // sortBy in the order the user specified them (so the user's sort
-            // intent drives column_index). Then append remaining group-by
-            // columns in declaration order with default ASC. This is what
-            // makes `group by status, status_priority` + `sort by status_priority`
-            // produce columns ordered by priority instead of alphabetical status.
+            // Group-by columns referenced in sortBy lead in user-specified
+            // order; remaining group-bys follow in declaration order.
             const sortedGroupBys = sortBy.filter(isGroupByColumn);
             const sortedGroupByRefs = new Set(
                 sortedGroupBys.map((s) => s.reference),


### PR DESCRIPTION
Relates to: https://github.com/lightdash/lightdash/issues/20117

### Description:

When a pivot query has multiple group-by columns and a `sortBy` referencing only one of them, the `column_index` `DENSE_RANK()` window function was previously ordering by the group-by columns in their declaration order, ignoring the user-specified sort. This meant that if `status` was declared before `status_priority`, the ranking would be driven by `status` alphabetically, with `status_priority` only acting as a tiebreaker — even when the user explicitly sorted by `status_priority`.

The fix reorders the `OVER (ORDER BY ...)` clause so that group-by columns referenced in `sortBy` come first (in the order the user specified them), followed by any remaining group-by columns in their original declaration order. This ensures the pivot column ordering reflects the user's intent.

**Before**

![before_group_by_fix.png](https://app.graphite.com/user-attachments/assets/c7216723-d3e4-4caa-8363-eb4efe8f332c.png)

```sql
WITH
  original_query AS (
    SELECT
      "raw_order_statuses".status_priority AS "raw_order_statuses_status_priority",
      "orders".status AS "orders_status",
      "orders".shipping_method AS "orders_shipping_method",
      COUNT(DISTINCT "orders".order_id) AS "orders_unique_order_count"
    FROM
      "postgres"."jaffle"."orders" AS "orders"
      LEFT OUTER JOIN "postgres"."jaffle"."raw_order_statuses" AS "raw_order_statuses" ON ("orders".status) = ("raw_order_statuses".status)
    GROUP BY
      1,
      2,
      3
    ORDER BY
      "raw_order_statuses_status_priority"
  ),
  group_by_query AS (
    SELECT
      "orders_status",
      "raw_order_statuses_status_priority",
      "orders_shipping_method",
      (ARRAY_AGG("orders_unique_order_count")) [1] AS "orders_unique_order_count_any"
    FROM
      original_query
    group by
      "orders_status",
      "raw_order_statuses_status_priority",
      "orders_shipping_method"
  ),
  pivot_query AS (
    SELECT
      g."orders_shipping_method",
      g."orders_status",
      g."raw_order_statuses_status_priority",
      g."orders_unique_order_count_any",
      DENSE_RANK() OVER (
        ORDER BY
          g."orders_shipping_method" ASC
      ) AS "row_index",
      DENSE_RANK() OVER (
        ORDER BY
          g."orders_status" ASC,
          g."raw_order_statuses_status_priority" ASC
      ) AS "column_index"
    FROM
      group_by_query g
  ),
  filtered_rows AS (
    SELECT
      *
    FROM
      pivot_query
    WHERE
      "row_index" <= 500
  ),
  total_columns AS (
    SELECT
      COUNT(*) AS total_columns
    FROM
      (
        SELECT DISTINCT
          "orders_status",
          "raw_order_statuses_status_priority"
        FROM
          filtered_rows
      ) AS distinct_groups
  )
SELECT
  p.*,
  t.total_columns
FROM
  pivot_query p
  CROSS JOIN total_columns t
WHERE
  p."row_index" <= 500
  and p."column_index" <= 200
order by
  p."row_index",
  p."column_index"

```

**After**

![after_group_by_fix.png](https://app.graphite.com/user-attachments/assets/35c04e5f-a532-4570-80a0-23fb13c3fc0b.png)

```sql
WITH
  original_query AS (
    SELECT
      "raw_order_statuses".status_priority AS "raw_order_statuses_status_priority",
      "orders".status AS "orders_status",
      "orders".shipping_method AS "orders_shipping_method",
      COUNT(DISTINCT "orders".order_id) AS "orders_unique_order_count"
    FROM
      "postgres"."jaffle"."orders" AS "orders"
      LEFT OUTER JOIN "postgres"."jaffle"."raw_order_statuses" AS "raw_order_statuses" ON ("orders".status) = ("raw_order_statuses".status)
    GROUP BY
      1,
      2,
      3
    ORDER BY
      "raw_order_statuses_status_priority"
  ),
  group_by_query AS (
    SELECT
      "orders_status",
      "raw_order_statuses_status_priority",
      "orders_shipping_method",
      (ARRAY_AGG("orders_unique_order_count")) [1] AS "orders_unique_order_count_any"
    FROM
      original_query
    group by
      "orders_status",
      "raw_order_statuses_status_priority",
      "orders_shipping_method"
  ),
  pivot_query AS (
    SELECT
      g."orders_shipping_method",
      g."orders_status",
      g."raw_order_statuses_status_priority",
      g."orders_unique_order_count_any",
      DENSE_RANK() OVER (
        ORDER BY
          g."orders_shipping_method" ASC
      ) AS "row_index",
      DENSE_RANK() OVER (
        ORDER BY
          g."raw_order_statuses_status_priority" ASC,
          g."orders_status" ASC
      ) AS "column_index"
    FROM
      group_by_query g
  ),
  filtered_rows AS (
    SELECT
      *
    FROM
      pivot_query
    WHERE
      "row_index" <= 500
  ),
  total_columns AS (
    SELECT
      COUNT(*) AS total_columns
    FROM
      (
        SELECT DISTINCT
          "orders_status",
          "raw_order_statuses_status_priority"
        FROM
          filtered_rows
      ) AS distinct_groups
  )
SELECT
  p.*,
  t.total_columns
FROM
  pivot_query p
  CROSS JOIN total_columns t
WHERE
  p."row_index" <= 500
  and p."column_index" <= 200
order by
  p."row_index",
  p."column_index"

```