### PR TITLE
fix: refresh Databricks oauth_m2m credentials in embed warehouse client

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -778,11 +778,20 @@ export class EmbedService extends BaseService {
         }
     }
 
-    private async _getWarehouseClient(projectUuid: string, explore: Explore) {
+    private async _getWarehouseClient(
+        account: AnonymousAccount,
+        projectUuid: string,
+        explore: Explore,
+    ) {
+        // Resolve via ProjectService so OAuth tokens are refreshed before use
+        // (e.g. Databricks oauth_m2m must exchange client_id+secret for an
+        // access token — fetching the raw row from the model would yield an
+        // empty `token` and crash the warehouse client).
         const credentials =
-            await this.projectModel.getWarehouseCredentialsForProject(
+            await this.projectService.getWarehouseCredentialsForEmbed({
                 projectUuid,
-            );
+                account,
+            });
 
         const { warehouseClient, sshTunnel } =
             await this.projectService._getWarehouseClient(
@@ -855,6 +864,7 @@ export class EmbedService extends BaseService {
         useTimezoneAwareDateTrunc: boolean;
     }) {
         const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
+            account,
             projectUuid,
             explore,
         );

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -125,6 +125,9 @@ jest.mock('@lightdash/warehouses', () => ({
         connect: jest.fn(() => warehouseClientMock.credentials),
         disconnect: jest.fn(),
     })),
+    exchangeDatabricksOAuthCredentials: jest.fn(),
+    refreshDatabricksOAuthToken: jest.fn(),
+    DATABRICKS_DEFAULT_OAUTH_CLIENT_ID: 'default-client-id',
 }));
 
 const projectModel = {
@@ -622,6 +625,84 @@ describe('ProjectService', () => {
 
             // User credentials should NOT have been fetched
             expect(findForProjectWithSecretsMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getWarehouseCredentialsForEmbed', () => {
+        test('should refresh Databricks oauth_m2m credentials so the access token is populated', async () => {
+            const { exchangeDatabricksOAuthCredentials } = jest.requireMock(
+                '@lightdash/warehouses',
+            );
+
+            // Project credentials as stored in DB: m2m client id/secret but no token yet.
+            const projectCredentials = {
+                type: WarehouseTypes.DATABRICKS,
+                authenticationType: 'oauth_m2m',
+                serverHostName: 'test.databricks.com',
+                httpPath: '/sql/test',
+                database: 'test_db',
+                catalog: 'test_catalog',
+                oauthClientId: 'client-id',
+                oauthClientSecret: 'client-secret',
+            };
+            (
+                projectModel.getWarehouseCredentialsForProject as jest.Mock
+            ).mockResolvedValueOnce(projectCredentials);
+
+            (
+                exchangeDatabricksOAuthCredentials as jest.Mock
+            ).mockResolvedValueOnce({
+                accessToken: 'fresh-m2m-access-token',
+                refreshToken: 'fresh-m2m-refresh-token',
+            });
+
+            const embedAccount = buildAccount({
+                accountType: 'jwt',
+                userType: 'anonymous',
+            });
+
+            const credentials = await service.getWarehouseCredentialsForEmbed({
+                projectUuid,
+                // The mock buildAccount returns Account; AnonymousAccount is structurally compatible.
+                account: embedAccount as never,
+            });
+
+            expect(exchangeDatabricksOAuthCredentials).toHaveBeenCalledWith(
+                'test.databricks.com',
+                'client-id',
+                'client-secret',
+            );
+            // Token must be present, otherwise DatabricksWarehouseClient throws
+            // "Databricks OAuth access token is required for OAuth oauth_m2m authentication"
+            expect(credentials).toMatchObject({
+                token: 'fresh-m2m-access-token',
+                authenticationType: 'oauth_m2m',
+            });
+        });
+
+        test('should throw when project requires user credentials', async () => {
+            (
+                projectModel.getWarehouseCredentialsForProject as jest.Mock
+            ).mockResolvedValueOnce({
+                type: WarehouseTypes.DATABRICKS,
+                authenticationType: 'oauth_u2m',
+                serverHostName: 'test.databricks.com',
+                httpPath: '/sql/test',
+                database: 'test_db',
+                requireUserCredentials: true,
+            });
+
+            const embedAccount = buildAccount({
+                accountType: 'jwt',
+                userType: 'anonymous',
+            });
+
+            await expect(
+                service.getWarehouseCredentialsForEmbed({
+                    projectUuid,
+                    account: embedAccount as never,
+                }),
+            ).rejects.toBeInstanceOf(ForbiddenError);
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4,6 +4,7 @@ import {
     addDashboardFiltersToMetricQuery,
     AlreadyExistsError,
     AndFilterGroup,
+    AnonymousAccount,
     AnyType,
     ApiChartAndResults,
     ApiCreatePreviewResults,
@@ -1366,12 +1367,39 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError(
                 'Embedded users cannot use personal warehouse credentials',
             );
+        } else if (!organizationWarehouseCredentialsUuid) {
+            // Refresh project credentials for the embed user. Required for auth
+            // types that mint a short-lived token from project-level secrets
+            // (e.g. Databricks oauth_m2m exchanges client_id+secret for a token).
+            this.logger.debug(
+                `Refreshing warehouse credentials for embed user ${userId}`,
+            );
+            credentials = await this.refreshCredentials(credentials, userId);
         }
 
         return {
             ...credentials,
             userWarehouseCredentialsUuid,
         };
+    }
+
+    /**
+     * Resolves warehouse credentials for an embed (anonymous JWT) request.
+     * Same shape as `getWarehouseCredentials` but tailored for embed callers
+     * and exposed as a public method so EmbedService can reuse the refresh path.
+     */
+    async getWarehouseCredentialsForEmbed({
+        projectUuid,
+        account,
+    }: {
+        projectUuid: string;
+        account: AnonymousAccount;
+    }) {
+        return this.getWarehouseCredentials({
+            projectUuid,
+            userId: account.user.id,
+            isRegisteredUser: false,
+        });
     }
 
     async _getWarehouseClient(


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/22485



Before

![CleanShot 2026-04-29 at 11.22.12.png](https://app.graphite.com/user-attachments/assets/cf0da145-b3ef-48d1-8b73-2693e4c31be2.png)



After



![CleanShot 2026-04-29 at 12.19.00.png](https://app.graphite.com/user-attachments/assets/396bfba7-523b-4c82-bf91-ac212e7d7d55.png)



### Description:

Fixes an issue where Databricks `oauth_m2m` connections would fail for embedded (anonymous JWT) users because the raw warehouse credentials fetched directly from the database contain no access token — only the client ID and secret. The warehouse client then crashes with "Databricks OAuth access token is required for OAuth oauth_m2m authentication".

`EmbedService._getWarehouseClient` now delegates credential resolution to `ProjectService.getWarehouseCredentialsForEmbed` instead of reading the raw row directly from the model. This ensures the OAuth token exchange step (`exchangeDatabricksOAuthCredentials`) is performed before the credentials are handed to the warehouse client, producing a valid short-lived access token.

A new `getWarehouseCredentialsForEmbed` method is added to `ProjectService` as a public, embed-scoped entry point that routes through the existing `getWarehouseCredentials` + `refreshCredentials` path. Projects that require user-level credentials continue to throw a `ForbiddenError` for anonymous embed accounts.