### PR TITLE
feat(permissions): hide "Edit calculation" in column header for SQL table calcs

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -12,6 +12,7 @@ import {
     isMetricWithDateValue,
     isNumericItem,
     isPeriodOverPeriodAdditionalMetric,
+    isSqlTableCalculation,
     isTableCalculation,
     isTimeBasedDimension,
     type TableCalculation,
@@ -306,20 +307,24 @@ const ContextMenu: FC<ContextMenuProps> = ({
 
                 <Menu.Divider />
 
-                <Menu.Item
-                    leftSection={<MantineIcon icon={IconPencil} />}
-                    onClick={() => {
-                        track({
-                            name: EventName.EDIT_TABLE_CALCULATION_BUTTON_CLICKED,
-                        });
+                {!(isSqlTableCalculation(item) && cannotAuthorCustomSql) && (
+                    <>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconPencil} />}
+                            onClick={() => {
+                                track({
+                                    name: EventName.EDIT_TABLE_CALCULATION_BUTTON_CLICKED,
+                                });
 
-                        onToggleCalculationEditModal(true);
-                    }}
-                >
-                    Edit calculation
-                </Menu.Item>
+                                onToggleCalculationEditModal(true);
+                            }}
+                        >
+                            Edit calculation
+                        </Menu.Item>
 
-                <Menu.Divider />
+                        <Menu.Divider />
+                    </>
+                )}
 
                 <ColumnHeaderSortMenuOptions item={item} sort={sort} />
 


### PR DESCRIPTION
### Summary

The column-header context menu showed **"Edit calculation"** for every table calc regardless of variant or scope. For SQL table calcs that exposed the SQL editor — and the authored SQL — to users without `manage:CustomFields`. The backend rejects on save, but the editor wastes time getting there.

Mirrors the existing custom-dim gate in the same file: hide the menu item when `isSqlTableCalculation(item) && cannotAuthorCustomSql`. Formula and Template table calcs are unaffected because they don't expose a `sql` body.

This is a follow-up that came out of [PROD-7180](https://linear.app/lightdash/issue/PROD-7180) manual testing — separate from that PR ([#22488](https://github.com/lightdash/lightdash/pull/22488)) since the affordance lives in a different surface.

### What changed

`packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx`:
- Import `isSqlTableCalculation` from `@lightdash/common`.
- Wrap the existing "Edit calculation" `Menu.Item` (and the divider that follows it) in `{!(isSqlTableCalculation(item) && cannotAuthorCustomSql) && (…)}` — same predicate already used for the custom-dim Edit just above.

### Test plan

- [ ] As an Editor (no `manage:CustomFields`), open a saved chart that has a SQL table calc → expand the Results card → click the column header menu on the SQL table calc → "Edit calculation" is **not** in the menu (only Filter, Sort, Remove visible).
- [ ] Same flow on a **Formula** or **Template** table calc → "Edit calculation" is visible (those variants don't expose a sql body, so they're not gated).
- [ ] As an Admin → "Edit calculation" is visible for the SQL table calc.
- [ ] Existing custom-dim Edit gate (immediately above this block) still works for both personas.
