### PR TITLE
feat(permissions): strip SQL bodies from explore-from-here URLs

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -61,6 +61,7 @@ import {
     ItemsMap,
     KnexPaginateArgs,
     KnexPaginatedData,
+    mergeSavedSqlBodiesIntoMetricQuery,
     MetricQuery,
     normalizeIndexColumns,
     NotFoundError,
@@ -3540,14 +3541,11 @@ export class AsyncQueryService extends ProjectService {
     /**
      * Throws if the incoming query contains SQL-authored fields (custom SQL
      * dimensions or SQL table calculations) that are new or modified compared
-     * to the saved chart, and the user lacks `manage:CustomFields`.
-     *
-     * If `savedChartUuid` is provided, the saved chart's metricQuery is loaded
-     * so we only gate fields that differ from what was saved — letting users
-     * without the scope still run/explore charts that already contain SQL
-     * fields someone else authored.
+     * to the saved chart, and the user lacks `manage:CustomFields`. Returns
+     * the metricQuery with empty SQL bodies rehydrated from the saved chart,
+     * which supports stripped-on-encode share links.
      */
-    private async assertCanRunSqlAuthoredFields({
+    private async assertCanRunSqlAuthoredFields<T extends MetricQuery>({
         auditedAbility,
         organizationUuid,
         projectUuid,
@@ -3559,12 +3557,9 @@ export class AsyncQueryService extends ProjectService {
         organizationUuid: string;
         projectUuid: string;
         exploreName: string;
-        metricQuery: Pick<
-            MetricQuery,
-            'customDimensions' | 'tableCalculations'
-        >;
+        metricQuery: T;
         savedChartUuid?: string;
-    }): Promise<void> {
+    }): Promise<T> {
         let savedMetricQuery: Pick<
             MetricQuery,
             'customDimensions' | 'tableCalculations'
@@ -3592,22 +3587,25 @@ export class AsyncQueryService extends ProjectService {
             }
         }
 
-        if (!hasModifiedSqlAuthoredFields(metricQuery, savedMetricQuery)) {
-            return;
+        if (hasModifiedSqlAuthoredFields(metricQuery, savedMetricQuery)) {
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('CustomFields', {
+                        organizationUuid,
+                        projectUuid,
+                        metadata: { exploreName },
+                    }),
+                )
+            ) {
+                throw new CustomSqlQueryForbiddenError();
+            }
         }
 
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('CustomFields', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: { exploreName },
-                }),
-            )
-        ) {
-            throw new CustomSqlQueryForbiddenError();
-        }
+        return mergeSavedSqlBodiesIntoMetricQuery(
+            metricQuery,
+            savedMetricQuery,
+        );
     }
 
     // execute
