### PR TITLE
feat(data-apps): opt-in chart sample data in generation prompts

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -91,6 +91,34 @@ Where the template metadata lives:
 | Frontend metadata + prompt composition | `packages/frontend/src/features/apps/templates.ts`                                           |
 | Wizard UI                              | `AppTemplatePicker.tsx`, `AppTemplateQuestions.tsx`; orchestrated by `pages/AppGenerate.tsx` |
 
+### Sample data (opt-in)
+
+Chart and dashboard references are passed to Claude as **structure only by default** — the metric query JSON tells the
+generator what columns and metrics exist, but not what values they take. That's enough for layout and component choice
+but not for content-level decisions ("we only have 2026 data", "regions are short codes not country names"). To close
+that gap, each chart chip and the dashboard chip in the picker carry a per-resource **Include sample data** toggle.
+
+Behavior:
+
+- **Off by default.** The toggle is opt-in because rows can be sensitive (PII, revenue, etc.). The user has to flip it
+  knowingly per resource. The dashboard toggle is a shortcut that applies to every chart resolved from its tiles.
+- **Frontend wire format.** The request body sends structured refs instead of flat UUID arrays:
+  `charts: { uuid, includeSampleData }[]` and `dashboard: { uuid, includeSampleData }`.
+- **Backend resolution.** When `includeSampleData` is true for a resolved chart, `AppGenerateService.fetchChartSample()`
+  calls `ProjectService.runViewChartQuery()` (which enforces the same `view:SavedChart` permission the chart picker
+  already does) and slices the first **10 rows**. Sample fetches run concurrently with chart loads.
+- **Failure mode.** If the sample query fails (broken explore, timeout, warehouse error) the chart reference is still
+  attached without sample data and the prepended file listing notes "sample data unavailable" so Claude doesn't
+  fabricate values.
+- **Sandbox layout.** Each `/tmp/metric-queries/{slug}.json` gains an optional `sampleData` field shaped as a
+  discriminated union: `{ status: 'available', rows: Record<string,string>[], truncated: boolean }` or
+  `{ status: 'unavailable', reason: string }`. `null` when the user did not opt in. Rows hold formatted values only
+  (no raw types) — small enough to be cheap, useful enough to ground the generator.
+- **No persistence.** Sample data lives only inside the sandbox `/tmp` filesystem during a build; it is **not** written
+  into `app_versions.prompt`, the source tarball uploaded to S3, or the chart resources row. The user's intent (which
+  charts they sampled) survives implicitly via the original prompt and the chart UUIDs already persisted on
+  `AppVersionChartResource`.
+
 ### Iteration
 
 When users send follow-up prompts, the system creates a new `DbAppVersion` and either:

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -58,8 +58,8 @@ export class AppGenerateController extends BaseController {
             body.prompt,
             body.imageId,
             body.appUuid,
-            body.chartUuids,
-            body.dashboardUuid,
+            body.charts,
+            body.dashboard,
             body.template,
         );
         return {
@@ -160,8 +160,8 @@ export class AppGenerateController extends BaseController {
             appUuid,
             body.prompt,
             body.imageId,
-            body.chartUuids,
-            body.dashboardUuid,
+            body.charts,
+            body.dashboard,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -92,6 +92,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     spacePermissionService:
                         repository.getSpacePermissionService(),
                     dashboardService: repository.getDashboardService(),
+                    projectService: repository.getProjectService(),
                 }),
             embedService: ({ repository, context, models }) =>
                 new EmbedService({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -15,10 +15,14 @@ import {
     isDashboardChartTileType,
     MissingConfigError,
     ParameterError,
+    QueryExecutionContext,
+    type AppChartReference,
+    type AppDashboardReference,
     type AppGeneratePipelineJobPayload,
     type AppVersionChartResource,
     type AppVersionResources,
     type ChartReference,
+    type ChartSampleData,
     type DataAppTemplate,
     type SessionUser,
     type TogglePinnedItemInfo,
@@ -49,6 +53,7 @@ import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
 import type { DashboardService } from '../../../services/DashboardService/DashboardService';
+import type { ProjectService } from '../../../services/ProjectService/ProjectService';
 import type { SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
@@ -67,6 +72,7 @@ type AppGenerateServiceDeps = {
     savedChartService: SavedChartService;
     spacePermissionService: SpacePermissionService;
     dashboardService: DashboardService;
+    projectService: ProjectService;
 };
 
 type GenerateAppResult = {
@@ -104,6 +110,8 @@ export class AppGenerateService extends BaseService {
 
     private readonly dashboardService: DashboardService;
 
+    private readonly projectService: ProjectService;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -117,6 +125,7 @@ export class AppGenerateService extends BaseService {
         savedChartService,
         spacePermissionService,
         dashboardService,
+        projectService,
     }: AppGenerateServiceDeps) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -131,6 +140,7 @@ export class AppGenerateService extends BaseService {
         this.savedChartService = savedChartService;
         this.spacePermissionService = spacePermissionService;
         this.dashboardService = dashboardService;
+        this.projectService = projectService;
     }
 
     /**
@@ -825,6 +835,7 @@ export class AppGenerateService extends BaseService {
 
         const slugCounts = new Map<string, number>();
         const fileEntries: string[] = [];
+        let sampleCount = 0;
 
         for (const ref of chartReferences) {
             // Generate slug from chart name
@@ -846,17 +857,35 @@ export class AppGenerateService extends BaseService {
             // eslint-disable-next-line no-await-in-loop
             await sandbox.files.write(`/tmp/metric-queries/${filename}`, json);
 
+            // Surface sample-data status per file so Claude knows to look —
+            // a "data sample" annotation on the listing is more discoverable
+            // than expecting the model to spot the field inside each JSON.
+            let sampleSuffix = '';
+            if (ref.sampleData?.status === 'available') {
+                const truncatedNote = ref.sampleData.truncated
+                    ? ' (truncated)'
+                    : '';
+                sampleSuffix = ` — includes ${ref.sampleData.rows.length}-row data sample${truncatedNote}`;
+                sampleCount += 1;
+            } else if (ref.sampleData?.status === 'unavailable') {
+                sampleSuffix = ` — sample data unavailable (${ref.sampleData.reason})`;
+            }
             fileEntries.push(
-                `- ${filename} ("${ref.chartName}", explore: ${ref.exploreName})`,
+                `- ${filename} ("${ref.chartName}", explore: ${ref.exploreName})${sampleSuffix}`,
             );
         }
 
         this.logger.info(
-            `App ${appUuid}: wrote ${chartReferences.length} chart reference(s) to /tmp/metric-queries/`,
+            `App ${appUuid}: wrote ${chartReferences.length} chart reference(s) to /tmp/metric-queries/ (${sampleCount} with sample data)`,
         );
 
+        const sampleHint =
+            sampleCount > 0
+                ? ` Some files include a "sampleData" field with up to ${AppGenerateService.SAMPLE_ROW_LIMIT} formatted rows from the actual query — useful when you need to know what real values look like (date ranges, category labels, magnitudes). Treat sample data as illustrative, not exhaustive.`
+                : '';
+
         return (
-            `[Referenced saved charts — metric queries available at /tmp/metric-queries/]\n` +
+            `[Referenced saved charts — metric queries available at /tmp/metric-queries/]${sampleHint}\n` +
             `${fileEntries.join('\n')}\n\n`
         );
     }
@@ -2113,25 +2142,156 @@ export class AppGenerateService extends BaseService {
         };
     }
 
+    /**
+     * Merge explicit chart picks with charts inherited from a dashboard
+     * tile. The dashboard's `includeSampleData` flag applies to every chart
+     * it contributes; if a chart appears in both lists, the explicit and
+     * inherited flags are OR'd so the user gets every sample they opted
+     * into, no matter which chip they toggled.
+     */
+    private async collectChartReferences(
+        charts: AppChartReference[] | undefined,
+        dashboard: AppDashboardReference | undefined,
+        user: SessionUser,
+    ): Promise<{
+        refs: AppChartReference[];
+        dashboardName: string | null;
+    }> {
+        const flagByUuid = new Map<string, boolean>();
+        for (const c of charts ?? []) {
+            flagByUuid.set(
+                c.uuid,
+                (flagByUuid.get(c.uuid) ?? false) || c.includeSampleData,
+            );
+        }
+        let dashboardName: string | null = null;
+        if (dashboard) {
+            const result = await this.resolveDashboardToChartUuids(
+                dashboard.uuid,
+                user,
+            );
+            dashboardName = result.dashboardName;
+            for (const uuid of result.chartUuids) {
+                flagByUuid.set(
+                    uuid,
+                    (flagByUuid.get(uuid) ?? false) ||
+                        dashboard.includeSampleData,
+                );
+            }
+        }
+        const refs: AppChartReference[] = [...flagByUuid.entries()].map(
+            ([uuid, includeSampleData]) => ({ uuid, includeSampleData }),
+        );
+        return { refs, dashboardName };
+    }
+
+    /**
+     * Hard cap on rows returned per chart sample. Sample data is opt-in but
+     * still potentially sensitive — keeping this small bounds both the
+     * exposure surface and the prompt token cost.
+     */
+    private static readonly SAMPLE_ROW_LIMIT = 10;
+
+    /**
+     * Run a saved chart's metric query and return at most SAMPLE_ROW_LIMIT
+     * formatted rows. Returns `unavailable` (with a short reason string) on
+     * any failure — sample data is best-effort by design.
+     */
+    private async fetchChartSample(
+        chartUuid: string,
+        user: SessionUser,
+    ): Promise<ChartSampleData> {
+        const account = fromSession(user);
+        try {
+            const result = await this.projectService.runViewChartQuery({
+                account,
+                chartUuid,
+                context: QueryExecutionContext.DATA_APP_SAMPLE,
+            });
+            const truncated =
+                result.rows.length > AppGenerateService.SAMPLE_ROW_LIMIT;
+            const rows = result.rows
+                .slice(0, AppGenerateService.SAMPLE_ROW_LIMIT)
+                .map((row) => {
+                    const flat: Record<string, string> = {};
+                    for (const [field, cell] of Object.entries(row)) {
+                        flat[field] = cell.value.formatted;
+                    }
+                    return flat;
+                });
+            return { status: 'available', rows, truncated };
+        } catch (error) {
+            this.logger.warn(
+                `Sample query failed for chart ${chartUuid}: ${getErrorMessage(error)}`,
+            );
+            return {
+                status: 'unavailable',
+                reason: 'Sample query failed.',
+            };
+        }
+    }
+
+    /**
+     * Resolve a list of (uuid, includeSampleData) refs into ChartReferences.
+     * Charts the user can't view, can't load, or that are deleted are
+     * skipped silently — same forgiving behavior as before.
+     *
+     * When `includeSampleData` is set on a ref, the chart's metric query is
+     * executed and a small row sample is attached to the reference. Sample
+     * fetches are concurrent with chart loads so they don't serialise.
+     */
     private async resolveChartReferences(
-        chartUuids: string[],
+        chartRefs: AppChartReference[],
         user: SessionUser,
     ): Promise<{
         references: ChartReference[];
         chartResources: AppVersionChartResource[];
+        sampleStats: { requested: number; available: number };
     }> {
-        const uuids = [...new Set(chartUuids)];
-        if (uuids.length === 0) return { references: [], chartResources: [] };
+        // Dedupe by uuid; if any duplicate asks for sample data, the union
+        // wins so the user gets the data they opted into.
+        const dedup = new Map<string, boolean>();
+        for (const ref of chartRefs) {
+            dedup.set(
+                ref.uuid,
+                (dedup.get(ref.uuid) ?? false) || ref.includeSampleData,
+            );
+        }
+        if (dedup.size === 0) {
+            return {
+                references: [],
+                chartResources: [],
+                sampleStats: { requested: 0, available: 0 },
+            };
+        }
 
+        const uuids = [...dedup.keys()];
         const account = fromSession(user);
 
-        const results = await Promise.allSettled(
+        const chartResults = await Promise.allSettled(
             uuids.map((uuid) => this.savedChartService.get(uuid, account)),
         );
 
+        // Kick off sample fetches in parallel, only for charts that resolved
+        // and were opted-in. Track which uuids actually requested a sample
+        // so we can attach the result back to the right reference.
+        const sampleUuids: string[] = [];
+        chartResults.forEach((result, i) => {
+            if (result.status === 'fulfilled' && dedup.get(uuids[i])) {
+                sampleUuids.push(uuids[i]);
+            }
+        });
+        const sampleResults = await Promise.all(
+            sampleUuids.map((uuid) => this.fetchChartSample(uuid, user)),
+        );
+        const sampleByUuid = new Map<string, ChartSampleData>();
+        sampleUuids.forEach((uuid, i) => {
+            sampleByUuid.set(uuid, sampleResults[i]);
+        });
+
         const references: ChartReference[] = [];
         const chartResources: AppVersionChartResource[] = [];
-        results.forEach((result, i) => {
+        chartResults.forEach((result, i) => {
             if (result.status === 'fulfilled') {
                 const chart = result.value;
                 references.push({
@@ -2139,6 +2299,7 @@ export class AppGenerateService extends BaseService {
                     chartDescription: chart.description ?? '',
                     exploreName: chart.tableName,
                     metricQuery: chart.metricQuery,
+                    sampleData: sampleByUuid.get(uuids[i]) ?? null,
                 });
                 chartResources.push({
                     chartUuid: uuids[i],
@@ -2149,13 +2310,24 @@ export class AppGenerateService extends BaseService {
             // Rejected = not a chart UUID, no access, or deleted — skip silently
         });
 
+        const availableSamples = [...sampleByUuid.values()].filter(
+            (s) => s.status === 'available',
+        ).length;
         if (references.length > 0) {
             this.logger.info(
-                `Resolved ${references.length} chart reference(s) from ${uuids.length} UUID(s)`,
+                `Resolved ${references.length} chart reference(s) from ${uuids.length} UUID(s); ` +
+                    `${availableSamples}/${sampleUuids.length} sample(s) attached`,
             );
         }
 
-        return { references, chartResources };
+        return {
+            references,
+            chartResources,
+            sampleStats: {
+                requested: sampleUuids.length,
+                available: availableSamples,
+            },
+        };
     }
 
     async generateApp(
@@ -2164,8 +2336,8 @@ export class AppGenerateService extends BaseService {
         prompt: string,
         imageId?: string,
         preGeneratedAppUuid?: string,
-        chartUuids?: string[],
-        dashboardUuid?: string,
+        charts?: AppChartReference[],
+        dashboard?: AppDashboardReference,
         template?: DataAppTemplate,
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
@@ -2189,20 +2361,16 @@ export class AppGenerateService extends BaseService {
             `App ${appUuid}: generation started (promptLength=${prompt.length})`,
         );
 
-        let allChartUuids = [...(chartUuids ?? [])];
-        let dashboardName: string | null = null;
-        if (dashboardUuid) {
-            const result = await this.resolveDashboardToChartUuids(
-                dashboardUuid,
-                user,
-            );
-            allChartUuids = [
-                ...new Set([...allChartUuids, ...result.chartUuids]),
-            ];
-            dashboardName = result.dashboardName;
-        }
-        const { references: chartReferences, chartResources } =
-            await this.resolveChartReferences(allChartUuids, user);
+        const { refs, dashboardName } = await this.collectChartReferences(
+            charts,
+            dashboard,
+            user,
+        );
+        const {
+            references: chartReferences,
+            chartResources,
+            sampleStats,
+        } = await this.resolveChartReferences(refs, user);
 
         // Build resources metadata to persist with the version
         const resources: AppVersionResources = {
@@ -2241,6 +2409,8 @@ export class AppGenerateService extends BaseService {
                 promptLength: prompt.length,
                 hasImage: imageId !== undefined,
                 template: template ?? null,
+                samplesRequested: sampleStats.requested,
+                samplesAvailable: sampleStats.available,
             },
         });
 
@@ -2267,8 +2437,8 @@ export class AppGenerateService extends BaseService {
         appUuid: string,
         prompt: string,
         imageId?: string,
-        chartUuids?: string[],
-        dashboardUuid?: string,
+        charts?: AppChartReference[],
+        dashboard?: AppDashboardReference,
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
 
@@ -2299,20 +2469,16 @@ export class AppGenerateService extends BaseService {
             `App ${appUuid}: iteration started (version=${newVersion}, promptLength=${prompt.length})`,
         );
 
-        let allChartUuids = [...(chartUuids ?? [])];
-        let dashboardName: string | null = null;
-        if (dashboardUuid) {
-            const result = await this.resolveDashboardToChartUuids(
-                dashboardUuid,
-                user,
-            );
-            allChartUuids = [
-                ...new Set([...allChartUuids, ...result.chartUuids]),
-            ];
-            dashboardName = result.dashboardName;
-        }
-        const { references: chartReferences, chartResources } =
-            await this.resolveChartReferences(allChartUuids, user);
+        const { refs, dashboardName } = await this.collectChartReferences(
+            charts,
+            dashboard,
+            user,
+        );
+        const {
+            references: chartReferences,
+            chartResources,
+            sampleStats,
+        } = await this.resolveChartReferences(refs, user);
 
         const resources: AppVersionResources = {
             images: imageId ? [{ imageId }] : [],
@@ -2343,6 +2509,8 @@ export class AppGenerateService extends BaseService {
                 msSinceLastVersion: latestVersion?.created_at
                     ? Date.now() - latestVersion.created_at.getTime()
                     : null,
+                samplesRequested: sampleStats.requested,
+                samplesAvailable: sampleStats.available,
             },
         });
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6898,15 +6898,39 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AppChartReference: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                includeSampleData: { dataType: 'boolean', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AppDashboardReference: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                includeSampleData: { dataType: 'boolean', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     GenerateAppRequestBody: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                dashboardUuid: { dataType: 'string' },
-                chartUuids: {
+                dashboard: { ref: 'AppDashboardReference' },
+                charts: {
                     dataType: 'array',
-                    array: { dataType: 'string' },
+                    array: { dataType: 'refAlias', ref: 'AppChartReference' },
                 },
                 appUuid: { dataType: 'string' },
                 imageId: { dataType: 'string' },
@@ -20980,7 +21004,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20990,7 +21014,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21000,7 +21024,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21013,7 +21037,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21424,7 +21448,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21434,7 +21458,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21444,7 +21468,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21457,7 +21481,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -27623,6 +27647,7 @@ const models: TsoaRoute.Models = {
             'cli',
             'metricsExplorer',
             'preAggregateMaterialization',
+            'dataAppSample',
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8279,14 +8279,40 @@
                 "type": "string",
                 "enum": ["dashboard", "slideshow", "pdf", "custom"]
             },
+            "AppChartReference": {
+                "properties": {
+                    "includeSampleData": {
+                        "type": "boolean"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["includeSampleData", "uuid"],
+                "type": "object",
+                "description": "A saved-chart reference attached to a generation request.\n`includeSampleData` is opt-in per chart: when true the backend runs the\nunderlying metric query and inlines a small sample of rows into the\nsandbox so Claude can see actual values (e.g. \"season 2026 only\")."
+            },
+            "AppDashboardReference": {
+                "properties": {
+                    "includeSampleData": {
+                        "type": "boolean"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["includeSampleData", "uuid"],
+                "type": "object",
+                "description": "A dashboard reference attached to a generation request. The dashboard is\nexpanded server-side into its chart tiles. When `includeSampleData` is\ntrue, every resolved chart in the dashboard receives a sample."
+            },
             "GenerateAppRequestBody": {
                 "properties": {
-                    "dashboardUuid": {
-                        "type": "string"
+                    "dashboard": {
+                        "$ref": "#/components/schemas/AppDashboardReference"
                     },
-                    "chartUuids": {
+                    "charts": {
                         "items": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/AppChartReference"
                         },
                         "type": "array"
                     },
@@ -22365,22 +22391,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -22735,22 +22761,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -28826,7 +28852,8 @@
                     "api",
                     "cli",
                     "metricsExplorer",
-                    "preAggregateMaterialization"
+                    "preAggregateMaterialization",
+                    "dataAppSample"
                 ],
                 "type": "string"
             },
@@ -31221,7 +31248,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2836.1",
+        "version": "0.2839.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -44,13 +44,34 @@ export const DATA_APP_TEMPLATES = [
 ] as const;
 export type DataAppTemplate = (typeof DATA_APP_TEMPLATES)[number];
 
+/**
+ * A saved-chart reference attached to a generation request.
+ * `includeSampleData` is opt-in per chart: when true the backend runs the
+ * underlying metric query and inlines a small sample of rows into the
+ * sandbox so Claude can see actual values (e.g. "season 2026 only").
+ */
+export type AppChartReference = {
+    uuid: string;
+    includeSampleData: boolean;
+};
+
+/**
+ * A dashboard reference attached to a generation request. The dashboard is
+ * expanded server-side into its chart tiles. When `includeSampleData` is
+ * true, every resolved chart in the dashboard receives a sample.
+ */
+export type AppDashboardReference = {
+    uuid: string;
+    includeSampleData: boolean;
+};
+
 export type GenerateAppRequestBody = {
     prompt: string;
     template?: DataAppTemplate; // starter template selected on app creation; ignored on iteration
     imageId?: string;
     appUuid?: string; // pre-generated UUID so images can be scoped to the app in S3
-    chartUuids?: string[]; // saved chart UUIDs to resolve and pass as structured metric queries
-    dashboardUuid?: string; // dashboard UUID — resolved server-side to its chart tiles
+    charts?: AppChartReference[]; // saved charts to resolve, optionally with sample rows
+    dashboard?: AppDashboardReference; // dashboard — resolved server-side to its chart tiles
 };
 
 export type ApiPreviewTokenResponse = ApiSuccess<{
@@ -126,11 +147,33 @@ export type ApiAppSummary = {
     lastVersionStatus: AppVersionStatus | null;
 };
 
+/**
+ * Sample of rows from a chart's underlying query, captured at request time
+ * and inlined into the sandbox alongside the chart's metric query. Opt-in
+ * per chart via `AppChartReference.includeSampleData`.
+ *
+ * Discriminated on `status`:
+ * - `available` — query ran; up to SAMPLE_ROW_LIMIT formatted rows attached
+ * - `unavailable` — query failed or was skipped; `reason` is informational
+ *   text the prompt surfaces to Claude so it doesn't fabricate values
+ */
+export type ChartSampleData =
+    | {
+          status: 'available';
+          rows: Record<string, string>[];
+          truncated: boolean;
+      }
+    | {
+          status: 'unavailable';
+          reason: string;
+      };
+
 export type ChartReference = {
     chartName: string;
     chartDescription: string;
     exploreName: string;
     metricQuery: MetricQuery;
+    sampleData: ChartSampleData | null; // null when the user did not opt in
 };
 
 export type ApiMyAppsResponse = ApiSuccess<{

--- a/packages/common/src/types/analytics.ts
+++ b/packages/common/src/types/analytics.ts
@@ -98,4 +98,5 @@ export enum QueryExecutionContext {
     CLI = 'cli',
     METRICS_EXPLORER = 'metricsExplorer',
     PRE_AGGREGATE_MATERIALIZATION = 'preAggregateMaterialization',
+    DATA_APP_SAMPLE = 'dataAppSample',
 }

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -11,9 +11,12 @@ import {
     ScrollArea,
     Text,
     TextInput,
+    Tooltip,
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
+    IconDatabase,
+    IconDatabaseOff,
     IconLayoutDashboard,
     IconPlus,
     IconSearch,
@@ -32,12 +35,25 @@ export type SelectedChart = {
     uuid: string;
     name: string;
     chartKind?: ChartKind;
+    /**
+     * Opt-in: when true, the backend runs this chart's query and inlines up
+     * to 10 sample rows alongside the metric query so the generator can see
+     * actual values. Default false because rows can be sensitive.
+     */
+    includeSampleData: boolean;
 };
 
 export type SelectedDashboard = {
     uuid: string;
     name: string;
+    /**
+     * Opt-in: applies to every chart resolved from this dashboard's tiles.
+     */
+    includeSampleData: boolean;
 };
+
+const SAMPLE_DATA_TOOLTIP =
+    'Include sample data - runs this query and shares up to 10 rows with the app generator so it can see actual values (date ranges, labels, magnitudes). Off by default because rows can be sensitive.';
 
 /**
  * Button that triggers the file input for image upload.
@@ -122,6 +138,7 @@ export const QueryButton: FC<{
                 uuid: chart.uuid,
                 name: chart.name,
                 chartKind: chart.chartKind ?? ChartKind.VERTICAL_BAR,
+                includeSampleData: false,
             });
         },
         [onSelect],
@@ -274,11 +291,14 @@ export const SelectedImageSection: FC<{
 
 /**
  * Renders selected queries as a list using the same visual as the picker.
+ * Each row carries a per-chart sample-data toggle; off by default because
+ * sample rows can include sensitive values.
  */
 export const SelectedQuerySection: FC<{
     charts: SelectedChart[];
     onRemove: (uuid: string) => void;
-}> = ({ charts, onRemove }) => {
+    onToggleSampleData: (uuid: string) => void;
+}> = ({ charts, onRemove, onToggleSampleData }) => {
     if (charts.length === 0) return null;
 
     return (
@@ -291,6 +311,35 @@ export const SelectedQuerySection: FC<{
                     <Text size="xs" fw={500} truncate flex={1}>
                         {chart.name}
                     </Text>
+                    <Tooltip
+                        label={SAMPLE_DATA_TOOLTIP}
+                        multiline
+                        w={260}
+                        withArrow
+                    >
+                        <ActionIcon
+                            size="xs"
+                            variant={
+                                chart.includeSampleData ? 'filled' : 'default'
+                            }
+                            color={chart.includeSampleData ? 'blue' : 'gray'}
+                            onClick={() => onToggleSampleData(chart.uuid)}
+                            aria-label={
+                                chart.includeSampleData
+                                    ? 'Sample data: on'
+                                    : 'Sample data: off'
+                            }
+                        >
+                            <MantineIcon
+                                icon={
+                                    chart.includeSampleData
+                                        ? IconDatabase
+                                        : IconDatabaseOff
+                                }
+                                size={12}
+                            />
+                        </ActionIcon>
+                    </Tooltip>
                     <ActionIcon
                         size="xs"
                         variant="subtle"
@@ -331,7 +380,11 @@ export const DashboardButton: FC<{
 
     const handleSelect = useCallback(
         (dashboard: { uuid: string; name: string }) => {
-            onSelect({ uuid: dashboard.uuid, name: dashboard.name });
+            onSelect({
+                uuid: dashboard.uuid,
+                name: dashboard.name,
+                includeSampleData: false,
+            });
             setOpened(false);
             setSearchQuery('');
         },
@@ -412,18 +465,47 @@ export const DashboardButton: FC<{
 };
 
 /**
- * Renders the selected dashboard with a remove button.
+ * Renders the selected dashboard with a remove button. The sample-data
+ * toggle here applies to every chart resolved from this dashboard's tiles.
  */
 export const SelectedDashboardSection: FC<{
     dashboard: SelectedDashboard;
     onRemove: () => void;
-}> = ({ dashboard, onRemove }) => (
+    onToggleSampleData: () => void;
+}> = ({ dashboard, onRemove, onToggleSampleData }) => (
     <Box className={classes.selectedQueryList}>
         <Box className={classes.selectedQueryItem}>
             <IconBox icon={IconLayoutDashboard} color="green.6" />
             <Text size="xs" fw={500} truncate flex={1}>
                 {dashboard.name}
             </Text>
+            <Tooltip
+                label={`${SAMPLE_DATA_TOOLTIP} Applies to every chart in this dashboard.`}
+                multiline
+                w={260}
+                withArrow
+            >
+                <ActionIcon
+                    size="xs"
+                    variant={dashboard.includeSampleData ? 'filled' : 'default'}
+                    color={dashboard.includeSampleData ? 'blue' : 'gray'}
+                    onClick={onToggleSampleData}
+                    aria-label={
+                        dashboard.includeSampleData
+                            ? 'Sample data: on'
+                            : 'Sample data: off'
+                    }
+                >
+                    <MantineIcon
+                        icon={
+                            dashboard.includeSampleData
+                                ? IconDatabase
+                                : IconDatabaseOff
+                        }
+                        size={12}
+                    />
+                </ActionIcon>
+            </Tooltip>
             <ActionIcon
                 size="xs"
                 variant="subtle"

--- a/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
@@ -1,6 +1,8 @@
 import {
     type ApiError,
     type ApiGenerateAppResponse,
+    type AppChartReference,
+    type AppDashboardReference,
     type DataAppTemplate,
 } from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
@@ -12,8 +14,8 @@ type GenerateAppParams = {
     template?: DataAppTemplate;
     imageId?: string;
     appUuid?: string; // pre-generated UUID so images are scoped to the app in S3
-    chartUuids?: string[];
-    dashboardUuid?: string;
+    charts?: AppChartReference[];
+    dashboard?: AppDashboardReference;
 };
 
 type GenerateAppResult = ApiGenerateAppResponse['results'];
@@ -24,8 +26,8 @@ const generateApp = async ({
     template,
     imageId,
     appUuid,
-    chartUuids,
-    dashboardUuid,
+    charts,
+    dashboard,
 }: GenerateAppParams): Promise<GenerateAppResult> => {
     const data = await lightdashApi<GenerateAppResult>({
         method: 'POST',
@@ -35,8 +37,8 @@ const generateApp = async ({
             template,
             imageId,
             appUuid,
-            chartUuids,
-            dashboardUuid,
+            charts,
+            dashboard,
         }),
     });
     return data;

--- a/packages/frontend/src/features/apps/hooks/useIterateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useIterateApp.ts
@@ -1,4 +1,9 @@
-import { type ApiError, type ApiGenerateAppResponse } from '@lightdash/common';
+import {
+    type ApiError,
+    type ApiGenerateAppResponse,
+    type AppChartReference,
+    type AppDashboardReference,
+} from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
@@ -7,8 +12,8 @@ type IterateAppParams = {
     appUuid: string;
     prompt: string;
     imageId?: string;
-    chartUuids?: string[];
-    dashboardUuid?: string;
+    charts?: AppChartReference[];
+    dashboard?: AppDashboardReference;
 };
 
 type IterateAppResult = ApiGenerateAppResponse['results'];
@@ -18,13 +23,13 @@ const iterateApp = async ({
     appUuid,
     prompt,
     imageId,
-    chartUuids,
-    dashboardUuid,
+    charts,
+    dashboard,
 }: IterateAppParams): Promise<IterateAppResult> => {
     const data = await lightdashApi<IterateAppResult>({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/apps/${appUuid}/versions`,
-        body: JSON.stringify({ prompt, imageId, chartUuids, dashboardUuid }),
+        body: JSON.stringify({ prompt, imageId, charts, dashboard }),
     });
     return data;
 };

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -638,10 +638,15 @@ const AppGenerate: FC = () => {
         const trimmed = prompt.trim();
         if (!trimmed || isLoading) return;
 
-        // Collect chart UUIDs to send as structured data (resolved server-side)
-        const chartUuids =
+        // Send structured chart refs (uuid + per-chart sample-data opt-in).
+        // The backend resolves these server-side so the client never sees
+        // chart configs or rows.
+        const charts =
             selectedCharts.length > 0
-                ? selectedCharts.map((c) => c.uuid)
+                ? selectedCharts.map((c) => ({
+                      uuid: c.uuid,
+                      includeSampleData: c.includeSampleData,
+                  }))
                 : undefined;
 
         // For new apps, pre-generate the UUID so the image upload and
@@ -684,7 +689,12 @@ const AppGenerate: FC = () => {
             sentDashboardByPrompt.current.set(trimmed, sentDashboardName);
         }
 
-        const dashboardUuid = selectedDashboard?.uuid;
+        const dashboard = selectedDashboard
+            ? {
+                  uuid: selectedDashboard.uuid,
+                  includeSampleData: selectedDashboard.includeSampleData,
+              }
+            : undefined;
 
         setLocalMessages((prev) => [
             ...prev,
@@ -746,8 +756,8 @@ const AppGenerate: FC = () => {
                     appUuid: activeAppUuid,
                     prompt: trimmed,
                     imageId,
-                    chartUuids,
-                    dashboardUuid,
+                    charts,
+                    dashboard,
                 },
                 callbacks,
             );
@@ -759,8 +769,8 @@ const AppGenerate: FC = () => {
                     template: selectedTemplate ?? undefined,
                     imageId,
                     appUuid: newAppUuid,
-                    chartUuids,
-                    dashboardUuid,
+                    charts,
+                    dashboard,
                 },
                 callbacks,
             );
@@ -1190,6 +1200,23 @@ const AppGenerate: FC = () => {
                                                                 ),
                                                         )
                                                     }
+                                                    onToggleSampleData={(
+                                                        uuid,
+                                                    ) =>
+                                                        setSelectedCharts(
+                                                            (prev) =>
+                                                                prev.map((c) =>
+                                                                    c.uuid ===
+                                                                    uuid
+                                                                        ? {
+                                                                              ...c,
+                                                                              includeSampleData:
+                                                                                  !c.includeSampleData,
+                                                                          }
+                                                                        : c,
+                                                                ),
+                                                        )
+                                                    }
                                                 />
                                             )}
                                             {selectedDashboard && (
@@ -1200,6 +1227,18 @@ const AppGenerate: FC = () => {
                                                     onRemove={() =>
                                                         setSelectedDashboard(
                                                             null,
+                                                        )
+                                                    }
+                                                    onToggleSampleData={() =>
+                                                        setSelectedDashboard(
+                                                            (prev) =>
+                                                                prev
+                                                                    ? {
+                                                                          ...prev,
+                                                                          includeSampleData:
+                                                                              !prev.includeSampleData,
+                                                                      }
+                                                                    : null,
                                                         )
                                                     }
                                                 />


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-366/add-an-option-to-include-sample-data-with-queries

### Description:
Per-chart and per-dashboard toggle in the resource picker. When on, the backend runs the chart's metric query via runViewChartQuery and inlines up to 10 formatted rows into /tmp/metric-queries/{slug}.json in the sandbox so the generator can see actual values (e.g. "we only have 2026 data") instead of guessing from column names alone. Off by default because rows can be sensitive; failed sample queries fall back silently with an "unavailable" annotation in the prompt prepend.