### PR TITLE
feat: add Rename and Move-to-space actions to My Apps menu

### DIFF
--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -1,4 +1,8 @@
-import { type ApiAppSummary } from '@lightdash/common';
+import {
+    ContentType,
+    ResourceViewItemType,
+    type ApiAppSummary,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
@@ -11,15 +15,19 @@ import {
 } from '@mantine-8/core';
 import {
     IconClock,
+    IconCode,
     IconDots,
     IconExternalLink,
     IconFolder,
+    IconFolderPlus,
+    IconFolderSymlink,
     IconLayoutDashboard,
     IconPencil,
     IconRadar,
     IconTextCaption,
     IconTrash,
 } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
     MantineReactTable,
     useMantineReactTable,
@@ -35,11 +43,64 @@ import {
 } from 'react';
 import { Link } from 'react-router';
 import { useMyApps } from '../../../features/apps/hooks/useMyApps';
+import { useContentAction } from '../../../hooks/useContent';
 import MantineIcon from '../../common/MantineIcon';
 import AppDeleteModal from '../../common/modal/AppDeleteModal';
+import AppUpdateModal from '../../common/modal/AppUpdateModal';
+import TransferItemsModal from '../../common/TransferItemsModal/TransferItemsModal';
 
 const hasReadyVersion = (app: ApiAppSummary) =>
     app.lastVersionStatus === 'ready' && !!app.lastVersionNumber;
+
+const MoveAppToSpaceModal: FC<{
+    app: ApiAppSummary;
+    onClose: () => void;
+}> = ({ app, onClose }) => {
+    const queryClient = useQueryClient();
+    const { mutateAsync: contentAction, isLoading } = useContentAction(
+        app.projectUuid,
+    );
+    return (
+        <TransferItemsModal
+            projectUuid={app.projectUuid}
+            opened
+            onClose={onClose}
+            items={[
+                {
+                    type: ResourceViewItemType.DATA_APP,
+                    data: {
+                        uuid: app.appUuid,
+                        name: app.name,
+                        description: app.description || undefined,
+                        spaceUuid: app.spaceUuid,
+                        createdByUserUuid: null,
+                        updatedAt: new Date(),
+                        updatedByUser: null,
+                        views: 0,
+                        firstViewedAt: null,
+                        latestVersionNumber: app.lastVersionNumber,
+                        latestVersionStatus: app.lastVersionStatus,
+                        pinnedListUuid: null,
+                        pinnedListOrder: null,
+                    },
+                },
+            ]}
+            isLoading={isLoading}
+            onConfirm={async (targetSpaceUuid) => {
+                if (!targetSpaceUuid) return;
+                await contentAction({
+                    action: { type: 'move', targetSpaceUuid },
+                    item: {
+                        uuid: app.appUuid,
+                        contentType: ContentType.DATA_APP,
+                    },
+                });
+                await queryClient.invalidateQueries({ queryKey: ['myApps'] });
+                onClose();
+            }}
+        />
+    );
+};
 
 const statusColor = (status: string | null) => {
     switch (status) {
@@ -58,6 +119,8 @@ const MyAppsPanel: FC = () => {
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const { data, fetchNextPage, isFetching, isLoading, isError } = useMyApps();
     const [appToDelete, setAppToDelete] = useState<ApiAppSummary | null>(null);
+    const [appToMove, setAppToMove] = useState<ApiAppSummary | null>(null);
+    const [appToRename, setAppToRename] = useState<ApiAppSummary | null>(null);
 
     const flatData = useMemo<ApiAppSummary[]>(
         () => data?.pages.flatMap((page) => page.data) ?? [],
@@ -270,9 +333,30 @@ const MyAppsPanel: FC = () => {
                                 <Menu.Item
                                     component={Link}
                                     to={`/projects/${app.projectUuid}/apps/${app.appUuid}`}
-                                    leftSection={<IconPencil size={14} />}
+                                    leftSection={<IconCode size={14} />}
                                 >
                                     Continue building
+                                </Menu.Item>
+                                <Menu.Divider />
+                                <Menu.Item
+                                    leftSection={<IconPencil size={14} />}
+                                    onClick={() => setAppToRename(app)}
+                                >
+                                    Rename
+                                </Menu.Item>
+                                <Menu.Item
+                                    leftSection={
+                                        app.spaceUuid ? (
+                                            <IconFolderSymlink size={14} />
+                                        ) : (
+                                            <IconFolderPlus size={14} />
+                                        )
+                                    }
+                                    onClick={() => setAppToMove(app)}
+                                >
+                                    {app.spaceUuid
+                                        ? 'Move to space'
+                                        : 'Add to space'}
                                 </Menu.Item>
                                 <Menu.Divider />
                                 <Menu.Item
@@ -348,6 +432,23 @@ const MyAppsPanel: FC = () => {
                     name={appToDelete.name}
                     onClose={() => setAppToDelete(null)}
                     onConfirm={() => setAppToDelete(null)}
+                />
+            )}
+            {appToMove && (
+                <MoveAppToSpaceModal
+                    app={appToMove}
+                    onClose={() => setAppToMove(null)}
+                />
+            )}
+            {appToRename && (
+                <AppUpdateModal
+                    opened
+                    projectUuid={appToRename.projectUuid}
+                    uuid={appToRename.appUuid}
+                    initialName={appToRename.name}
+                    initialDescription={appToRename.description}
+                    onClose={() => setAppToRename(null)}
+                    onConfirm={() => setAppToRename(null)}
                 />
             )}
         </Stack>

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -314,7 +314,7 @@ const MyAppsPanel: FC = () => {
                                     color="gray"
                                     size="sm"
                                 >
-                                    <IconDots size={16} />
+                                    <MantineIcon icon={IconDots} size={16} />
                                 </ActionIcon>
                             </Menu.Target>
                             <Menu.Dropdown>
@@ -324,7 +324,10 @@ const MyAppsPanel: FC = () => {
                                         to={`/projects/${app.projectUuid}/apps/${app.appUuid}/preview`}
                                         target="_blank"
                                         leftSection={
-                                            <IconExternalLink size={14} />
+                                            <MantineIcon
+                                                icon={IconExternalLink}
+                                                size={14}
+                                            />
                                         }
                                     >
                                         Preview latest
@@ -333,13 +336,23 @@ const MyAppsPanel: FC = () => {
                                 <Menu.Item
                                     component={Link}
                                     to={`/projects/${app.projectUuid}/apps/${app.appUuid}`}
-                                    leftSection={<IconCode size={14} />}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconCode}
+                                            size={14}
+                                        />
+                                    }
                                 >
                                     Continue building
                                 </Menu.Item>
                                 <Menu.Divider />
                                 <Menu.Item
-                                    leftSection={<IconPencil size={14} />}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconPencil}
+                                            size={14}
+                                        />
+                                    }
                                     onClick={() => setAppToRename(app)}
                                 >
                                     Rename
@@ -347,9 +360,15 @@ const MyAppsPanel: FC = () => {
                                 <Menu.Item
                                     leftSection={
                                         app.spaceUuid ? (
-                                            <IconFolderSymlink size={14} />
+                                            <MantineIcon
+                                                icon={IconFolderSymlink}
+                                                size={14}
+                                            />
                                         ) : (
-                                            <IconFolderPlus size={14} />
+                                            <MantineIcon
+                                                icon={IconFolderPlus}
+                                                size={14}
+                                            />
                                         )
                                     }
                                     onClick={() => setAppToMove(app)}

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -232,9 +232,11 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                         />
                     );
                 case ResourceViewItemType.DATA_APP:
+                    if (!projectUuid) return null;
                     return (
                         <AppUpdateModal
                             opened
+                            projectUuid={projectUuid}
                             uuid={action.item.data.uuid}
                             initialName={action.item.data.name}
                             initialDescription={

--- a/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
@@ -10,12 +10,12 @@ import { IconAppWindow } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { z } from 'zod';
 import { useUpdateApp } from '../../../features/apps/hooks/useUpdateApp';
-import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import MantineModal from '../MantineModal';
 
 interface AppUpdateModalProps {
     opened: ModalProps['opened'];
     onClose: ModalProps['onClose'];
+    projectUuid: string;
     uuid: string;
     initialName: string;
     initialDescription: string;
@@ -30,13 +30,13 @@ const updateAppSchema = z.object({
 type FormState = z.infer<typeof updateAppSchema>;
 
 const AppUpdateModal: FC<AppUpdateModalProps> = ({
+    projectUuid,
     uuid,
     initialName,
     initialDescription,
     onConfirm,
     ...modalProps
 }) => {
-    const projectUuid = useProjectUuid();
     const { mutateAsync, isLoading: isUpdating } = useUpdateApp();
 
     const form = useForm<FormState>({
@@ -47,10 +47,6 @@ const AppUpdateModal: FC<AppUpdateModalProps> = ({
         validate: zodResolver(updateAppSchema),
         validateInputOnChange: true,
     });
-
-    if (!projectUuid) {
-        return null;
-    }
 
     const handleConfirm = form.onSubmit(async (data) => {
         const trimmedName = data.name.trim();

--- a/packages/frontend/src/features/apps/hooks/useUpdateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useUpdateApp.ts
@@ -37,6 +37,7 @@ export const useUpdateApp = () => {
             void queryClient.invalidateQueries({
                 queryKey: ['app', variables.projectUuid, variables.appUuid],
             });
+            void queryClient.invalidateQueries({ queryKey: ['myApps'] });
             void invalidateContent(queryClient, variables.projectUuid);
             const field = variables.name
                 ? 'name'

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1311,7 +1311,7 @@ const AppGenerate: FC = () => {
                                             }
                                         >
                                             {appSpaceUuid
-                                                ? 'Move'
+                                                ? 'Move to space'
                                                 : 'Add to space'}
                                         </Menu.Item>
                                         <Menu.Divider />
@@ -1384,6 +1384,7 @@ const AppGenerate: FC = () => {
                         {isUpdateModalOpen && activeAppUuid && (
                             <AppUpdateModal
                                 opened
+                                projectUuid={projectUuid}
                                 uuid={activeAppUuid}
                                 initialName={appName}
                                 initialDescription={appDescription}


### PR DESCRIPTION
### Description:
Mirror the AppGenerate page menu in the 'My Apps' settings table so apps can be renamed and moved between spaces (or added to a space when personal) without leaving settings. AppUpdateModal now takes projectUuid as a prop so it works outside project-scoped routes, and useUpdateApp also invalidates the myApps query so renames refresh the list.

