### PR TITLE
fix(explorer): prevent sidebar crash on invalid custom-dimension SQL refs [PROD-6838]

### DIFF
--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -355,9 +355,15 @@ export const selectMissingCustomDimensions = createSelector(
 
             const isCustomSqlDimensionMissing =
                 isCustomSqlDimension(customDimension) &&
-                getAllReferences(customDimension.sql)
-                    .map((ref) => convertFieldRefToFieldId(ref))
-                    .some((refFieldId) => !fieldIds.includes(refFieldId));
+                getAllReferences(customDimension.sql).some((ref) => {
+                    try {
+                        return !fieldIds.includes(
+                            convertFieldRefToFieldId(ref),
+                        );
+                    } catch {
+                        return true;
+                    }
+                });
 
             return isCustomBinDimensionMissing || isCustomSqlDimensionMissing;
         });


### PR DESCRIPTION
## Summary

- Wraps the per-reference `convertFieldRefToFieldId` call inside `selectMissingCustomDimensions` in `try/catch`. A malformed `${ref}` (no `table.field` separator) in a custom SQL dimension previously threw a `CompileError` on every render of `ExploreTree`, which the sidebar `ErrorBoundary` caught and replaced the entire field tree with the Sentry fallback — blocking the user from interacting with the explore.
- A malformed reference now treats the dimension as **missing**, surfacing the existing yellow-alert UI on the broken dimension instead of crashing the sidebar.
- Smallest possible FE change (one selector, ~6 lines). The misleading error wording in `packages/common/src/types/field.ts` (says "Table calculation… must be `table.field`") is intentionally left for a follow-up since the user-visible blocker is now gone.

Fixes [PROD-6838](https://linear.app/lightdash/issue/PROD-6838/improve-error-handling-in-table-calculations).

## Test plan

- [ ] Open a saved chart that contains a custom SQL dimension whose SQL has a malformed reference (e.g. `\${spend_team_sub_label}` with no dot). Confirm the left sidebar renders normally instead of showing the Sentry "Something went wrong" fallback.
- [ ] Confirm the broken dimension is flagged with the existing "missing" yellow alert in the field tree.
- [ ] Open an existing chart with a valid custom SQL dimension and confirm no regression — the dimension is **not** flagged as missing.
- [ ] `pnpm -F frontend typecheck` and `pnpm -F frontend lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)