### PR TITLE
feat(permissions): strip or fail on SQL-authored field reads

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.sqlAuthoredFields.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.sqlAuthoredFields.test.ts
@@ -6,8 +6,10 @@ import {
     DimensionType,
     OrganizationMemberRole,
     PossibleAbilities,
+    TableCalculationType,
     type ChartAsCode,
     type CustomSqlDimension,
+    type SqlTableCalculation,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
@@ -120,5 +122,118 @@ describe('CoderService.upsertChart — SQL-authored field gate', () => {
             ),
         ).rejects.toThrow(CustomSqlQueryForbiddenError);
         expect(savedChartModel.find).not.toHaveBeenCalled();
+    });
+});
+
+const sqlTableCalc: SqlTableCalculation = {
+    name: 'doubled',
+    displayName: 'doubled',
+    sql: '${orders.amount} * 2',
+    type: TableCalculationType.NUMBER,
+};
+
+const buildSavedChart = (
+    overrides: {
+        customDimensions?: CustomSqlDimension[];
+        tableCalculations?: SqlTableCalculation[];
+    } = {},
+) => ({
+    uuid: 'saved-chart-uuid',
+    organizationUuid,
+    projectUuid,
+    spaceUuid: 'space-uuid',
+    spaceName: 'space',
+    name: 'Naughty chart',
+    description: '',
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: [],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: overrides.tableCalculations ?? [],
+        customDimensions: overrides.customDimensions ?? [],
+    },
+    chartConfig: { type: ChartType.CARTESIAN, config: undefined },
+    tableConfig: { columnOrder: [] },
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    dashboardUuid: null,
+    dashboardName: null,
+    colorPalette: [],
+    slug: 'naughty-chart',
+    verification: null,
+    updatedAt: new Date(),
+});
+
+const adminUserWithoutCustomFields = {
+    ...baseUser,
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'ContentAsCode', action: 'manage' },
+        { subject: 'Project', action: 'manage' },
+    ]),
+};
+
+describe('CoderService.getCharts — SQL-authored field gate', () => {
+    const savedChartModelGetCharts = {
+        find: jest.fn(async () => [
+            { uuid: 'saved-chart-uuid', spaceUuid: 'space-uuid' },
+        ]),
+        get: jest.fn(async () =>
+            buildSavedChart({
+                customDimensions: [sqlCustomDim],
+                tableCalculations: [sqlTableCalc],
+            }),
+        ),
+        getSlugsForUuids: jest.fn(async () => ['naughty-chart']),
+    };
+
+    const dashboardModelMock = {
+        getSlugsForUuids: jest.fn(async () => ({})),
+    };
+
+    const spaceModelMock = {
+        find: jest.fn(async () => [
+            {
+                uuid: 'space-uuid',
+                projectUuid,
+                organizationUuid,
+                path: 'jaffle_shop',
+            },
+        ]),
+    };
+
+    const contentVerificationModelMock = {
+        getByContentUuids: jest.fn(async () => new Map()),
+    };
+
+    const service = new CoderService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartModel: savedChartModelGetCharts as unknown as SavedChartModel,
+        savedSqlModel: {} as unknown as SavedSqlModel,
+        dashboardModel: dashboardModelMock as unknown as DashboardModel,
+        spaceModel: spaceModelMock as unknown as SpaceModel,
+        schedulerClient: {} as unknown as SchedulerClient,
+        promoteService: {} as unknown as PromoteService,
+        spacePermissionService: {} as unknown as SpacePermissionService,
+        contentVerificationModel:
+            contentVerificationModelMock as unknown as ContentVerificationModel,
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('throws CustomSqlQueryForbiddenError listing offending chart names when user lacks manage:CustomFields', async () => {
+        await expect(
+            service.getCharts(adminUserWithoutCustomFields, projectUuid),
+        ).rejects.toThrow(/Naughty chart/);
+        expect(
+            contentVerificationModelMock.getByContentUuids,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -9,6 +9,7 @@ import {
     ContentType,
     CreateSavedChart,
     currentVersion,
+    CustomSqlQueryForbiddenError,
     DashboardAsCode,
     DashboardAsCodeInternalization,
     DashboardDAO,
@@ -52,7 +53,10 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
-import { assertCanWriteSqlAuthoredFields } from '../../utils/SqlAuthoredFieldsGuard';
+import {
+    assertCanAccessSqlAuthoredFields,
+    hasForbiddenSqlAuthoredFields,
+} from '../../utils/SqlAuthoredFieldsGuard';
 import { BaseService } from '../BaseService';
 import { PromoteService } from '../PromoteService/PromoteService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -813,6 +817,21 @@ export class CoderService extends BaseService {
         );
         const charts = await Promise.all(chartPromises);
 
+        const blockedCharts = charts.filter((chart) =>
+            hasForbiddenSqlAuthoredFields({
+                ability: auditedAbility,
+                organizationUuid: chart.organizationUuid,
+                projectUuid: chart.projectUuid,
+                metricQuery: chart.metricQuery,
+            }),
+        );
+        if (blockedCharts.length > 0) {
+            const names = blockedCharts.map((chart) => chart.name).join(', ');
+            throw new CustomSqlQueryForbiddenError(
+                `User cannot download charts containing custom SQL fields: ${names}`,
+            );
+        }
+
         // get all spaces to map  dashboardSlug
         const dashboardUuids = charts.reduce<string[]>((acc, chart) => {
             if (chart.dashboardUuid) {
@@ -1098,7 +1117,7 @@ export class CoderService extends BaseService {
             throw new ForbiddenError();
         }
 
-        assertCanWriteSqlAuthoredFields({
+        assertCanAccessSqlAuthoredFields({
             ability: auditedAbility,
             organizationUuid: project.organizationUuid,
             projectUuid: project.projectUuid,

--- a/packages/backend/src/services/PromoteService/PromoteService.sqlAuthoredFields.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.sqlAuthoredFields.test.ts
@@ -117,3 +117,79 @@ describe('PromoteService.upsertCharts — SQL-authored field gate', () => {
         ).rejects.toThrow(/Naughty chart/);
     });
 });
+
+describe('PromoteService.getPromoteChartDiff — SQL-authored field gate', () => {
+    const upstreamProjectUuid = 'upstream-project-uuid';
+    const chartWithSqlFields = {
+        ...promotedChart.chart,
+        name: 'Naughty chart',
+        metricQuery: {
+            ...promotedChart.chart.metricQuery,
+            customDimensions: [sqlCustomDim],
+        },
+    };
+
+    const savedChartModel = {
+        getSummary: jest.fn(async () => ({
+            projectUuid: promotedChart.chart.projectUuid,
+        })),
+        get: jest.fn(async () => chartWithSqlFields),
+        find: jest.fn(async () => []),
+    };
+    const projectModel = {
+        getSummary: jest.fn(async () => ({ upstreamProjectUuid })),
+    };
+    const spaceModel = {
+        getSpaceSummary: jest.fn(async () => promotedChart.space),
+        getSpaceAncestors: jest.fn(async () => []),
+        find: jest.fn(async () => []),
+    };
+    const spacePermissionService = {
+        getSpaceAccessContext: jest.fn(async () => ({
+            organizationUuid: promotedChart.chart.organizationUuid,
+            projectUuid: promotedChart.chart.projectUuid,
+            inheritsFromOrgOrProject: true,
+            access: [],
+        })),
+    };
+
+    const service = new PromoteService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        savedSqlModel: {} as unknown as SavedSqlModel,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        dashboardModel: {} as unknown as DashboardModel,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('throws CustomSqlQueryForbiddenError when source chart contains SQL fields and user lacks manage:CustomFields at destination', async () => {
+        await expect(
+            service.getPromoteChartDiff(
+                userWithoutCustomFields,
+                promotedChart.chart.uuid,
+            ),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+    });
+
+    it('does not throw when user has manage:CustomFields', async () => {
+        const userWithCustomFields = {
+            ...userWithoutCustomFields,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'CustomFields', action: 'manage' },
+            ]),
+        };
+        await expect(
+            service.getPromoteChartDiff(
+                userWithCustomFields,
+                promotedChart.chart.uuid,
+            ),
+        ).resolves.toBeDefined();
+    });
+});

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -8,7 +8,6 @@ import {
     ForbiddenError,
     getDeepestPaths,
     getErrorMessage,
-    hasSqlAuthoredFields,
     isDashboardChartTileType,
     isSubPath,
     NotFoundError,
@@ -36,6 +35,10 @@ import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SpaceModel } from '../../models/SpaceModel';
+import {
+    assertCanAccessSqlAuthoredFields,
+    hasForbiddenSqlAuthoredFields,
+} from '../../utils/SqlAuthoredFieldsGuard';
 import { BaseService } from '../BaseService';
 import type {
     SpaceAccessContextForCasl,
@@ -783,16 +786,13 @@ export class PromoteService extends BaseService {
                     change.action === PromotionAction.UPDATE,
             )
             .map((change) => change.data)
-            .filter(
-                (chart) =>
-                    hasSqlAuthoredFields(chart.metricQuery) &&
-                    auditedAbility.cannot(
-                        'manage',
-                        subject('CustomFields', {
-                            organizationUuid: chart.organizationUuid,
-                            projectUuid: chart.projectUuid,
-                        }),
-                    ),
+            .filter((chart) =>
+                hasForbiddenSqlAuthoredFields({
+                    ability: auditedAbility,
+                    organizationUuid: chart.organizationUuid,
+                    projectUuid: chart.projectUuid,
+                    metricQuery: chart.metricQuery,
+                }),
             );
         if (blockedCharts.length > 0) {
             const names = blockedCharts.map((chart) => chart.name).join(', ');
@@ -1155,6 +1155,16 @@ export class PromoteService extends BaseService {
             chartUuid,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
+        assertCanAccessSqlAuthoredFields({
+            ability: auditedAbility,
+            organizationUuid: promotedChart.chart.organizationUuid,
+            projectUuid: upstreamProjectUuid,
+            metricQuery: promotedChart.chart.metricQuery,
+            errorMessage:
+                'User cannot view promotion diff for charts containing custom SQL fields',
+        });
+
         const promotionChanges = await this.getChartChanges(
             promotedChart,
             upstreamChart,
@@ -1300,6 +1310,24 @@ export class PromoteService extends BaseService {
                 promotedDashboard,
                 upstreamDashboard,
             );
+
+        const auditedAbility = this.createAuditedAbility(user);
+        const blockedCharts = promotionChanges.charts
+            .map((change) => change.data)
+            .filter((chart) =>
+                hasForbiddenSqlAuthoredFields({
+                    ability: auditedAbility,
+                    organizationUuid: chart.organizationUuid,
+                    projectUuid: upstreamProjectUuid,
+                    metricQuery: chart.metricQuery,
+                }),
+            );
+        if (blockedCharts.length > 0) {
+            const names = blockedCharts.map((chart) => chart.name).join(', ');
+            throw new CustomSqlQueryForbiddenError(
+                `User cannot view promotion diff for dashboard charts containing custom SQL fields: ${names}`,
+            );
+        }
 
         return {
             ...promotionChanges,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.readSqlAuthoredFields.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.readSqlAuthoredFields.test.ts
@@ -1,0 +1,197 @@
+import { Ability } from '@casl/ability';
+import {
+    ChartType,
+    CustomDimensionType,
+    DimensionType,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    TableCalculationType,
+    type CustomSqlDimension,
+    type SqlTableCalculation,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { fromSession } from '../../auth/account';
+import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
+import { SlackClient } from '../../clients/Slack/SlackClient';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ContentVerificationModel } from '../../models/ContentVerificationModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { PinnedListModel } from '../../models/PinnedListModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SchedulerModel } from '../../models/SchedulerModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { PermissionsService } from '../PermissionsService/PermissionsService';
+import { SchedulerService } from '../SchedulerService/SchedulerService';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { UserService } from '../UserService';
+import { SavedChartService } from './SavedChartService';
+
+const organizationUuid = 'org-uuid';
+const projectUuid = 'project-uuid';
+const spaceUuid = 'space-uuid';
+const chartUuid = 'chart-uuid';
+
+const sqlCustomDim: CustomSqlDimension = {
+    id: 'dim-1',
+    name: 'Bucketed amount',
+    type: CustomDimensionType.SQL,
+    table: 'orders',
+    sql: 'CASE WHEN x > 0 THEN 1 ELSE 0 END',
+    dimensionType: DimensionType.NUMBER,
+};
+
+const sqlTableCalc: SqlTableCalculation = {
+    name: 'doubled',
+    displayName: 'doubled',
+    sql: '${orders.amount} * 2',
+    type: TableCalculationType.NUMBER,
+};
+
+const savedChartData = {
+    uuid: chartUuid,
+    organizationUuid,
+    projectUuid,
+    spaceUuid,
+    spaceName: 'space',
+    name: 'apple chart',
+    description: '',
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: [],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [sqlTableCalc],
+        customDimensions: [sqlCustomDim],
+    },
+    chartConfig: { type: ChartType.CARTESIAN, config: undefined },
+    tableConfig: { columnOrder: [] },
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    dashboardUuid: null,
+    dashboardName: null,
+    colorPalette: [],
+    slug: 'apple-chart',
+    verification: null,
+    updatedAt: new Date(),
+};
+
+const baseUser = {
+    userUuid: 'user-uuid',
+    email: 'user@test.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid,
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.VIEWER,
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const userWithoutCustomFields = {
+    ...baseUser,
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'SavedChart', action: ['view'] },
+    ]),
+};
+
+const userWithCustomFields = {
+    ...baseUser,
+    ability: new Ability<PossibleAbilities>([
+        { subject: 'SavedChart', action: ['view'] },
+        { subject: 'CustomFields', action: 'manage' },
+    ]),
+};
+
+const accountWithout = fromSession(userWithoutCustomFields, 'cookie');
+const accountWith = fromSession(userWithCustomFields, 'cookie');
+
+const savedChartModel = {
+    get: jest.fn(async () => savedChartData),
+};
+
+const spaceModel = {
+    getSpaceSummary: jest.fn(async () => ({
+        uuid: spaceUuid,
+        organizationUuid,
+        projectUuid,
+    })),
+};
+
+const spacePermissionService = {
+    getSpaceAccessContext: jest.fn(async () => ({
+        organizationUuid,
+        projectUuid,
+        inheritsFromOrgOrProject: true,
+        access: [],
+    })),
+};
+
+const analyticsModel = {
+    addChartViewEvent: jest.fn(async () => {}),
+};
+
+describe('SavedChartService.get — SQL-body strip on read', () => {
+    const service = new SavedChartService({
+        analytics: analyticsMock,
+        lightdashConfig: lightdashConfigMock,
+        projectModel: {
+            getExploreFromCache: jest.fn(async () => null),
+        } as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        analyticsModel: analyticsModel as unknown as AnalyticsModel,
+        pinnedListModel: {} as unknown as PinnedListModel,
+        schedulerModel: {} as unknown as SchedulerModel,
+        schedulerService: {} as unknown as SchedulerService,
+        schedulerClient: {} as unknown as SchedulerClient,
+        slackClient: {} as unknown as SlackClient,
+        dashboardModel: {} as unknown as DashboardModel,
+        catalogModel: {} as unknown as CatalogModel,
+        permissionsService: {} as unknown as PermissionsService,
+        googleDriveClient: {} as unknown as GoogleDriveClient,
+        userService: {} as unknown as UserService,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+        contentVerificationModel: {} as unknown as ContentVerificationModel,
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('strips SQL bodies when caller lacks manage:CustomFields', async () => {
+        const result = await service.get(chartUuid, accountWithout);
+
+        expect(result.metricQuery.customDimensions?.[0]).toEqual(
+            expect.objectContaining({ sql: '' }),
+        );
+        expect(result.metricQuery.tableCalculations[0]).toEqual(
+            expect.objectContaining({ sql: '' }),
+        );
+    });
+
+    it('preserves SQL bodies when caller has manage:CustomFields', async () => {
+        const result = await service.get(chartUuid, accountWith);
+
+        expect(result.metricQuery.customDimensions?.[0]).toEqual(
+            expect.objectContaining({ sql: sqlCustomDim.sql }),
+        );
+        expect(result.metricQuery.tableCalculations[0]).toEqual(
+            expect.objectContaining({ sql: sqlTableCalc.sql }),
+        );
+    });
+});

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -79,7 +79,10 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
-import { assertCanWriteSqlAuthoredFields } from '../../utils/SqlAuthoredFieldsGuard';
+import {
+    assertCanAccessSqlAuthoredFields,
+    stripSqlBodiesIfForbidden,
+} from '../../utils/SqlAuthoredFieldsGuard';
 import { BaseService } from '../BaseService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
@@ -1084,8 +1087,17 @@ export class SavedChartService
             },
         });
 
+        const auditedAbility = this.createAuditedAbility(account);
+        const metricQuery = stripSqlBodiesIfForbidden({
+            ability: auditedAbility,
+            organizationUuid: savedChart.organizationUuid,
+            projectUuid: savedChart.projectUuid,
+            metricQuery: savedChart.metricQuery,
+        });
+
         return {
             ...savedChart,
+            metricQuery,
             inheritsFromOrgOrProject,
             access,
         };
@@ -1240,11 +1252,12 @@ export class SavedChartService
             throw new ForbiddenError();
         }
 
-        assertCanWriteSqlAuthoredFields({
+        assertCanAccessSqlAuthoredFields({
             ability: auditedAbility,
             organizationUuid,
             projectUuid,
             metricQuery: savedChart.metricQuery,
+            errorMessage: 'User cannot save queries with custom SQL fields',
         });
 
         if (!resolvedSpaceUuid && !savedChart.dashboardUuid) {

--- a/packages/backend/src/utils/SqlAuthoredFieldsGuard.test.ts
+++ b/packages/backend/src/utils/SqlAuthoredFieldsGuard.test.ts
@@ -9,7 +9,10 @@ import {
     type SqlTableCalculation,
 } from '@lightdash/common';
 import { type CaslAuditWrapper } from '../logging/caslAuditWrapper';
-import { assertCanWriteSqlAuthoredFields } from './SqlAuthoredFieldsGuard';
+import {
+    assertCanAccessSqlAuthoredFields,
+    stripSqlBodiesIfForbidden,
+} from './SqlAuthoredFieldsGuard';
 
 const baseMetricQuery: Pick<
     MetricQuery,
@@ -37,10 +40,11 @@ const sqlTableCalc: SqlTableCalculation = {
 
 const buildAbility = (allowed: boolean): CaslAuditWrapper<Ability> =>
     ({
+        can: jest.fn(() => allowed),
         cannot: jest.fn(() => !allowed),
     }) as unknown as CaslAuditWrapper<Ability>;
 
-describe('assertCanWriteSqlAuthoredFields', () => {
+describe('assertCanAccessSqlAuthoredFields', () => {
     const args = {
         organizationUuid: 'org-uuid',
         projectUuid: 'project-uuid',
@@ -48,7 +52,7 @@ describe('assertCanWriteSqlAuthoredFields', () => {
 
     it('does not throw when metricQuery has no SQL-authored fields', () => {
         expect(() =>
-            assertCanWriteSqlAuthoredFields({
+            assertCanAccessSqlAuthoredFields({
                 ...args,
                 ability: buildAbility(false),
                 metricQuery: baseMetricQuery,
@@ -58,14 +62,14 @@ describe('assertCanWriteSqlAuthoredFields', () => {
 
     it('does not throw when metricQuery is null or undefined', () => {
         expect(() =>
-            assertCanWriteSqlAuthoredFields({
+            assertCanAccessSqlAuthoredFields({
                 ...args,
                 ability: buildAbility(false),
                 metricQuery: null,
             }),
         ).not.toThrow();
         expect(() =>
-            assertCanWriteSqlAuthoredFields({
+            assertCanAccessSqlAuthoredFields({
                 ...args,
                 ability: buildAbility(false),
                 metricQuery: undefined,
@@ -75,7 +79,7 @@ describe('assertCanWriteSqlAuthoredFields', () => {
 
     it('throws when metricQuery has a SQL custom dimension and user lacks scope', () => {
         expect(() =>
-            assertCanWriteSqlAuthoredFields({
+            assertCanAccessSqlAuthoredFields({
                 ...args,
                 ability: buildAbility(false),
                 metricQuery: {
@@ -88,7 +92,7 @@ describe('assertCanWriteSqlAuthoredFields', () => {
 
     it('does not throw when metricQuery has a SQL custom dimension and user has scope', () => {
         expect(() =>
-            assertCanWriteSqlAuthoredFields({
+            assertCanAccessSqlAuthoredFields({
                 ...args,
                 ability: buildAbility(true),
                 metricQuery: {
@@ -101,7 +105,7 @@ describe('assertCanWriteSqlAuthoredFields', () => {
 
     it('throws when metricQuery has a SQL table calculation and user lacks scope', () => {
         expect(() =>
-            assertCanWriteSqlAuthoredFields({
+            assertCanAccessSqlAuthoredFields({
                 ...args,
                 ability: buildAbility(false),
                 metricQuery: {
@@ -114,7 +118,7 @@ describe('assertCanWriteSqlAuthoredFields', () => {
 
     it('does not throw when metricQuery has a SQL table calculation and user has scope', () => {
         expect(() =>
-            assertCanWriteSqlAuthoredFields({
+            assertCanAccessSqlAuthoredFields({
                 ...args,
                 ability: buildAbility(true),
                 metricQuery: {
@@ -127,7 +131,7 @@ describe('assertCanWriteSqlAuthoredFields', () => {
 
     it('uses the supplied error message when provided', () => {
         expect(() =>
-            assertCanWriteSqlAuthoredFields({
+            assertCanAccessSqlAuthoredFields({
                 ...args,
                 ability: buildAbility(false),
                 metricQuery: {
@@ -137,5 +141,51 @@ describe('assertCanWriteSqlAuthoredFields', () => {
                 errorMessage: 'custom write-context message',
             }),
         ).toThrow('custom write-context message');
+    });
+});
+
+describe('stripSqlBodiesIfForbidden', () => {
+    const args = {
+        organizationUuid: 'org-uuid',
+        projectUuid: 'project-uuid',
+    };
+
+    const fullMetricQuery: MetricQuery = {
+        exploreName: 'orders',
+        dimensions: [],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [sqlTableCalc],
+        customDimensions: [sqlCustomDim],
+    };
+
+    it('returns the metricQuery unchanged when user has scope', () => {
+        const result = stripSqlBodiesIfForbidden({
+            ...args,
+            ability: buildAbility(true),
+            metricQuery: fullMetricQuery,
+        });
+        expect(result.customDimensions?.[0]).toEqual(
+            expect.objectContaining({ sql: sqlCustomDim.sql }),
+        );
+        expect(result.tableCalculations[0]).toEqual(
+            expect.objectContaining({ sql: sqlTableCalc.sql }),
+        );
+    });
+
+    it('strips SQL bodies from custom dimensions and table calculations when user lacks scope', () => {
+        const result = stripSqlBodiesIfForbidden({
+            ...args,
+            ability: buildAbility(false),
+            metricQuery: fullMetricQuery,
+        });
+        expect(result.customDimensions?.[0]).toEqual(
+            expect.objectContaining({ sql: '' }),
+        );
+        expect(result.tableCalculations[0]).toEqual(
+            expect.objectContaining({ sql: '' }),
+        );
     });
 });

--- a/packages/backend/src/utils/SqlAuthoredFieldsGuard.ts
+++ b/packages/backend/src/utils/SqlAuthoredFieldsGuard.ts
@@ -2,11 +2,39 @@ import { subject, type Ability } from '@casl/ability';
 import {
     CustomSqlQueryForbiddenError,
     hasSqlAuthoredFields,
+    stripSqlBodiesFromMetricQuery,
     type MetricQuery,
 } from '@lightdash/common';
 import { type CaslAuditWrapper } from '../logging/caslAuditWrapper';
 
-export const assertCanWriteSqlAuthoredFields = ({
+const canManageCustomFields = (
+    ability: CaslAuditWrapper<Ability>,
+    organizationUuid: string,
+    projectUuid: string,
+): boolean =>
+    ability.can(
+        'manage',
+        subject('CustomFields', { organizationUuid, projectUuid }),
+    );
+
+export const hasForbiddenSqlAuthoredFields = ({
+    ability,
+    organizationUuid,
+    projectUuid,
+    metricQuery,
+}: {
+    ability: CaslAuditWrapper<Ability>;
+    organizationUuid: string;
+    projectUuid: string;
+    metricQuery:
+        | Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>
+        | null
+        | undefined;
+}): boolean =>
+    hasSqlAuthoredFields(metricQuery) &&
+    !canManageCustomFields(ability, organizationUuid, projectUuid);
+
+export const assertCanAccessSqlAuthoredFields = ({
     ability,
     organizationUuid,
     projectUuid,
@@ -23,14 +51,24 @@ export const assertCanWriteSqlAuthoredFields = ({
     errorMessage?: string;
 }): void => {
     if (!hasSqlAuthoredFields(metricQuery)) return;
-    if (
-        ability.cannot(
-            'manage',
-            subject('CustomFields', { organizationUuid, projectUuid }),
-        )
-    ) {
+    if (!canManageCustomFields(ability, organizationUuid, projectUuid)) {
         throw new CustomSqlQueryForbiddenError(
-            errorMessage ?? 'User cannot save queries with custom SQL fields',
+            errorMessage ?? 'User cannot access custom SQL fields',
         );
     }
 };
+
+export const stripSqlBodiesIfForbidden = <T extends MetricQuery>({
+    ability,
+    organizationUuid,
+    projectUuid,
+    metricQuery,
+}: {
+    ability: CaslAuditWrapper<Ability>;
+    organizationUuid: string;
+    projectUuid: string;
+    metricQuery: T;
+}): T =>
+    canManageCustomFields(ability, organizationUuid, projectUuid)
+        ? metricQuery
+        : stripSqlBodiesFromMetricQuery(metricQuery);


### PR DESCRIPTION
Closes: [PROD-7028](https://linear.app/lightdash/issue/PROD-7028). Stacked on top of #22507.

## What this fixes

Three read-side paths today return chart definitions including raw `customDimensions[].sql` and SQL table calculation bodies to callers who do not hold `manage:CustomFields`. PR 1 (#22507) closed the *write* side; this PR closes the *read* side.

| Endpoint | Behaviour | Why this strategy |
| --- | --- | --- |
| `SavedChartService.get()` | **Strip** SQL bodies via `stripSqlBodiesFromMetricQuery()` for callers without the scope | General-purpose chart fetch hit by every chart load (incl. dashboard tiles, which are references-only and resolve through this method). Strip-on-read mirrors the URL-encoding pattern already used on the frontend; `mergeSavedSqlBodiesIntoMetricQuery` rehydrates on the run-side so editing/running still works for callers with the scope. |
| `CoderService.getCharts()` | **Fail** with `CustomSqlQueryForbiddenError`, listing offending chart names | Authoring-tier path. `lightdash download` is realistically only run by Developers or service accounts (already hold the scope). Returning a YAML with empty SQL would be silently corrupt and the user could not re-upload it anyway (PR 1 blocks that). Fail loud. |
| `PromoteService.getPromoteChartDiff()` and `getPromoteDashboardDiff()` | **Fail** with `CustomSqlQueryForbiddenError`, listing offending chart names | Diff endpoints exist to support the privileged promote operation, which PR 1 blocks at the destination scope. Showing a diff the user cannot act on is just confusing — fail at the same layer. |

The dashboard endpoint is unchanged: `DashboardChartTileProperties` is references-only (just `savedChartUuid` + display metadata), and the chart fetch flows through `SavedChartService.get()` which is now stripped. No separate dashboard-side leak.

## Helper changes (`utils/SqlAuthoredFieldsGuard.ts`)

- Renamed `assertCanWriteSqlAuthoredFields` → `assertCanAccessSqlAuthoredFields`. The underlying check ("metricQuery has SQL fields AND caller lacks the scope") applies equally to write and read contexts, so the neutral name is more accurate. Call sites from PR 1 updated to the new name.
- Added `stripSqlBodiesIfForbidden` — pure helper that returns the metricQuery unchanged when the caller holds the scope, or with empty SQL bodies otherwise. Used by `SavedChartService.get()`.

## Who's affected (read-side)

| Caller class | Has `manage:CustomFields`? | Effect |
| --- | --- | --- |
| Service accounts (org-admin default) | Yes | No change |
| Developer / Editor / Admin system roles | Yes | No change |
| Viewer-equivalent custom roles | Often no | Chart-fetch responses now contain empty `sql` fields. The chart still renders normally; the empty body is only visible when inspecting the API response or opening the SQL editor (which `CustomDimensionModal` already hides for these users). |
| Custom role: ContentAsCode without CustomFields | No | Cannot download YAML — gets 403 with chart names |
| Custom role attempting promotion without destination CustomFields | No | Cannot view promotion diff — gets 403 with chart names |

No known customer configurations rely on these read paths returning SQL bodies to callers without the scope.

## Out of scope (deferred)

The Linear comment flagged that other endpoints returning chart definitions inline (catalog, search results, expanded spaces, v1 list endpoints) may also leak SQL bodies. This PR sticks to the three call sites the comment explicitly identified. A comprehensive sweep of all chart-returning endpoints is the natural follow-up.

## Test plan

- [x] `pnpm -F backend lint` — clean
- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend exec jest --testPathPattern='SqlAuthoredFieldsGuard|sqlAuthoredFields|readSqlAuthoredFields|SavedChartService|CoderService|PromoteService'` — all 62 tests pass
- [ ] Manual: as a Developer (has `manage:CustomFields`), opening a chart with a custom SQL dim still shows the full SQL body in the editor
- [ ] Manual: as a Viewer, opening the same chart renders correctly but the API response contains empty `sql` fields (run path uses `mergeSavedSqlBodiesIntoMetricQuery` to rehydrate from the saved chart)
- [ ] Manual: `lightdash download` for a custom role granting only `ContentAsCode` returns 403 with chart names
- [ ] Manual: `GET /api/v1/saved/{uuid}/promoteDiff` for a user lacking destination `manage:CustomFields` returns 403

test-all