@@ -3659,7 +3657,7 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        await this.assertCanRunSqlAuthoredFields({
+        const resolvedMetricQuery = await this.assertCanRunSqlAuthoredFields({
             auditedAbility,
             organizationUuid,
             projectUuid,
@@ -3672,7 +3670,7 @@ export class AsyncQueryService extends ProjectService {
             ...this.getUserQueryTags(account),
             organization_uuid: organizationUuid,
             project_uuid: projectUuid,
-            explore_name: metricQuery.exploreName,
+            explore_name: resolvedMetricQuery.exploreName,
             query_context: context,
         };
 
@@ -3681,7 +3679,7 @@ export class AsyncQueryService extends ProjectService {
         const explore = await this.getExploreForMetricQueryExecution({
             account,
             projectUuid,
-            exploreName: metricQuery.exploreName,
+            exploreName: resolvedMetricQuery.exploreName,
             organizationUuid,
             materializationRole:
                 context === QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
@@ -3727,7 +3725,7 @@ export class AsyncQueryService extends ProjectService {
             useTimezoneAwareDateTrunc,
         } = await this.prepareMetricQueryAsyncQueryArgs({
             account,
-            metricQuery,
+            metricQuery: resolvedMetricQuery,
             dateZoom,
             explore,
             warehouseSqlBuilder,
@@ -3742,19 +3740,19 @@ export class AsyncQueryService extends ProjectService {
 
         const requestParameters: ExecuteAsyncMetricQueryRequestParams = {
             context,
-            query: metricQuery,
+            query: resolvedMetricQuery,
             parameters: combinedParameters,
         };
 
         const routingDecision = this.getPreAggregationRoutingDecision({
-            metricQuery,
+            metricQuery: resolvedMetricQuery,
             explore,
             context,
             forceWarehouse: usePreAggregateCache === false,
         });
 
         this.logger.info(
-            `Metric query prep for ${metricQuery.exploreName}: get_explore=${getExploreMs}ms get_wh_credentials=${getWarehouseCredentialsMs}ms prepare_query=${prepareMs}ms routing=${routingDecision.target} total=${Date.now() - metricQueryStart}ms`,
+            `Metric query prep for ${resolvedMetricQuery.exploreName}: get_explore=${getExploreMs}ms get_wh_credentials=${getWarehouseCredentialsMs}ms prepare_query=${prepareMs}ms routing=${routingDecision.target} total=${Date.now() - metricQueryStart}ms`,
         );
 
         if (routingDecision.preAggregateMetadata) {
@@ -3767,7 +3765,7 @@ export class AsyncQueryService extends ProjectService {
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 account,
-                metricQuery,
+                metricQuery: resolvedMetricQuery,
                 projectUuid,
                 explore,
                 context,
@@ -6073,7 +6071,7 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        await this.assertCanRunSqlAuthoredFields({
+        const resolvedMetricQuery = await this.assertCanRunSqlAuthoredFields({
             auditedAbility,
             organizationUuid,
             projectUuid,
@@ -6100,7 +6098,7 @@ export class AsyncQueryService extends ProjectService {
                 account,
                 projectUuid,
                 organizationUuid,
-                metricQuery: data.metricQuery,
+                metricQuery: resolvedMetricQuery,
                 explore,
                 context: QueryExecutionContext.CALCULATE_TOTAL,
                 queryTags: {
@@ -6148,7 +6146,7 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        await this.assertCanRunSqlAuthoredFields({
+        const resolvedMetricQuery = await this.assertCanRunSqlAuthoredFields({
             auditedAbility,
             organizationUuid,
             projectUuid,
@@ -6172,7 +6170,7 @@ export class AsyncQueryService extends ProjectService {
 
         const { dimensionGroupsToSubtotal, analyticsData } =
             SubtotalsCalculator.prepareDimensionGroups(
-                data.metricQuery,
+                resolvedMetricQuery,
                 data.columnOrder,
                 data.pivotDimensions,
             );
@@ -6196,7 +6194,7 @@ export class AsyncQueryService extends ProjectService {
             account,
             projectUuid,
             organizationUuid,
-            metricQuery: data.metricQuery,
+            metricQuery: resolvedMetricQuery,
             explore,
             context: QueryExecutionContext.CALCULATE_SUBTOTAL,
             queryTags: {

--- a/packages/common/src/utils/sqlAuthoredFields.test.ts
+++ b/packages/common/src/utils/sqlAuthoredFields.test.ts
@@ -12,7 +12,22 @@ import {
     getModifiedSqlAuthoredFields,
     hasModifiedSqlAuthoredFields,
     hasSqlAuthoredFields,
+    mergeSavedSqlBodiesIntoMetricQuery,
+    stripSqlBodiesFromMetricQuery,
 } from './sqlAuthoredFields';
+
+const fullMq = (overrides: Partial<MetricQuery> = {}): MetricQuery => ({
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+    additionalMetrics: [],
+    customDimensions: [],
+    ...overrides,
+});
 
 const sqlDim = (id: string, sql: string, name = id): CustomSqlDimension => ({
     id,
@@ -293,5 +308,176 @@ describe('hasModifiedSqlAuthoredFields', () => {
                 mq({ customDimensions: [dim], tableCalculations: [calc] }),
             ),
         ).toBe(false);
+    });
+});
+
+describe('getModifiedSqlAuthoredFields — strip-on-encode round-trip', () => {
+    it('treats empty incoming custom dim sql as preserved when saved has a body', () => {
+        const result = getModifiedSqlAuthoredFields(
+            mq({ customDimensions: [sqlDim('d1', '')] }),
+            mq({ customDimensions: [sqlDim('d1', '${orders.amount}')] }),
+        );
+
+        expect(result.customDimensions).toEqual([]);
+    });
+
+    it('treats empty incoming table calc sql as preserved when saved has a body', () => {
+        const result = getModifiedSqlAuthoredFields(
+            mq({ tableCalculations: [sqlCalc('c1', '')] }),
+            mq({ tableCalculations: [sqlCalc('c1', 'sum(x)')] }),
+        );
+
+        expect(result.tableCalculations).toEqual([]);
+    });
+
+    it('flags empty incoming SQL custom dim as modified when there is no saved counterpart', () => {
+        // Custom SQL dims are identified by `type === SQL` regardless of body.
+        const result = getModifiedSqlAuthoredFields(
+            mq({ customDimensions: [sqlDim('d_new', '')] }),
+            mq({}),
+        );
+        expect(result.customDimensions).toHaveLength(1);
+    });
+
+    it('does not flag an empty incoming SQL table calc when no saved match exists', () => {
+        // SQL table calcs are identified by a *non-empty* sql body, so a
+        // calc with empty body falls outside the SQL variant entirely.
+        // Compile would still reject it downstream — gate stays out of it.
+        const result = getModifiedSqlAuthoredFields(
+            mq({ tableCalculations: [sqlCalc('c_new', '')] }),
+            mq({}),
+        );
+        expect(result.tableCalculations).toEqual([]);
+    });
+});
+
+describe('stripSqlBodiesFromMetricQuery', () => {
+    it('blanks the sql of every SQL custom dim while leaving bin dims untouched', () => {
+        const result = stripSqlBodiesFromMetricQuery(
+            fullMq({
+                customDimensions: [
+                    sqlDim('d1', '${orders.amount}'),
+                    binDim('b1'),
+                ],
+            }),
+        );
+
+        expect(result.customDimensions).toEqual([
+            expect.objectContaining({ id: 'd1', sql: '' }),
+            expect.objectContaining({ id: 'b1' }),
+        ]);
+        // Bin dim shape preserved
+        expect(result.customDimensions?.[1]).not.toHaveProperty('sql');
+    });
+
+    it('blanks the sql of every SQL table calc while leaving formula and template untouched', () => {
+        const result = stripSqlBodiesFromMetricQuery(
+            fullMq({
+                tableCalculations: [
+                    sqlCalc('s1', 'sum(x)'),
+                    formulaCalc('f1', '=SUM(x)'),
+                    templateCalc('t1'),
+                ],
+            }),
+        );
+
+        expect(result.tableCalculations).toEqual([
+            expect.objectContaining({ name: 's1', sql: '' }),
+            expect.objectContaining({ name: 'f1', formula: '=SUM(x)' }),
+            expect.objectContaining({ name: 't1' }),
+        ]);
+    });
+
+    it('returns an equivalent shape (idempotent) when there are no SQL fields', () => {
+        const input = fullMq({
+            customDimensions: [binDim('b1')],
+            tableCalculations: [
+                formulaCalc('f1', '=AVG(x)'),
+                templateCalc('t1'),
+            ],
+        });
+        const result = stripSqlBodiesFromMetricQuery(input);
+
+        expect(result.customDimensions).toEqual(input.customDimensions);
+        expect(result.tableCalculations).toEqual(input.tableCalculations);
+    });
+});
+
+describe('mergeSavedSqlBodiesIntoMetricQuery', () => {
+    it('rehydrates an empty SQL custom dim from the saved chart by id', () => {
+        const result = mergeSavedSqlBodiesIntoMetricQuery(
+            fullMq({ customDimensions: [sqlDim('d1', '')] }),
+            mq({ customDimensions: [sqlDim('d1', '${orders.amount}')] }),
+        );
+
+        expect(result.customDimensions).toEqual([
+            expect.objectContaining({ id: 'd1', sql: '${orders.amount}' }),
+        ]);
+    });
+
+    it('rehydrates an empty SQL table calc from the saved chart by name', () => {
+        const result = mergeSavedSqlBodiesIntoMetricQuery(
+            fullMq({ tableCalculations: [sqlCalc('c1', '')] }),
+            mq({ tableCalculations: [sqlCalc('c1', 'sum(x)')] }),
+        );
+
+        expect(result.tableCalculations).toEqual([
+            expect.objectContaining({ name: 'c1', sql: 'sum(x)' }),
+        ]);
+    });
+
+    it('leaves non-empty incoming SQL untouched (does not overwrite user edits)', () => {
+        const result = mergeSavedSqlBodiesIntoMetricQuery(
+            fullMq({ customDimensions: [sqlDim('d1', 'modified')] }),
+            mq({ customDimensions: [sqlDim('d1', 'saved')] }),
+        );
+
+        expect(result.customDimensions).toEqual([
+            expect.objectContaining({ sql: 'modified' }),
+        ]);
+    });
+
+    it('leaves empty incoming SQL untouched when there is no matching saved field', () => {
+        const result = mergeSavedSqlBodiesIntoMetricQuery(
+            fullMq({ customDimensions: [sqlDim('d_orphan', '')] }),
+            mq({ customDimensions: [sqlDim('d_other', 'sql')] }),
+        );
+
+        expect(result.customDimensions).toEqual([
+            expect.objectContaining({ id: 'd_orphan', sql: '' }),
+        ]);
+    });
+
+    it('returns the input untouched when saved is null', () => {
+        const incoming = fullMq({
+            customDimensions: [sqlDim('d1', '${orders.amount}')],
+            tableCalculations: [sqlCalc('c1', 'sum(x)')],
+        });
+        expect(mergeSavedSqlBodiesIntoMetricQuery(incoming, null)).toBe(
+            incoming,
+        );
+    });
+});
+
+describe('strip + merge round-trip', () => {
+    it('reconstructs the original metricQuery for SQL custom dims and table calcs', () => {
+        const original = fullMq({
+            customDimensions: [sqlDim('d1', '${orders.amount}'), binDim('b1')],
+            tableCalculations: [
+                sqlCalc('s1', 'sum(x)'),
+                formulaCalc('f1', '=SUM(x)'),
+            ],
+        });
+
+        const stripped = stripSqlBodiesFromMetricQuery(original);
+        const rehydrated = mergeSavedSqlBodiesIntoMetricQuery(
+            stripped,
+            original,
+        );
+
+        expect(rehydrated.customDimensions).toEqual(original.customDimensions);
+        expect(rehydrated.tableCalculations).toEqual(
+            original.tableCalculations,
+        );
     });
 });

--- a/packages/common/src/utils/sqlAuthoredFields.ts
+++ b/packages/common/src/utils/sqlAuthoredFields.ts
@@ -1,8 +1,10 @@
 import {
     isCustomSqlDimension,
     isSqlTableCalculation,
+    type CustomDimension,
     type CustomSqlDimension,
     type SqlTableCalculation,
+    type TableCalculation,
 } from '../types/field';
 import { type MetricQuery } from '../types/metricQuery';
 
@@ -30,6 +32,11 @@ export const hasSqlAuthoredFields = (
     getSqlCustomDimensions(metricQuery).length > 0 ||
     getSqlTableCalculations(metricQuery).length > 0;
 
+// Empty incoming sql against a non-empty saved value is treated as preserved
+// — supports stripped-on-encode round-trips where the body never travels.
+const isPreservedSqlBody = (incoming: string, saved: string): boolean =>
+    incoming === saved || (incoming === '' && saved !== '');
+
 export const getModifiedSqlAuthoredFields = (
     incoming:
         | Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>
@@ -46,7 +53,7 @@ export const getModifiedSqlAuthoredFields = (
     );
     const modifiedCustomDimensions = incomingDims.filter((dim) => {
         const savedDim = savedDimsById.get(dim.id);
-        return !savedDim || savedDim.sql !== dim.sql;
+        return !savedDim || !isPreservedSqlBody(dim.sql, savedDim.sql);
     });
 
     const incomingCalcs = getSqlTableCalculations(incoming);
@@ -55,12 +62,74 @@ export const getModifiedSqlAuthoredFields = (
     );
     const modifiedTableCalculations = incomingCalcs.filter((calc) => {
         const savedCalc = savedCalcsByName.get(calc.name);
-        return !savedCalc || savedCalc.sql !== calc.sql;
+        return !savedCalc || !isPreservedSqlBody(calc.sql, savedCalc.sql);
     });
 
     return {
         customDimensions: modifiedCustomDimensions,
         tableCalculations: modifiedTableCalculations,
+    };
+};
+
+// Strips the `sql` body from custom SQL dims and SQL table calcs — used for
+// serialising metric queries into URLs without leaking authored SQL.
+export const stripSqlBodiesFromMetricQuery = <
+    T extends Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>,
+>(
+    metricQuery: T,
+): T => ({
+    ...metricQuery,
+    customDimensions: metricQuery.customDimensions?.map(
+        (dim): CustomDimension =>
+            isCustomSqlDimension(dim) ? { ...dim, sql: '' } : dim,
+    ),
+    tableCalculations: metricQuery.tableCalculations.map(
+        (calc): TableCalculation =>
+            isSqlTableCalculation(calc) ? { ...calc, sql: '' } : calc,
+    ),
+});
+
+// Replaces empty `sql` bodies on incoming SQL fields with the saved chart's
+// SQL where ids/names match — enables stripped-on-encode round-trips.
+// Stripped SQL table calcs are identified structurally because
+// `isSqlTableCalculation` requires a non-empty sql body.
+const hasEmptySqlBody = (calc: TableCalculation): boolean =>
+    'sql' in calc &&
+    typeof (calc as { sql?: unknown }).sql === 'string' &&
+    (calc as { sql: string }).sql === '';
+
+export const mergeSavedSqlBodiesIntoMetricQuery = <T extends MetricQuery>(
+    incoming: T,
+    saved:
+        | Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>
+        | null
+        | undefined,
+): T => {
+    if (!saved) return incoming;
+    const savedSqlDimsById = new Map(
+        getSqlCustomDimensions(saved).map((dim) => [dim.id, dim]),
+    );
+    const savedSqlCalcsByName = new Map(
+        getSqlTableCalculations(saved).map((calc) => [calc.name, calc]),
+    );
+    return {
+        ...incoming,
+        customDimensions: incoming.customDimensions?.map(
+            (dim): CustomDimension => {
+                if (!isCustomSqlDimension(dim) || dim.sql !== '') return dim;
+                const savedDim = savedSqlDimsById.get(dim.id);
+                return savedDim?.sql ? { ...dim, sql: savedDim.sql } : dim;
+            },
+        ),
+        tableCalculations: incoming.tableCalculations.map(
+            (calc): TableCalculation => {
+                if (!hasEmptySqlBody(calc)) return calc;
+                const savedCalc = savedSqlCalcsByName.get(calc.name);
+                return savedCalc?.sql
+                    ? ({ ...calc, sql: savedCalc.sql } as TableCalculation)
+                    : calc;
+            },
+        ),
     };
 };
 

--- a/packages/e2e/cypress/e2e/app/exploreFromHere.cy.ts
+++ b/packages/e2e/cypress/e2e/app/exploreFromHere.cy.ts
@@ -1,0 +1,205 @@
+import {
+    ChartType,
+    CustomDimensionType,
+    DimensionType,
+    SEED_PROJECT,
+    type CreateChartInSpace,
+    type SavedChart,
+} from '@lightdash/common';
+
+/* eslint-disable no-template-curly-in-string */
+const customSqlDim = {
+    id: 'efh_custom_sql_dim',
+    name: 'efh custom sql dim',
+    type: CustomDimensionType.SQL as const,
+    table: 'orders',
+    sql: '${orders.amount}',
+    dimensionType: DimensionType.NUMBER,
+};
+
+const sqlTableCalc = {
+    name: 'efh_sql_calc',
+    displayName: 'efh sql calc',
+    // Reference a dim that's actually in the metricQuery so the calc compiles.
+    sql: '${orders.status}',
+    type: 'string' as const,
+};
+/* eslint-enable no-template-curly-in-string */
+
+const buildChartBody = (spaceUuid: string): CreateChartInSpace => ({
+    name: 'Explore-from-here gating fixture',
+    description:
+        'Created by exploreFromHere.cy.ts — has SQL custom dim + SQL table calc',
+    tableName: 'orders',
+    spaceUuid,
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: [customSqlDim.id, 'orders_status'],
+        metrics: ['orders_total_order_amount'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [sqlTableCalc],
+        additionalMetrics: [],
+        customDimensions: [customSqlDim],
+    } as CreateChartInSpace['metricQuery'],
+    chartConfig: {
+        type: ChartType.TABLE,
+        config: { showColumnCalculation: true } as Record<string, unknown>,
+    } as CreateChartInSpace['chartConfig'],
+    tableConfig: { columnOrder: [] },
+});
+
+const buildOldStyleUrl = (projectUuid: string, chart: SavedChart): string => {
+    const params = new URLSearchParams();
+    params.set(
+        'create_saved_chart_version',
+        JSON.stringify({
+            uuid: chart.uuid,
+            projectUuid,
+            tableName: chart.tableName,
+            metricQuery: chart.metricQuery,
+            chartConfig: chart.chartConfig,
+            tableConfig: chart.tableConfig,
+        }),
+    );
+    params.set('isExploreFromHere', 'true');
+    return `/projects/${projectUuid}/tables/${chart.tableName}?${params.toString()}`;
+};
+
+describe('Explore from here — SQL bodies must not leak into the URL', () => {
+    let chart: SavedChart;
+    let spaceUuid: string;
+
+    before(() => {
+        cy.login();
+        // Public space (inherits org/project access) so the seed editor user
+        // can see the chart without needing a direct grant.
+        cy.request({
+            method: 'POST',
+            url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/spaces/`,
+            body: {
+                name: `EFH gate ${Date.now()}`,
+                inheritParentPermissions: true,
+            },
+        })
+            .then((resp) => {
+                expect(resp.status).to.eq(200);
+                spaceUuid = resp.body.results.uuid;
+                return cy.createChartInSpace(
+                    SEED_PROJECT.project_uuid,
+                    buildChartBody(spaceUuid),
+                );
+            })
+            .then((createdChart) => {
+                chart = createdChart as unknown as SavedChart;
+            });
+    });
+
+    describe('Admin (manage:CustomFields)', () => {
+        beforeEach(() => {
+            cy.login();
+        });
+
+        it('preserves SQL bodies in the URL — round-trip is intact', () => {
+            cy.intercept('POST', '/api/v1/share').as('createShare');
+            cy.visit(
+                `/projects/${SEED_PROJECT.project_uuid}/saved/${chart.uuid}/view`,
+            );
+            cy.findByText('Explore from here', { timeout: 15000 }).click();
+
+            cy.wait('@createShare')
+                .its('request.body')
+                .then((body) => {
+                    const decoded = decodeURIComponent(body.params);
+                    expect(decoded).to.contain(customSqlDim.sql);
+                    expect(decoded).to.contain(sqlTableCalc.sql);
+                    expect(decoded).to.contain('savedChartUuid=');
+                });
+        });
+    });
+
+    describe('Editor (no manage:CustomFields)', () => {
+        beforeEach(() => {
+            cy.loginAsEditor();
+        });
+
+        it('strips SQL bodies and carries savedChartUuid in the share payload', () => {
+            cy.intercept('POST', '/api/v1/share').as('createShare');
+            cy.visit(
+                `/projects/${SEED_PROJECT.project_uuid}/saved/${chart.uuid}/view`,
+            );
+            cy.findByText('Explore from here', { timeout: 15000 }).click();
+
+            cy.wait('@createShare')
+                .its('request.body')
+                .then((body) => {
+                    const decoded = decodeURIComponent(body.params);
+                    expect(decoded).to.not.contain(customSqlDim.sql);
+                    expect(decoded).to.not.contain(sqlTableCalc.sql);
+                    expect(decoded).to.contain(`savedChartUuid=${chart.uuid}`);
+                });
+        });
+
+        it('runs the destination query (200 on metric-query + calculate-total) thanks to the saved-version exemption', () => {
+            cy.intercept(
+                'POST',
+                `**/api/v2/projects/${SEED_PROJECT.project_uuid}/query/metric-query`,
+            ).as('metricQuery');
+            cy.intercept(
+                'POST',
+                `**/api/v1/projects/${SEED_PROJECT.project_uuid}/calculate-total`,
+            ).as('calculateTotal');
+
+            cy.visit(
+                `/projects/${SEED_PROJECT.project_uuid}/saved/${chart.uuid}/view`,
+            );
+            cy.findByText('Explore from here', { timeout: 15000 }).click();
+
+            cy.wait('@metricQuery')
+                .its('response.statusCode')
+                .should('eq', 200);
+            cy.wait('@calculateTotal')
+                .its('response.statusCode')
+                .should('eq', 200);
+        });
+
+        it('still works for OLD share links that have full SQL but no savedChartUuid query param (backward compat)', () => {
+            // Pre-PROD-7180 share links don't include savedChartUuid, but
+            // their JSON payload carries chart.uuid — useSourceSavedChartUuid
+            // falls back to it so the saved-version exemption still fires.
+            cy.intercept(
+                'POST',
+                `**/api/v2/projects/${SEED_PROJECT.project_uuid}/query/metric-query`,
+            ).as('metricQuery');
+
+            cy.visit(buildOldStyleUrl(SEED_PROJECT.project_uuid, chart));
+
+            cy.wait('@metricQuery').then((interception) => {
+                expect(interception.response?.statusCode).to.eq(200);
+                // Body must include savedChartUuid sourced from the JSON.uuid fallback
+                expect(interception.request.body.savedChartUuid).to.eq(
+                    chart.uuid,
+                );
+            });
+        });
+    });
+
+    after(() => {
+        if (chart?.uuid) {
+            cy.login();
+            cy.request({
+                method: 'DELETE',
+                url: `/api/v1/saved/${chart.uuid}`,
+                failOnStatusCode: false,
+            });
+        }
+        if (spaceUuid) {
+            cy.request({
+                method: 'DELETE',
+                url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/spaces/${spaceUuid}`,
+                failOnStatusCode: false,
+            });
+        }
+    });
+});

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1010,8 +1010,12 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                 chartWithDashboardFilters.projectUuid,
                 chartWithDashboardFilters,
                 true,
+                {
+                    originSavedChartUuid: chartWithDashboardFilters.uuid,
+                    cannotAuthorCustomSql: !userCanUseCustomFields,
+                },
             );
-        }, [chartWithDashboardFilters]);
+        }, [chartWithDashboardFilters, userCanUseCustomFields]);
 
         const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);
         const showComments = useDashboardContext(

--- a/packages/frontend/src/components/ExploreFromHereButton/index.tsx
+++ b/packages/frontend/src/components/ExploreFromHereButton/index.tsx
@@ -9,22 +9,29 @@ import {
 } from '../../features/explorer/store';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
+import { useCannotAuthorCustomSql } from '../../hooks/user/useCannotAuthorCustomSql';
 import { useCreateShareMutation } from '../../hooks/useShare';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
 
 const ExploreFromHereButton = () => {
-    // Get savedChart from Redux
     const savedChart = useExplorerSelector(selectSavedChart);
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(
+        savedChart?.projectUuid,
+    );
     const exploreFromHereUrl = useMemo(() => {
         if (savedChart) {
             return getExplorerUrlFromCreateSavedChartVersion(
                 savedChart.projectUuid,
                 savedChart,
                 true,
+                {
+                    originSavedChartUuid: savedChart.uuid,
+                    cannotAuthorCustomSql,
+                },
             );
         }
-    }, [savedChart]);
+    }, [savedChart, cannotAuthorCustomSql]);
 
     const { user } = useApp();
     const navigate = useNavigate();

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -19,6 +19,7 @@ import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
 import { useProject } from '../../../hooks/useProject';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useCannotAuthorCustomSql } from '../../../hooks/user/useCannotAuthorCustomSql';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
@@ -101,19 +102,29 @@ const ExplorerHeader: FC = memo(() => {
         return null;
     }, [userCanCreateChartsInSpace, userCanCreateSpace]);
 
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
     const urlToShare = useMemo(() => {
         if (unsavedChartVersion) {
             const urlArgs = getExplorerUrlFromCreateSavedChartVersion(
                 projectUuid,
                 unsavedChartVersion,
                 true,
+                {
+                    originSavedChartUuid: savedChart?.uuid,
+                    cannotAuthorCustomSql,
+                },
             );
             return {
                 pathname: urlArgs.pathname,
                 search: `?${urlArgs.search}`,
             };
         }
-    }, [unsavedChartVersion, projectUuid]);
+    }, [
+        unsavedChartVersion,
+        projectUuid,
+        savedChart?.uuid,
+        cannotAuthorCustomSql,
+    ]);
 
     useEffect(() => {
         const checkReload = (event: BeforeUnloadEvent) => {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -39,6 +39,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useSourceSavedChartUuid } from '../../../hooks/explorer/useSourceSavedChartUuid';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplore } from '../../../hooks/useExplore';
@@ -90,8 +91,8 @@ const VisualizationCard: FC<Props> = memo((props) => {
         return org?.chartColors ?? ECHARTS_DEFAULT_COLORS;
     }, [colorScheme, org?.chartColors, org?.chartDarkColors]);
 
-    // Get savedChart from Redux
     const savedChart = useExplorerSelector(selectSavedChart);
+    const sourceSavedChartUuid = useSourceSavedChartUuid();
 
     const {
         query,
@@ -295,7 +296,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                 columnOrder={unsavedChartVersion.tableConfig.columnOrder}
                 onSeriesContextMenu={onSeriesContextMenu}
                 pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
-                savedChartUuid={savedChart?.uuid}
+                savedChartUuid={sourceSavedChartUuid}
                 onChartConfigChange={handleSetChartConfig}
                 onChartTypeChange={handleSetChartType}
                 onPivotDimensionsChange={handleSetPivotFields}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/ExploreFromHereButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/ExploreFromHereButton.tsx
@@ -4,6 +4,7 @@ import { IconExternalLink } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../../hooks/useExplorerRoute';
+import { useCannotAuthorCustomSql } from '../../../../hooks/user/useCannotAuthorCustomSql';
 import { useCreateShareMutation } from '../../../../hooks/useShare';
 
 type Props = {
@@ -17,14 +18,16 @@ export const ExploreFromHereButton: FC<Props> = ({
     unsavedChartVersion,
     canExplore,
 }) => {
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
     const openInExploreUrl = useMemo(() => {
         if (!unsavedChartVersion) return undefined;
         return getExplorerUrlFromCreateSavedChartVersion(
             projectUuid,
             unsavedChartVersion,
             true, // preserves series config in the url
+            { cannotAuthorCustomSql },
         );
-    }, [projectUuid, unsavedChartVersion]);
+    }, [projectUuid, unsavedChartVersion, cannotAuthorCustomSql]);
 
     const { mutateAsync: createShareUrl, isLoading: isCreatingShareUrl } =
         useCreateShareMutation();

--- a/packages/frontend/src/hooks/explorer/useSourceSavedChartUuid.ts
+++ b/packages/frontend/src/hooks/explorer/useSourceSavedChartUuid.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router';
+import {
+    selectSavedChart,
+    useExplorerSelector,
+} from '../../features/explorer/store';
+
+const extractUuidFromCreateSavedChartVersionParam = (
+    raw: string | null,
+): string | undefined => {
+    if (!raw) return undefined;
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (
+            parsed &&
+            typeof parsed === 'object' &&
+            'uuid' in parsed &&
+            typeof (parsed as { uuid: unknown }).uuid === 'string'
+        ) {
+            return (parsed as { uuid: string }).uuid;
+        }
+    } catch {
+        // Malformed URL — caller falls through to undefined.
+    }
+    return undefined;
+};
+
+// The saved chart this explorer state originated from. Sources, in order:
+//  1. Redux — `/saved/{uuid}` route loads the chart there.
+//  2. `savedChartUuid` query param — modern "Explore from here" URLs.
+//  3. `uuid` inside `create_saved_chart_version` — backward-compat for share
+//     links generated before the param was added.
+export const useSourceSavedChartUuid = (): string | undefined => {
+    const savedChart = useExplorerSelector(selectSavedChart);
+    const [searchParams] = useSearchParams();
+
+    return useMemo(() => {
+        if (savedChart?.uuid) return savedChart.uuid;
+        const fromQueryParam = searchParams.get('savedChartUuid');
+        if (fromQueryParam) return fromQueryParam;
+        return extractUuidFromCreateSavedChartVersionParam(
+            searchParams.get('create_saved_chart_version'),
+        );
+    }, [savedChart?.uuid, searchParams]);
+};

--- a/packages/frontend/src/hooks/explorer/useSourceSavedChartUuid.ts
+++ b/packages/frontend/src/hooks/explorer/useSourceSavedChartUuid.ts
@@ -5,6 +5,15 @@ import {
     useExplorerSelector,
 } from '../../features/explorer/store';
 
+/**
+ * Extracts a saved chart UUID from the raw value of the
+ * `create_saved_chart_version` URL query parameter, which is a JSON-encoded
+ * object expected to contain a `uuid` string field.
+ *
+ * @param raw - The raw query-parameter value, or `null` when absent.
+ * @returns The extracted UUID, or `undefined` if the value is missing,
+ *   malformed, or has no string `uuid` field.
+ */
 const extractUuidFromCreateSavedChartVersionParam = (
     raw: string | null,
 ): string | undefined => {

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -55,13 +55,13 @@ import {
     selectIsEditMode,
     selectMetricOverrides,
     selectParameters,
-    selectSavedChart,
     selectSorts,
     selectTableCalculations,
     selectTableName,
     useExplorerSelector,
 } from '../features/explorer/store';
 import { getFieldColors } from '../utils/fieldColors';
+import { useSourceSavedChartUuid } from './explorer/useSourceSavedChartUuid';
 import { TableCellBar } from './TableCellBar';
 import { useCalculateTotal } from './useCalculateTotal';
 import { useExplore } from './useExplore';
@@ -397,7 +397,7 @@ export const useColumns = (): TableColumn[] => {
     const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
     const sorts = useExplorerSelector(selectSorts);
     const metricOverrides = useExplorerSelector(selectMetricOverrides);
-    const savedChart = useExplorerSelector(selectSavedChart);
+    const sourceSavedChartUuid = useSourceSavedChartUuid();
     const isEditMode = useExplorerSelector(selectIsEditMode);
 
     const { activeFields, query, validQueryArgs } = useExplorerQuery();
@@ -512,7 +512,7 @@ export const useColumns = (): TableColumn[] => {
     const { data: totals } = useCalculateTotal({
         metricQuery: resultsMetricQuery,
         explore: exploreData?.baseTable,
-        savedChartUuid: savedChart?.uuid,
+        savedChartUuid: sourceSavedChartUuid,
         isEditMode,
         fieldIds: resultsMetricQuery
             ? itemsInMetricQuery(resultsMetricQuery)

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -21,6 +21,7 @@ import {
 } from '../features/explorer/store';
 import { useQueryExecutor } from '../providers/Explorer/useQueryExecutor';
 import { buildQueryArgs } from './explorer/buildQueryArgs';
+import { useSourceSavedChartUuid } from './explorer/useSourceSavedChartUuid';
 import { useExplore } from './useExplore';
 import { useDateZoomGranularitySearch } from './useExplorerRoute';
 import { usePreAggregateCacheEnabled } from './usePreAggregateCacheEnabled';
@@ -65,11 +66,15 @@ export const useExplorerQueryManager = () => {
         savedQueryUuid: string;
         projectUuid: string;
     }>();
-    const savedQueryUuid = embed?.savedQueryUuid || params.savedQueryUuid;
+    const sourceSavedChartUuid = useSourceSavedChartUuid();
+    const savedQueryUuid =
+        embed?.savedQueryUuid || params.savedQueryUuid || sourceSavedChartUuid;
     const projectUuid = embed?.projectUuid || params.projectUuid!;
     const viewModeQueryArgs = useMemo(() => {
-        return savedQueryUuid ? { chartUuid: savedQueryUuid } : undefined;
-    }, [savedQueryUuid]);
+        return params.savedQueryUuid
+            ? { chartUuid: params.savedQueryUuid }
+            : undefined;
+    }, [params.savedQueryUuid]);
 
     const dateZoomGranularity = useDateZoomGranularitySearch();
 

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -66,15 +66,16 @@ export const useExplorerQueryManager = () => {
         savedQueryUuid: string;
         projectUuid: string;
     }>();
+    const routeSavedChartUuid = params.savedQueryUuid;
     const sourceSavedChartUuid = useSourceSavedChartUuid();
-    const savedQueryUuid =
-        embed?.savedQueryUuid || params.savedQueryUuid || sourceSavedChartUuid;
+    const savedChartUuidForQuery =
+        embed?.savedQueryUuid || routeSavedChartUuid || sourceSavedChartUuid;
     const projectUuid = embed?.projectUuid || params.projectUuid!;
     const viewModeQueryArgs = useMemo(() => {
-        return params.savedQueryUuid
-            ? { chartUuid: params.savedQueryUuid }
+        return routeSavedChartUuid
+            ? { chartUuid: routeSavedChartUuid }
             : undefined;
-    }, [params.savedQueryUuid]);
+    }, [routeSavedChartUuid]);
 
     const dateZoomGranularity = useDateZoomGranularitySearch();
 
@@ -174,7 +175,7 @@ export const useExplorerQueryManager = () => {
             minimal,
             usePreAggregateCache: preAggCacheEnabled,
             savedChart: chartConfigForQuery,
-            savedChartUuid: savedQueryUuid,
+            savedChartUuid: savedChartUuidForQuery,
         });
 
         if (mainQueryArgs) {
@@ -194,7 +195,7 @@ export const useExplorerQueryManager = () => {
         minimal,
         preAggCacheEnabled,
         chartConfigForQuery,
-        savedQueryUuid,
+        savedChartUuidForQuery,
         dispatch,
     ]);
 

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -5,6 +5,7 @@ import {
     DateGranularity,
     getItemId,
     isCartesianChartConfig,
+    stripSqlBodiesFromMetricQuery,
     type BinRange,
     type ChartConfig,
     type CreateSavedChartVersion,
@@ -37,6 +38,7 @@ import {
     type ExplorerReduceState,
 } from '../providers/Explorer/types';
 import useToaster from './toaster/useToaster';
+import { useCannotAuthorCustomSql } from './user/useCannotAuthorCustomSql';
 
 export const DEFAULT_EMPTY_EXPLORE_CONFIG: CreateSavedChartVersion = {
     tableName: '',
@@ -69,6 +71,10 @@ export const getExplorerUrlFromCreateSavedChartVersion = (
     // For example, the explore from here button uses the entire URL to create
     // shareable, shortened links.
     preserveLongUrl?: boolean,
+    options?: {
+        originSavedChartUuid?: string;
+        cannotAuthorCustomSql?: boolean;
+    },
 ): { pathname: string; search: string } => {
     if (!projectUuid) {
         return { pathname: '', search: '' };
@@ -76,22 +82,31 @@ export const getExplorerUrlFromCreateSavedChartVersion = (
     // Preserve existing search params (like fromSpace, fromDashboard, etc)
     const newParams = new URLSearchParams(window.location.search);
 
-    let stringifiedChart = JSON.stringify(createSavedChart);
+    const chartForUrl = options?.cannotAuthorCustomSql
+        ? {
+              ...createSavedChart,
+              metricQuery: stripSqlBodiesFromMetricQuery(
+                  createSavedChart.metricQuery,
+              ),
+          }
+        : createSavedChart;
+
+    let stringifiedChart = JSON.stringify(chartForUrl);
     const stringifiedChartSize = stringifiedChart.length;
     if (
         stringifiedChartSize > 3000 &&
         !preserveLongUrl &&
-        isCartesianChartConfig(createSavedChart.chartConfig.config)
+        isCartesianChartConfig(chartForUrl.chartConfig.config)
     ) {
         console.warn(
             `Chart config is too large to store in url "${stringifiedChartSize}", removing series to reduce size`,
         );
         const reducedCreateSavedChart = {
-            ...createSavedChart,
+            ...chartForUrl,
             chartConfig: {
-                ...createSavedChart.chartConfig,
+                ...chartForUrl.chartConfig,
                 config: {
-                    ...createSavedChart.chartConfig.config,
+                    ...chartForUrl.chartConfig.config,
                     eChartsConfig: {},
                 },
             },
@@ -106,8 +121,12 @@ export const getExplorerUrlFromCreateSavedChartVersion = (
     // Always set isExploreFromHere to true when creating the url for shareable links this ensures the query is executed when the url is loaded
     newParams.set('isExploreFromHere', 'true');
 
+    if (options?.originSavedChartUuid) {
+        newParams.set('savedChartUuid', options.originSavedChartUuid);
+    }
+
     return {
-        pathname: `/projects/${projectUuid}/tables/${createSavedChart.tableName}`,
+        pathname: `/projects/${projectUuid}/tables/${chartForUrl.tableName}`,
         search: newParams.toString(),
     };
 };
@@ -220,6 +239,9 @@ export const useExplorerRoute = () => {
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
     const metricQuery = useExplorerSelector(selectMetricQuery);
     const tableName = useExplorerSelector(selectTableName);
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(
+        pathParams.projectUuid,
+    );
 
     // Update url params based on pristine state
     // Only sync URL when we're actually on a table page (pathParams.tableId exists)
@@ -229,6 +251,8 @@ export const useExplorerRoute = () => {
                 getExplorerUrlFromCreateSavedChartVersion(
                     pathParams.projectUuid,
                     unsavedChartVersion,
+                    false,
+                    { cannotAuthorCustomSql },
                 ),
                 { replace: true },
             );
@@ -240,6 +264,7 @@ export const useExplorerRoute = () => {
         pathParams.tableId,
         unsavedChartVersion,
         tableName,
+        cannotAuthorCustomSql,
     ]);
 
     useEffect(() => {


### PR DESCRIPTION
### Summary

Stops "Explore from here" URLs from leaking the `sql` body of every custom SQL dimension and SQL table calculation into browser history, share-link records, and the URL bar — for users without `manage:CustomFields`. Admin / Developer URLs still round-trip the SQL so shareable links remain reproducible end-to-end.

Closes [PROD-7180](https://linear.app/lightdash/issue/PROD-7180). Builds on the saved-version exemption that landed via [#22451](https://github.com/lightdash/lightdash/pull/22451).

### Architecture (strip → carry → exempt → rehydrate)

1. **Strip on encode.** `getExplorerUrlFromCreateSavedChartVersion` accepts a `cannotAuthorCustomSql` option. When true, the URL builder runs the new `stripSqlBodiesFromMetricQuery` helper from `@lightdash/common` to blank every SQL field's `sql` body before serialising into `create_saved_chart_version`.
2. **Carry the source UUID.** A new `savedChartUuid` query param holds the originating chart's UUID so the destination can identify the saved version.
3. **Saved-version exemption.** The diff helper already exempted unchanged SQL fields. It now treats *empty incoming SQL against a non-empty saved value as preserved* — so the strip-on-encode round-trip doesn't fire the gate.
4. **Rehydrate before execution.** `assertCanRunSqlAuthoredFields` returns a resolved metric query with `mergeSavedSqlBodiesIntoMetricQuery` overlaying saved SQL bodies onto empty incoming ones. `executeAsyncMetricQuery`, `calculateTotalFromQuery`, and `calculateSubtotalsFromQuery` use the resolved query for execution so the warehouse SQL still compiles.

### Where the source UUID flows in

A new `useSourceSavedChartUuid` hook centralises the lookup with three fallbacks:

1. Redux `selectSavedChart` — loaded by the `/saved/{uuid}` route.
2. `savedChartUuid` URL search param — modern explore-from-here URLs.
3. **Backward compat:** `uuid` field inside `create_saved_chart_version` JSON — pre-PROD-7180 share links don't carry the new query param but do carry the chart UUID inside the payload, so the saved-version exemption still fires for existing share links.

`useColumns`, `useExplorerQueryManager`, and `VisualizationCard` consume the hook so run / totals / subtotals all forward `savedChartUuid` consistently.

### URL builder callers updated

- `components/ExploreFromHereButton/index.tsx` (main toolbar button)
- `features/metricsCatalog/components/MetricExploreModal/ExploreFromHereButton.tsx`
- `components/Explorer/ExplorerHeader/index.tsx` (share button)
- `components/DashboardTiles/DashboardChartTile.tsx` (dashboard tile menu)
- `hooks/useExplorerRoute.ts` (continuous URL sync as the user edits the explorer)

### Behaviour matrix

| Persona | Action | URL has SQL? | `savedChartUuid` carried? | Run + Totals + Subtotals |
| --- | --- | --- | --- | --- |
| Admin | Explore from here | ✅ yes (round-trip preserved) | ✅ yes | ✅ all 200 |
| Editor | Explore from here | 🚫 stripped | ✅ yes (new param) | ✅ all 200 |
| Editor | Opens an OLD-style share link | 🚫 stripped on next URL sync | ✅ from JSON.uuid fallback | ✅ all 200 |
| Editor | Modifies SQL after explore-from-here | 🚫 stripped | ✅ yes | 🚫 403 (correctly gated) |
| Editor | Receives an admin's **ad-hoc** share link (no saved chart) | URL initially leaks but URL sync rewrites to stripped on first state change | 🚫 no (no chart to fall back to) | 🚫 403 — query can't run without an exemption source. **This case is partially closed; full closure needs a server-side draft handoff (ticket's option 2).** |

### Out of scope

- **Admin URLs still contain SQL bodies.** Per the ticket's acceptance criteria; the longer-term server-side draft handoff is the way to remove SQL from admin URLs too.
- **Peripheral URL-builder callers** (drill-down modal, omnibar search results, query inspector, `getOpenInExploreUrl` utility) don't yet pass the `cannotAuthorCustomSql` option. Backward-compatible — they continue to behave as before.
- **API-level info disclosure** — `SavedChartService.get` and `CoderService.getCharts` still return raw SQL bodies. That's [PROD-7028](https://linear.app/lightdash/issue/PROD-7028) sub-issue B.

### Test plan

- [ ] Run `pnpm -F common test` — 1,877 tests pass including 13 new cases for the strip / merge / round-trip helpers and the diff edge cases.
- [ ] Run `pnpm -F e2e cypress:run --spec cypress/e2e/app/exploreFromHere.cy.ts` against a local instance — 4/4 pass in ~24s. Covers all four matrix rows.
- [ ] Manual smoke as Admin (demo@lightdash.com): open a saved chart with SQL custom dim + SQL table calc → click Explore from here → URL has `${...}` literal SQL → query runs.
- [ ] Manual smoke as Editor (demo2@lightdash.com): same chart → Explore from here → URL has `sql=""` for both fields → query runs (200 on metric-query and calculate-total).
- [ ] Manual: editor opens an OLD-style URL (full SQL, no `savedChartUuid`) → query still runs (200) thanks to the JSON.uuid fallback.
- [ ] Manual: editor modifies the SQL custom dim's body after explore-from-here → run query 403s with `CustomSqlQueryForbiddenError` (correctly gated).
