### PR TITLE
feat(audit-log): surface user attribution caveat for service accounts [SPK-391]

### DIFF
--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -125,12 +125,22 @@ export const fromServiceAccount = (
     sessionUser: SessionUser,
     source: string,
 ): ServiceAcctAccount => {
+    if (!sessionUser.serviceAccount) {
+        throw new ForbiddenError(
+            'SessionUser is missing serviceAccount context; the service-account auth middleware must run first.',
+        );
+    }
     const [organization, user] = extractOrganizationFromUser(sessionUser);
 
     return createAccount({
         authentication: {
             type: 'service-account',
             source,
+            serviceAccountUuid: sessionUser.serviceAccount.uuid,
+            serviceAccountDescription:
+                sessionUser.serviceAccount.description ?? '',
+            attributedUserUuid: sessionUser.userUuid,
+            attributedUserEmail: sessionUser.serviceAccount.attributedUserEmail,
         },
         organization,
         user: {

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -131,6 +131,11 @@ export const isScimAuthenticated: RequestHandler = async (req, res, next) => {
             abilityRules: builder.rules,
             createdAt: serviceAccount.createdAt,
             updatedAt: serviceAccount.createdAt,
+            serviceAccount: {
+                uuid: serviceAccount.uuid,
+                description: serviceAccount.description,
+                attributedUserEmail: adminUser.email,
+            },
         };
 
         if (req?.account?.isAuthenticated()) {
@@ -245,6 +250,11 @@ export const authenticateServiceAccount: RequestHandler = async (
             abilityRules: builder.rules,
             createdAt: serviceAccount.createdAt,
             updatedAt: serviceAccount.createdAt,
+            serviceAccount: {
+                uuid: serviceAccount.uuid,
+                description: serviceAccount.description,
+                attributedUserEmail: adminUser.email,
+            },
         };
 
         if (req?.account?.isAuthenticated()) {

--- a/packages/backend/src/ee/authentication/serviceAccount.mock.ts
+++ b/packages/backend/src/ee/authentication/serviceAccount.mock.ts
@@ -30,6 +30,7 @@ export const mockOrganization = {
 export const mockAdminUser = {
     userUuid: 'test-user-uuid',
     userId: 1,
+    email: 'admin@example.com',
 };
 
 // Mock requests for different scenarios

--- a/packages/backend/src/logging/auditLog.ts
+++ b/packages/backend/src/logging/auditLog.ts
@@ -33,8 +33,18 @@ export const UserAuditActorSchema = BaseUserActorSchema.extend({
     type: z.enum(['session', 'pat', 'oauth']),
 });
 
-export const ServiceAccountAuditActorSchema = BaseUserActorSchema.extend({
+// `uuid` is the service-account UUID — the actual actor.
+// `attributedUserUuid` is the admin user the action gets recorded against
+// due to an FK on the users table; surfaced so auditors can reconcile with
+// user-level activity views. @see https://github.com/lightdash/lightdash/issues/15466
+export const ServiceAccountAuditActorSchema = z.object({
     type: z.literal('service-account'),
+    uuid: z.string(),
+    description: z.string().optional(),
+    organizationUuid: z.string(),
+    organizationRole: z.string(),
+    attributedUserUuid: z.string(),
+    attributedUserEmail: z.string().optional(),
 });
 
 export const AnonymousAuditActorSchema = z.object({

--- a/packages/backend/src/logging/caslAuditWrapper.test.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.test.ts
@@ -546,7 +546,17 @@ describe('CaslAuditWrapper', () => {
             withImpersonation: boolean;
         }): Account =>
             ({
-                authentication: { type: overrides.authType, source: 'src' },
+                authentication:
+                    overrides.authType === 'service-account'
+                        ? {
+                              type: 'service-account',
+                              source: 'src',
+                              serviceAccountUuid: 'sa-uuid',
+                              serviceAccountDescription: 'ci-deploy',
+                              attributedUserUuid: 'user-789',
+                              attributedUserEmail: 'user@example.com',
+                          }
+                        : { type: overrides.authType, source: 'src' },
                 organization: { organizationUuid: 'org-uuid' },
                 user: {
                     id: 'user-789',
@@ -615,6 +625,23 @@ describe('CaslAuditWrapper', () => {
             expect(actor.type).toBe('oauth');
             if (actor.type !== 'oauth') return;
             expect(actor.impersonatedBy).toBeUndefined();
+        });
+
+        it('should map service-account UUID, description and attributed user from authentication', () => {
+            const account = buildSessionAccount({
+                authType: 'service-account',
+                withImpersonation: false,
+            });
+            const actor = createActorFromAccount(account);
+
+            expect(actor.type).toBe('service-account');
+            if (actor.type !== 'service-account') return;
+            expect(actor.uuid).toBe('sa-uuid');
+            expect(actor.description).toBe('ci-deploy');
+            expect(actor.attributedUserUuid).toBe('user-789');
+            expect(actor.attributedUserEmail).toBe('user@example.com');
+            expect(actor.organizationUuid).toBe('org-uuid');
+            expect(actor.organizationRole).toBe(OrganizationMemberRole.VIEWER);
         });
     });
 });

--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -6,6 +6,7 @@ import {
     type Account,
     type AnonymousAccount,
     type ImpersonationContext,
+    type ServiceAcctAccount,
     type SessionUser,
 } from '@lightdash/common';
 import {
@@ -34,6 +35,7 @@ export type AuditableUser = Pick<
     | 'organizationUuid'
     | 'role'
     | 'impersonation'
+    | 'serviceAccount'
 >;
 
 type AuditableCaslSubjectObject = ForcedSubject<CaslSubjectNames> & {
@@ -70,16 +72,22 @@ export const createActorFromAccount = (account: Account): AuditActor => {
     }
 
     if (account.isServiceAccount()) {
+        const svcAccount = account as ServiceAcctAccount;
+        const {
+            serviceAccountUuid,
+            serviceAccountDescription,
+            attributedUserUuid,
+            attributedUserEmail,
+        } = svcAccount.authentication;
         return {
-            type: 'service-account' as const,
-            uuid: account.user.id,
-            email: account.user.email || '',
+            type: 'service-account',
+            uuid: serviceAccountUuid,
+            description: serviceAccountDescription || undefined,
             organizationUuid:
-                account.organization.organizationUuid || 'unknown',
-            organizationRole:
-                'role' in account.user
-                    ? (account.user as { role?: string }).role || 'unknown'
-                    : 'unknown',
+                svcAccount.organization.organizationUuid || 'unknown',
+            organizationRole: svcAccount.user.role || 'unknown',
+            attributedUserUuid,
+            attributedUserEmail,
         };
     }
 
@@ -132,6 +140,21 @@ export const createActorFromAccount = (account: Account): AuditActor => {
  * @deprecated Prefer createActorFromAccount with Account type
  */
 export const createActorFromUser = (user: AuditableUser): AuditActor => {
+    // Service-account requests stamp `req.user.serviceAccount` alongside the
+    // attributed admin user, so the legacy SessionUser path can still produce
+    // a service-account audit actor.
+    if (user.serviceAccount) {
+        return {
+            type: 'service-account',
+            uuid: user.serviceAccount.uuid,
+            description: user.serviceAccount.description || undefined,
+            organizationUuid: user.organizationUuid || 'unknown',
+            organizationRole: user.role || 'unknown',
+            attributedUserUuid: user.userUuid,
+            attributedUserEmail: user.serviceAccount.attributedUserEmail,
+        };
+    }
+
     // Impersonation is only attached to session users; PAT/OAuth/service-account
     // sessions cannot be impersonated.
     const impersonatedBy = user.impersonation

--- a/packages/backend/src/logging/winston.test.ts
+++ b/packages/backend/src/logging/winston.test.ts
@@ -67,26 +67,27 @@ describe('formatAuditActor', () => {
         ).toBe('user-uuid');
     });
 
-    it('shows service-account with email', () => {
+    it('shows service-account with description', () => {
         expect(
             formatAuditActor({
                 type: 'service-account',
                 uuid: 'sa-uuid',
-                email: 'ci-deploy@company.com',
+                description: 'ci-deploy',
                 organizationUuid: 'org-uuid',
                 organizationRole: 'admin',
+                attributedUserUuid: 'admin-uuid',
             }),
-        ).toBe('service-account "ci-deploy@company.com"');
+        ).toBe('service-account "ci-deploy"');
     });
 
-    it('shows service-account with uuid when email is missing', () => {
+    it('shows service-account with uuid when description is missing', () => {
         expect(
             formatAuditActor({
                 type: 'service-account',
                 uuid: 'sa-uuid',
-                email: '',
                 organizationUuid: 'org-uuid',
                 organizationRole: 'admin',
+                attributedUserUuid: 'admin-uuid',
             }),
         ).toBe('service-account sa-uuid');
     });
@@ -229,16 +230,18 @@ describe('formatAuditMessage', () => {
         );
     });
 
-    it('formats service account event', () => {
+    it('formats service account event with attribution caveat (email)', () => {
         expect(
             formatAuditMessage({
                 ...baseEvent,
                 actor: {
                     type: 'service-account',
                     uuid: 'sa-uuid',
-                    email: 'ci@company.com',
+                    description: 'ci-deploy',
                     organizationUuid: 'org-uuid',
                     organizationRole: 'admin',
+                    attributedUserUuid: 'admin-uuid',
+                    attributedUserEmail: 'admin@company.com',
                 },
                 action: 'manage',
                 resource: {
@@ -251,7 +254,31 @@ describe('formatAuditMessage', () => {
                 },
             }),
         ).toBe(
-            'service-account "ci@company.com" managed Group -> groupUuid: group-uuid, groupName: Engineering (allowed)',
+            'service-account "ci-deploy" managed Group -> groupUuid: group-uuid, groupName: Engineering (allowed) (recorded against user admin@company.com)',
+        );
+    });
+
+    it('formats service account event with attribution caveat falling back to uuid', () => {
+        expect(
+            formatAuditMessage({
+                ...baseEvent,
+                actor: {
+                    type: 'service-account',
+                    uuid: 'sa-uuid',
+                    description: 'ci-deploy',
+                    organizationUuid: 'org-uuid',
+                    organizationRole: 'admin',
+                    attributedUserUuid: 'admin-uuid',
+                },
+                action: 'manage',
+                resource: {
+                    type: 'Group',
+                    metadata: { groupUuid: 'group-uuid' },
+                    organizationUuid: 'org-uuid',
+                },
+            }),
+        ).toBe(
+            'service-account "ci-deploy" managed Group -> groupUuid: group-uuid (allowed) (recorded against user admin-uuid)',
         );
     });
 

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -167,8 +167,8 @@ export const formatAuditActor = (actor: AuditActor): string => {
         return 'anonymous user';
     }
     if (actor.type === 'service-account') {
-        if ('email' in actor && actor.email) {
-            return `service-account "${actor.email}"`;
+        if (actor.description) {
+            return `service-account "${actor.description}"`;
         }
         return `service-account ${actor.uuid}`;
     }
@@ -213,7 +213,17 @@ export const formatAuditMessage = (event: AuditLogEvent): string => {
     const resource = formatAuditResource(event.resource);
     const status = `(${event.status})`;
     const reason = event.reason ? ` - ${event.reason}` : '';
-    return `${actor} ${action} ${resource} ${status}${reason}`;
+    // Service-account actions are recorded against an admin user due to an FK
+    // constraint; flag this so auditors can reconcile with user-level views.
+    // @see https://github.com/lightdash/lightdash/issues/15466
+    const caveat =
+        event.actor.type === 'service-account'
+            ? ` (recorded against user ${
+                  event.actor.attributedUserEmail ||
+                  event.actor.attributedUserUuid
+              })`
+            : '';
+    return `${actor} ${action} ${resource} ${status}${reason}${caveat}`;
 };
 
 export const logAuditEvent = (event: AuditLogEvent): void => {

--- a/packages/backend/src/services/AdminNotificationService/AdminNotificationService.mock.ts
+++ b/packages/backend/src/services/AdminNotificationService/AdminNotificationService.mock.ts
@@ -113,7 +113,11 @@ const createMockAccount = (
             ? {
                   type: 'service-account' as const,
                   source: 'mock-service-account-token',
-                  description: overrides.serviceAccountDescription,
+                  serviceAccountUuid: 'mock-service-account-uuid',
+                  serviceAccountDescription:
+                      overrides.serviceAccountDescription ?? '',
+                  attributedUserUuid: overrides.userUuid ?? 'changer-uuid',
+                  attributedUserEmail: overrides.email ?? 'changer@example.com',
               }
             : { type: 'session' as const, source: 'mock-session-cookie' },
         user: {

--- a/packages/backend/src/services/AdminNotificationService/AdminNotificationService.ts
+++ b/packages/backend/src/services/AdminNotificationService/AdminNotificationService.ts
@@ -56,8 +56,7 @@ export class AdminNotificationService extends BaseService {
         account: Account,
     ): string | undefined {
         if (account.authentication?.type === 'service-account') {
-            return (account.authentication as { description?: string })
-                .description;
+            return account.authentication.serviceAccountDescription;
         }
         return undefined;
     }

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -47,6 +47,13 @@ export type JwtAuth = {
 export type ServiceAccountAuth = {
     type: 'service-account';
     source: string; // The service account token
+    serviceAccountUuid: string;
+    serviceAccountDescription: string;
+    // Admin user UUID/email the action is recorded against due to an FK on the
+    // users table. Used by audit logs to flag the attribution caveat.
+    // @see https://github.com/lightdash/lightdash/issues/15466
+    attributedUserUuid: string;
+    attributedUserEmail?: string;
 };
 
 export type OauthAuth = {

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -89,6 +89,28 @@ export interface SessionUser extends LightdashUserWithAbilityRules {
     };
     /* Set only when an admin is impersonating this user via session auth */
     impersonation?: ImpersonationContext;
+    /**
+     * Set only when the request was authenticated via a service-account token.
+     * `req.user` is the admin user the action is recorded against (FK
+     * constraint on `users`), and this field carries the actual service-account
+     * identity so audit logging can attribute correctly even when call sites
+     * receive SessionUser rather than Account.
+     *
+     * `attributedUserEmail` holds the *real* admin user's email. We can't read
+     * it from `email` on this SessionUser because the service-account auth
+     * middleware overwrites `email` with the placeholder
+     * `service-account@lightdash.com` (and `firstName`/`lastName` similarly) so
+     * downstream code that surfaces the actor sees a service-account label
+     * rather than leaking the admin user's identity. The audit log still needs
+     * the real admin email to flag the FK attribution caveat, so we stash it
+     * here at middleware time.
+     * @see https://github.com/lightdash/lightdash/issues/15466
+     */
+    serviceAccount?: {
+        uuid: string;
+        description?: string;
+        attributedUserEmail?: string;
+    };
 }
 
 export interface ImpersonationContext {


### PR DESCRIPTION
## Summary

- Service accounts perform actions under an admin user's UUID (FK constraint on the `users` table). Audit log entries now flag this so auditors can reconcile activity surfaced under the admin user with the service account that actually performed it.
- Adds `serviceAccountUuid`, `serviceAccountDescription`, `attributedUserUuid`, `attributedUserEmail` to `ServiceAccountAuth` and to the audit-actor schema; the formatted message gets a `(recorded against user <email-or-uuid>)` suffix for service-account events.
- The real admin email is captured at middleware time and stashed on `SessionUser.serviceAccount.attributedUserEmail`, because `req.user.email` gets overwritten with the placeholder `service-account@lightdash.com` to avoid leaking admin identity through other actor surfaces.

Linear: https://linear.app/lightdash/issue/SPK-391

## Test plan

- [x] `pnpm -F backend exec jest src/logging src/ee/authentication src/services/AdminNotificationService src/auth` passes
- [x] Hit any service-account authenticated endpoint and inspect the audit log entries — confirm the message includes the real admin user's email in the `(recorded against user ...)` suffix
- [x] Confirm SCIM endpoints (also service-account-authenticated) include the same suffix
- [x] Confirm session/PAT/OAuth audit log entries are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)