### PR TITLE
feat(data-apps): improve PDF export margins in generated reports

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -19,11 +19,13 @@ Build a slideshow-style data app:
 
 const PDF_REPORT_INSTRUCTIONS = `[Starter template: PDF Report]
 Build a print-optimized report:
-- Layout for A4/Letter portrait pages with comfortable margins.
+- Layout for A4/Letter portrait pages with comfortable internal padding.
+- Set \`@page { margin: 0; size: A4 }\` so the design fills the sheet edge-to-edge — apply your own padding inside each page (e.g. \`p-12\`) instead of relying on the browser's default page margin (which is ugly and shrinks the canvas).
 - Use a clean, document-style typography hierarchy (title, section headings, body).
 - Render charts at fixed widths so they reflow across pages cleanly.
 - Include a title page header (title, subtitle, generated-on date) and section dividers.
 - Apply CSS \`@media print\` rules and \`page-break-inside: avoid\` on cards and figures.
+- Note: browsers may inject their own header/footer on printed pages (URL, page number, date), controlled by the user's print dialog — not removable via CSS. Keep critical content away from the very top and bottom edges so it doesn't sit underneath.
 - Prefer narrative copy with charts as supporting evidence, not a dense dashboard grid.`;
 
 export const getTemplateInstructions = (


### PR DESCRIPTION
### Description:
When a generated PDF Report app is exported via the browser print dialog, the browser's default page margin shrinks the design into a fraction of the sheet, ruining the visual. Update the PDF Report template prompt so Claude sets `@page { margin: 0 }` and applies internal padding instead, producing edge-to-edge designs that print correctly.

Also adds guidance about browser-injected print headers/footers (URL, page number, date), which are user-controlled and not CSS-removable — generated layouts should keep critical content away from page edges.


### Testing

#### Before
<img width="1734" height="1477" alt="image" src="https://github.com/user-attachments/assets/48677311-ee01-4170-95bc-4f5ad30561ca" />


#### After
<img width="1734" height="1477" alt="image" src="https://github.com/user-attachments/assets/439b3feb-69a3-4fd7-a15d-2cb5064a69f7" />
