### PR TITLE
refactor(audited-ability): migrate leaf services to Account [SPK-416]

### DIFF
--- a/packages/backend/src/controllers/googleDriveController.ts
+++ b/packages/backend/src/controllers/googleDriveController.ts
@@ -64,7 +64,7 @@ export class GoogleDriveController extends BaseController {
             status: 'ok',
             results: await req.services
                 .getGdriveService()
-                .scheduleUploadGsheet(req.user!, body),
+                .scheduleUploadGsheet(req.account!, body),
         };
     }
 }

--- a/packages/backend/src/controllers/projectCompileLogController.ts
+++ b/packages/backend/src/controllers/projectCompileLogController.ts
@@ -73,7 +73,7 @@ export class ProjectCompileLogController extends BaseController {
             results: await this.services
                 .getProjectCompileLogService()
                 .getProjectCompileLogs(
-                    req.user!,
+                    req.account!,
                     projectUuid,
                     paginateArgs,
                     sort,
@@ -105,7 +105,11 @@ export class ProjectCompileLogController extends BaseController {
             results: {
                 log: await this.services
                     .getProjectCompileLogService()
-                    .getProjectCompileLogByJob(req.user!, projectUuid, jobUuid),
+                    .getProjectCompileLogByJob(
+                        req.account!,
+                        projectUuid,
+                        jobUuid,
+                    ),
             },
         };
     }

--- a/packages/backend/src/controllers/shareController.ts
+++ b/packages/backend/src/controllers/shareController.ts
@@ -42,7 +42,7 @@ export class ShareController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getShareService()
-                .getShareUrl(req.user!, nanoId),
+                .getShareUrl(req.account!, nanoId),
         };
     }
 

