### PR TITLE
chore: migrate `UserImpersonation` to legacy feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -351,9 +351,6 @@ export const lightdashConfigMock: LightdashConfig = {
             region: 'mock_region',
         },
     },
-    userImpersonation: {
-        enabled: undefined,
-    },
     metricDashboardFilters: {
         enabled: undefined,
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -838,6 +838,7 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['SHOW_HIDE_COLUMNS_ENABLED', 'show-hide-columns'],
         ['GOOGLE_CHAT_ENABLED', 'google-chat-enabled'],
         ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
+        ['USER_IMPERSONATION_ENABLED', 'user-impersonation'],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1258,9 +1258,6 @@ export type LightdashConfig = {
         duckdbQueryMemoryLimit: string | null;
         s3?: Omit<S3Config, 'expirationTime'>;
     };
-    userImpersonation: {
-        enabled: boolean | undefined;
-    };
     metricDashboardFilters: {
         enabled: boolean | undefined;
     };
@@ -1556,6 +1553,7 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     // instances pick up the DB-backed flag as enabled without needing per-DB
     // bootstrapping.
     ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
+    ['USER_IMPERSONATION_ENABLED', 'user-impersonation'],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
@@ -2284,12 +2282,6 @@ export const parseConfig = (): LightdashConfig => {
             duckdbQueryMemoryLimit:
                 process.env.PRE_AGGREGATE_DUCKDB_QUERY_MEMORY_LIMIT ?? null,
             s3: preAggregatesS3,
-        },
-        userImpersonation: {
-            enabled:
-                process.env.USER_IMPERSONATION_ENABLED === 'true'
-                    ? true
-                    : undefined,
         },
         metricDashboardFilters: {
             enabled: process.env.METRIC_DASHBOARD_FILTERS_ENABLED

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -41,8 +41,6 @@ export class FeatureFlagModel {
             [FeatureFlags.EditYamlInUi]: this.getEditYamlInUiEnabled.bind(this),
             [FeatureFlags.ShowExecutionTime]:
                 this.getShowExecutionTimeEnabled.bind(this),
-            [FeatureFlags.UserImpersonation]:
-                this.getUserImpersonationEnabled.bind(this),
             [FeatureFlags.MetricDashboardFilters]:
                 this.getMetricDashboardFiltersEnabled.bind(this),
             [FeatureFlags.EnableTimezoneSupport]:
@@ -147,24 +145,6 @@ export class FeatureFlagModel {
         return {
             id: featureFlagId,
             enabled: this.lightdashConfig.query.showExecutionTime ?? false,
-        };
-    }
-
-    private async getUserImpersonationEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.userImpersonation.enabled ??
-            (user
-                ? await isFeatureFlagEnabled(FeatureFlags.UserImpersonation, {
-                      userUuid: user.userUuid,
-                      organizationUuid: user.organizationUuid,
-                  })
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
         };
     }
 


### PR DESCRIPTION
Closes:

### Description:
Migrates the `UserImpersonation` feature flag from a custom config-based implementation to the standard legacy feature flag system.

The `userImpersonation` config block and its dedicated `getUserImpersonationEnabled` handler in `FeatureFlagModel` have been removed. The `USER_IMPERSONATION_ENABLED` environment variable is now handled through the shared `LEGACY_ENABLE_ENV_VARS` mechanism, consistent with how other feature flags like `change-chart-explore`, `show-hide-rows`, and `show-hide-columns` are managed.