### PR TITLE
refactor(audited-ability): rename actor → user [SPK-416]

### DIFF
--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -54,14 +54,14 @@ export class GroupsService extends BaseService {
     }
 
     async addGroupMember(
-        actor: SessionUser,
+        user: SessionUser,
         member: GroupMembership,
     ): Promise<GroupMembership | undefined> {
-        if (!(await this.isGroupServiceEnabled(actor))) {
+        if (!(await this.isGroupServiceEnabled(user))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         const group = await this.groupsModel.getGroup(member.groupUuid);
         if (
             auditedAbility.cannot(
@@ -86,7 +86,7 @@ export class GroupsService extends BaseService {
                 member.groupUuid,
             );
             this.analytics.track({
-                userId: actor.userUuid,
+                userId: user.userUuid,
                 event: 'group.updated',
                 properties: {
                     organizationId: updatedGroup.organizationUuid,
@@ -102,14 +102,14 @@ export class GroupsService extends BaseService {
     }
 
     async removeGroupMember(
-        actor: SessionUser,
+        user: SessionUser,
         member: GroupMembership,
     ): Promise<boolean> {
-        if (!(await this.isGroupServiceEnabled(actor))) {
+        if (!(await this.isGroupServiceEnabled(user))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         const group = await this.groupsModel.getGroup(member.groupUuid);
         if (
             auditedAbility.cannot(
@@ -133,7 +133,7 @@ export class GroupsService extends BaseService {
                 member.groupUuid,
             );
             this.analytics.track({
-                userId: actor.userUuid,
+                userId: user.userUuid,
                 event: 'group.updated',
                 properties: {
                     organizationId: updatedGroup.organizationUuid,
@@ -148,12 +148,12 @@ export class GroupsService extends BaseService {
         return isGroupMemberRemoved;
     }
 
-    async delete(actor: SessionUser, groupUuid: string): Promise<void> {
-        if (!(await this.isGroupServiceEnabled(actor))) {
+    async delete(user: SessionUser, groupUuid: string): Promise<void> {
+        if (!(await this.isGroupServiceEnabled(user))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         const group = await this.groupsModel.getGroup(groupUuid);
         if (
             auditedAbility.cannot(
@@ -171,7 +171,7 @@ export class GroupsService extends BaseService {
         }
         await this.groupsModel.deleteGroup(groupUuid);
         this.analytics.track({
-            userId: actor.userUuid,
+            userId: user.userUuid,
             event: 'group.deleted',
             properties: {
                 organizationId: group.organizationUuid,
@@ -182,12 +182,12 @@ export class GroupsService extends BaseService {
     }
 
     async get(
-        actor: SessionUser,
+        user: SessionUser,
         groupUuid: string,
         includeMembers?: number,
         offset?: number,
     ): Promise<Group | GroupWithMembers> {
-        if (!(await this.isGroupServiceEnabled(actor))) {
+        if (!(await this.isGroupServiceEnabled(user))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -200,7 +200,7 @@ export class GroupsService extends BaseService {
                       offset,
                   );
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 'view',
@@ -219,15 +219,15 @@ export class GroupsService extends BaseService {
     }
 
     async update(
-        actor: SessionUser,
+        user: SessionUser,
         groupUuid: string,
         update: UpdateGroupWithMembers,
     ): Promise<Group | GroupWithMembers> {
-        if (!(await this.isGroupServiceEnabled(actor))) {
+        if (!(await this.isGroupServiceEnabled(user))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         const group = await this.groupsModel.getGroup(groupUuid);
         if (
             auditedAbility.cannot(
@@ -244,12 +244,12 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError();
         }
         const updatedGroup = await this.groupsModel.updateGroup({
-            updatedByUserUuid: actor.userUuid,
+            updatedByUserUuid: user.userUuid,
             groupUuid,
             update,
         });
         this.analytics.track({
-            userId: actor.userUuid,
+            userId: user.userUuid,
             event: 'group.updated',
             properties: {
                 organizationId: updatedGroup.organizationUuid,
@@ -264,14 +264,14 @@ export class GroupsService extends BaseService {
     }
 
     async getGroupMembers(
-        actor: SessionUser,
+        user: SessionUser,
         groupUuid: string,
     ): Promise<GroupMember[]> {
-        if (!(await this.isGroupServiceEnabled(actor))) {
+        if (!(await this.isGroupServiceEnabled(user))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         const group = await this.groupsModel.getGroupWithMembers(groupUuid);
         if (
             auditedAbility.cannot(
@@ -291,14 +291,14 @@ export class GroupsService extends BaseService {
     }
 
     async addProjectAccess(
-        actor: SessionUser,
+        user: SessionUser,
         { groupUuid, projectUuid, role }: ProjectGroupAccess,
     ): Promise<ProjectGroupAccess> {
-        if (!(await this.isGroupServiceEnabled(actor))) {
+        if (!(await this.isGroupServiceEnabled(user))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
@@ -346,17 +346,17 @@ export class GroupsService extends BaseService {
     }
 
     async removeProjectAccess(
-        actor: SessionUser,
+        user: SessionUser,
         {
             groupUuid,
             projectUuid,
         }: Pick<ProjectGroupAccess, 'groupUuid' | 'projectUuid'>,
     ) {
-        if (!(await this.isGroupServiceEnabled(actor))) {
+        if (!(await this.isGroupServiceEnabled(user))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
@@ -399,18 +399,18 @@ export class GroupsService extends BaseService {
     }
 
     async updateProjectAccess(
-        actor: SessionUser,
+        user: SessionUser,
         {
             groupUuid,
             projectUuid,
         }: Pick<ProjectGroupAccess, 'groupUuid' | 'projectUuid'>,
         updateAttributes: UpdateDBProjectGroupAccess,
     ): Promise<ProjectGroupAccess> {
-        if (!(await this.isGroupServiceEnabled(actor))) {
+        if (!(await this.isGroupServiceEnabled(user))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -575,16 +575,16 @@ export class OrganizationService extends BaseService {
     }
 
     async addGroupToOrganization(
-        actor: SessionUser,
+        user: SessionUser,
         createGroup: CreateGroup,
     ): Promise<GroupWithMembers> {
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            actor.organizationUuid === undefined ||
+            user.organizationUuid === undefined ||
             auditedAbility.cannot(
                 'create',
                 subject('Group', {
-                    organizationUuid: actor.organizationUuid,
+                    organizationUuid: user.organizationUuid,
                 }),
             )
         ) {
@@ -592,15 +592,15 @@ export class OrganizationService extends BaseService {
         }
 
         const groupWithMembers = await this.groupsModel.createGroup({
-            createdByUserUuid: actor.userUuid,
+            createdByUserUuid: user.userUuid,
             createGroup: {
-                organizationUuid: actor.organizationUuid,
+                organizationUuid: user.organizationUuid,
                 ...createGroup,
             },
         });
 
         this.analytics.track({
-            userId: actor.userUuid,
+            userId: user.userUuid,
             event: 'group.created',
             properties: {
                 organizationId: groupWithMembers.organizationUuid,
@@ -615,23 +615,23 @@ export class OrganizationService extends BaseService {
     }
 
     async listGroupsInOrganization(
-        actor: SessionUser,
+        user: SessionUser,
         includeMembers?: number,
         paginateArgs?: KnexPaginateArgs,
         searchQuery?: string,
     ): Promise<KnexPaginatedData<Group[] | GroupWithMembers[]>> {
-        if (actor.organizationUuid === undefined) {
+        if (user.organizationUuid === undefined) {
             throw new ForbiddenError();
         }
         const { pagination, data: groups } = await this.groupsModel.find(
             {
-                organizationUuid: actor.organizationUuid,
+                organizationUuid: user.organizationUuid,
                 searchQuery,
             },
             paginateArgs,
         );
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         const allowedGroups = groups.filter((group) =>
             auditedAbility.can('view', subject('Group', group)),
         );
@@ -645,7 +645,7 @@ export class OrganizationService extends BaseService {
 
         // fetch members for each group
         const { data: groupMembers } = await this.groupsModel.findGroupMembers({
-            organizationUuid: actor.organizationUuid,
+            organizationUuid: user.organizationUuid,
             groupUuids: allowedGroups.map((group) => group.uuid),
         });
         const groupMembersMap = groupBy(groupMembers, 'groupUuid');

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6524,13 +6524,13 @@ export class ProjectService extends BaseService {
     }
 
     async getProjectGroupAccesses(
-        actor: SessionUser,
+        user: SessionUser,
         projectUuid: string,
     ): Promise<ProjectGroupAccess[]> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 'manage',

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -31,15 +31,15 @@ export class SpacePermissionService extends BaseService {
     }
 
     /**
-     * Checks if the actor has access to all the space uuids
+     * Checks if the user has access to all the space uuids
      * @param action - The action to check permissions for
-     * @param actor - The session user to check permissions for
+     * @param user - The session user to check permissions for
      * @param spaceUuids - The space uuids to check permissions for
      * @returns The access context for the given space uuids
      */
     async can(
         action: AbilityAction,
-        actor: SessionUser,
+        user: SessionUser,
         spaceUuids: string[] | string,
     ): Promise<boolean> {
         const spaceUuidsArray = Array.isArray(spaceUuids)
@@ -47,32 +47,32 @@ export class SpacePermissionService extends BaseService {
             : [spaceUuids];
 
         const accessContext = await this.getSpacesCaslContext(spaceUuidsArray, {
-            userUuid: actor.userUuid,
+            userUuid: user.userUuid,
         });
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         return Object.values(accessContext).every((access) =>
             auditedAbility.can(action, subject('Space', access)),
         );
     }
 
     /**
-     * Gets the accessible space uuids for a given action and actor
+     * Gets the accessible space uuids for a given action and user
      * @param action - The action to check permissions for
-     * @param actor - The session user to check permissions for
+     * @param user - The session user to check permissions for
      * @param spaceUuids - The space uuids to get the accessible space uuids for
      * @returns The accessible space uuids
      */
     async getAccessibleSpaceUuids(
         action: AbilityAction,
-        actor: SessionUser,
+        user: SessionUser,
         spaceUuids: string[],
     ): Promise<string[]> {
         const accessContext = await this.getSpacesCaslContext(spaceUuids, {
-            userUuid: actor.userUuid,
+            userUuid: user.userUuid,
         });
 
-        const auditedAbility = this.createAuditedAbility(actor);
+        const auditedAbility = this.createAuditedAbility(user);
         return Object.entries(accessContext)
             .filter(([_, access]) =>
                 auditedAbility.can(action, subject('Space', access)),
@@ -256,18 +256,18 @@ export class SpacePermissionService extends BaseService {
     }
 
     /**
-     * Returns the UUID of the first root space the actor can view in the project.
+     * Returns the UUID of the first root space the user can view in the project.
      * Uses CASL-based permission checking via getAccessibleSpaceUuids.
      */
     async getFirstViewableSpaceUuid(
-        actor: SessionUser,
+        user: SessionUser,
         projectUuid: string,
     ): Promise<string> {
         const allRootSpaceUuids =
             await this.spaceModel.getRootSpaceUuidsForProject(projectUuid);
         const accessible = await this.getAccessibleSpaceUuids(
             'view',
-            actor,
+            user,
             allRootSpaceUuids,
         );
         if (accessible.length === 0) {


### PR DESCRIPTION
## Summary

Prep PR for [SPK-416](https://linear.app/lightdash/issue/SPK-416) — refactoring `BaseService.createAuditedAbility` to require `Account` and drop the `SessionUser` overload.

This PR is a no-op rename to set up clean diffs for the per-service migration PRs that follow. It only standardises argument names — no signature or behaviour changes.

## Changes

- **GroupService** — renamed parameter `actor: SessionUser` → `user: SessionUser` across 9 methods.
- **OrganizationService** — renamed `actor: SessionUser` → `user: SessionUser` in 2 methods. (Left `authenticatedUser` alone — distinct semantic role in that function.)
- **ProjectService** — renamed `actor` → `user` in `getProjectGroupAccesses`.
- **SpacePermissionService** — renamed `actor` → `user` across 3 methods (and JSDoc).

## Skipped (deliberately deferred)

- `UserService.ts` — `sessionUser` / `requestUser` / `adminUser` carry distinct semantic meaning in impersonation flows.
- `OrganizationService.ts` — `authenticatedUser` distinguishes from other users in scope.
- `AsyncQueryService.ts` — `args.account` already account-form, accessed via destructure.
- `DashboardService.ts` — `actor.user` is an object-shape pattern; will be handled in PR 8.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [ ] CI green