### PR TITLE
chore: migrate `WriteBackCustomBinDimensions` feature flag

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -34,7 +34,10 @@ import {
 import useToaster from '../../../../../hooks/toaster/useToaster';
 import { useFilteredFields } from '../../../../../hooks/useFilters';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
-import { useClientFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
+import {
+    useClientFeatureFlag,
+    useServerFeatureFlag,
+} from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -73,9 +76,11 @@ const TreeSingleNodeActions: FC<Props> = ({
         return isDimension(item) ? getCustomMetricType(item.type) : [];
     }, [item]);
 
-    const isWriteBackCustomBinDimensionsEnabled = useClientFeatureFlag(
+    const { data: writeBackCustomBinDimensionsFlag } = useServerFeatureFlag(
         FeatureFlags.WriteBackCustomBinDimensions,
     );
+    const isWriteBackCustomBinDimensionsEnabled =
+        writeBackCustomBinDimensionsFlag?.enabled ?? false;
 
     const isCustomGroupBinsEnabled = useClientFeatureFlag(
         FeatureFlags.CustomGroupBins,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -11,7 +11,7 @@ import {
     useExplorerSelector,
 } from '../../../../../features/explorer/store';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
-import { useClientFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -41,9 +41,11 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
     const allCustomDimensions = useExplorerSelector(selectCustomDimensions);
 
     // Feature flag for bin dimensions write-back
-    const isWriteBackCustomBinDimensionsEnabled = useClientFeatureFlag(
+    const { data: writeBackCustomBinDimensionsFlag } = useServerFeatureFlag(
         FeatureFlags.WriteBackCustomBinDimensions,
     );
+    const isWriteBackCustomBinDimensionsEnabled =
+        writeBackCustomBinDimensionsFlag?.enabled ?? false;
 
     // Filter custom dimensions based on feature flag
     const customDimensionsToWriteBack = useMemo(() => {


### PR DESCRIPTION
Closes:

### Description:
Switches the `WriteBackCustomBinDimensions` feature flag check from a client-side evaluation (`useClientFeatureFlag`) to a server-side evaluation (`useServerFeatureFlag`) in both `TreeSingleNodeActions` and `VirtualSectionHeader`. The enabled state is now derived from the server response, defaulting to `false` if the flag data is unavailable.