### PR TITLE
fix(trino): cast DATE to TIMESTAMP for sub-day DATE_TRUNC

### DIFF
--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -143,6 +143,16 @@ export const dateTruncTimezoneConversions: Record<
     },
 };
 
+export const SUB_DAY_TIME_FRAMES: ReadonlySet<TimeFrames> = new Set([
+    TimeFrames.MILLISECOND,
+    TimeFrames.SECOND,
+    TimeFrames.MINUTE,
+    TimeFrames.HOUR,
+]);
+
+export const isSubDayTimeFrame = (tf: TimeFrames): boolean =>
+    SUB_DAY_TIME_FRAMES.has(tf);
+
 const bigqueryStartOfWeekMap: Record<WeekDay, string> = {
     [WeekDay.MONDAY]: 'MONDAY',
     [WeekDay.TUESDAY]: 'TUESDAY',
@@ -380,12 +390,18 @@ const databricksConfig: WarehouseConfig = {
 };
 
 const trinoConfig: WarehouseConfig = {
+    // Trino rejects sub-day DATE_TRUNC on DATE columns ('SECOND' is not a
+    // valid DATE field). Cast to TIMESTAMP for sub-day grains; no-op when the
+    // input is already a TIMESTAMP.
     getSqlForTruncatedDate: (timeFrame, originalSql, _, startOfWeek) => {
+        const sql = isSubDayTimeFrame(timeFrame)
+            ? `CAST(${originalSql} AS TIMESTAMP)`
+            : originalSql;
         if (timeFrame === TimeFrames.WEEK && isWeekDay(startOfWeek)) {
             const intervalDiff = `'${startOfWeek}' day`;
-            return `(DATE_TRUNC('${timeFrame}', (${originalSql} - interval ${intervalDiff})) + interval ${intervalDiff})`;
+            return `(DATE_TRUNC('${timeFrame}', (${sql} - interval ${intervalDiff})) + interval ${intervalDiff})`;
         }
-        return `DATE_TRUNC('${timeFrame}', ${originalSql})`;
+        return `DATE_TRUNC('${timeFrame}', ${sql})`;
     },
     getSqlForDatePart: (
         timeFrame: TimeFrames,


### PR DESCRIPTION
Closes https://github.com/lightdash/lightdash/issues/22484

Trino rejects `DATE_TRUNC('SECOND', date_col)` on a DATE column with `'SECOND' is not a valid DATE field`. Postgres / Snowflake / Databricks auto-promote DATE to TIMESTAMP under DATE_TRUNC; Trino doesn't, so we cast explicitly for sub-day grains. Athena inherits the fix.

```sql
-- before
DATE_TRUNC('SECOND', "orders".order_date)
-- after
DATE_TRUNC('SECOND', CAST("orders".order_date AS TIMESTAMP))
```

Also adds `SUB_DAY_TIME_FRAMES` / `isSubDayTimeFrame` for the SQL layer, alongside the existing user-facing `SUB_DAY_GRANULARITIES`.

**Before**
<img width="1083" height="734" alt="CleanShot 2026-04-29 at 12 36 28" src="https://github.com/user-attachments/assets/601fe1fc-8455-4989-b2ea-1777725cb478" />

```sql
SELECT
  DATE_TRUNC('SECOND', "orders".order_date) AS "orders_order_date_second",
  AVG("orders".amount) AS "orders_average_order_size"
FROM
  "staging_postgres_trino"."jaffle"."orders" AS "orders"
GROUP BY
  1
ORDER BY
  "orders_order_date_second" DESC
LIMIT
  500
```

**After**
<img width="828" height="1007" alt="CleanShot 2026-04-29 at 12 34 39" src="https://github.com/user-attachments/assets/a3b9d6c0-e814-4a72-a2cb-8090e8027bd8" />

```sql
SELECT
  DATE_TRUNC('SECOND', CAST("orders".order_date AS TIMESTAMP)) AS "orders_order_date_second",
  AVG("orders".amount) AS "orders_average_order_size"
FROM
  "staging_postgres_trino"."jaffle"."orders" AS "orders"
GROUP BY
  1
ORDER BY
  "orders_order_date_second" DESC
LIMIT
  500
```
