### PR TITLE
refactor(audited-ability): migrate EmbedService + ScimService to Account [SPK-416]

### DIFF
--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -122,7 +122,7 @@ export class EmbedController extends BaseController {
         return {
             status: 'ok',
             results: await this.getEmbedService().getConfig(
-                req.account.user,
+                req.account,
                 projectUuid,
             ),
         };
@@ -142,7 +142,7 @@ export class EmbedController extends BaseController {
         return {
             status: 'ok',
             results: await this.getEmbedService().createConfig(
-                req.account.user,
+                req.account,
                 projectUuid,
                 body,
             ),

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -45,7 +45,6 @@ import {
     isFilterableDimension,
     isFilterInteractivityEnabled,
     isParameterInteractivityEnabled,
-    LightdashSessionUser,
     MetricQuery,
     NotFoundError,
     NotSupportedError,
@@ -194,10 +193,11 @@ export class EmbedService extends BaseService {
     }
 
     async getConfig(
-        user: LightdashSessionUser,
+        account: SessionAccount,
         projectUuid: string,
     ): Promise<DecodedEmbed> {
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
+        const { user } = account;
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         await this.isFeatureEnabled({
@@ -226,11 +226,12 @@ export class EmbedService extends BaseService {
     }
 
     async createConfig(
-        user: LightdashSessionUser,
+        account: SessionAccount,
         projectUuid: string,
         data: CreateEmbedRequestBody,
     ): Promise<DecodedEmbed> {
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
+        const { user } = account;
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         await this.isFeatureEnabled({
@@ -261,7 +262,7 @@ export class EmbedService extends BaseService {
             this.lightdashConfig.embedding.allowAll.charts,
         );
 
-        return this.getConfig(user, projectUuid);
+        return this.getConfig(account, projectUuid);
     }
 
     async updateDashboards(

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -30,7 +30,6 @@ import {
     ScimUpsertUser,
     ScimUser,
     ScimUserRole,
-    SessionUser,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { groupBy } from 'lodash';
@@ -121,13 +120,13 @@ export class ScimService extends BaseService {
         this.openIdIdentityModel = openIdIdentityModel;
     }
 
-    private throwForbiddenErrorOnNoPermission(user: SessionUser) {
-        const auditedAbility = this.createAuditedAbility(user);
+    private throwForbiddenErrorOnNoPermission(account: Account) {
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
-                    organizationUuid: user.organizationUuid!,
+                    organizationUuid: account.organization.organizationUuid!,
                 }),
             )
         ) {


### PR DESCRIPTION
## Summary

Part of [SPK-416](https://linear.app/lightdash/issue/SPK-416). Converts the last `user`-form callers in services that already overwhelmingly use `Account` form, so PR 11 (the final narrowing of `BaseService.createAuditedAbility`) has fewer files to touch.

Stacked on #22501.

## Changes

- **EmbedService** — `getConfig` and `createConfig` now take `account: SessionAccount` instead of `user: LightdashSessionUser`, matching the pattern of `getEmbedUrl` / `updateConfig` / `updateDashboards` already in this file. The internal recursive call (`createConfig` → `getConfig`) is updated, and `LightdashSessionUser` import is removed.
- **embedController** — passes `req.account` instead of `req.account.user` for the two affected endpoints. `assertSessionAuth(req.account)` was already in place.
- **ScimService** — converts the (currently unused) `throwForbiddenErrorOnNoPermission` helper from `user: SessionUser` to `account: Account`. Drops the now-unused `SessionUser` import.

## Files left as-is in scope

- `RolesService` (17/17 already account)
- `OrganizationWarehouseCredentialsService` (2/2 already account)
- `AsyncQueryService` — only one non-`account` call site is `args.account` (account form, just destructured), no change needed.
- `ScimService`'s 12 other call sites — already `account` form.
- `EmbedService`'s 3 other call sites — already `account` form.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [ ] CI green