### PR TITLE
fix(slack): validate Slack block payloads to avoid invalid_blocks [PROD-7209]

### DIFF
--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
@@ -1,0 +1,420 @@
+import { PartialFailureType, type PartialFailure } from '@lightdash/common';
+import { KnownBlock } from '@slack/bolt';
+import {
+    getChartAndDashboardBlocks,
+    getChartCsvResultsBlocks,
+    getDashboardCsvResultsBlocks,
+} from './SlackMessageBlocks';
+
+const SLACK_MAX_BLOCKS = 50;
+const SLACK_MAX_URL = 3000;
+
+const findBlocks = <T extends KnownBlock['type']>(
+    blocks: KnownBlock[],
+    type: T,
+): Extract<KnownBlock, { type: T }>[] =>
+    blocks.filter(
+        (b): b is Extract<KnownBlock, { type: T }> => b.type === type,
+    );
+
+describe('SlackMessageBlocks', () => {
+    describe('block count cap (PROD-7209)', () => {
+        it('caps a dashboard with 60 chart downloads under Slack 50-block limit', () => {
+            const csvUrls = Array.from({ length: 60 }, (_, i) => ({
+                filename: `chart-${i}.csv`,
+                path: `https://s3.example.com/exports/chart-${i}.csv`,
+                localPath: `/tmp/chart-${i}.csv`,
+                truncated: false,
+            }));
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'Big dashboard',
+                name: 'Big dashboard',
+                description: 'Many charts',
+                ctaUrl: 'https://app.lightdash.com/dashboard/abc',
+                csvUrls,
+                footerMarkdown: 'sent by scheduler',
+            });
+
+            expect(blocks.length).toBeLessThan(SLACK_MAX_BLOCKS);
+        });
+
+        it('includes a summary indicator when dashboard charts exceed the cap', () => {
+            const csvUrls = Array.from({ length: 60 }, (_, i) => ({
+                filename: `chart-${i}.csv`,
+                path: `https://s3.example.com/exports/chart-${i}.csv`,
+                localPath: `/tmp/chart-${i}.csv`,
+                truncated: false,
+            }));
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'Big dashboard',
+                name: 'Big dashboard',
+                description: 'Many charts',
+                ctaUrl: 'https://app.lightdash.com/dashboard/abc',
+                csvUrls,
+                footerMarkdown: 'sent by scheduler',
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const sectionTexts = sections
+                .map((s) => s.text?.text ?? '')
+                .join('\n');
+            expect(sectionTexts).toMatch(/more|additional|view in lightdash/i);
+        });
+
+        it('embeds per-chart download links in the collapsed section as mrkdwn', () => {
+            const csvUrls = Array.from({ length: 60 }, (_, i) => ({
+                filename: `chart-${i}.csv`,
+                path: `https://s3.example.com/exports/chart-${i}.csv`,
+                localPath: `/tmp/chart-${i}.csv`,
+                truncated: false,
+            }));
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'Big dashboard',
+                name: 'Big dashboard',
+                description: 'Many charts',
+                ctaUrl: 'https://app.lightdash.com/dashboard/abc',
+                csvUrls,
+            });
+
+            const sectionTexts = findBlocks(blocks, 'section')
+                .map((s) => s.text?.text ?? '')
+                .join('\n');
+            expect(sectionTexts).toMatch(
+                /<https:\/\/s3\.example\.com\/exports\/chart-0\.csv\|chart-0\.csv>/,
+            );
+        });
+
+        it('marks invalid per-chart URLs in the collapsed section without a link', () => {
+            const csvUrls = [
+                ...Array.from({ length: 35 }, (_, i) => ({
+                    filename: `chart-${i}.csv`,
+                    path: `https://s3.example.com/exports/chart-${i}.csv`,
+                    localPath: `/tmp/chart-${i}.csv`,
+                    truncated: false,
+                })),
+                {
+                    filename: 'oversized.csv',
+                    path: `https://s3.example.com/${'a'.repeat(
+                        SLACK_MAX_URL + 100,
+                    )}`,
+                    localPath: '/tmp/oversized.csv',
+                    truncated: false,
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'Big dashboard',
+                name: 'Big dashboard',
+                description: 'Many charts',
+                ctaUrl: 'https://app.lightdash.com/dashboard/abc',
+                csvUrls,
+            });
+
+            const sectionTexts = findBlocks(blocks, 'section')
+                .map((s) => s.text?.text ?? '')
+                .join('\n');
+            // The invalid URL must not appear linked.
+            expect(sectionTexts).not.toMatch(/oversized\.csv\|oversized\.csv>/);
+        });
+
+        it('does not collapse when the dashboard has only a few charts', () => {
+            const csvUrls = Array.from({ length: 3 }, (_, i) => ({
+                filename: `chart-${i}.csv`,
+                path: `https://s3.example.com/exports/chart-${i}.csv`,
+                localPath: `/tmp/chart-${i}.csv`,
+                truncated: false,
+            }));
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'Small dashboard',
+                name: 'Small dashboard',
+                description: 'A few charts',
+                ctaUrl: 'https://app.lightdash.com/dashboard/abc',
+                csvUrls,
+                footerMarkdown: 'sent by scheduler',
+            });
+
+            const actionsButtons = blocks.filter(
+                (b) =>
+                    b.type === 'section' &&
+                    'accessory' in b &&
+                    b.accessory?.type === 'button',
+            );
+            expect(actionsButtons.length).toBeGreaterThanOrEqual(3);
+        });
+    });
+
+    describe('button URL validation', () => {
+        it('drops the chart-CSV download button when csvUrl exceeds 3000 chars', () => {
+            const longCsvUrl = `https://s3.example.com/${'a'.repeat(
+                SLACK_MAX_URL + 100,
+            )}`;
+
+            const blocks = getChartCsvResultsBlocks({
+                name: 'Big chart',
+                title: 'Big chart',
+                description: 'Big chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+                csvUrl: longCsvUrl,
+            });
+
+            const buttons = blocks.flatMap((b) =>
+                b.type === 'actions' ? b.elements : [],
+            );
+            const downloadButtons = buttons.filter(
+                (e) => 'action_id' in e && e.action_id === 'download-results',
+            );
+            expect(downloadButtons).toHaveLength(0);
+        });
+
+        it('drops the Open-in-Lightdash button when ctaUrl exceeds 3000 chars', () => {
+            const longCta = `https://app.example.com/${'a'.repeat(
+                SLACK_MAX_URL + 100,
+            )}`;
+
+            const blocks = getChartAndDashboardBlocks({
+                title: 'Chart',
+                name: 'Chart',
+                description: 'Chart desc',
+                ctaUrl: longCta,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const accessories = sections
+                .map((s) => s.accessory)
+                .filter((a): a is NonNullable<typeof a> => Boolean(a));
+            expect(accessories).toHaveLength(0);
+        });
+
+        it('drops malformed button URLs (not parseable)', () => {
+            const blocks = getChartCsvResultsBlocks({
+                name: 'Chart',
+                title: 'Chart',
+                description: 'Chart desc',
+                ctaUrl: 'not-a-real-url',
+                csvUrl: 'still-not-a-url',
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            sections.forEach((s) => {
+                if (s.accessory && s.accessory.type === 'button') {
+                    throw new Error(
+                        'malformed ctaUrl should not produce a button accessory',
+                    );
+                }
+            });
+
+            const buttons = blocks.flatMap((b) =>
+                b.type === 'actions' ? b.elements : [],
+            );
+            expect(buttons).toHaveLength(0);
+        });
+    });
+
+    describe('warning messages replace dropped content', () => {
+        it('shows a download-unavailable warning when csvUrl is too long', () => {
+            const longCsvUrl = `https://s3.example.com/${'a'.repeat(
+                SLACK_MAX_URL + 100,
+            )}`;
+
+            const blocks = getChartCsvResultsBlocks({
+                name: 'Big chart',
+                title: 'Big chart',
+                description: 'Big chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+                csvUrl: longCsvUrl,
+            });
+
+            const sectionTexts = findBlocks(blocks, 'section')
+                .map((s) => s.text?.text ?? '')
+                .join('\n');
+            expect(sectionTexts).toMatch(/download/i);
+            expect(sectionTexts).toMatch(
+                /unavailable|too long|open in lightdash/i,
+            );
+        });
+
+        it('shows a preview-unavailable warning when imageUrl is invalid', () => {
+            const blocks = getChartAndDashboardBlocks({
+                title: 'Chart',
+                name: 'Chart',
+                description: 'Chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+                imageUrl: 'not-a-url',
+            });
+
+            const sectionTexts = findBlocks(blocks, 'section')
+                .map((s) => s.text?.text ?? '')
+                .join('\n');
+            expect(sectionTexts).toMatch(/preview|chart image/i);
+            expect(sectionTexts).toMatch(/unavailable|open in lightdash/i);
+        });
+
+        it('marks per-chart dashboard rows whose download URL is invalid', () => {
+            const csvUrls = [
+                {
+                    filename: 'good.csv',
+                    path: 'https://s3.example.com/good.csv',
+                    localPath: '/tmp/good.csv',
+                    truncated: false,
+                },
+                {
+                    filename: 'bad.csv',
+                    path: `https://s3.example.com/${'a'.repeat(
+                        SLACK_MAX_URL + 100,
+                    )}`,
+                    localPath: '/tmp/bad.csv',
+                    truncated: false,
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'Dashboard',
+                name: 'Dashboard',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/dashboard/abc',
+                csvUrls,
+            });
+
+            const sectionsWithBadFilename = findBlocks(
+                blocks,
+                'section',
+            ).filter((s) => s.text?.text?.includes('bad.csv'));
+            expect(sectionsWithBadFilename.length).toBeGreaterThanOrEqual(1);
+            const text = sectionsWithBadFilename
+                .map((s) => s.text?.text ?? '')
+                .join('\n');
+            expect(text).toMatch(/unavailable|warning/i);
+
+            // Bad row should not still have a download button.
+            sectionsWithBadFilename.forEach((s) => {
+                expect(
+                    s.accessory && s.accessory.type === 'button'
+                        ? s.accessory.action_id
+                        : 'no-button',
+                ).not.toMatch(/^download-results-/);
+            });
+        });
+    });
+
+    describe('image URL validation', () => {
+        it('drops the image block when image_url exceeds 3000 chars', () => {
+            const longImage = `https://s3.example.com/${'a'.repeat(
+                SLACK_MAX_URL + 100,
+            )}`;
+
+            const blocks = getChartAndDashboardBlocks({
+                title: 'Chart',
+                name: 'Chart',
+                description: 'Chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+                imageUrl: longImage,
+            });
+
+            expect(findBlocks(blocks, 'image')).toHaveLength(0);
+        });
+
+        it('keeps the image block when image_url is well-formed and short', () => {
+            const blocks = getChartAndDashboardBlocks({
+                title: 'Chart',
+                name: 'Chart',
+                description: 'Chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+                imageUrl: 'https://s3.example.com/img.png',
+            });
+
+            expect(findBlocks(blocks, 'image')).toHaveLength(1);
+        });
+    });
+
+    describe('header sanitisation', () => {
+        it('omits the header block when title is empty', () => {
+            const blocks = getChartAndDashboardBlocks({
+                title: '',
+                name: 'Chart',
+                description: 'Chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+            });
+
+            expect(findBlocks(blocks, 'header')).toHaveLength(0);
+        });
+
+        it('omits the header block when title is only whitespace', () => {
+            const blocks = getChartCsvResultsBlocks({
+                name: 'Chart',
+                title: '   \n  ',
+                description: 'Chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+                csvUrl: 'https://s3.example.com/x.csv',
+            });
+
+            expect(findBlocks(blocks, 'header')).toHaveLength(0);
+        });
+
+        it('keeps the header block when title is non-empty', () => {
+            const blocks = getChartAndDashboardBlocks({
+                title: 'Real title',
+                name: 'Chart',
+                description: 'Chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+            });
+
+            const headers = findBlocks(blocks, 'header');
+            expect(headers).toHaveLength(1);
+            expect(headers[0].text.text).toBe('Real title');
+        });
+    });
+
+    describe('regression — typical inputs', () => {
+        it('chart-and-dashboard blocks contain header, fields, image, footer', () => {
+            const blocks = getChartAndDashboardBlocks({
+                title: 'My chart',
+                name: 'My chart',
+                description: 'A description',
+                message: 'Custom message',
+                imageUrl: 'https://s3.example.com/img.png',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+                footerMarkdown: 'sent by scheduler',
+            });
+            expect(findBlocks(blocks, 'header')).toHaveLength(1);
+            expect(findBlocks(blocks, 'image')).toHaveLength(1);
+            expect(findBlocks(blocks, 'context')).toHaveLength(1);
+        });
+
+        it('dashboard-csv with partial failures still emits a failure block', () => {
+            const csvUrls = Array.from({ length: 2 }, (_, i) => ({
+                filename: `chart-${i}.csv`,
+                path: `https://s3.example.com/exports/chart-${i}.csv`,
+                localPath: `/tmp/chart-${i}.csv`,
+                truncated: false,
+            }));
+            const failures: PartialFailure[] = [
+                {
+                    type: PartialFailureType.DASHBOARD_CHART,
+                    chartName: 'Failing chart',
+                    error: 'Query timed out',
+                    chartUuid: 'chart-uuid',
+                    tileUuid: 'tile-uuid',
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'Dashboard',
+                name: 'Dashboard',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/dashboard/abc',
+                csvUrls,
+                failures,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const failureSection = sections.find((s) =>
+                s.text?.text?.includes('Failing chart'),
+            );
+            expect(failureSection).toBeDefined();
+        });
+    });
+});

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -16,14 +16,19 @@ import {
 } from '@slack/bolt';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
 
-// Slack Block Kit text limits
+// Slack Block Kit text and structural limits
 const SLACK_LIMITS = {
     HEADER_TEXT: 150,
     SECTION_TEXT: 3000,
     SECTION_FIELD_TEXT: 2000,
     BUTTON_TEXT: 75,
     ALT_TEXT: 2000,
+    URL: 3000,
 } as const;
+
+// Beyond this many per-chart download blocks, dashboard CSV deliveries collapse
+// into a single grouped section to stay under Slack's 50-block message cap.
+const DASHBOARD_CSV_COLLAPSE_THRESHOLD = 35;
 
 // Truncate text to fit Slack limits and add ellipsis if needed
 const truncateText = (text: string, maxLength: number): string => {
@@ -35,6 +40,34 @@ const truncateText = (text: string, maxLength: number): string => {
 const sanitizeText = (text: string | undefined): string => {
     if (!text || text.trim() === '') return ' ';
     return text.trim();
+};
+
+// Header blocks reject empty or whitespace-only text — returning undefined lets
+// the caller drop the block entirely instead of emitting a single space.
+const sanitizeHeaderText = (text: string | undefined): string | undefined => {
+    const trimmed = text?.trim();
+    if (!trimmed) return undefined;
+    return truncateText(trimmed, SLACK_LIMITS.HEADER_TEXT);
+};
+
+// Slack rejects button.url and image_url values that are malformed or longer
+// than 3000 chars. Returns undefined when the URL would be rejected so callers
+// can drop the surrounding block / accessory.
+const safeUrl = (
+    url: string | undefined,
+    maxLength: number = SLACK_LIMITS.URL,
+): string | undefined => {
+    if (!url) return undefined;
+    if (url.length > maxLength) return undefined;
+    try {
+        const parsed = new URL(url);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return undefined;
+        }
+    } catch {
+        return undefined;
+    }
+    return url;
 };
 
 type GetChartAndDashboardBlocksArgs = {
@@ -74,6 +107,22 @@ const getSectionFields = (
 const getBlocks = (blocks: (KnownBlock | undefined)[]): KnownBlock[] =>
     blocks.filter((block): block is KnownBlock => Boolean(block));
 
+// Inline notice that replaces a block we had to drop (oversized URL,
+// malformed image, etc). Better than a silent omission — the user sees
+// where the content would have been and how to recover.
+const unavailableSection = (message: string): KnownBlock => ({
+    type: 'section',
+    text: {
+        type: 'mrkdwn',
+        text: truncateText(`:warning: ${message}`, SLACK_LIMITS.SECTION_TEXT),
+    },
+});
+
+const DOWNLOAD_UNAVAILABLE_MESSAGE =
+    'Download link unavailable for this delivery (the URL was too long or invalid). Open in Lightdash to download.';
+const PREVIEW_UNAVAILABLE_MESSAGE =
+    'Chart preview unavailable (the image URL was too long or invalid). Open in Lightdash to view.';
+
 export const getChartAndDashboardBlocks = ({
     title,
     name,
@@ -84,30 +133,48 @@ export const getChartAndDashboardBlocks = ({
     footerMarkdown,
     includeLinks,
 }: GetChartAndDashboardBlocksArgs): KnownBlock[] => {
-    const lightdashLink: SectionBlockAccessory | undefined =
-        includeLinks === false
-            ? undefined
-            : {
-                  type: 'button',
+    const safeCtaUrl = includeLinks === false ? undefined : safeUrl(ctaUrl);
+    const lightdashLink: SectionBlockAccessory | undefined = safeCtaUrl
+        ? {
+              type: 'button',
+              text: {
+                  type: 'plain_text',
+                  text: 'Open in Lightdash',
+                  emoji: true,
+              },
+              url: safeCtaUrl,
+              action_id: 'button-action',
+          }
+        : undefined;
+    const headerText = sanitizeHeaderText(title);
+    const hasImageUrl = Boolean(imageUrl?.trim());
+    const safeImageUrl = safeUrl(imageUrl);
+    const buildImageBlock = (): KnownBlock | undefined => {
+        if (safeImageUrl) {
+            return {
+                type: 'image',
+                image_url: safeImageUrl,
+                alt_text: truncateText(
+                    sanitizeText(title),
+                    SLACK_LIMITS.ALT_TEXT,
+                ),
+            };
+        }
+        if (hasImageUrl) {
+            return unavailableSection(PREVIEW_UNAVAILABLE_MESSAGE);
+        }
+        return undefined;
+    };
+    return getBlocks([
+        headerText
+            ? {
+                  type: 'header',
                   text: {
                       type: 'plain_text',
-                      text: 'Open in Lightdash',
-                      emoji: true,
+                      text: headerText,
                   },
-                  url: ctaUrl,
-                  action_id: 'button-action',
-              };
-    return getBlocks([
-        {
-            type: 'header',
-            text: {
-                type: 'plain_text',
-                text: truncateText(
-                    sanitizeText(title),
-                    SLACK_LIMITS.HEADER_TEXT,
-                ),
-            },
-        },
+              }
+            : undefined,
         message?.trim()
             ? {
                   type: 'section',
@@ -128,16 +195,7 @@ export const getChartAndDashboardBlocks = ({
             ]),
             accessory: lightdashLink,
         },
-        imageUrl?.trim()
-            ? {
-                  type: 'image',
-                  image_url: imageUrl,
-                  alt_text: truncateText(
-                      sanitizeText(title),
-                      SLACK_LIMITS.ALT_TEXT,
-                  ),
-              }
-            : undefined,
+        buildImageBlock(),
         footerMarkdown?.trim()
             ? {
                   type: 'context',
@@ -174,30 +232,62 @@ export const getChartCsvResultsBlocks = ({
     footerMarkdown,
     includeLinks,
 }: GetChartCsvResultsBlocksArgs): KnownBlock[] => {
-    const lightdashLink: SectionBlockAccessory | undefined =
-        includeLinks === false
-            ? undefined
-            : {
-                  type: 'button',
+    const safeCtaUrl = includeLinks === false ? undefined : safeUrl(ctaUrl);
+    const lightdashLink: SectionBlockAccessory | undefined = safeCtaUrl
+        ? {
+              type: 'button',
+              text: {
+                  type: 'plain_text',
+                  text: 'Open in Lightdash',
+                  emoji: true,
+              },
+              url: safeCtaUrl,
+              action_id: 'button-action',
+          }
+        : undefined;
+    const headerText = sanitizeHeaderText(title);
+    const hasCsvUrl = Boolean(csvUrl?.trim());
+    const safeCsvUrl = safeUrl(csvUrl);
+    const buildDownloadActions = (): KnownBlock | undefined => {
+        if (safeCsvUrl) {
+            return {
+                type: 'actions',
+                elements: [
+                    {
+                        type: 'button',
+                        text: {
+                            type: 'plain_text',
+                            text: 'Download results',
+                            emoji: true,
+                        },
+                        url: safeCsvUrl,
+                        action_id: 'download-results',
+                    },
+                ],
+            };
+        }
+        if (!hasCsvUrl) {
+            return {
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: '*_This query returned no results_*',
+                },
+            };
+        }
+        return unavailableSection(DOWNLOAD_UNAVAILABLE_MESSAGE);
+    };
+    const downloadActions = buildDownloadActions();
+    return getBlocks([
+        headerText
+            ? {
+                  type: 'header',
                   text: {
                       type: 'plain_text',
-                      text: 'Open in Lightdash',
-                      emoji: true,
+                      text: headerText,
                   },
-                  url: ctaUrl,
-                  action_id: 'button-action',
-              };
-    return getBlocks([
-        {
-            type: 'header',
-            text: {
-                type: 'plain_text',
-                text: truncateText(
-                    sanitizeText(title),
-                    SLACK_LIMITS.HEADER_TEXT,
-                ),
-            },
-        },
+              }
+            : undefined,
         message?.trim()
             ? {
                   type: 'section',
@@ -218,31 +308,7 @@ export const getChartCsvResultsBlocks = ({
             ]),
             accessory: lightdashLink,
         },
-
-        csvUrl?.trim()
-            ? {
-                  type: 'actions',
-                  elements: [
-                      {
-                          type: 'button',
-                          text: {
-                              type: 'plain_text',
-                              text: 'Download results',
-                              emoji: true,
-                          },
-                          url: csvUrl,
-                          action_id: 'download-results',
-                      },
-                  ],
-              }
-            : {
-                  type: 'section',
-                  text: {
-                      type: 'mrkdwn',
-                      text: '*_This query returned no results_*',
-                  },
-              },
-
+        downloadActions,
         footerMarkdown?.trim()
             ? {
                   type: 'context',
@@ -284,19 +350,38 @@ export const getChartThresholdAlertBlocks = ({
 }: GetChartThresholdBlocksArgs): KnownBlock[] => {
     // TODO only pass threshold conditions met
     // TODO send field name from explore or results (instead of friendly name)
-    const lightdashLink: SectionBlockAccessory | undefined =
-        includeLinks === false
-            ? undefined
-            : {
-                  type: 'button',
-                  text: {
-                      type: 'plain_text',
-                      text: 'Open in Lightdash',
-                      emoji: true,
-                  },
-                  url: ctaUrl,
-                  action_id: 'button-action',
-              };
+    const safeCtaUrl = includeLinks === false ? undefined : safeUrl(ctaUrl);
+    const lightdashLink: SectionBlockAccessory | undefined = safeCtaUrl
+        ? {
+              type: 'button',
+              text: {
+                  type: 'plain_text',
+                  text: 'Open in Lightdash',
+                  emoji: true,
+              },
+              url: safeCtaUrl,
+              action_id: 'button-action',
+          }
+        : undefined;
+    const headerText = sanitizeHeaderText(title);
+    const hasImageUrl = Boolean(imageUrl?.trim());
+    const safeImageUrl = safeUrl(imageUrl);
+    const buildImageBlock = (): KnownBlock | undefined => {
+        if (safeImageUrl) {
+            return {
+                type: 'image',
+                image_url: safeImageUrl,
+                alt_text: truncateText(
+                    sanitizeText(title),
+                    SLACK_LIMITS.ALT_TEXT,
+                ),
+            };
+        }
+        if (hasImageUrl) {
+            return unavailableSection(PREVIEW_UNAVAILABLE_MESSAGE);
+        }
+        return undefined;
+    };
     const thresholdBlocks: KnownBlock[] = thresholds.map((threshold) => ({
         type: 'section',
         text: {
@@ -312,16 +397,15 @@ export const getChartThresholdAlertBlocks = ({
         },
     }));
     return getBlocks([
-        {
-            type: 'header',
-            text: {
-                type: 'plain_text',
-                text: truncateText(
-                    sanitizeText(title),
-                    SLACK_LIMITS.HEADER_TEXT,
-                ),
-            },
-        },
+        headerText
+            ? {
+                  type: 'header',
+                  text: {
+                      type: 'plain_text',
+                      text: headerText,
+                  },
+              }
+            : undefined,
         message?.trim()
             ? {
                   type: 'section',
@@ -349,16 +433,7 @@ export const getChartThresholdAlertBlocks = ({
             accessory: lightdashLink,
         },
         ...thresholdBlocks,
-        imageUrl?.trim()
-            ? {
-                  type: 'image',
-                  image_url: imageUrl,
-                  alt_text: truncateText(
-                      sanitizeText(title),
-                      SLACK_LIMITS.ALT_TEXT,
-                  ),
-              }
-            : undefined,
+        buildImageBlock(),
         footerMarkdown?.trim()
             ? {
                   type: 'context',
@@ -464,17 +539,130 @@ export const getDashboardCsvResultsBlocks = ({
         };
     };
 
-    return getBlocks([
-        {
-            type: 'header',
+    const safeCtaUrl = safeUrl(ctaUrl);
+    const headerText = sanitizeHeaderText(title);
+
+    const perChartBlock = (
+        csvUrl: AttachmentUrl,
+        index: number,
+    ): KnownBlock => {
+        if (csvUrl.path === '#no-results') {
+            return {
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: '*_This query returned no results_*',
+                },
+            };
+        }
+        const safeDownloadUrl = safeUrl(csvUrl.path);
+        if (safeDownloadUrl) {
+            return {
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: truncateText(
+                        `:black_small_square: ${sanitizeText(csvUrl.filename)}`,
+                        SLACK_LIMITS.SECTION_TEXT,
+                    ),
+                },
+                accessory: {
+                    type: 'button',
+                    text: {
+                        type: 'plain_text',
+                        text: 'Download results',
+                        emoji: true,
+                    },
+                    url: safeDownloadUrl,
+                    action_id: `download-results-${index}`,
+                },
+            };
+        }
+        return {
+            type: 'section',
             text: {
-                type: 'plain_text',
+                type: 'mrkdwn',
                 text: truncateText(
-                    sanitizeText(title),
-                    SLACK_LIMITS.HEADER_TEXT,
+                    `:warning: ${sanitizeText(
+                        csvUrl.filename,
+                    )} — download unavailable. Open in Lightdash to access this result.`,
+                    SLACK_LIMITS.SECTION_TEXT,
                 ),
             },
-        },
+        };
+    };
+
+    // When the dashboard has too many charts, n per-chart blocks would push
+    // the message past Slack's 50-block hard cap. Collapse into a single
+    // grouped section listing each filename as a clickable mrkdwn link to its
+    // download URL, with one CTA so delivery still succeeds.
+    //
+    // The budget leaves headroom for the trailing "+ N more" summary line plus
+    // mrkdwn syntax so we never need to truncate mid-link (which would emit
+    // malformed mrkdwn and re-trigger invalid_blocks).
+    const COLLAPSE_TEXT_BUDGET = SLACK_LIMITS.SECTION_TEXT - 200;
+    const buildCsvRow = (u: AttachmentUrl): string => {
+        const filename = sanitizeText(u.filename);
+        const downloadUrl = safeUrl(u.path);
+        return downloadUrl
+            ? `:black_small_square: <${downloadUrl}|${filename}>`
+            : `:warning: ${filename} — download unavailable`;
+    };
+    const buildCollapsedSection = (): KnownBlock => {
+        const lines: string[] = [];
+        let used = 0;
+        let included = 0;
+        for (const u of csvUrls) {
+            const line = buildCsvRow(u);
+            const cost = line.length + 1; // +1 for the joining newline
+            if (used + cost > COLLAPSE_TEXT_BUDGET) break;
+            lines.push(line);
+            used += cost;
+            included += 1;
+        }
+        const remaining = csvUrls.length - included;
+        if (remaining > 0) {
+            lines.push(
+                `\n+ ${remaining} more — open in Lightdash to access all downloads.`,
+            );
+        }
+        return {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: truncateText(lines.join('\n'), SLACK_LIMITS.SECTION_TEXT),
+            },
+            ...(safeCtaUrl
+                ? {
+                      accessory: {
+                          type: 'button',
+                          text: {
+                              type: 'plain_text',
+                              text: 'Open in Lightdash',
+                              emoji: true,
+                          },
+                          url: safeCtaUrl,
+                          action_id: 'open-in-lightdash',
+                      },
+                  }
+                : {}),
+        };
+    };
+    const csvSections: KnownBlock[] =
+        csvUrls.length > DASHBOARD_CSV_COLLAPSE_THRESHOLD
+            ? [buildCollapsedSection()]
+            : csvUrls.map<KnownBlock>(perChartBlock);
+
+    return getBlocks([
+        headerText
+            ? {
+                  type: 'header',
+                  text: {
+                      type: 'plain_text',
+                      text: headerText,
+                  },
+              }
+            : undefined,
         message?.trim()
             ? {
                   type: 'section',
@@ -493,49 +681,22 @@ export const getDashboardCsvResultsBlocks = ({
                 ['name', name],
                 ['description', description],
             ]),
-            accessory: {
-                type: 'button',
-                text: {
-                    type: 'plain_text',
-                    text: 'Open in Lightdash',
-                    emoji: true,
-                },
-                url: ctaUrl,
-                action_id: 'button-action',
-            },
-        },
-        ...csvUrls.map<KnownBlock>((csvUrl, index) =>
-            csvUrl.path !== '#no-results'
+            ...(safeCtaUrl
                 ? {
-                      type: 'section',
-                      text: {
-                          type: 'mrkdwn',
-                          text: truncateText(
-                              `:black_small_square: ${sanitizeText(
-                                  csvUrl.filename,
-                              )}`,
-                              SLACK_LIMITS.SECTION_TEXT,
-                          ),
-                      },
                       accessory: {
                           type: 'button',
                           text: {
                               type: 'plain_text',
-                              text: 'Download results',
+                              text: 'Open in Lightdash',
                               emoji: true,
                           },
-                          url: csvUrl.path,
-                          action_id: `download-results-${index}`,
+                          url: safeCtaUrl,
+                          action_id: 'button-action',
                       },
                   }
-                : {
-                      type: 'section',
-                      text: {
-                          type: 'mrkdwn',
-                          text: '*_This query returned no results_*',
-                      },
-                  },
-        ),
+                : {}),
+        },
+        ...csvSections,
         getFailureBlock(),
         footerMarkdown?.trim()
             ? {
@@ -558,8 +719,10 @@ const getExploreBlocks = (
     title: string,
     ctaUrl: string,
     imageUrl: string | undefined,
-): KnownBlock[] =>
-    getBlocks([
+): KnownBlock[] => {
+    const safeCtaUrl = safeUrl(ctaUrl);
+    const safeImageUrl = safeUrl(imageUrl);
+    return getBlocks([
         {
             type: 'section',
             text: {
@@ -569,21 +732,25 @@ const getExploreBlocks = (
                     SLACK_LIMITS.SECTION_TEXT,
                 ),
             },
-            accessory: {
-                type: 'button',
-                text: {
-                    type: 'plain_text',
-                    text: 'Open in Lightdash',
-                    emoji: true,
-                },
-                url: ctaUrl,
-                action_id: 'button-action',
-            },
+            ...(safeCtaUrl
+                ? {
+                      accessory: {
+                          type: 'button',
+                          text: {
+                              type: 'plain_text',
+                              text: 'Open in Lightdash',
+                              emoji: true,
+                          },
+                          url: safeCtaUrl,
+                          action_id: 'button-action',
+                      },
+                  }
+                : {}),
         },
-        imageUrl?.trim()
+        safeImageUrl
             ? {
                   type: 'image',
-                  image_url: imageUrl,
+                  image_url: safeImageUrl,
                   alt_text: truncateText(
                       sanitizeText(title),
                       SLACK_LIMITS.ALT_TEXT,
@@ -591,6 +758,7 @@ const getExploreBlocks = (
               }
             : undefined,
     ]);
+};
 
 export type Unfurl = {
     title: string;
@@ -629,20 +797,21 @@ export const getNotificationChannelErrorBlocks = (
     resourceUrl: string,
     type: 'Scheduled delivery' | 'Google Sync' = 'Scheduled delivery',
     isDisabled: boolean = false,
-): KnownBlock[] =>
-    getBlocks([
-        {
-            type: 'header',
-            text: {
-                type: 'plain_text',
-                text: truncateText(
-                    `❌ Error sending ${type}: "${sanitizeText(
-                        schedulerName,
-                    )}"`,
-                    SLACK_LIMITS.HEADER_TEXT,
-                ),
-            },
-        },
+): KnownBlock[] => {
+    const headerText = sanitizeHeaderText(
+        `❌ Error sending ${type}: "${sanitizeText(schedulerName)}"`,
+    );
+    const safeResourceUrl = safeUrl(resourceUrl);
+    return getBlocks([
+        headerText
+            ? {
+                  type: 'header',
+                  text: {
+                      type: 'plain_text',
+                      text: headerText,
+                  },
+              }
+            : undefined,
 
         {
             type: 'section',
@@ -650,16 +819,20 @@ export const getNotificationChannelErrorBlocks = (
                 type: 'mrkdwn',
                 text: `*Details:*`,
             },
-            accessory: {
-                type: 'button',
-                text: {
-                    type: 'plain_text',
-                    text: 'Open in Lightdash',
-                    emoji: true,
-                },
-                url: resourceUrl,
-                action_id: 'button-action',
-            },
+            ...(safeResourceUrl
+                ? {
+                      accessory: {
+                          type: 'button',
+                          text: {
+                              type: 'plain_text',
+                              text: 'Open in Lightdash',
+                              emoji: true,
+                          },
+                          url: safeResourceUrl,
+                          action_id: 'button-action',
+                      },
+                  }
+                : {}),
         },
         {
             type: 'section',
@@ -686,3 +859,4 @@ export const getNotificationChannelErrorBlocks = (
               }
             : undefined,
     ]);
+};


### PR DESCRIPTION
## Summary

Layer 1 of [PROD-7169](https://linear.app/lightdash/issue/PROD-7169) — prevent Slack scheduled deliveries from failing with `invalid_blocks` by validating Block Kit constraints before posting. When a constraint can't be met, the dropped element is replaced with an inline warning so the user knows what happened and how to recover (open in Lightdash) instead of silently losing content.

Linear: [PROD-7209](https://linear.app/lightdash/issue/PROD-7209)

### What `invalid_blocks` is

Slack rejects any `chat.postMessage` whose payload violates Block Kit limits — too many blocks (max 50), section text > 3000 chars, button/image URLs > 3000 chars, malformed mrkdwn, etc. Today the user sees the literal `invalid_blocks` string in scheduler logs and the entire delivery is lost. This PR closes the most common failure modes.

### What changed

`packages/backend/src/clients/Slack/SlackMessageBlocks.ts`:

- New `safeUrl(url, maxLen)` — returns `undefined` when a URL is > 3000 chars, malformed, or non-http(s). Applied to every `accessory.button.url`, `actions.elements.button.url`, and `image_url` site across all 6 builders.
- New `sanitizeHeaderText(text)` — returns `undefined` for empty/whitespace titles so the header block is dropped instead of emitting a single space.
- New `unavailableSection(message)` — renders `:warning: …` in place of a dropped block so the user sees what happened (with a CTA: open in Lightdash).
- Dashboard CSV deliveries with > 35 charts now collapse into a **single grouped section** with each filename rendered as a clickable mrkdwn `<url|filename>` link, plus a `+ N more — open in Lightdash …` summary line. Char budget keeps the section under the 3000-char limit and never truncates mid-link.
- Per-chart rows whose download URL is invalid render as `:warning: <filename> — download unavailable. Open in Lightdash to access this result.` (no button) so a single bad URL no longer brings down the whole message.

`packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts` (new) — 18 unit tests covering: block-count cap, mrkdwn link embedding, invalid-URL handling, warning messages, header sanitisation, and regression coverage of the typical inputs.

No DB / API / frontend changes.

## Before / After

### 1. Dashboard CSV with too many charts (the production trigger)

**Before** — 60-chart dashboard:
> Slack rejects the whole post with `invalid_blocks` (60+ section blocks > 50 cap). User gets nothing; scheduler log shows literal `invalid_blocks`.

**After** — same 60-chart dashboard:
```
┌─────────────────────────────────────────────────────────┐
│  Sales overview — daily delivery                        │  ← header
│                                                          │
│  name              description                          │  ← fields
│  Sales overview    Daily snapshot of pipeline           │
│                                                  [Open] │
│                                                          │
│  ▪ revenue-by-region.csv   ← clickable mrkdwn link      │  ← collapsed
│  ▪ deals-by-stage.csv      ← clickable                  │     section
│  ▪ pipeline-velocity.csv   ← clickable                  │     (one block)
│  …                                                       │
│  + 35 more — open in Lightdash to access all downloads. │
│                                                  [Open] │
│                                                          │
│  This is a scheduled delivery every day at 9 AM ...     │  ← context
└─────────────────────────────────────────────────────────┘
```
~5 blocks total, well under Slack's 50-block cap. Delivery succeeds, every visible filename is a clickable download link to its S3 URL, and the "+ N more" CTA points to the dashboard's Lightdash URL.

### 2. Chart CSV where the presigned download URL is too long

**Before**: Slack rejects with `invalid_blocks` → delivery fails entirely.

**After**:
```
┌─────────────────────────────────────────────────────────┐
│  Weekly revenue                                          │
│                                                          │
│  name              description                          │
│  Weekly revenue    YoY revenue by week           [Open] │
│                                                          │
│  ⚠️ Download link unavailable for this delivery (the    │  ← warning
│  URL was too long or invalid). Open in Lightdash to     │     replaces
│  download.                                               │     dropped
│                                                          │     button
│  This is a scheduled delivery every Monday ...          │
└─────────────────────────────────────────────────────────┘
```

### 3. Chart image where the image URL is malformed/too long

**Before**: Slack rejects with `invalid_blocks` → no message at all.

**After**:
```
┌─────────────────────────────────────────────────────────┐
│  Conversion funnel                                       │
│                                                          │
│  name              description                          │
│  Conversion funnel Step-by-step drop-off          [Open] │
│                                                          │
│  ⚠️ Chart preview unavailable (the image URL was too    │  ← warning
│  long or invalid). Open in Lightdash to view.           │     replaces
│                                                          │     image
│  This is a scheduled delivery every Monday ...          │
└─────────────────────────────────────────────────────────┘
```

### 4. Dashboard CSV with one bad row (mixed)

Only the bad row gets the warning suffix; the others keep their download buttons.

**After**:
```
  ▪ revenue-by-region.csv                       [Download]
  ⚠️ deals-by-stage.csv — download unavailable.
     Open in Lightdash to access this result.
  ▪ pipeline-velocity.csv                       [Download]
```

## Layered fix

This PR is one of four sub-tickets under PROD-7169. Together they make `invalid_blocks` rare and recoverable:

- **PROD-7209 (this PR) — Prevention** in `SlackMessageBlocks.ts`.
- **PROD-7210 — Fallback** in `SlackClient.postMessage`: retry once with text-only payload on `invalid_blocks`.
- **PROD-7211 — Friendly error** in `SchedulerTask.ts`: translate the raw error in the scheduler log.
- **PROD-7212 — Diagnostics**: structured breadcrumbs in the existing warn log so we can confirm causes from production.

## Test plan

- [x] `pnpm -F backend test src/clients/Slack/SlackMessageBlocks.test.ts` — 18 passing
- [x] `pnpm -F backend test src/clients/Slack/ src/scheduler/ src/services/UnfurlService/` — 33 passing (no regressions)
- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend linter src/clients/Slack/SlackMessageBlocks*.ts` — clean
- [ ] Manual: trigger a dashboard CSV delivery with >35 charts in local dev, confirm the collapsed section renders with clickable links

🤖 Generated with [Claude Code](https://claude.com/claude-code)