### PR TITLE
chore: migrate `GoogleChatEnabled` feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -289,9 +289,6 @@ export const lightdashConfigMock: LightdashConfig = {
     microsoftTeams: {
         enabled: false,
     },
-    googleChat: {
-        enabled: false,
-    },
     serviceAccount: {
         enabled: false,
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -836,6 +836,7 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['CHANGE_CHART_EXPLORE_ENABLED', 'change-chart-explore'],
         ['SHOW_HIDE_ROWS_ENABLED', 'show-hide-rows'],
         ['SHOW_HIDE_COLUMNS_ENABLED', 'show-hide-columns'],
+        ['GOOGLE_CHAT_ENABLED', 'google-chat-enabled'],
         ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1158,9 +1158,6 @@ export type LightdashConfig = {
     microsoftTeams: {
         enabled: boolean;
     };
-    googleChat: {
-        enabled: boolean;
-    };
     googleCloudPlatform: {
         projectId?: string;
     };
@@ -1553,6 +1550,7 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     ['CHANGE_CHART_EXPLORE_ENABLED', 'change-chart-explore'],
     ['SHOW_HIDE_ROWS_ENABLED', 'show-hide-rows'],
     ['SHOW_HIDE_COLUMNS_ENABLED', 'show-hide-columns'],
+    ['GOOGLE_CHAT_ENABLED', 'google-chat-enabled'],
     // helm defaults set USE_SQL_PIVOT_RESULTS=true for all cloud deployments;
     // translating to enabledFeatureFlags ensures both existing and new cloud
     // instances pick up the DB-backed flag as enabled without needing per-DB
@@ -2231,9 +2229,6 @@ export const parseConfig = (): LightdashConfig => {
         },
         microsoftTeams: {
             enabled: process.env.MICROSOFT_TEAMS_ENABLED === 'true',
-        },
-        googleChat: {
-            enabled: process.env.GOOGLE_CHAT_ENABLED === 'true',
         },
         googleCloudPlatform: {
             projectId: process.env.GOOGLE_CLOUD_PROJECT_ID,

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -41,8 +41,6 @@ export class FeatureFlagModel {
             [FeatureFlags.EditYamlInUi]: this.getEditYamlInUiEnabled.bind(this),
             [FeatureFlags.ShowExecutionTime]:
                 this.getShowExecutionTimeEnabled.bind(this),
-            [FeatureFlags.GoogleChatEnabled]:
-                this.getGoogleChatEnabled.bind(this),
             [FeatureFlags.UserImpersonation]:
                 this.getUserImpersonationEnabled.bind(this),
             [FeatureFlags.MetricDashboardFilters]:
@@ -149,31 +147,6 @@ export class FeatureFlagModel {
         return {
             id: featureFlagId,
             enabled: this.lightdashConfig.query.showExecutionTime ?? false,
-        };
-    }
-
-    private async getGoogleChatEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.googleChat.enabled ||
-            (user
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.GoogleChatEnabled,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
         };
     }
 


### PR DESCRIPTION
Closes:

### Description:
Migrates the Google Chat feature flag from a dedicated config property (`lightdashConfig.googleChat.enabled`) to the existing legacy feature flag environment variable system. The `GOOGLE_CHAT_ENABLED` env var is now handled via `LEGACY_ENABLE_ENV_VARS`, mapping it to the `google-chat-enabled` feature flag ID, rather than being parsed as a standalone config field. The custom `getGoogleChatEnabled` logic in `FeatureFlagModel` has been removed in favor of the standard legacy flag resolution path.