### PR TITLE
feat(permissions): gate SQL-authored field writes

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.sqlAuthoredFields.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.sqlAuthoredFields.test.ts
@@ -1,0 +1,124 @@
+import { Ability } from '@casl/ability';
+import {
+    ChartType,
+    CustomDimensionType,
+    CustomSqlQueryForbiddenError,
+    DimensionType,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    type ChartAsCode,
+    type CustomSqlDimension,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { ContentVerificationModel } from '../../models/ContentVerificationModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SavedSqlModel } from '../../models/SavedSqlModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { PromoteService } from '../PromoteService/PromoteService';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { CoderService } from './CoderService';
+
+const organizationUuid = 'org-uuid';
+const projectUuid = 'project-uuid';
+
+const sqlCustomDim: CustomSqlDimension = {
+    id: 'dim-1',
+    name: 'Bucketed amount',
+    type: CustomDimensionType.SQL,
+    table: 'orders',
+    sql: 'CASE WHEN x > 0 THEN 1 ELSE 0 END',
+    dimensionType: DimensionType.NUMBER,
+};
+
+const buildChartAsCode = (
+    customDimensions: CustomSqlDimension[] = [],
+): ChartAsCode => ({
+    name: 'test chart',
+    description: '',
+    tableName: 'orders',
+    slug: 'test-chart',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: [],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+        customDimensions,
+    },
+    chartConfig: { type: ChartType.CARTESIAN, config: undefined },
+    spaceSlug: 'jaffle-shop',
+    dashboardSlug: undefined,
+    version: 1,
+});
+
+const baseUser = {
+    userUuid: 'user-uuid',
+    email: 'user@test.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid,
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.EDITOR,
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const userWithoutCustomFields = {
+    ...baseUser,
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'ContentAsCode', action: 'manage' },
+    ]),
+};
+
+const projectModel = {
+    get: jest.fn(async () => ({ projectUuid, organizationUuid })),
+};
+
+const savedChartModel = {
+    find: jest.fn(async () => []),
+};
+
+describe('CoderService.upsertChart — SQL-authored field gate', () => {
+    const service = new CoderService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        savedSqlModel: {} as unknown as SavedSqlModel,
+        dashboardModel: {} as unknown as DashboardModel,
+        spaceModel: {} as unknown as SpaceModel,
+        schedulerClient: {} as unknown as SchedulerClient,
+        promoteService: {} as unknown as PromoteService,
+        spacePermissionService: {} as unknown as SpacePermissionService,
+        contentVerificationModel: {} as unknown as ContentVerificationModel,
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('throws CustomSqlQueryForbiddenError when chart contains SQL custom fields and user lacks manage:CustomFields', async () => {
+        await expect(
+            service.upsertChart(
+                userWithoutCustomFields,
+                projectUuid,
+                'test-chart',
+                buildChartAsCode([sqlCustomDim]),
+            ),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+        expect(savedChartModel.find).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -52,6 +52,7 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { assertCanWriteSqlAuthoredFields } from '../../utils/SqlAuthoredFieldsGuard';
 import { BaseService } from '../BaseService';
 import { PromoteService } from '../PromoteService/PromoteService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -1096,6 +1097,15 @@ export class CoderService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
+
+        assertCanWriteSqlAuthoredFields({
+            ability: auditedAbility,
+            organizationUuid: project.organizationUuid,
+            projectUuid: project.projectUuid,
+            metricQuery: chartAsCode.metricQuery,
+            errorMessage:
+                'User cannot upload charts containing custom SQL fields',
+        });
 
         // Default optional fields when missing (e.g. user-authored YAML)
         const chartWithDefaults = {

--- a/packages/backend/src/services/PromoteService/PromoteService.sqlAuthoredFields.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.sqlAuthoredFields.test.ts
@@ -1,0 +1,119 @@
+import { Ability } from '@casl/ability';
+import {
+    CustomDimensionType,
+    CustomSqlQueryForbiddenError,
+    DimensionType,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    PromotionAction,
+    type CustomSqlDimension,
+    type PromotionChanges,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SavedSqlModel } from '../../models/SavedSqlModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { PromoteService } from './PromoteService';
+import { promotedChart } from './PromoteService.mock';
+
+const sqlCustomDim: CustomSqlDimension = {
+    id: 'dim-1',
+    name: 'Bucketed amount',
+    type: CustomDimensionType.SQL,
+    table: 'orders',
+    sql: 'CASE WHEN x > 0 THEN 1 ELSE 0 END',
+    dimensionType: DimensionType.NUMBER,
+};
+
+const buildPromotionChanges = (
+    customDimensions: CustomSqlDimension[],
+): PromotionChanges => ({
+    spaces: [],
+    dashboards: [],
+    charts: [
+        {
+            action: PromotionAction.CREATE,
+            data: {
+                ...promotedChart.chart,
+                metricQuery: {
+                    ...promotedChart.chart.metricQuery,
+                    customDimensions,
+                },
+                spaceSlug: 'jaffle-shop',
+                spacePath: 'jaffle_shop',
+                oldUuid: promotedChart.chart.uuid,
+            },
+        },
+    ],
+});
+
+const baseUser = {
+    userUuid: 'user-uuid',
+    email: 'user@test.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid: promotedChart.chart.organizationUuid,
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.EDITOR,
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const userWithoutCustomFields = {
+    ...baseUser,
+    ability: new Ability<PossibleAbilities>([]),
+};
+
+describe('PromoteService.upsertCharts — SQL-authored field gate', () => {
+    const savedChartModel = {
+        update: jest.fn(),
+        create: jest.fn(),
+        createVersion: jest.fn(),
+    };
+
+    const service = new PromoteService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: {} as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        savedSqlModel: {} as unknown as SavedSqlModel,
+        spaceModel: {} as unknown as SpaceModel,
+        dashboardModel: {} as unknown as DashboardModel,
+        spacePermissionService: {} as unknown as SpacePermissionService,
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('throws CustomSqlQueryForbiddenError when any chart in the batch has SQL fields and user lacks manage:CustomFields', async () => {
+        await expect(
+            service.upsertCharts(
+                userWithoutCustomFields,
+                buildPromotionChanges([sqlCustomDim]),
+            ),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+        expect(savedChartModel.create).not.toHaveBeenCalled();
+        expect(savedChartModel.update).not.toHaveBeenCalled();
+    });
+
+    it('enumerates offending chart names in the error message', async () => {
+        const changes = buildPromotionChanges([sqlCustomDim]);
+        changes.charts[0].data.name = 'Naughty chart';
+
+        await expect(
+            service.upsertCharts(userWithoutCustomFields, changes),
+        ).rejects.toThrow(/Naughty chart/);
+    });
+});

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -2,11 +2,13 @@ import { Ability, subject } from '@casl/ability';
 import {
     AlreadyExistsError,
     ChartSummary,
+    CustomSqlQueryForbiddenError,
     DashboardDAO,
     DashboardTileTypes,
     ForbiddenError,
     getDeepestPaths,
     getErrorMessage,
+    hasSqlAuthoredFields,
     isDashboardChartTileType,
     isSubPath,
     NotFoundError,
@@ -772,6 +774,32 @@ export class PromoteService extends BaseService {
         promotedDashboardUuid?: string, // dashboard uuid if chart belongs to dashboard
     ): Promise<PromotionChanges> {
         const { charts } = promotionChanges;
+
+        const auditedAbility = this.createAuditedAbility(user);
+        const blockedCharts = charts
+            .filter(
+                (change) =>
+                    change.action === PromotionAction.CREATE ||
+                    change.action === PromotionAction.UPDATE,
+            )
+            .map((change) => change.data)
+            .filter(
+                (chart) =>
+                    hasSqlAuthoredFields(chart.metricQuery) &&
+                    auditedAbility.cannot(
+                        'manage',
+                        subject('CustomFields', {
+                            organizationUuid: chart.organizationUuid,
+                            projectUuid: chart.projectUuid,
+                        }),
+                    ),
+            );
+        if (blockedCharts.length > 0) {
+            const names = blockedCharts.map((chart) => chart.name).join(', ');
+            throw new CustomSqlQueryForbiddenError(
+                `User cannot promote charts containing custom SQL fields: ${names}`,
+            );
+        }
 
         const existingCharts = charts.filter(
             (change) => change.action === PromotionAction.NO_CHANGES,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.sqlAuthoredFields.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.sqlAuthoredFields.test.ts
@@ -1,0 +1,204 @@
+import { Ability } from '@casl/ability';
+import {
+    ChartType,
+    CustomDimensionType,
+    CustomSqlQueryForbiddenError,
+    DimensionType,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    TableCalculationType,
+    type CreateSavedChart,
+    type CustomSqlDimension,
+    type SqlTableCalculation,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
+import { SlackClient } from '../../clients/Slack/SlackClient';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ContentVerificationModel } from '../../models/ContentVerificationModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { PinnedListModel } from '../../models/PinnedListModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SchedulerModel } from '../../models/SchedulerModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { PermissionsService } from '../PermissionsService/PermissionsService';
+import { SchedulerService } from '../SchedulerService/SchedulerService';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { UserService } from '../UserService';
+import { SavedChartService } from './SavedChartService';
+
+const organizationUuid = 'org-uuid';
+const projectUuid = 'project-uuid';
+const spaceUuid = 'space-uuid';
+
+const baseMetricQuery = {
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [] as SqlTableCalculation[],
+    customDimensions: [] as CustomSqlDimension[],
+};
+
+const sqlCustomDim: CustomSqlDimension = {
+    id: 'dim-1',
+    name: 'Bucketed amount',
+    type: CustomDimensionType.SQL,
+    table: 'orders',
+    sql: 'CASE WHEN x > 0 THEN 1 ELSE 0 END',
+    dimensionType: DimensionType.NUMBER,
+};
+
+const sqlTableCalc: SqlTableCalculation = {
+    name: 'doubled',
+    displayName: 'doubled',
+    sql: '${orders.amount} * 2',
+    type: TableCalculationType.NUMBER,
+};
+
+const buildChart = (
+    overrides: Partial<typeof baseMetricQuery> = {},
+): CreateSavedChart => ({
+    name: 'test chart',
+    tableName: 'orders',
+    metricQuery: { ...baseMetricQuery, ...overrides },
+    chartConfig: { type: ChartType.CARTESIAN, config: undefined },
+    tableConfig: { columnOrder: [] },
+    spaceUuid,
+    dashboardUuid: null,
+});
+
+const baseUser = {
+    userUuid: 'user-uuid',
+    email: 'user@test.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid,
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.EDITOR,
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const userWithoutCustomFields = {
+    ...baseUser,
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'SavedChart', action: ['view', 'create', 'update'] },
+    ]),
+};
+
+const userWithCustomFields = {
+    ...baseUser,
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'SavedChart', action: ['view', 'create', 'update'] },
+        { subject: 'CustomFields', action: 'manage' },
+    ]),
+};
+
+const savedChartModel = {
+    create: jest.fn(async () => ({
+        ...buildChart(),
+        uuid: 'chart-uuid',
+        organizationUuid,
+        projectUuid,
+        spaceUuid,
+        spaceName: 'space',
+        pinnedListUuid: null,
+        pinnedListOrder: null,
+        dashboardUuid: null,
+        dashboardName: null,
+        colorPalette: [],
+        slug: 'test-chart',
+        verification: null,
+        updatedAt: new Date(),
+    })),
+};
+
+const projectModel = {
+    getSummary: jest.fn(async () => ({ organizationUuid, projectUuid })),
+    getExploreFromCache: jest.fn(async () => null),
+};
+
+const spacePermissionService = {
+    getFirstViewableSpaceUuid: jest.fn(async () => spaceUuid),
+    getSpaceAccessContext: jest.fn(async () => ({
+        organizationUuid,
+        projectUuid,
+        inheritsFromOrgOrProject: true,
+        access: [],
+    })),
+};
+
+describe('SavedChartService.create — SQL-authored field gate', () => {
+    const service = new SavedChartService({
+        analytics: analyticsMock,
+        lightdashConfig: lightdashConfigMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        spaceModel: {} as unknown as SpaceModel,
+        analyticsModel: {} as unknown as AnalyticsModel,
+        pinnedListModel: {} as unknown as PinnedListModel,
+        schedulerModel: {} as unknown as SchedulerModel,
+        schedulerService: {} as unknown as SchedulerService,
+        schedulerClient: {} as unknown as SchedulerClient,
+        slackClient: {} as unknown as SlackClient,
+        dashboardModel: {} as unknown as DashboardModel,
+        catalogModel: {} as unknown as CatalogModel,
+        permissionsService: {} as unknown as PermissionsService,
+        googleDriveClient: {} as unknown as GoogleDriveClient,
+        userService: {} as unknown as UserService,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+        contentVerificationModel: {} as unknown as ContentVerificationModel,
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('throws CustomSqlQueryForbiddenError when chart contains a SQL custom dimension and user lacks manage:CustomFields', async () => {
+        await expect(
+            service.create(
+                userWithoutCustomFields,
+                projectUuid,
+                buildChart({ customDimensions: [sqlCustomDim] }),
+            ),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+        expect(savedChartModel.create).not.toHaveBeenCalled();
+    });
+
+    it('throws CustomSqlQueryForbiddenError when chart contains a SQL table calculation and user lacks manage:CustomFields', async () => {
+        await expect(
+            service.create(
+                userWithoutCustomFields,
+                projectUuid,
+                buildChart({ tableCalculations: [sqlTableCalc] }),
+            ),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+        expect(savedChartModel.create).not.toHaveBeenCalled();
+    });
+
+    it('allows creation when user has manage:CustomFields', async () => {
+        await expect(
+            service.create(
+                userWithCustomFields,
+                projectUuid,
+                buildChart({ customDimensions: [sqlCustomDim] }),
+            ),
+        ).resolves.toBeDefined();
+        expect(savedChartModel.create).toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -79,6 +79,7 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { assertCanWriteSqlAuthoredFields } from '../../utils/SqlAuthoredFieldsGuard';
 import { BaseService } from '../BaseService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
@@ -1239,22 +1240,12 @@ export class SavedChartService
             throw new ForbiddenError();
         }
 
-        if (
-            savedChart.metricQuery.tableCalculations.some(
-                isSqlTableCalculation,
-            ) &&
-            auditedAbility.cannot(
-                'manage',
-                subject('CustomFields', {
-                    organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'User cannot save queries with custom SQL table calculations',
-            );
-        }
+        assertCanWriteSqlAuthoredFields({
+            ability: auditedAbility,
+            organizationUuid,
+            projectUuid,
+            metricQuery: savedChart.metricQuery,
+        });
 
         if (!resolvedSpaceUuid && !savedChart.dashboardUuid) {
             throw new Error(

--- a/packages/backend/src/utils/SqlAuthoredFieldsGuard.test.ts
+++ b/packages/backend/src/utils/SqlAuthoredFieldsGuard.test.ts
@@ -1,0 +1,141 @@
+import { type Ability } from '@casl/ability';
+import {
+    CustomDimensionType,
+    CustomSqlQueryForbiddenError,
+    DimensionType,
+    TableCalculationType,
+    type CustomSqlDimension,
+    type MetricQuery,
+    type SqlTableCalculation,
+} from '@lightdash/common';
+import { type CaslAuditWrapper } from '../logging/caslAuditWrapper';
+import { assertCanWriteSqlAuthoredFields } from './SqlAuthoredFieldsGuard';
+
+const baseMetricQuery: Pick<
+    MetricQuery,
+    'customDimensions' | 'tableCalculations'
+> = {
+    customDimensions: [],
+    tableCalculations: [],
+};
+
+const sqlCustomDim: CustomSqlDimension = {
+    id: 'dim-1',
+    name: 'Bucketed amount',
+    type: CustomDimensionType.SQL,
+    table: 'orders',
+    sql: "CASE WHEN amount > 100 THEN 'big' ELSE 'small' END",
+    dimensionType: DimensionType.STRING,
+};
+
+const sqlTableCalc: SqlTableCalculation = {
+    name: 'doubled',
+    displayName: 'doubled',
+    sql: '${orders.amount} * 2',
+    type: TableCalculationType.NUMBER,
+};
+
+const buildAbility = (allowed: boolean): CaslAuditWrapper<Ability> =>
+    ({
+        cannot: jest.fn(() => !allowed),
+    }) as unknown as CaslAuditWrapper<Ability>;
+
+describe('assertCanWriteSqlAuthoredFields', () => {
+    const args = {
+        organizationUuid: 'org-uuid',
+        projectUuid: 'project-uuid',
+    };
+
+    it('does not throw when metricQuery has no SQL-authored fields', () => {
+        expect(() =>
+            assertCanWriteSqlAuthoredFields({
+                ...args,
+                ability: buildAbility(false),
+                metricQuery: baseMetricQuery,
+            }),
+        ).not.toThrow();
+    });
+
+    it('does not throw when metricQuery is null or undefined', () => {
+        expect(() =>
+            assertCanWriteSqlAuthoredFields({
+                ...args,
+                ability: buildAbility(false),
+                metricQuery: null,
+            }),
+        ).not.toThrow();
+        expect(() =>
+            assertCanWriteSqlAuthoredFields({
+                ...args,
+                ability: buildAbility(false),
+                metricQuery: undefined,
+            }),
+        ).not.toThrow();
+    });
+
+    it('throws when metricQuery has a SQL custom dimension and user lacks scope', () => {
+        expect(() =>
+            assertCanWriteSqlAuthoredFields({
+                ...args,
+                ability: buildAbility(false),
+                metricQuery: {
+                    ...baseMetricQuery,
+                    customDimensions: [sqlCustomDim],
+                },
+            }),
+        ).toThrow(CustomSqlQueryForbiddenError);
+    });
+
+    it('does not throw when metricQuery has a SQL custom dimension and user has scope', () => {
+        expect(() =>
+            assertCanWriteSqlAuthoredFields({
+                ...args,
+                ability: buildAbility(true),
+                metricQuery: {
+                    ...baseMetricQuery,
+                    customDimensions: [sqlCustomDim],
+                },
+            }),
+        ).not.toThrow();
+    });
+
+    it('throws when metricQuery has a SQL table calculation and user lacks scope', () => {
+        expect(() =>
+            assertCanWriteSqlAuthoredFields({
+                ...args,
+                ability: buildAbility(false),
+                metricQuery: {
+                    ...baseMetricQuery,
+                    tableCalculations: [sqlTableCalc],
+                },
+            }),
+        ).toThrow(CustomSqlQueryForbiddenError);
+    });
+
+    it('does not throw when metricQuery has a SQL table calculation and user has scope', () => {
+        expect(() =>
+            assertCanWriteSqlAuthoredFields({
+                ...args,
+                ability: buildAbility(true),
+                metricQuery: {
+                    ...baseMetricQuery,
+                    tableCalculations: [sqlTableCalc],
+                },
+            }),
+        ).not.toThrow();
+    });
+
+    it('uses the supplied error message when provided', () => {
+        expect(() =>
+            assertCanWriteSqlAuthoredFields({
+                ...args,
+                ability: buildAbility(false),
+                metricQuery: {
+                    ...baseMetricQuery,
+                    customDimensions: [sqlCustomDim],
+                },
+                errorMessage: 'custom write-context message',
+            }),
+        ).toThrow('custom write-context message');
+    });
+});

--- a/packages/backend/src/utils/SqlAuthoredFieldsGuard.ts
+++ b/packages/backend/src/utils/SqlAuthoredFieldsGuard.ts
@@ -1,0 +1,36 @@
+import { subject, type Ability } from '@casl/ability';
+import {
+    CustomSqlQueryForbiddenError,
+    hasSqlAuthoredFields,
+    type MetricQuery,
+} from '@lightdash/common';
+import { type CaslAuditWrapper } from '../logging/caslAuditWrapper';
+
+export const assertCanWriteSqlAuthoredFields = ({
+    ability,
+    organizationUuid,
+    projectUuid,
+    metricQuery,
+    errorMessage,
+}: {
+    ability: CaslAuditWrapper<Ability>;
+    organizationUuid: string;
+    projectUuid: string;
+    metricQuery:
+        | Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>
+        | null
+        | undefined;
+    errorMessage?: string;
+}): void => {
+    if (!hasSqlAuthoredFields(metricQuery)) return;
+    if (
+        ability.cannot(
+            'manage',
+            subject('CustomFields', { organizationUuid, projectUuid }),
+        )
+    ) {
+        throw new CustomSqlQueryForbiddenError(
+            errorMessage ?? 'User cannot save queries with custom SQL fields',
+        );
+    }
+};


### PR DESCRIPTION
Closes part 1 of [PROD-7028](https://linear.app/lightdash/issue/PROD-7028).

## What this fixes

Three persistence paths today write a chart's `metricQuery` without checking that the caller holds `manage:CustomFields` — meaning a user with the right combination of lower-tier scopes can author or upload charts containing custom SQL dimensions or SQL table calculations and bypass the intended gate.

| Path | Today | After this PR |
| --- | --- | --- |
| `SavedChartService.create()` | Gates SQL table calcs only; **misses custom SQL dimensions** | Gates both via the shared guard |
| `CoderService.upsertChart()` | Only checks `manage:ContentAsCode` | Also requires `manage:CustomFields` if payload contains custom SQL fields |
| `PromoteService.upsertCharts()` | No `manage:CustomFields` check at all | Walks the whole batch, fails atomically with all offending chart names enumerated |

## How

New shared utility `assertCanWriteSqlAuthoredFields` in `packages/backend/src/utils/SqlAuthoredFieldsGuard.ts`. Wraps `hasSqlAuthoredFields()` from `@lightdash/common` (covers both custom SQL dims and SQL table calcs) and the `manage:CustomFields` CASL check. Throws `CustomSqlQueryForbiddenError` with a write-context message.

Strict semantics — any SQL-authored field requires the scope, no diff-based exemption. The existing `assertCanRunSqlAuthoredFields` in `AsyncQueryService` keeps its diff-based exemption for the run-side (re-running an existing saved chart's SQL is intentionally allowed without the scope; modifying it is not).

## Who's affected

| User class | Holds `manage:CustomFields`? | Affected? |
| --- | --- | --- |
| Service accounts (CI/CD, default org-admin) | Yes | No |
| Developer system role | Yes | No |
| Editor / Viewer system roles | No, but no `manage:ContentAsCode` either | No (cannot reach Coder/Promote) |
| Custom role: ContentAsCode + CustomFields | Yes | No |
| Custom role: ContentAsCode **without** CustomFields | No | **Yes** — cannot upload/promote charts with SQL fields. *This is the bypass we are closing.* |
| Cross-project promotion: scope in source, not destination | Mixed | **Yes** — cannot promote SQL fields into a destination where authoring would be denied. Correct-by-spec. |

In practice, chart-as-code and promotion are run by service accounts (org-admin) or Developer-equivalent users — both already hold the scope. No known customer configurations rely on the affected behaviour.

## Test plan

- [x] `pnpm -F backend lint` — clean
- [x] `pnpm -F backend typecheck` — only pre-existing errors (verified by stashing changes and re-running on bare `main`)
- [x] `pnpm -F backend exec jest --testPathPattern='SqlAuthoredFieldsGuard|sqlAuthoredFields|SavedChartService|CoderService|PromoteService'` — all 55 tests pass (1 unit suite on the new utility + 1 integration case per call site, plus regression coverage on the existing SavedChartService suites)
- [ ] Manual: as Developer, creating a chart with a custom SQL dim still works end-to-end
- [ ] Manual: as a custom role with only `manage:ContentAsCode`, `lightdash upload` of a chart containing a custom SQL dim returns 403 with the new error message
- [ ] Manual: cross-project promotion of a chart with custom SQL into a destination project where the user lacks `manage:CustomFields` returns 403 listing the offending chart name

## Follow-ups in the same Linear thread

- **PR 2 (#22510)** — read-side info disclosure (strip in `SavedChartService.get`, fail in `CoderService.getCharts` and `PromoteService.getPromote*Diff`)
- **PR 3 (#22511)** — drill-into post-revocation re-check in `AsyncQueryService.executeAsyncUnderlyingDataQuery`