### PR TITLE
fix(scim): pass missing account arg in ScimService.createUser tests

### DIFF
--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -287,6 +287,7 @@ describe('ScimService', () => {
             };
 
             await service.createUser({
+                account: mockScimAccount,
                 user: scimUser,
                 organizationUuid: 'org-uuid',
             });
@@ -327,6 +328,7 @@ describe('ScimService', () => {
 
             await expect(
                 service.createUser({
+                    account: mockScimAccount,
                     user: scimUser,
                     organizationUuid: 'org-uuid',
                 }),


### PR DESCRIPTION
## Summary
- Two `ScimService.createUser` tests were missing the required `account` argument, causing the test suite to fail to compile.
- Added `account: mockScimAccount` to match the surrounding tests.

## Test plan
- [x] `pnpm -F backend test -- src/ee/services/ScimService/ScimService.test.ts` (41 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)