--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -282,7 +282,7 @@ export class SlackController extends BaseController {
     ): Promise<ApiSuccessEmpty> {
         await this.services
             .getSlackIntegrationService()
-            .deleteInstallationFromOrganizationUuid(req.user!);
+            .deleteInstallationFromOrganizationUuid(req.account!);
 
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/spotlightController.ts
+++ b/packages/backend/src/controllers/spotlightController.ts
@@ -50,7 +50,7 @@ export class SpotlightController extends BaseController {
     ): Promise<ApiSuccessEmpty> {
         await this.services
             .getSpotlightService()
-            .createSpotlightTableConfig(req.user!, projectUuid, body);
+            .createSpotlightTableConfig(req.account!, projectUuid, body);
 
         this.setStatus(201);
         return {
@@ -73,7 +73,7 @@ export class SpotlightController extends BaseController {
     ): Promise<ApiGetSpotlightTableConfig> {
         const { columnConfig } = await this.services
             .getSpotlightService()
-            .getSpotlightTableConfig(req.user!, projectUuid);
+            .getSpotlightTableConfig(req.account!, projectUuid);
 
         this.setStatus(200);
         return {
@@ -102,7 +102,7 @@ export class SpotlightController extends BaseController {
     ): Promise<ApiSuccessEmpty> {
         await this.services
             .getSpotlightService()
-            .resetSpotlightTableConfig(req.user!, projectUuid);
+            .resetSpotlightTableConfig(req.account!, projectUuid);
 
         this.setStatus(200);
         return {

--- a/packages/backend/src/controllers/userActivityController.ts
+++ b/packages/backend/src/controllers/userActivityController.ts
@@ -56,7 +56,7 @@ export class UserActivityController extends BaseController {
         this.setStatus(200);
         const userActivity = await req.services
             .getAnalyticsService()
-            .getUserActivity(projectUuid, req.user!);
+            .getUserActivity(projectUuid, req.account!);
         return {
             status: 'ok',
             results: userActivity,
@@ -82,7 +82,7 @@ export class UserActivityController extends BaseController {
         this.setStatus(200);
         const userActivity = await req.services
             .getAnalyticsService()
-            .exportUserActivityRawCsv(projectUuid, req.user!);
+            .exportUserActivityRawCsv(projectUuid, req.account!);
         return {
             status: 'ok',
             results: userActivity,

--- a/packages/backend/src/controllers/v2/DeployController.ts
+++ b/packages/backend/src/controllers/v2/DeployController.ts
@@ -49,7 +49,7 @@ export class DeployController extends BaseController {
         this.setStatus(200);
         const result = await this.services
             .getDeployService()
-            .startDeploySession(req.user!, projectUuid);
+            .startDeploySession(req.account!, projectUuid);
         return {
             status: 'ok',
             results: result,

--- a/packages/backend/src/controllers/v2/ParametersController.ts
+++ b/packages/backend/src/controllers/v2/ParametersController.ts
@@ -61,7 +61,7 @@ export class ParametersController extends BaseController {
         const results = await this.services
             .getProjectParametersService()
             .findProjectParametersPaginated(
-                req.user!,
+                req.account!,
                 projectUuid,
                 paginateArgs,
                 { search, sortBy, sortOrder },

--- a/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
+++ b/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
@@ -1,4 +1,9 @@
-import { ForbiddenError, SessionUser, SlackSettings } from '@lightdash/common';
+import {
+    Account,
+    ForbiddenError,
+    SessionUser,
+    SlackSettings,
+} from '@lightdash/common';
 import {
     SlackIntegrationService,
     SlackIntegrationServiceArguments,
@@ -57,11 +62,11 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
         return response;
     }
 
-    async deleteInstallationFromOrganizationUuid(user: SessionUser) {
-        await super.deleteInstallationFromOrganizationUuid(user);
+    async deleteInstallationFromOrganizationUuid(account: Account) {
+        await super.deleteInstallationFromOrganizationUuid(account);
 
         await this.aiAgentModel.deleteSlackIntegrations({
-            organizationUuid: user.organizationUuid!,
+            organizationUuid: account.organization.organizationUuid!,
         });
     }
 }

--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -173,7 +173,7 @@ dashboardRouter.post(
             const results = await req.services
                 .getCsvService()
                 .scheduleExportCsvDashboard(
-                    req.user!,
+                    req.account!,
                     req.params.dashboardUuid,
                     req.body.filters,
                     validatedSelectedTabs,

--- a/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
+++ b/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
@@ -1,12 +1,12 @@
 import { subject } from '@casl/ability';
 import {
     AnyType,
+    assertIsAccountWithOrg,
     ForbiddenError,
-    isUserWithOrg,
     NotFoundError,
     SchedulerJobStatus,
-    SessionUser,
     UserActivity,
+    type Account,
 } from '@lightdash/common';
 import { stringify } from 'csv-stringify/sync';
 import { nanoid } from 'nanoid';
@@ -46,15 +46,13 @@ export class AnalyticsService extends BaseService {
 
     async getUserActivity(
         projectUuid: string,
-        user: SessionUser,
+        account: Account,
     ): Promise<UserActivity> {
-        if (!isUserWithOrg(user)) {
-            throw new ForbiddenError('User is not part of an organization');
-        }
+        assertIsAccountWithOrg(account);
         const { organizationUuid, name: projectName } =
             await this.projectModel.get(projectUuid);
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'view',
@@ -70,30 +68,28 @@ export class AnalyticsService extends BaseService {
 
         this.analytics.track({
             event: 'usage_analytics.dashboard_viewed',
-            userId: user.userUuid,
+            userId: account.user.id,
             properties: {
                 projectId: projectUuid,
-                organizationId: user.organizationUuid,
+                organizationId: account.organization.organizationUuid,
                 dashboardType: 'user_activity',
             },
         });
 
         return this.analyticsModel.getUserActivity(
             projectUuid,
-            user.organizationUuid,
+            account.organization.organizationUuid,
         );
     }
 
     async exportUserActivityRawCsv(
         projectUuid: string,
-        user: SessionUser,
+        account: Account,
     ): Promise<string> {
-        if (!isUserWithOrg(user)) {
-            throw new ForbiddenError('User is not part of an organization');
-        }
+        assertIsAccountWithOrg(account);
         const { organizationUuid, name: projectName } =
             await this.projectModel.get(projectUuid);
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'view',
@@ -109,10 +105,10 @@ export class AnalyticsService extends BaseService {
 
         this.analytics.track({
             event: 'usage_analytics.csv_download',
-            userId: user.userUuid,
+            userId: account.user.id,
             properties: {
                 projectId: projectUuid,
-                organizationId: user.organizationUuid,
+                organizationId: account.organization.organizationUuid,
                 dashboardType: 'user_activity',
             },
         });
@@ -135,7 +131,7 @@ export class AnalyticsService extends BaseService {
             fileName,
             projectUuid,
             organizationUuid,
-            createdByUserUuid: user.userUuid,
+            createdByUserUuid: account.user.id,
         });
         return upload.path;
     }

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     AnyType,
     ApiSqlQueryResults,
     DashboardFilters,
@@ -620,7 +621,7 @@ export class CsvService extends BaseService {
      * This method is used to schedule a CSV download for a dashboard.
      */
     async scheduleExportCsvDashboard(
-        user: SessionUser,
+        account: Account,
         dashboardUuid: string,
         dashboardFilters: DashboardFilters,
         selectedTabs: string[] | null,
@@ -628,7 +629,7 @@ export class CsvService extends BaseService {
     ) {
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'manage',
@@ -653,7 +654,7 @@ export class CsvService extends BaseService {
             // TraceTaskBase
             organizationUuid: dashboard.organizationUuid,
             projectUuid: dashboard.projectUuid,
-            userUuid: user.userUuid,
+            userUuid: account.user.id,
             schedulerUuid: undefined,
         };
         const { jobId } = await this.schedulerClient.scheduleTask(

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     calculateExploreWarningReport,
     DeploySessionStatus,
     Explore,
@@ -59,7 +60,7 @@ export class DeployService extends BaseService {
     }
 
     async startDeploySession(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
     ): Promise<{ deploySessionUuid: string }> {
         // Check deploy permission
@@ -68,7 +69,7 @@ export class DeployService extends BaseService {
 
         // manage:DeployProject for non-preview projects (restrictable via custom roles)
         // manage:DeployProject@self for preview projects created by the user
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'manage',
@@ -92,7 +93,7 @@ export class DeployService extends BaseService {
         // Create a new deploy session
         const sessionUuid = await this.deploySessionModel.createSession(
             projectUuid,
-            user.userUuid,
+            account.user.id,
         );
 
         this.logger.info(

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -1,13 +1,12 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     CustomSqlQueryForbiddenError,
     ForbiddenError,
     hasSqlAuthoredFields,
-    SessionUser,
     UploadMetricGsheet,
     UploadMetricGsheetPayload,
 } from '@lightdash/common';
-import { fromSession } from '../../auth/account';
 import { LightdashConfig } from '../../config/parseConfig';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -62,13 +61,13 @@ export class GdriveService extends BaseService {
     }
 
     async scheduleUploadGsheet(
-        user: SessionUser,
+        account: Account,
         gsheetOptions: UploadMetricGsheet,
     ) {
         const projectSummary = await this.projectModel.getSummary(
             gsheetOptions.projectUuid,
         );
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         const projectMetadata = {
             projectUuid: projectSummary.projectUuid,
             projectName: projectSummary.name,
@@ -115,12 +114,12 @@ export class GdriveService extends BaseService {
 
         const { organizationUuid } = await this.projectService.getProject(
             gsheetOptions.projectUuid,
-            fromSession(user),
+            account,
         );
 
         const payload: UploadMetricGsheetPayload = {
             ...gsheetOptions,
-            userUuid: user.userUuid,
+            userUuid: account.user.id,
             organizationUuid,
         };
 

--- a/packages/backend/src/services/ProjectCompileLogService/ProjectCompileLogService.ts
+++ b/packages/backend/src/services/ProjectCompileLogService/ProjectCompileLogService.ts
@@ -4,8 +4,8 @@ import {
     ForbiddenError,
     KnexPaginateArgs,
     KnexPaginatedData,
+    type Account,
     type ProjectCompileLog,
-    type SessionUser,
 } from '@lightdash/common';
 import {
     DbProjectCompileLogSortColumns,
@@ -26,7 +26,7 @@ export class ProjectCompileLogService extends BaseService {
     }
 
     async getProjectCompileLogs(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         paginateArgs?: KnexPaginateArgs,
         sort?: {
@@ -38,14 +38,14 @@ export class ProjectCompileLogService extends BaseService {
             source?: CompilationSource;
         },
     ): Promise<KnexPaginatedData<ProjectCompileLog[]>> {
-        const { organizationUuid } = user;
+        const { organizationUuid } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError(
                 'User does not have access to an organization',
             );
         }
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'update',
@@ -69,18 +69,18 @@ export class ProjectCompileLogService extends BaseService {
     }
 
     async getProjectCompileLogByJob(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         jobUuid: string,
     ): Promise<ProjectCompileLog | undefined> {
-        const { organizationUuid } = user;
+        const { organizationUuid } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError(
                 'User does not have access to an organization',
             );
         }
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'update',

--- a/packages/backend/src/services/ProjectParametersService.ts
+++ b/packages/backend/src/services/ProjectParametersService.ts
@@ -2,7 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     KnexPaginateArgs,
-    type SessionUser,
+    type Account,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../config/parseConfig';
@@ -39,7 +39,7 @@ export class ProjectParametersService extends BaseService {
     }
 
     async findProjectParametersPaginated(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         paginateArgs?: KnexPaginateArgs,
         options?: {
@@ -51,7 +51,7 @@ export class ProjectParametersService extends BaseService {
         const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'view',

--- a/packages/backend/src/services/ShareService/ShareService.mock.ts
+++ b/packages/backend/src/services/ShareService/ShareService.mock.ts
@@ -3,9 +3,11 @@ import {
     LightdashMode,
     OrganizationMemberRole,
     PossibleAbilities,
+    SessionAccount,
     SessionUser,
     ShareUrl,
 } from '@lightdash/common';
+import { fromSession } from '../../auth/account';
 import { LightdashConfig } from '../../config/parseConfig';
 
 export const Config = {
@@ -50,6 +52,10 @@ export const UserFromAnotherOrg: SessionUser = {
         },
     ]),
 };
+
+export const Account: SessionAccount = fromSession(User);
+export const AccountFromAnotherOrg: SessionAccount =
+    fromSession(UserFromAnotherOrg);
 
 export const SampleShareUrl: ShareUrl = {
     nanoid: 'abc123',

--- a/packages/backend/src/services/ShareService/ShareService.test.ts
+++ b/packages/backend/src/services/ShareService/ShareService.test.ts
@@ -3,13 +3,14 @@ import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { ShareModel } from '../../models/ShareModel';
 import { ShareService } from './ShareService';
 import {
+    Account,
+    AccountFromAnotherOrg,
     Config,
     FullShareUrl,
     FullShareUrlWithoutParams,
     SampleShareUrl,
     ShareUrlWithoutParams,
     User,
-    UserFromAnotherOrg,
 } from './ShareService.mock';
 
 const shareModel = {
@@ -39,7 +40,7 @@ describe('share', () => {
     });
     it('Should get saved sharedUrl', async () => {
         expect(
-            await shareService.getShareUrl(User, SampleShareUrl.nanoid),
+            await shareService.getShareUrl(Account, SampleShareUrl.nanoid),
         ).toEqual(FullShareUrl);
     });
 
@@ -49,13 +50,19 @@ describe('share', () => {
         );
 
         expect(
-            await shareService.getShareUrl(User, ShareUrlWithoutParams.nanoid),
+            await shareService.getShareUrl(
+                Account,
+                ShareUrlWithoutParams.nanoid,
+            ),
         ).toEqual(FullShareUrlWithoutParams);
     });
 
     it('Should throw error if user does not have access to the organization', async () => {
         await expect(
-            shareService.getShareUrl(UserFromAnotherOrg, SampleShareUrl.nanoid),
+            shareService.getShareUrl(
+                AccountFromAnotherOrg,
+                SampleShareUrl.nanoid,
+            ),
         ).rejects.toThrowError(ForbiddenError);
     });
 });

--- a/packages/backend/src/services/ShareService/ShareService.ts
+++ b/packages/backend/src/services/ShareService/ShareService.ts
@@ -1,5 +1,7 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
+    assertIsAccountWithOrg,
     ForbiddenError,
     isUserWithOrg,
     NotFoundError,
@@ -42,16 +44,14 @@ export class ShareService extends BaseService {
         };
     }
 
-    async getShareUrl(user: SessionUser, nanoid: string): Promise<ShareUrl> {
-        if (!isUserWithOrg(user)) {
-            throw new ForbiddenError('User is not part of an organization');
-        }
+    async getShareUrl(account: Account, nanoid: string): Promise<ShareUrl> {
+        assertIsAccountWithOrg(account);
         const shareUrl = await this.shareModel.getSharedUrl(nanoid);
         if (!shareUrl.organizationUuid) {
             throw new NotFoundError('Shared link does not exist');
         }
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'view',
@@ -64,11 +64,11 @@ export class ShareService extends BaseService {
             throw new ForbiddenError();
         }
         this.analytics.track({
-            userId: user.userUuid,
+            userId: account.user.id,
             event: 'share_url.used',
             properties: {
                 path: shareUrl.path,
-                organizationId: user.organizationUuid,
+                organizationId: account.organization.organizationUuid,
             },
         });
         return this.shareUrlWithHost(shareUrl);

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     ForbiddenError,
     NotFoundError,
     SessionUser,
@@ -104,11 +105,11 @@ export class SlackIntegrationService<
         return response;
     }
 
-    async deleteInstallationFromOrganizationUuid(user: SessionUser) {
-        const organizationUuid = user?.organizationUuid;
+    async deleteInstallationFromOrganizationUuid(account: Account) {
+        const { organizationUuid } = account.organization;
         if (!organizationUuid) throw new ForbiddenError();
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'manage',
@@ -124,7 +125,7 @@ export class SlackIntegrationService<
 
         this.analytics.track({
             event: 'share_slack.delete',
-            userId: user.userUuid,
+            userId: account.user.id,
             properties: {
                 organizationId: organizationUuid,
             },

--- a/packages/backend/src/services/SpotlightService/SpotlightService.ts
+++ b/packages/backend/src/services/SpotlightService/SpotlightService.ts
@@ -2,7 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     NotFoundError,
-    type SessionUser,
+    type Account,
     type SpotlightTableConfig,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -35,12 +35,12 @@ export class SpotlightService extends BaseService {
     }
 
     async createSpotlightTableConfig(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         tableConfig: Pick<SpotlightTableConfig, 'columnConfig'>,
     ): Promise<void> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'manage',
@@ -64,11 +64,11 @@ export class SpotlightService extends BaseService {
     }
 
     async getSpotlightTableConfig(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
     ): Promise<SpotlightTableConfig> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'view',
@@ -100,11 +100,11 @@ export class SpotlightService extends BaseService {
     }
 
     async resetSpotlightTableConfig(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
     ): Promise<void> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'manage',


### PR DESCRIPTION
## Summary

Part of [SPK-416](https://linear.app/lightdash/issue/SPK-416). Migrates the audited methods of leaf services (single-controller, no `SpacePermissionService` cascade) from `user: SessionUser` → `account: Account`.

Stacked on #22503.

## Services migrated (audited methods only)

| Service | Method(s) |
|---|---|
| ShareService | `getShareUrl` |
| ProjectParametersService | `findProjectParametersPaginated` |
| GdriveService | `scheduleUploadGsheet` |
| SlackIntegrationService | `deleteInstallationFromOrganizationUuid` |
| DeployService | `startDeploySession` |
| CsvService | `scheduleExportCsvDashboard` |
| ProjectCompileLogService | `getProjectCompileLogs`, `getProjectCompileLogByJob` |
| AnalyticsService | `getUserActivity`, `exportUserActivityRawCsv` |
| SpotlightService | `createSpotlightTableConfig`, `getSpotlightTableConfig`, `resetSpotlightTableConfig` |

Plus subclass override: **CommercialSlackIntegrationService.deleteInstallationFromOrganizationUuid** (matches base signature).

## Property migrations

- `user.organizationUuid` → `account.organization.organizationUuid`
- `user.userUuid` → `account.user.id`
- `isUserWithOrg(user)` (throws ForbiddenError on false) → `assertIsAccountWithOrg(account)` (throws same error)

## Controllers updated

- `shareController` (`req.user!` → `req.account!`)
- `slackController` (deleteInstallation only)
- `googleDriveController`
- `v2/DeployController` (startDeploySession only)
- `v2/ParametersController` (findProjectParametersPaginated only)
- `routers/dashboardRouter` (scheduleExportCsvDashboard only)
- `projectCompileLogController`
- `userActivityController`
- `spotlightController`

## Tests

- ShareService.test.ts updated to pass `Account` (built via `fromSession`) instead of `SessionUser`. New `Account` and `AccountFromAnotherOrg` exports added to `ShareService.mock.ts`.

## Skipped (deferred to later PRs)

- **SearchService, PinningService, FavoritesService, UnfurlService** — all call `SpacePermissionService` (which still takes `SessionUser`); migration must wait for SpacePermissionService conversion.
- **FunnelService** — its audited helper is called from methods that pass `user` to `projectService.runSqlQuery` (still SessionUser-form).
- **GitlabAppService, GithubAppService** — audited helper (`canManageOrg`) is called from many other methods that take `user`; converting requires changing their signatures, larger scope.

These remaining services + SpacePermissionService will be batched into the next leaf bundle PR.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend test:dev:nowatch ShareService` — passes
- [ ] CI green