### PR TITLE
fix: update OAuth clients icon to `IconApps`

### DIFF
--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { Box, ScrollArea, Stack, Text, Title } from '@mantine-8/core';
 import {
     IconAppWindow,
+    IconApps,
     IconBolt,
     IconBrain,
     IconBrowser,
@@ -779,7 +780,7 @@ const Settings: FC = () => {
                                         exact
                                         to="/generalSettings/oauthClients"
                                         leftSection={
-                                            <MantineIcon icon={IconPlug} />
+                                            <MantineIcon icon={IconApps} />
                                         }
                                     />
                                 )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

so it's not the same as integrations 

![CleanShot 2026-04-28 at 18.20.16.png](https://app.graphite.com/user-attachments/assets/bd2b0c7f-ac3c-4046-afa6-30d7ab47c87d.png)



<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->