### PR TITLE
fix: revert "fix(pivot): respect explicit sortBy order over groupByColumns declaration"

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -754,43 +754,6 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('ORDER BY "date" ASC, "event" DESC');
         });
 
-        test('Should lead column_index ORDER BY with the sorted group-by column, not declaration order', () => {
-            // Without this, DENSE_RANK orders columns by the first declared
-            // group-by alphabetically, with the user-sorted column only
-            // acting as a tiebreaker.
-            const pivotConfiguration = {
-                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
-                valuesColumns: [
-                    {
-                        reference: 'event_id',
-                        aggregation: VizAggregationOptions.SUM,
-                    },
-                ],
-                groupByColumns: [
-                    { reference: 'status' },
-                    { reference: 'status_priority' },
-                ],
-                sortBy: [
-                    {
-                        reference: 'status_priority',
-                        direction: SortByDirection.ASC,
-                    },
-                ],
-            };
-
-            const builder = new PivotQueryBuilder(
-                baseSql,
-                pivotConfiguration,
-                mockWarehouseSqlBuilder,
-            );
-
-            const result = builder.toSql();
-
-            expect(result.toLowerCase()).toContain(
-                'dense_rank() over (order by g."status_priority" asc, g."status" asc) as "column_index"',
-            );
-        });
-
         test('Should use index column sort for row_index in pivot queries', () => {
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -459,11 +459,9 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Builds the ORDER BY clause used to rank pivot columns (column_index).
-     * Group-by columns referenced in sortBy lead in user-specified order; any
-     * remaining group-bys follow in declaration order. Value columns sorted
-     * by an anchor CTE are prepended or appended depending on whether the
-     * first sort entry is a value or a group-by.
+     * Builds ORDER BY clause for groupBy columns with their sort directions.
+     * Respects sortBy order and uses column anchor values for value columns when available.
+     * Appends any missing group by columns at the end.
      * @param groupByColumns - Group by columns to order by
      * @param valuesColumns - Value columns configuration
      * @param sortBy - Sort configuration for columns
@@ -520,41 +518,20 @@ export class PivotQueryBuilder {
                     return acc;
                 }, []);
 
-            // Group-by columns referenced in sortBy lead in user-specified
-            // order; remaining group-bys follow in declaration order.
-            const sortedGroupBys = sortBy.filter(isGroupByColumn);
-            const sortedGroupByRefs = new Set(
-                sortedGroupBys.map((s) => s.reference),
-            );
-            const sortedGroupByParts = sortedGroupBys.map((sort) => {
+            // Create groups order parts. Note that groups parts should follow the groupsByColumns order rather than sortBy order.
+            const groupsOrderByParts = groupByColumns.map((col) => {
+                const sort = sortBy.find((s) => s.reference === col.reference);
                 const sortExpr = this.resolveSortField(
-                    sort.reference,
-                    sort.direction === SortByDirection.DESC,
-                    sort.nullsFirst,
+                    col.reference,
+                    sort?.direction === SortByDirection.DESC,
+                    sort?.nullsFirst,
                 );
                 return this.prefixSortExprWithAlias(
                     sortExpr,
-                    sort.reference,
+                    col.reference,
                     'g',
                 );
             });
-            const remainingGroupByParts = groupByColumns
-                .filter((col) => !sortedGroupByRefs.has(col.reference))
-                .map((col) => {
-                    const sortExpr = this.resolveSortField(
-                        col.reference,
-                        false,
-                    );
-                    return this.prefixSortExprWithAlias(
-                        sortExpr,
-                        col.reference,
-                        'g',
-                    );
-                });
-            const groupsOrderByParts = [
-                ...sortedGroupByParts,
-                ...remainingGroupByParts,
-            ];
 
             // Order parts cannot have values and groups interleaved. We have to ensure they are together by type
             const sortByValuesFirst = isValueColumn(


### PR DESCRIPTION
Reverts #22454.

The pivot table renderer treats `groupByColumns` declaration order as the **column hierarchy** (first entry = outermost header) and merges adjacent value columns that share the same outer value. The SQL has to emit columns in the same order for header merging to be correct.

#22454 put the `sortBy` group-by first in the column rank's `ORDER BY`, which restructures the SQL hierarchy without telling the renderer. With M:N group-bys this produces wrong header merging — e.g. `groupByColumns: [payment_method, status]` sorted by `status` ends up rendering "bank_transfer" merged across four columns that are actually four different payment methods, all `completed`.

#22454's own example worked only because its two group-bys were 1:1, so flipping their order in the rank had no observable effect on the column clustering — just on the visible sort.

**Chart config**
<img width="388" height="484" alt="CleanShot 2026-04-29 at 10 52 47" src="https://github.com/user-attachments/assets/53e3b7e2-2775-4f18-b459-cae6287eb598" />

**Before (bug)**
<img width="1667" height="341" alt="CleanShot 2026-04-29 at 10 50 30" src="https://github.com/user-attachments/assets/05e433f2-ddc7-4995-9a0e-2fab380d13bb" />

**After**
<img width="1491" height="340" alt="CleanShot 2026-04-29 at 10 52 19" src="https://github.com/user-attachments/assets/0b51ba4c-37be-46c7-9250-0d647768fd55" />
