### PR TITLE
refactor(audited-ability): migrate small EE services to Account [SPK-416]

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -92,7 +92,7 @@ export class AiAgentAdminController extends BaseController {
             : undefined;
 
         const threads = await this.getAiAgentAdminService().getAllThreads(
-            req.user!,
+            req.account!,
             paginateArgs,
             filters,
             sort,
@@ -119,7 +119,9 @@ export class AiAgentAdminController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await this.getAiAgentAdminService().listAgents(req.user!),
+            results: await this.getAiAgentAdminService().listAgents(
+                req.account!,
+            ),
         };
     }
 
@@ -132,7 +134,7 @@ export class AiAgentAdminController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: string; results: { token: string; url: string } }> {
         const results = await this.getAiAgentAdminService().generateEmbedToken(
-            req.user!,
+            req.account!,
         );
 
         this.setStatus(200);
@@ -155,7 +157,7 @@ export class AiAgentAdminController extends BaseController {
     ): Promise<ApiAiOrganizationSettingsResponse> {
         const settings =
             await this.getAiOrganizationSettingsService().getSettings(
-                req.user!,
+                req.account!,
             );
 
         this.setStatus(200);
@@ -183,7 +185,7 @@ export class AiAgentAdminController extends BaseController {
     ): Promise<ApiUpdateAiOrganizationSettingsResponse> {
         const settings =
             await this.getAiOrganizationSettingsService().upsertSettings(
-                req.user!,
+                req.account!,
                 body,
             );
 

--- a/packages/backend/src/ee/controllers/managedAgentController.ts
+++ b/packages/backend/src/ee/controllers/managedAgentController.ts
@@ -45,7 +45,7 @@ export class ManagedAgentController extends BaseController {
         @Path() projectUuid: string,
     ): Promise<{ status: 'ok'; results: ManagedAgentSettings | null }> {
         const results = await this.getManagedAgentService().getSettings(
-            req.user!,
+            req.account!,
             projectUuid,
         );
         this.setStatus(200);
@@ -61,9 +61,9 @@ export class ManagedAgentController extends BaseController {
         @Body() body: UpdateManagedAgentSettings,
     ): Promise<{ status: 'ok'; results: ManagedAgentSettings }> {
         const results = await this.getManagedAgentService().updateSettings(
-            req.user!,
+            req.account!,
             projectUuid,
-            req.user!.userUuid,
+            req.account!.user.id,
             body,
         );
         this.setStatus(200);
@@ -81,7 +81,7 @@ export class ManagedAgentController extends BaseController {
         @Query() sessionId?: string,
     ): Promise<{ status: 'ok'; results: ManagedAgentAction[] }> {
         const results = await this.getManagedAgentService().getActions(
-            req.user!,
+            req.account!,
             projectUuid,
             {
                 date,
@@ -102,10 +102,10 @@ export class ManagedAgentController extends BaseController {
         @Path() actionUuid: string,
     ): Promise<{ status: 'ok'; results: ManagedAgentAction }> {
         const results = await this.getManagedAgentService().reverseAction(
-            req.user!,
+            req.account!,
             projectUuid,
             actionUuid,
-            req.user!.userUuid,
+            req.account!.user.id,
         );
         this.setStatus(200);
         return { status: 'ok', results };

--- a/packages/backend/src/ee/controllers/scimOrganizationAccessTokenController.ts
+++ b/packages/backend/src/ee/controllers/scimOrganizationAccessTokenController.ts
@@ -52,7 +52,7 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ServiceAccount[] }> {
         const results = await this.getServiceAccountService().list(
-            req.user!,
+            req.account!,
             SCIM_SCOPES,
         );
         this.setStatus(200);
@@ -78,10 +78,11 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         @Body() body: ApiCreateScimServiceAccountRequest, // Service account request without scopes
     ): Promise<{ status: 'ok'; results: ServiceAccount }> {
         const token = await this.getServiceAccountService().create({
-            user: req.user!,
+            account: req.account!,
             tokenDetails: {
                 ...body,
-                organizationUuid: req.user?.organizationUuid as string,
+                organizationUuid: req.account!.organization
+                    .organizationUuid as string,
                 scopes: SCIM_SCOPES,
             },
             prefix: AuthTokenPrefix.SCIM,
@@ -109,7 +110,7 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         @Path() tokenUuid: string,
     ): Promise<{ status: 'ok'; results: undefined }> {
         await this.getServiceAccountService().delete({
-            user: req.user!,
+            account: req.account!,
             tokenUuid,
         });
         return {
@@ -138,7 +139,7 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         return {
             status: 'ok',
             results: await this.getServiceAccountService().get({
-                user: req.user!,
+                account: req.account!,
                 tokenUuid,
             }),
         };
@@ -171,7 +172,7 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         return {
             status: 'ok',
             results: await this.getServiceAccountService().rotate({
-                user: req.user!,
+                account: req.account!,
                 tokenUuid,
                 update: body,
                 prefix: AuthTokenPrefix.SCIM,

--- a/packages/backend/src/ee/controllers/serviceAccountsController.ts
+++ b/packages/backend/src/ee/controllers/serviceAccountsController.ts
@@ -49,7 +49,7 @@ export class ServiceAccountsController extends BaseController {
             (scope) => scope !== ServiceAccountScope.SCIM_MANAGE,
         );
         const results = await this.getServiceAccountService().list(
-            req.user!,
+            req.account!,
             scopes,
         );
         this.setStatus(200);
@@ -74,10 +74,11 @@ export class ServiceAccountsController extends BaseController {
         @Body() body: ApiCreateServiceAccountRequest,
     ): Promise<{ status: 'ok'; results: ServiceAccount }> {
         const token = await this.getServiceAccountService().create({
-            user: req.user!,
+            account: req.account!,
             tokenDetails: {
                 ...body,
-                organizationUuid: req.user?.organizationUuid as string,
+                organizationUuid: req.account!.organization
+                    .organizationUuid as string,
             },
             prefix: AuthTokenPrefix.SERVICE_ACCOUNT,
         });
@@ -103,7 +104,7 @@ export class ServiceAccountsController extends BaseController {
         @Path() tokenUuid: string,
     ): Promise<{ status: 'ok'; results: undefined }> {
         await this.getServiceAccountService().delete({
-            user: req.user!,
+            account: req.account!,
             tokenUuid,
         });
         return {

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -4,7 +4,6 @@ import {
     ServiceAccount,
     ServiceAccountScope,
     ServiceAccountWithToken,
-    SessionUser,
     UnexpectedDatabaseError,
 } from '@lightdash/common';
 import * as crypto from 'crypto';
@@ -43,27 +42,27 @@ export class ServiceAccountModel {
     }
 
     async create({
-        user,
+        createdByUserUuid,
         data,
         prefix = AuthTokenPrefix.SCIM,
     }: {
-        user: SessionUser;
+        createdByUserUuid: string;
         data: CreateServiceAccount;
         prefix?: string;
     }): Promise<ServiceAccountWithToken> {
         const token = ServiceAccountModel.generateToken(prefix);
-        return this.save(user, data, token);
+        return this.save(createdByUserUuid, data, token);
     }
 
     async save(
-        user: SessionUser | undefined,
+        createdByUserUuid: string | undefined,
         data: CreateServiceAccount,
         token: string,
     ): Promise<ServiceAccountWithToken> {
         const tokenHash = await hash(token);
         const [row] = await this.database('service_accounts')
             .insert({
-                created_by_user_uuid: user?.userUuid || null,
+                created_by_user_uuid: createdByUserUuid || null,
                 organization_uuid: data.organizationUuid,
                 expires_at: data.expiresAt,
                 description: data.description,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -7,7 +7,7 @@ import {
     ForbiddenError,
     KnexPaginateArgs,
     KnexPaginatedData,
-    type SessionUser,
+    type Account,
 } from '@lightdash/common';
 import jwt from 'jsonwebtoken';
 import { type LightdashConfig } from '../../config/parseConfig';
@@ -30,13 +30,13 @@ export class AiAgentAdminService extends BaseService {
         this.lightdashConfig = dependencies.lightdashConfig;
     }
 
-    private checkOrganizationAdminAccess(user: SessionUser): void {
-        const auditedAbility = this.createAuditedAbility(user);
+    private checkOrganizationAdminAccess(account: Account): void {
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
-                    organizationUuid: user.organizationUuid!,
+                    organizationUuid: account.organization.organizationUuid!,
                 }),
             )
         ) {
@@ -51,17 +51,17 @@ export class AiAgentAdminService extends BaseService {
      * Only accessible by organization admins
      */
     async getAllThreads(
-        user: SessionUser,
+        account: Account,
         paginateArgs?: KnexPaginateArgs,
         filters?: AiAgentAdminFilters,
         sort?: AiAgentAdminSort,
     ): Promise<KnexPaginatedData<AiAgentAdminConversationsSummary>> {
-        const { organizationUuid } = user;
+        const { organizationUuid } = account.organization;
 
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkOrganizationAdminAccess(account);
 
         // TODO: Check if filter contains userUuid and check if they exist in the organization
         // TODO: Check if filter contains agentUuid and check if they exist in the organization
@@ -75,12 +75,12 @@ export class AiAgentAdminService extends BaseService {
         });
     }
 
-    async listAgents(user: SessionUser): Promise<AiAgentSummary[]> {
-        const { organizationUuid } = user;
+    async listAgents(account: Account): Promise<AiAgentSummary[]> {
+        const { organizationUuid } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkOrganizationAdminAccess(account);
         return this.aiAgentModel.findAllAgents({
             organizationUuid,
         });
@@ -101,13 +101,13 @@ export class AiAgentAdminService extends BaseService {
      * @returns JWT token and embed URL for the analytics dashboard
      */
     async generateEmbedToken(
-        user: SessionUser,
+        account: Account,
     ): Promise<{ token: string; url: string }> {
-        const { organizationUuid } = user;
+        const { organizationUuid } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkOrganizationAdminAccess(account);
 
         const { analyticsEmbedSecret } = this.lightdashConfig;
 
@@ -145,8 +145,8 @@ export class AiAgentAdminService extends BaseService {
                 canViewUnderlyingData: false,
             },
             user: {
-                externalId: `org_${organizationUuid}_user_${user.userUuid}`,
-                email: user.email,
+                externalId: `org_${organizationUuid}_user_${account.user.id}`,
+                email: account.user.email,
             },
             userAttributes,
         };

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -6,7 +6,7 @@ import {
     ForbiddenError,
     LightdashUser,
     UpdateAiOrganizationSettings,
-    type SessionUser,
+    type Account,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
 import { OrganizationModel } from '../../models/OrganizationModel';
@@ -43,13 +43,13 @@ export class AiOrganizationSettingsService extends BaseService {
         this.lightdashConfig = dependencies.lightdashConfig;
     }
 
-    private checkManageAiAgentAccess(user: SessionUser): void {
-        const auditedAbility = this.createAuditedAbility(user);
+    private checkManageAiAgentAccess(account: Account): void {
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'manage',
                 subject('AiAgent', {
-                    organizationUuid: user.organizationUuid!,
+                    organizationUuid: account.organization.organizationUuid!,
                 }),
             )
         ) {
@@ -104,29 +104,35 @@ export class AiOrganizationSettingsService extends BaseService {
     }
 
     async getSettings(
-        user: SessionUser,
+        account: Account,
     ): Promise<AiOrganizationSettings & ComputedAiOrganizationSettings> {
-        if (!user.organizationUuid) {
+        const { organizationUuid, name: organizationName } =
+            account.organization;
+        if (!organizationUuid) {
             throw new ForbiddenError('User must belong to an organization');
         }
 
-        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        const isCopilotEnabled = await this.getIsCopilotEnabled({
+            userUuid: account.user.id,
+            organizationUuid,
+            organizationName,
+        });
 
         // Check if organization qualifies for trial
         const isTrialEligible = await this.isEligibleForTrial(
             isCopilotEnabled,
-            user.organizationUuid,
+            organizationUuid,
         );
 
         const settings =
             await this.aiOrganizationSettingsModel.findByOrganizationUuid(
-                user.organizationUuid,
+                organizationUuid,
             );
 
         // Return default settings if none exist
         if (!settings) {
             return {
-                organizationUuid: user.organizationUuid,
+                organizationUuid,
                 isCopilotEnabled,
                 aiAgentsVisible: true,
                 isTrial: isTrialEligible,
@@ -141,18 +147,16 @@ export class AiOrganizationSettingsService extends BaseService {
     }
 
     async upsertSettings(
-        user: SessionUser,
+        account: Account,
         data: UpdateAiOrganizationSettings,
     ): Promise<AiOrganizationSettings> {
-        if (!user.organizationUuid) {
+        const { organizationUuid } = account.organization;
+        if (!organizationUuid) {
             throw new ForbiddenError('User must belong to an organization');
         }
 
-        this.checkManageAiAgentAccess(user);
+        this.checkManageAiAgentAccess(account);
 
-        return this.aiOrganizationSettingsModel.upsert(
-            user.organizationUuid,
-            data,
-        );
+        return this.aiOrganizationSettingsModel.upsert(organizationUuid, data);
     }
 }

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -6,13 +6,13 @@ import {
     NotFoundError,
     ProjectType,
     ServiceAccountScope,
+    type Account,
     type ChartConfig,
     type ManagedAgentAction,
     type ManagedAgentActionFilters,
     type ManagedAgentSettings,
     type MetricQuery,
     type SavedChart,
-    type SessionUser,
     type UpdateManagedAgentSettings,
     type ValidationResponse,
 } from '@lightdash/common';
@@ -201,12 +201,12 @@ export class ManagedAgentService extends BaseService {
     // --- Authorization ---
 
     private async assertCanViewProject(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
     ): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'view',
@@ -218,12 +218,12 @@ export class ManagedAgentService extends BaseService {
     }
 
     private async assertCanManageProject(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
     ): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'update',
@@ -237,20 +237,20 @@ export class ManagedAgentService extends BaseService {
     // --- Settings API ---
 
     async getSettings(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
     ): Promise<ManagedAgentSettings | null> {
-        await this.assertCanViewProject(user, projectUuid);
+        await this.assertCanViewProject(account, projectUuid);
         return this.managedAgentModel.getSettings(projectUuid);
     }
 
     async updateSettings(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         userUuid: string,
         update: UpdateManagedAgentSettings,
     ): Promise<ManagedAgentSettings> {
-        await this.assertCanManageProject(user, projectUuid);
+        await this.assertCanManageProject(account, projectUuid);
         const settings = await this.managedAgentModel.upsertSettings(
             projectUuid,
             userUuid,
@@ -268,7 +268,7 @@ export class ManagedAgentService extends BaseService {
                 const { organizationUuid } =
                     await this.projectModel.getSummary(projectUuid);
                 const serviceAccount = await this.serviceAccountModel.create({
-                    user,
+                    createdByUserUuid: account.user.id,
                     data: {
                         organizationUuid,
                         description: `Autopilot (${projectUuid})`,
@@ -308,21 +308,21 @@ export class ManagedAgentService extends BaseService {
     // --- Actions API ---
 
     async getActions(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         filters: ManagedAgentActionFilters = {},
     ): Promise<ManagedAgentAction[]> {
-        await this.assertCanViewProject(user, projectUuid);
+        await this.assertCanViewProject(account, projectUuid);
         return this.managedAgentModel.getActions(projectUuid, filters);
     }
 
     async reverseAction(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         actionUuid: string,
         userUuid: string,
     ): Promise<ManagedAgentAction> {
-        await this.assertCanManageProject(user, projectUuid);
+        await this.assertCanManageProject(account, projectUuid);
         const action = await this.managedAgentModel.getAction(actionUuid);
         if (!action) {
             throw new NotFoundError(`Action ${actionUuid} not found`);

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -55,6 +55,7 @@ import {
     LightdashAnalytics,
     McpToolCallEvent,
 } from '../../../analytics/LightdashAnalytics';
+import { fromSession } from '../../../auth/account';
 import { LightdashConfig } from '../../../config/parseConfig';
 import { CatalogSearchContext } from '../../../models/CatalogModel/CatalogModel';
 import { McpContextModel } from '../../../models/McpContextModel';
@@ -2455,8 +2456,9 @@ export class McpService extends BaseService {
         if (!user.organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        const settings =
-            await this.aiOrganizationSettingsService.getSettings(user);
+        const settings = await this.aiOrganizationSettingsService.getSettings(
+            fromSession(user),
+        );
         if (!settings.aiAgentsVisible) {
             throw new ForbiddenError(
                 'AI Agent features are disabled for this organization',

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     AuthTokenPrefix,
     CreateServiceAccount,
     ForbiddenError,
@@ -8,7 +9,6 @@ import {
     ServiceAccount,
     ServiceAccountScope,
     ServiceAccountWithToken,
-    SessionUser,
     UnexpectedDatabaseError,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
@@ -55,13 +55,13 @@ export class ServiceAccountService extends BaseService {
         this.commercialFeatureFlagModel = commercialFeatureFlagModel;
     }
 
-    private throwForbiddenErrorOnNoPermission(user: SessionUser) {
-        const auditedAbility = this.createAuditedAbility(user);
+    private throwForbiddenErrorOnNoPermission(account: Account) {
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
-                    organizationUuid: user.organizationUuid!,
+                    organizationUuid: account.organization.organizationUuid!,
                 }),
             )
         ) {
@@ -70,18 +70,18 @@ export class ServiceAccountService extends BaseService {
     }
 
     async create({
-        user,
+        account,
         tokenDetails,
         prefix = AuthTokenPrefix.SCIM,
     }: {
-        user: SessionUser;
+        account: Account;
         tokenDetails: CreateServiceAccount;
         prefix?: string;
     }): Promise<ServiceAccount> {
         try {
-            this.throwForbiddenErrorOnNoPermission(user);
+            this.throwForbiddenErrorOnNoPermission(account);
             const token = await this.serviceAccountModel.create({
-                user,
+                createdByUserUuid: account.user.id,
                 data: {
                     organizationUuid: tokenDetails.organizationUuid,
                     expiresAt: tokenDetails.expiresAt,
@@ -92,7 +92,7 @@ export class ServiceAccountService extends BaseService {
             });
             this.analytics.track<ScimAccessTokenEvent>({
                 event: 'scim_access_token.created',
-                userId: user.userUuid,
+                userId: account.user.id,
                 properties: {
                     organizationId: token.organizationUuid,
                 },
@@ -113,15 +113,16 @@ export class ServiceAccountService extends BaseService {
     }
 
     async delete({
-        user,
+        account,
         tokenUuid,
     }: {
-        user: SessionUser;
+        account: Account;
         tokenUuid: string;
     }): Promise<void> {
         try {
-            this.throwForbiddenErrorOnNoPermission(user);
-            const organizationUuid = user.organizationUuid as string;
+            this.throwForbiddenErrorOnNoPermission(account);
+            const organizationUuid = account.organization
+                .organizationUuid as string;
             // get by uuid to check if token exists
             const token =
                 await this.serviceAccountModel.getTokenbyUuid(tokenUuid);
@@ -139,7 +140,7 @@ export class ServiceAccountService extends BaseService {
             await this.serviceAccountModel.delete(tokenUuid);
             this.analytics.track<ScimAccessTokenEvent>({
                 event: 'scim_access_token.deleted',
-                userId: user.userUuid,
+                userId: account.user.id,
                 properties: {
                     organizationId: token.organizationUuid,
                 },
@@ -161,17 +162,17 @@ export class ServiceAccountService extends BaseService {
     }
 
     async rotate({
-        user,
+        account,
         tokenUuid,
         update,
         prefix = AuthTokenPrefix.SCIM,
     }: {
-        user: SessionUser;
+        account: Account;
         tokenUuid: string;
         update: { expiresAt: Date };
         prefix?: string;
     }): Promise<ServiceAccountWithToken> {
-        this.throwForbiddenErrorOnNoPermission(user);
+        this.throwForbiddenErrorOnNoPermission(account);
 
         if (update.expiresAt.getTime() < Date.now()) {
             throw new ParameterError('Expire time must be in the future');
@@ -184,7 +185,10 @@ export class ServiceAccountService extends BaseService {
             throw new NotFoundError(`Token with UUID ${tokenUuid} not found`);
         }
         // throw forbidden if token does not belong to organization
-        if (existingToken.organizationUuid !== user.organizationUuid) {
+        if (
+            existingToken.organizationUuid !==
+            account.organization.organizationUuid
+        ) {
             throw new ForbiddenError("Token doesn't belong to organization");
         }
 
@@ -204,13 +208,13 @@ export class ServiceAccountService extends BaseService {
 
         const newToken = await this.serviceAccountModel.rotate({
             serviceAccountUuid: tokenUuid,
-            rotatedByUserUuid: user.userUuid,
+            rotatedByUserUuid: account.user.id,
             expiresAt: update.expiresAt,
             prefix,
         });
         this.analytics.track<ScimAccessTokenEvent>({
             event: 'scim_access_token.rotated',
-            userId: user.userUuid,
+            userId: account.user.id,
             properties: {
                 organizationId: existingToken.organizationUuid,
             },
@@ -219,13 +223,13 @@ export class ServiceAccountService extends BaseService {
     }
 
     async get({
-        user,
+        account,
         tokenUuid,
     }: {
-        user: SessionUser;
+        account: Account;
         tokenUuid: string;
     }): Promise<ServiceAccount> {
-        this.throwForbiddenErrorOnNoPermission(user);
+        this.throwForbiddenErrorOnNoPermission(account);
 
         // get by uuid to check if token exists
         const existingToken =
@@ -234,19 +238,23 @@ export class ServiceAccountService extends BaseService {
             throw new NotFoundError(`Token with UUID ${tokenUuid} not found`);
         }
         // throw forbidden if token does not belong to organization
-        if (existingToken.organizationUuid !== user.organizationUuid) {
+        if (
+            existingToken.organizationUuid !==
+            account.organization.organizationUuid
+        ) {
             throw new ForbiddenError("Token doesn't belong to organization");
         }
         return existingToken;
     }
 
     async list(
-        user: SessionUser,
+        account: Account,
         scopes: ServiceAccountScope[],
     ): Promise<ServiceAccount[]> {
         try {
-            this.throwForbiddenErrorOnNoPermission(user);
-            const organizationUuid = user.organizationUuid as string;
+            this.throwForbiddenErrorOnNoPermission(account);
+            const organizationUuid = account.organization
+                .organizationUuid as string;
             const tokens = await this.serviceAccountModel.getAllForOrganization(
                 organizationUuid,
                 scopes,

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -219,7 +219,7 @@ export class InstanceConfigurationService extends BaseService {
             if (setup.serviceAccount && this.serviceAccountModel) {
                 this.logger.debug(`Initial setup: creating service account`);
                 await this.serviceAccountModel.save(
-                    sessionUser,
+                    sessionUser.userUuid,
                     {
                         organizationUuid,
                         expiresAt: setup.serviceAccount.expirationTime,


### PR DESCRIPTION
## Summary

Part of [SPK-416](https://linear.app/lightdash/issue/SPK-416). Migrates four small EE services from `user: SessionUser` → `account: Account`.

Stacked on #22513.

## Services migrated

| Service | Audited methods |
|---|---|
| ServiceAccountService | `throwForbiddenErrorOnNoPermission` (used by 5 public methods: `create`, `delete`, `rotate`, `get`, `list`) |
| AiOrganizationSettingsService | `checkManageAiAgentAccess` (used by `upsertSettings`); also converted `getSettings` and `upsertSettings` public methods |
| AiAgentAdminService | `checkOrganizationAdminAccess` (used by `getAllThreads`, `listAgents`, `generateEmbedToken`); all 3 public methods converted |
| ManagedAgentService | `assertCanViewProject`, `assertCanManageProject` (used by `getSettings`, `updateSettings`, `getActions`, `reverseAction`); all 4 public methods converted |

## Adjacent model refactor

`ServiceAccountModel.create` and `.save` now take `createdByUserUuid: string` instead of `user: SessionUser`. The model only ever read `user.userUuid`, so this drops a coupling to the full SessionUser shape and lets services pass `account.user.id` directly. Three callers updated:

- `ServiceAccountService.create` → `createdByUserUuid: account.user.id`
- `ManagedAgentService.updateSettings` → `createdByUserUuid: account.user.id`  
- `InstanceConfigurationService` → passes `sessionUser.userUuid` (one site) and `undefined` (another, unchanged)

## Adjacent boundary plumbing

`McpService.checkAiAgentsVisible` calls `aiOrganizationSettingsService.getSettings(...)` and still takes `SessionUser` (McpService is deferred to a later PR). Wraps with `fromSession(user)` at the call site so the AiOrgSettings type narrowing holds. Will be removed when McpService migrates.

## Property migrations

- `user.organizationUuid` → `account.organization.organizationUuid`
- `user.userUuid` → `account.user.id`
- `user.email` → `account.user.email`

## Controllers updated

- `AiAgentAdminController` — 3 routes
- `managedAgentController` — 4 routes
- `serviceAccountsController` — 3 routes
- `scimOrganizationAccessTokenController` — 5 routes (POST/GET/DELETE/PATCH + `req.account!.organization.organizationUuid` for tokenDetails)

## Skipped (deferred)

- **AppGenerateService** — 3 audited calls, but 7 SpacePermissionService deps. Wait for SPC migration.
- **McpService** — 9 audited calls. Larger; standalone PR.
- **AiAgentService** — 12 audited calls + 7 ad-hoc `fromSession(user)` plumbing sites to consolidate. Standalone PR.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [ ] CI green