### PR TITLE
chore: migrate `ShowExecutionTime` feature flag

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -21,7 +21,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showExecutionTime: false,
 
         retryQueryOnTransientErrors: false,
         enableTimezoneSupport: undefined,
@@ -60,7 +59,6 @@ export const lightdashConfigWithBasicSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showExecutionTime: false,
 
         retryQueryOnTransientErrors: false,
         enableTimezoneSupport: undefined,
@@ -86,7 +84,6 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showExecutionTime: false,
 
         retryQueryOnTransientErrors: false,
         enableTimezoneSupport: undefined,
@@ -108,7 +105,6 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showExecutionTime: false,
 
         retryQueryOnTransientErrors: false,
         enableTimezoneSupport: undefined,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -219,7 +219,6 @@ export const lightdashConfigMock: LightdashConfig = {
         defaultLimit: 500,
         csvCellsLimit: 100000,
         timezone: undefined,
-        showExecutionTime: false,
         retryQueryOnTransientErrors: true,
         enableTimezoneSupport: undefined,
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -840,6 +840,7 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
         ['USER_IMPERSONATION_ENABLED', 'user-impersonation'],
         ['GROUPS_ENABLED', 'user-groups-enabled'],
+        ['SHOW_EXECUTION_TIME', 'show-execution-time'],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1033,7 +1033,6 @@ export type LightdashConfig = {
         csvCellsLimit: number;
         timezone: string | undefined;
         maxPageSize: number;
-        showExecutionTime: boolean | undefined;
         retryQueryOnTransientErrors: boolean;
         enableTimezoneSupport: boolean | undefined;
     };
@@ -1558,6 +1557,7 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     // from the feature flag) — keep the config field, but translate the env
     // var to the unified allowlist for the flag system too.
     ['GROUPS_ENABLED', 'user-groups-enabled'],
+    ['SHOW_EXECUTION_TIME', 'show-execution-time'],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
@@ -1961,9 +1961,6 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_MAX_PAGE_SIZE',
                 ) || 2500, // Defaults to default limit * 5
-            showExecutionTime: process.env.SHOW_EXECUTION_TIME
-                ? process.env.SHOW_EXECUTION_TIME === 'true'
-                : undefined,
             retryQueryOnTransientErrors: process.env
                 .LIGHTDASH_QUERY_RETRY_ON_TRANSIENT_ERRORS
                 ? process.env.LIGHTDASH_QUERY_RETRY_ON_TRANSIENT_ERRORS ===

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -37,8 +37,6 @@ export class FeatureFlagModel {
         // Initialize the handlers for feature flag logic
         this.featureFlagHandlers = {
             [FeatureFlags.EditYamlInUi]: this.getEditYamlInUiEnabled.bind(this),
-            [FeatureFlags.ShowExecutionTime]:
-                this.getShowExecutionTimeEnabled.bind(this),
             [FeatureFlags.MetricDashboardFilters]:
                 this.getMetricDashboardFiltersEnabled.bind(this),
             [FeatureFlags.EnableTimezoneSupport]:
@@ -107,15 +105,6 @@ export class FeatureFlagModel {
         return {
             id: featureFlagId,
             enabled: this.lightdashConfig.editYamlInUi.enabled,
-        };
-    }
-
-    private async getShowExecutionTimeEnabled({
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        return {
-            id: featureFlagId,
-            enabled: this.lightdashConfig.query.showExecutionTime ?? false,
         };
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -480,7 +480,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showExecutionTime: false,
         retryQueryOnTransientErrors: false,
         enableTimezoneSupport: undefined,
     },

--- a/packages/frontend/src/components/DashboardTiles/TileExecutionInfo.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileExecutionInfo.tsx
@@ -16,10 +16,7 @@ import {
     IconServer,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
-import {
-    useClientFeatureFlag,
-    useServerFeatureFlag,
-} from '../../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../common/MantineIcon';
 import InfoRow from '../common/PageHeader/InfoRow';
 
@@ -42,11 +39,10 @@ const TileExecutionInfo: FC<TileExecutionInfoProps> = ({
     totalClientFetchTimeMs,
     totalResults,
 }) => {
-    const { data: serverFlag } = useServerFeatureFlag(
+    const { data: showExecutionTimeFlag } = useServerFeatureFlag(
         FeatureFlags.ShowExecutionTime,
     );
-    const posthogFlag = useClientFeatureFlag(FeatureFlags.ShowExecutionTime);
-    const isEnabled = serverFlag?.enabled || posthogFlag;
+    const isEnabled = showExecutionTimeFlag?.enabled ?? false;
 
     if (
         !isEnabled ||


### PR DESCRIPTION
Closes:

### Description:

Migrates the `ShowExecutionTime` feature flag from a dedicated `query.showExecutionTime` config field to the standard legacy feature flag environment variable system.

- Removes `showExecutionTime` from the `query` section of `LightdashConfig` and its associated parsing logic
- Adds `SHOW_EXECUTION_TIME` to the `LEGACY_ENABLE_ENV_VARS` list so it is handled uniformly alongside other feature flags via `show-execution-time`
- Removes the custom `getShowExecutionTimeEnabled` handler from `FeatureFlagModel`, as the flag is now resolved through the standard feature flag pipeline
- Simplifies `TileExecutionInfo` to rely solely on the server-side feature flag, removing the PostHog client-side flag check