### PR TITLE
fix: gate "Change explore" on chart-update permission instead of project-update [PROD-7185]

### DIFF
--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -34,6 +34,7 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import {
     getNameChanges,
     renameAlert,
@@ -50,6 +51,7 @@ type RenameServiceArguments = {
     dashboardModel: DashboardModel;
     schedulerClient: SchedulerClient;
     schedulerModel: SchedulerModel;
+    spacePermissionService: SpacePermissionService;
 };
 
 export class RenameService extends BaseService {
@@ -67,6 +69,8 @@ export class RenameService extends BaseService {
 
     private readonly schedulerModel: SchedulerModel;
 
+    private readonly spacePermissionService: SpacePermissionService;
+
     constructor(args: RenameServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
@@ -76,6 +80,7 @@ export class RenameService extends BaseService {
         this.dashboardModel = args.dashboardModel;
         this.schedulerClient = args.schedulerClient;
         this.schedulerModel = args.schedulerModel;
+        this.spacePermissionService = args.spacePermissionService;
     }
 
     async getFieldsForChart({
@@ -164,22 +169,47 @@ export class RenameService extends BaseService {
             );
         }
 
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const chart = await this.savedChartModel.get(chartUuid);
+        const { organizationUuid, spaceUuid, name: chartName } = chart;
+        const { inheritsFromOrgOrProject, access } =
+            await this.spacePermissionService.getSpaceAccessContext(
+                user.userUuid,
+                spaceUuid,
+            );
+
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 'update',
-                subject('Project', {
+                subject('SavedChart', {
                     organizationUuid,
                     projectUuid,
+                    inheritsFromOrgOrProject,
+                    access,
+                    metadata: {
+                        savedChartUuid: chartUuid,
+                        savedChartName: chartName,
+                    },
                 }),
             )
         ) {
             throw new ForbiddenError();
         }
 
-        const chart = await this.savedChartModel.get(chartUuid);
+        // The fixAll path schedules a project-wide rename via
+        // scheduleRenameResources, which itself requires update:Project. Check
+        // it here too so we fail before mutating the single chart — otherwise
+        // the inner check would 403 mid-flight and leave the chart updated
+        // while the API response reports failure.
+        if (
+            fixAll &&
+            auditedAbility.cannot(
+                'update',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
 
         const nameChanges = getNameChanges({
             from,

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -170,7 +170,15 @@ export class RenameService extends BaseService {
         }
 
         const chart = await this.savedChartModel.get(chartUuid);
-        const { organizationUuid, spaceUuid, name: chartName } = chart;
+        if (chart.projectUuid !== projectUuid) {
+            throw new NotFoundError(`Chart ${chartUuid} not found`);
+        }
+        const {
+            organizationUuid,
+            projectUuid: chartProjectUuid,
+            spaceUuid,
+            name: chartName,
+        } = chart;
         const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getSpaceAccessContext(
                 user.userUuid,
@@ -183,7 +191,7 @@ export class RenameService extends BaseService {
                 'update',
                 subject('SavedChart', {
                     organizationUuid,
-                    projectUuid,
+                    projectUuid: chartProjectUuid,
                     inheritsFromOrgOrProject,
                     access,
                     metadata: {
@@ -205,7 +213,10 @@ export class RenameService extends BaseService {
             fixAll &&
             auditedAbility.cannot(
                 'update',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid: chartProjectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1030,6 +1030,7 @@ export class ServiceRepository
                     dashboardModel: this.models.getDashboardModel(),
                     schedulerClient: this.clients.getSchedulerClient(),
                     schedulerModel: this.models.getSchedulerModel(),
+                    spacePermissionService: this.getSpacePermissionService(),
                 }),
         );
     }

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -338,14 +338,6 @@ const SavedChartsHeader: FC = () => {
         }),
     );
 
-    const userCanUpdateProject = user.data?.ability.can(
-        'update',
-        subject('Project', {
-            organizationUuid: user.data?.organizationUuid,
-            projectUuid,
-        }),
-    );
-
     const userCanCreateDeliveriesAndAlerts = user.data?.ability?.can(
         'create',
         subject('ScheduledDeliveries', {
@@ -748,7 +740,7 @@ const SavedChartsHeader: FC = () => {
                                     </Menu.Item>
                                 )}
                                 {changeChartExploreEnabled &&
-                                    userCanUpdateProject &&
+                                    userCanManageChart &&
                                     !isEditMode && (
                                         <Menu.Item
                                             leftSection={

--- a/packages/frontend/src/components/common/modal/ChangeChartExploreModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChangeChartExploreModal.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     getErrorMessage,
     isSummaryExploreError,
@@ -23,6 +24,7 @@ import { lightdashApi } from '../../../api';
 import { pollJobStatus } from '../../../features/scheduler/hooks/useScheduler';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useExplores } from '../../../hooks/useExplores';
+import useApp from '../../../providers/App/useApp';
 import MantineModal from '../MantineModal';
 
 const renameChartExplore = async ({
@@ -69,10 +71,19 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
     currentExploreName,
 }) => {
     const queryClient = useQueryClient();
+    const { user } = useApp();
     const [selectedExplore, setSelectedExplore] = useState<string | null>(null);
     const [fixAll, setFixAll] = useState(false);
     const [search, setSearch] = useState('');
     const { showToastSuccess, showToastError, showToastInfo } = useToaster();
+
+    const userCanUpdateProject = user.data?.ability.can(
+        'update',
+        subject('Project', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
 
     const { data: explores, isLoading: isLoadingExplores } = useExplores(
         projectUuid,
@@ -119,11 +130,13 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
         e.preventDefault();
         if (!selectedExplore || isSameExplore) return;
 
+        const fixAllAllowed = fixAll && userCanUpdateProject === true;
+
         try {
             const result = await rename({
                 from: currentExploreName,
                 to: selectedExplore,
-                fixAll,
+                fixAll: fixAllAllowed,
             });
 
             showToastSuccess({
@@ -131,7 +144,7 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
                 title: `Explore changed to "${selectedExplore}"`,
             });
 
-            if (fixAll && result?.jobId) {
+            if (fixAllAllowed && result?.jobId) {
                 showToastInfo({
                     key: 'change_chart_explore_fixall_toast',
                     title: `Updating other charts using "${currentExploreName}"...`,
@@ -232,12 +245,14 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
                         />
                     )}
 
-                    <Checkbox
-                        size="xs"
-                        label="Also update all other charts using this explore"
-                        checked={fixAll}
-                        onChange={(e) => setFixAll(e.currentTarget.checked)}
-                    />
+                    {userCanUpdateProject && (
+                        <Checkbox
+                            size="xs"
+                            label="Also update all other charts using this explore"
+                            checked={fixAll}
+                            onChange={(e) => setFixAll(e.currentTarget.checked)}
+                        />
+                    )}
                 </Stack>
             </form>
         </MantineModal>

--- a/packages/frontend/src/components/common/modal/ChangeChartExploreModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChangeChartExploreModal.tsx
@@ -77,13 +77,14 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
     const [search, setSearch] = useState('');
     const { showToastSuccess, showToastError, showToastInfo } = useToaster();
 
-    const userCanUpdateProject = user.data?.ability.can(
-        'update',
-        subject('Project', {
-            organizationUuid: user.data?.organizationUuid,
-            projectUuid,
-        }),
-    );
+    const userCanUpdateProject =
+        user.data?.ability.can(
+            'update',
+            subject('Project', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
 
     const { data: explores, isLoading: isLoadingExplores } = useExplores(
         projectUuid,
@@ -130,7 +131,7 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
         e.preventDefault();
         if (!selectedExplore || isSameExplore) return;
 
-        const fixAllAllowed = fixAll && userCanUpdateProject === true;
+        const fixAllAllowed = fixAll && userCanUpdateProject;
 
         try {
             const result = await rename({


### PR DESCRIPTION
## Summary

- Switches the gate on the **Change explore** chart action from `update:Project` → `update:SavedChart`, so users with edit access to a chart's space can remap its underlying explore without also being granted project-settings access (which unlocks warehouse / dbt connection editing).
- Bulk path (`fixAll: true`) still requires `update:Project`. The check is pulled forward in `renameChart()` to fail before the single-chart mutation runs.
- Hides the bulk-update checkbox in the UI for users without `update:Project` so the modal matches what the backend will accept.

Closes PROD-7185. Customer driver: an instance lead asked for non-admins to be able to use this action, but explicitly didn't want to grant `update:Project` (which would also unlock the warehouse connection settings). There's no surgical scope today that maps just to "Change explore", so we widened the gate to the most natural existing scope — chart edit.

## ⚠️ Caveat — pre-existing latent bugs exposed and fixed inside this PR

### 1. Partial-mutation race on `fixAll`

Before this change both checks (the outer one in `renameChart` and the inner one in `scheduleRenameResources`) were the same predicate (`update:Project`), so they always agreed. Splitting them — outer = `update:SavedChart`, inner = `update:Project` — exposed a partial-mutation bug:

```
1. Outer check: update:SavedChart  ✅  (Editor passes)
2. createVersion()                      ← chart already mutated
3. if (fixAll) call scheduleRenameResources()
       └─ Inner check: update:Project ❌  → 403
4. Throw → controller returns HTTP 403
```

A non-admin clicking "Change explore" with the bulk checkbox ticked would get a 403 toast saying the action failed, but their own chart would already be updated.

This PR fixes that by adding an early `update:Project` check in `renameChart()` when `fixAll === true`, before any mutation runs. Hiding the checkbox in the UI for non-admins is the matching front-end change so users don't see an option that will reliably 403.

The same partial-mutation pattern *technically* existed before this change too — it was just unreachable because the outer and inner checks were identical.

### 2. Mixed-source CASL subject (cross-project chart spoofing)

The original first commit on this branch built the `subject('SavedChart', { ... })` with `organizationUuid` pulled from the chart object but `projectUuid` from the URL path parameter. That mixed-source subject diverges from the canonical pattern in `SavedChartService.ts:182` and `RenameService.getFieldsForChart` (which both source both fields from the chart). It also leaves a small cross-project-spoofing surface: a request with a chartUuid from project A submitted under a URL pointing at project B produces a hybrid subject the CASL rules weren't designed for.

Fixed in `7a90fa866f` by destructuring `projectUuid` from the chart and adding an explicit `chart.projectUuid !== projectUuid` NotFoundError guard at the start of `renameChart`, before auth runs. This pattern was latent before the PR (the URL-vs-chart split existed pre-change) and the fix is a clean defensive guard regardless of the auth split.

If reviewers prefer either fix extracted into a separate PR I can do that, but neither felt safe to ship the permission split without.

## Verification (manual)

Tested as Admin, Editor (org-viewer + project-editor + space-editor), and Viewer against the same chart on local dev:

| Test | Admin | Editor | Viewer |
|---|---|---|---|
| Sees "Change explore" menu item | ✅ | ✅ **(new)** | ❌ (correctly hidden) |
| Sees the bulk-update checkbox in the modal | ✅ | ❌ (hidden) | n/a |
| `POST /rename/chart/...` with `fixAll: false` | 200 | 200 **(new)** | 403 |
| `POST /rename/chart/...` with `fixAll: true` | 200 | 403, **chart unchanged** | 403 |
| `POST /rename/chart/...` with mismatched URL projectUuid | 404, **chart unchanged** | 404 | 403 |

Backend logs confirmed each `ForbiddenError` and the new `NotFoundError` fired at the right spots in `RenameService.renameChart` rather than slipping through to inner checks or downstream code.

## Test plan

- [ ] As Admin/Developer: open any saved chart → three-dot menu → "Change explore" — modal shows the "Also update all other charts using this explore" checkbox; rename succeeds with and without the checkbox ticked
- [ ] As Editor (with Editor role on the chart's space): same menu → "Change explore" — modal does **not** show the bulk checkbox; single-chart rename succeeds
- [ ] As Interactive Viewer / Viewer: "Change explore" item does **not** appear in the menu
- [ ] As Editor, manually POST to `/api/v1/projects/<uuid>/rename/chart/<uuid>` with `fixAll: true` — receives 403 and chart's tableName is unchanged
- [ ] As any user: POST to `/api/v1/projects/<wrong-uuid>/rename/chart/<chartUuid>` where the URL projectUuid does not match the chart's project — receives 404 `Chart <uuid> not found` and chart's tableName is unchanged
- [ ] No regression to the Settings → Validator "Fix" flow (it also calls `POST /rename/chart` for field-level renames; same chart-update permission applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)