### PR TITLE
feat(content): inline verified badge on space overview (PROD-7194)

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
@@ -1,5 +1,6 @@
 import { ContentType, DashboardContent } from '@lightdash/common';
 import { Knex } from 'knex';
+import { ContentVerificationTableName } from '../../../database/entities/contentVerification';
 import {
     DashboardsTableName,
     DashboardVersionsTableName,
@@ -87,6 +88,25 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                     `updated_by_user.user_uuid`,
                     `last_version.updated_by_user_uuid`,
                 )
+                .leftJoin(
+                    ContentVerificationTableName,
+                    function verificationJoin() {
+                        this.on(
+                            `${ContentVerificationTableName}.content_uuid`,
+                            '=',
+                            `${DashboardsTableName}.dashboard_uuid`,
+                        ).andOn(
+                            `${ContentVerificationTableName}.content_type`,
+                            '=',
+                            knex.raw('?', [ContentType.DASHBOARD]),
+                        );
+                    },
+                )
+                .leftJoin(
+                    `${UserTableName} as verified_by_user`,
+                    `verified_by_user.user_uuid`,
+                    `${ContentVerificationTableName}.verified_by_user_uuid`,
+                )
                 .select<SummaryContentRow[]>([
                     knex.raw(`'${ContentType.DASHBOARD}' as content_type`),
                     knex.raw(
@@ -130,6 +150,10 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                     knex.raw(
                         `(SELECT last_name FROM users WHERE user_uuid = ${DashboardsTableName}.deleted_by_user_uuid) as deleted_by_user_last_name`,
                     ),
+                    `${ContentVerificationTableName}.verified_at as verified_at`,
+                    `verified_by_user.user_uuid as verified_by_user_uuid`,
+                    `verified_by_user.first_name as verified_by_user_first_name`,
+                    `verified_by_user.last_name as verified_by_user_last_name`,
                     knex.raw(
                         `json_build_object(${
                             filters.includeDescendantCounts
@@ -243,7 +267,20 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                     : null,
                 views: value.views,
                 firstViewedAt: value.first_viewed_at,
-                verification: null,
+                verification:
+                    value.verified_at !== null &&
+                    value.verified_by_user_uuid !== null &&
+                    value.verified_by_user_first_name !== null &&
+                    value.verified_by_user_last_name !== null
+                        ? {
+                              verifiedBy: {
+                                  userUuid: value.verified_by_user_uuid,
+                                  firstName: value.verified_by_user_first_name,
+                                  lastName: value.verified_by_user_last_name,
+                              },
+                              verifiedAt: value.verified_at,
+                          }
+                        : null,
             };
         },
     };

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -135,6 +135,10 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                     knex.raw(
                         `(SELECT last_name FROM users WHERE user_uuid = ${AppsTableName}.deleted_by_user_uuid) as deleted_by_user_last_name`,
                     ),
+                    knex.raw(`null::timestamp as verified_at`),
+                    knex.raw(`null::uuid as verified_by_user_uuid`),
+                    knex.raw(`null as verified_by_user_first_name`),
+                    knex.raw(`null as verified_by_user_last_name`),
                     knex.raw(
                         `json_build_object(
                             'latestVersionNumber', latest_version.version,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
@@ -5,6 +5,7 @@ import {
     ContentType,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { ContentVerificationTableName } from '../../../database/entities/contentVerification';
 import { DashboardsTableName } from '../../../database/entities/dashboards';
 import { OrganizationTableName } from '../../../database/entities/organizations';
 import {
@@ -87,6 +88,25 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                     `${SavedChartsTableName}.last_version_updated_by_user_uuid`,
                     `updatedByUser.user_uuid`,
                 )
+                .leftJoin(
+                    ContentVerificationTableName,
+                    function verificationJoin() {
+                        this.on(
+                            `${ContentVerificationTableName}.content_uuid`,
+                            '=',
+                            `${SavedChartsTableName}.saved_query_uuid`,
+                        ).andOn(
+                            `${ContentVerificationTableName}.content_type`,
+                            '=',
+                            knex.raw('?', [ContentType.CHART]),
+                        );
+                    },
+                )
+                .leftJoin(
+                    `${UserTableName} as verifiedByUser`,
+                    `verifiedByUser.user_uuid`,
+                    `${ContentVerificationTableName}.verified_by_user_uuid`,
+                )
                 .select<SelectSavedChart[]>([
                     knex.raw(`'${ContentType.CHART}' as content_type`),
                     knex.raw(
@@ -131,6 +151,10 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                     knex.raw(
                         `(SELECT last_name FROM users WHERE user_uuid = ${SavedChartsTableName}.deleted_by_user_uuid) as deleted_by_user_last_name`,
                     ),
+                    `${ContentVerificationTableName}.verified_at as verified_at`,
+                    `verifiedByUser.user_uuid as verified_by_user_uuid`,
+                    `verifiedByUser.first_name as verified_by_user_first_name`,
+                    `verifiedByUser.last_name as verified_by_user_last_name`,
                     knex.raw(`json_build_object(
                     'source','${ChartSourceType.DBT_EXPLORE}',
                     'chart_kind', ${SavedChartsTableName}.last_version_chart_kind,
@@ -249,7 +273,20 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                     : null,
                 views: value.views,
                 firstViewedAt: value.first_viewed_at,
-                verification: null,
+                verification:
+                    value.verified_at !== null &&
+                    value.verified_by_user_uuid !== null &&
+                    value.verified_by_user_first_name !== null &&
+                    value.verified_by_user_last_name !== null
+                        ? {
+                              verifiedBy: {
+                                  userUuid: value.verified_by_user_uuid,
+                                  firstName: value.verified_by_user_first_name,
+                                  lastName: value.verified_by_user_last_name,
+                              },
+                              verifiedAt: value.verified_at,
+                          }
+                        : null,
             };
         },
     };

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -107,6 +107,10 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                     `${SpaceTableName}.deleted_by_user_uuid`,
                     'deleted_by_user.first_name as deleted_by_user_first_name',
                     'deleted_by_user.last_name as deleted_by_user_last_name',
+                    knex.raw(`null::timestamp as verified_at`),
+                    knex.raw(`null::uuid as verified_by_user_uuid`),
+                    knex.raw(`null as verified_by_user_first_name`),
+                    knex.raw(`null as verified_by_user_last_name`),
                     knex.raw(`json_build_object(
                         'dashboardCount', (${
                             filters.includeDescendantCounts

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
@@ -5,6 +5,7 @@ import {
     ContentType,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { ContentVerificationTableName } from '../../../database/entities/contentVerification';
 import { DashboardsTableName } from '../../../database/entities/dashboards';
 import { OrganizationTableName } from '../../../database/entities/organizations';
 import { ProjectTableName } from '../../../database/entities/projects';
@@ -84,6 +85,25 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                     `${SavedSqlTableName}.last_version_updated_by_user_uuid`,
                     `updatedByUser.user_uuid`,
                 )
+                .leftJoin(
+                    ContentVerificationTableName,
+                    function verificationJoin() {
+                        this.on(
+                            `${ContentVerificationTableName}.content_uuid`,
+                            '=',
+                            `${SavedSqlTableName}.saved_sql_uuid`,
+                        ).andOn(
+                            `${ContentVerificationTableName}.content_type`,
+                            '=',
+                            knex.raw('?', [ContentType.CHART]),
+                        );
+                    },
+                )
+                .leftJoin(
+                    `${UserTableName} as verifiedByUser`,
+                    `verifiedByUser.user_uuid`,
+                    `${ContentVerificationTableName}.verified_by_user_uuid`,
+                )
                 .select<SelectSavedSql[]>([
                     knex.raw(`'${ContentType.CHART}' as content_type`),
                     knex.raw(
@@ -130,6 +150,10 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                     knex.raw(
                         `(SELECT last_name FROM ${UserTableName} WHERE user_uuid = ${SavedSqlTableName}.deleted_by_user_uuid) as deleted_by_user_last_name`,
                     ),
+                    `${ContentVerificationTableName}.verified_at as verified_at`,
+                    `verifiedByUser.user_uuid as verified_by_user_uuid`,
+                    `verifiedByUser.first_name as verified_by_user_first_name`,
+                    `verifiedByUser.last_name as verified_by_user_last_name`,
                     knex.raw(`json_build_object(
                     'source','${ChartSourceType.SQL}',
                     'chart_kind', ${SavedSqlTableName}.last_version_chart_kind,
@@ -236,7 +260,20 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                     : null,
                 views: value.views,
                 firstViewedAt: value.first_viewed_at,
-                verification: null,
+                verification:
+                    value.verified_at !== null &&
+                    value.verified_by_user_uuid !== null &&
+                    value.verified_by_user_first_name !== null &&
+                    value.verified_by_user_last_name !== null
+                        ? {
+                              verifiedBy: {
+                                  userUuid: value.verified_by_user_uuid,
+                                  firstName: value.verified_by_user_first_name,
+                                  lastName: value.verified_by_user_last_name,
+                              },
+                              verifiedAt: value.verified_at,
+                          }
+                        : null,
             };
         },
     };

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -73,6 +73,10 @@ export type SummaryContentRow<
     deleted_by_user_uuid: string | null;
     deleted_by_user_first_name: string | null;
     deleted_by_user_last_name: string | null;
+    verified_at: Date | null;
+    verified_by_user_uuid: string | null;
+    verified_by_user_first_name: string | null;
+    verified_by_user_last_name: string | null;
     metadata: T;
 };
 

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -18,6 +18,7 @@ import {
 } from '@tabler/icons-react';
 import { Link } from 'react-router';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import MantineIcon from '../MantineIcon';
 import { ResourceIcon, ResourceIndicator } from '../ResourceIcon';
 import { ResourceInfoPopup } from '../ResourceInfoPopup/ResourceInfoPopup';
 import AttributeCount from './ResourceAttributeCount';
@@ -94,47 +95,40 @@ const ResourceValidationErrorIndicator = ({
     );
 };
 
-type ResourceVerifiedIndicatorProps = {
+type ResourceVerifiedInlineBadgeProps = {
     verification: ContentVerificationInfo | null;
-    children: React.ReactNode;
 };
 
 /**
- * Wraps the provided children with a verified indicator if the resource is verified.
- * Should NOT be used when validation errors are present (errors take precedence).
+ * Inline verified badge rendered next to the resource title (Instagram-style).
+ * Renders nothing when the resource is not verified.
  */
-const ResourceVerifiedIndicator = ({
+const ResourceVerifiedInlineBadge = ({
     verification,
-    children,
-}: ResourceVerifiedIndicatorProps) => {
+}: ResourceVerifiedInlineBadgeProps) => {
     if (!verification) {
-        return children;
+        return null;
     }
 
     const verifiedDate = new Date(verification.verifiedAt).toLocaleDateString();
 
     return (
-        <ResourceIndicator
-            iconProps={{
-                icon: IconCircleCheckFilled,
-                color: 'green.6',
-            }}
-            tooltipProps={{
-                maw: 300,
-                withinPortal: true,
-                multiline: true,
-                offset: -2,
-                position: 'bottom',
-            }}
-            tooltipLabel={
+        <Tooltip
+            withinPortal
+            multiline
+            maw={300}
+            position="bottom"
+            label={
                 <>
                     Verified by {verification.verifiedBy.firstName}{' '}
                     {verification.verifiedBy.lastName} on {verifiedDate}
                 </>
             }
         >
-            {children}
-        </ResourceIndicator>
+            <Box component="span" lh={0} c="green.6">
+                <MantineIcon icon={IconCircleCheckFilled} size={16} />
+            </Box>
+        </Tooltip>
     );
 };
 
@@ -188,9 +182,7 @@ const InfiniteResourceTableColumnName = ({
                     canUserManageValidation={canUserManageValidation}
                     validationId={validationId}
                 >
-                    <ResourceVerifiedIndicator verification={verification}>
-                        <ResourceIcon item={item} />
-                    </ResourceVerifiedIndicator>
+                    <ResourceIcon item={item} />
                 </ResourceValidationErrorIndicator>
 
                 <Stack gap={2}>
@@ -202,6 +194,9 @@ const InfiniteResourceTableColumnName = ({
                         >
                             {item.data.name}
                         </Text>
+                        <ResourceVerifiedInlineBadge
+                            verification={verification}
+                        />
                         {!isSpace &&
                             // If there is no description, don't show the info icon on dashboards.
                             // For charts we still show it for the dashboard list


### PR DESCRIPTION
Stacked on #22321 (which adds the backend wiring for verification on the Space overview API).

## Summary

- Moves the verified indicator from a corner-overlay on the resource icon to an **inline badge next to the title** (Instagram-style)
- Same green `IconCircleCheckFilled`, same tooltip ("Verified by ___ on ___") — just a more visible placement so the seal actually works as an at-a-glance trust signal
- Scoped to the Space overview surface only. The other list/grid/card surfaces called out in PROD-7194 (root content, search, omnibar, pinned) follow in subsequent PRs

## Why this scope

PROD-7194 ([Linear](https://linear.app/lightdash/issue/PROD-7194/show-verified-badge-in-space-view-and-content-listings) / [GH #22475](https://github.com/lightdash/lightdash/issues/22475)) covers many list surfaces. Starting with Space overview gives a small, reviewable diff to validate the new placement with Paula before rolling it out everywhere.

The corner-overlay treatment shipped with the original verified seal feature, but in dense list views it's easy to miss — defeating the trust-signal purpose.

## Test plan

- [x] `pnpm -F frontend lint`
- [x] `pnpm -F frontend typecheck`
- [ ] Verify a chart in a space → green check appears inline next to its name in the Space overview list
- [ ] Unverified items in the same list show no badge
- [ ] Hover badge → tooltip shows "Verified by {name} on {date}"
- [ ] Validation-error indicator still wraps the icon as before (verified + validation-error coexist correctly: validation takes precedence on the icon, badge sits inline next to title)

🤖 Generated with [Claude Code](https://claude.com/claude-code)