### PR TITLE
chore: migrate `UseSqlPivotResults` feature flag

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -21,7 +21,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        useSqlPivotResults: false,
         showExecutionTime: false,
 
         retryQueryOnTransientErrors: false,
@@ -61,7 +60,6 @@ export const lightdashConfigWithBasicSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        useSqlPivotResults: false,
         showExecutionTime: false,
 
         retryQueryOnTransientErrors: false,
@@ -88,7 +86,6 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        useSqlPivotResults: false,
         showExecutionTime: false,
 
         retryQueryOnTransientErrors: false,
@@ -111,7 +108,6 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        useSqlPivotResults: false,
         showExecutionTime: false,
 
         retryQueryOnTransientErrors: false,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -219,7 +219,6 @@ export const lightdashConfigMock: LightdashConfig = {
         defaultLimit: 500,
         csvCellsLimit: 100000,
         timezone: undefined,
-        useSqlPivotResults: false,
         showExecutionTime: false,
         retryQueryOnTransientErrors: true,
         enableTimezoneSupport: undefined,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -671,19 +671,6 @@ describe('scheduler poll interval', () => {
     });
 });
 
-test('should set useSqlPivotResults only when the environment variable is set', () => {
-    const undefinedConfig = parseConfig();
-    expect(undefinedConfig.query.useSqlPivotResults).toBeUndefined();
-
-    process.env.USE_SQL_PIVOT_RESULTS = 'true';
-    const trueConfig = parseConfig();
-    expect(trueConfig.query.useSqlPivotResults).toBe(true);
-
-    process.env.USE_SQL_PIVOT_RESULTS = 'false';
-    const falseConfig = parseConfig();
-    expect(falseConfig.query.useSqlPivotResults).toBe(false);
-});
-
 test('should set groups.enabled only when the environment variable is set', () => {
     const undefinedConfig = parseConfig();
     expect(undefinedConfig.groups.enabled).toBeUndefined();
@@ -849,6 +836,7 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['CHANGE_CHART_EXPLORE_ENABLED', 'change-chart-explore'],
         ['SHOW_HIDE_ROWS_ENABLED', 'show-hide-rows'],
         ['SHOW_HIDE_COLUMNS_ENABLED', 'show-hide-columns'],
+        ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1033,7 +1033,6 @@ export type LightdashConfig = {
         csvCellsLimit: number;
         timezone: string | undefined;
         maxPageSize: number;
-        useSqlPivotResults: boolean | undefined;
         showExecutionTime: boolean | undefined;
         retryQueryOnTransientErrors: boolean;
         enableTimezoneSupport: boolean | undefined;
@@ -1555,6 +1554,11 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     ['CHANGE_CHART_EXPLORE_ENABLED', 'change-chart-explore'],
     ['SHOW_HIDE_ROWS_ENABLED', 'show-hide-rows'],
     ['SHOW_HIDE_COLUMNS_ENABLED', 'show-hide-columns'],
+    // helm defaults set USE_SQL_PIVOT_RESULTS=true for all cloud deployments;
+    // translating to enabledFeatureFlags ensures both existing and new cloud
+    // instances pick up the DB-backed flag as enabled without needing per-DB
+    // bootstrapping.
+    ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
@@ -1958,9 +1962,6 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_MAX_PAGE_SIZE',
                 ) || 2500, // Defaults to default limit * 5
-            useSqlPivotResults: process.env.USE_SQL_PIVOT_RESULTS
-                ? process.env.USE_SQL_PIVOT_RESULTS !== 'false'
-                : undefined,
             showExecutionTime: process.env.SHOW_EXECUTION_TIME
                 ? process.env.SHOW_EXECUTION_TIME === 'true'
                 : undefined,

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -38,8 +38,6 @@ export class FeatureFlagModel {
         this.featureFlagHandlers = {
             [FeatureFlags.UserGroupsEnabled]:
                 this.getUserGroupsEnabled.bind(this),
-            [FeatureFlags.UseSqlPivotResults]:
-                this.getUseSqlPivotResults.bind(this),
             [FeatureFlags.EditYamlInUi]: this.getEditYamlInUiEnabled.bind(this),
             [FeatureFlags.ShowExecutionTime]:
                 this.getShowExecutionTimeEnabled.bind(this),
@@ -130,32 +128,6 @@ export class FeatureFlagModel {
                       },
                   )
                 : false);
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private async getUseSqlPivotResults({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.query.useSqlPivotResults ??
-            (user
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.UseSqlPivotResults,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                      true,
-                  )
-                : true);
         return {
             id: featureFlagId,
             enabled,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -479,7 +479,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        useSqlPivotResults: false,
         showExecutionTime: false,
         retryQueryOnTransientErrors: false,
         enableTimezoneSupport: undefined,


### PR DESCRIPTION
Closes:

### Description:
Removes the `useSqlPivotResults` feature flag and its associated configuration. This includes removing the `USE_SQL_PIVOT_RESULTS` environment variable parsing, the `useSqlPivotResults` field from the `LightdashConfig` query type, the `getUseSqlPivotResults` handler from `FeatureFlagModel`, and all related test cases and mock data.