### PR TITLE
feat(permissions): re-check manage:CustomFields on underlying-data drill

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2377,4 +2377,54 @@ describe('AsyncQueryService', () => {
             });
         });
     });
+
+    describe('executeAsyncUnderlyingDataQuery — SQL-authored field gate', () => {
+        const service = getMockedAsyncQueryService(lightdashConfigMock);
+
+        const sqlCustomDim = {
+            id: 'dim-1',
+            name: 'Bucketed amount',
+            type: 'sql',
+            table: 'orders',
+            sql: 'CASE WHEN x > 0 THEN 1 ELSE 0 END',
+            dimensionType: DimensionType.NUMBER,
+        };
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+            (service.queryHistoryModel.get as jest.Mock).mockResolvedValue({
+                metricQuery: {
+                    exploreName: validExplore.name,
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                    customDimensions: [sqlCustomDim],
+                },
+                fields: {},
+            });
+        });
+
+        const accountWithoutCustomFields = buildAccount();
+        accountWithoutCustomFields.user.ability =
+            new Ability<PossibleAbilities>([
+                { subject: 'UnderlyingData', action: ['view'] },
+            ]);
+
+        it('throws CustomSqlQueryForbiddenError when historical query contains SQL fields and user lacks manage:CustomFields', async () => {
+            await expect(
+                service.executeAsyncUnderlyingDataQuery({
+                    account: accountWithoutCustomFields,
+                    projectUuid,
+                    underlyingDataSourceQueryUuid: 'history-uuid',
+                    filters: {},
+                    context: QueryExecutionContext.EXPLORE,
+                }),
+            ).rejects.toThrow(
+                'User cannot drill into queries with custom SQL fields',
+            );
+        });
+    });
 });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -146,6 +146,7 @@ import {
     applyLimitToSqlQuery,
     replaceUserAttributesAsStrings,
 } from '../../utils/QueryBuilder/utils';
+import { assertCanAccessSqlAuthoredFields } from '../../utils/SqlAuthoredFieldsGuard';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
@@ -4606,6 +4607,15 @@ export class AsyncQueryService extends ProjectService {
                 projectUuid,
                 account,
             );
+
+        assertCanAccessSqlAuthoredFields({
+            ability: auditedAbility,
+            organizationUuid,
+            projectUuid,
+            metricQuery,
+            errorMessage:
+                'User cannot drill into queries with custom SQL fields',
+        });
 
         const { exploreName } = metricQuery;
 


### PR DESCRIPTION
Closes part 3 of [PROD-7028](https://linear.app/lightdash/issue/PROD-7028). Stacked on top of #22510 and #22507.

## What this fixes

Closes the niche-but-real "drill-into post-revocation" gap. `AsyncQueryService.executeAsyncUnderlyingDataQuery()` loads the original `metricQuery` from `query_history` and runs an underlying-data variant of it. Until now the only permission check was `view:UnderlyingData` — `manage:CustomFields` was never re-evaluated against the historical query.

The result: a user who **had** `manage:CustomFields` when they originally executed a query containing a custom SQL dim or SQL table calc, then **lost** the scope, could still drill into their own historical query and re-execute against the warehouse using SQL they no longer have authority to author. Per-user isolation in `queryHistoryModel.get()` already prevents cross-user exploitation, so this is strictly the post-revocation case for a single user.

## How

One call to `assertCanAccessSqlAuthoredFields` (the shared guard introduced in PR 1 / renamed in PR 2) right after `queryHistoryModel.get()` returns the historical metricQuery and before any warehouse work happens:

```ts
assertCanAccessSqlAuthoredFields({
    ability: auditedAbility,
    organizationUuid,
    projectUuid,
    metricQuery,
    errorMessage: 'User cannot drill into queries with custom SQL fields',
});
```

Strict semantics — any SQL-authored field in the historical query requires the scope at drill time. No saved-chart exemption: drill is conceptually a fresh query authored against historical data, not a re-run of a saved chart, so the run-side exemption does not apply.

## Who's affected

| Scenario | Affected? |
| --- | --- |
| User originally had `manage:CustomFields`, still has it, drills | No — passes |
| User originally had `manage:CustomFields`, lost it, drills on a query with SQL fields | **Yes** — now blocked. *This is the fix.* |
| User had `manage:CustomFields`, lost it, drills on a query without SQL fields | No — passes |
| User never had the scope but somehow has access to a historical queryUuid | Already blocked at query-history load (per-user isolation in `queryHistoryModel.get()`); the new gate is a defence-in-depth backstop |

No effect on default system roles (Developer keeps `manage:CustomFields`; Viewer/Editor would not have authored a SQL-fields query in the first place). The case requires an active permission revocation between the original execution and the drill — niche, but the fix is mechanical and worth closing for completeness.

## Test plan

- [x] `pnpm -F backend lint` — clean
- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend exec jest --testPathPattern='AsyncQueryService'` — 41/41 pass (40 existing + 1 new)
- [ ] Manual: as a Developer (has `manage:CustomFields`), drill from a chart with a custom SQL dim still runs end-to-end
- [ ] Manual: revoke `manage:CustomFields` from the user mid-session, then drill on a previously-run query with custom SQL — expect 403 with the new error message