### PR TITLE
chore: migrate `EnableUserTimezones` to server feature flag

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -20,7 +20,7 @@ import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExp
 import { useProject } from '../../../hooks/useProject';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
-import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import useApp from '../../../providers/App/useApp';
@@ -130,9 +130,10 @@ const ExplorerHeader: FC = memo(() => {
         };
     }, [getHasDashboardChanges]);
 
-    const userTimeZonesEnabled = useClientFeatureFlag(
+    const { data: enableUserTimezonesFlag } = useServerFeatureFlag(
         FeatureFlags.EnableUserTimezones,
     );
+    const userTimeZonesEnabled = enableUserTimezonesFlag?.enabled ?? false;
 
     const { data: project } = useProject(projectUuid);
     const timezonePlaceholder = useMemo(() => {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
@@ -2,7 +2,7 @@ import { FeatureFlags, getTimezoneLabel } from '@lightdash/common';
 import { Badge, Tooltip } from '@mantine-8/core';
 import { IconClock } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 
 type Props = {
@@ -17,9 +17,10 @@ const VisualizationTimezone: FC<Props> = ({
     resolvedTimezone,
     metricQueryTimezone,
 }) => {
-    const userTimeZonesEnabled = useClientFeatureFlag(
+    const { data: enableUserTimezonesFlag } = useServerFeatureFlag(
         FeatureFlags.EnableUserTimezones,
     );
+    const userTimeZonesEnabled = enableUserTimezonesFlag?.enabled ?? false;
     const timezone =
         resolvedTimezone ?? (userTimeZonesEnabled ? metricQueryTimezone : null);
     if (!timezone) return null;


### PR DESCRIPTION
Closes:

### Description:
Switches the `EnableUserTimezones` feature flag from a client-side check (`useClientFeatureFlag`) to a server-side check (`useServerFeatureFlag`) in both `ExplorerHeader` and `VisualizationTimezone`. The resolved flag value defaults to `false` if the server response is unavailable.