### PR TITLE
chore: migrate `AiCustomViz` feature flag to server flag

### DIFF
--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -243,15 +243,12 @@ export class AiService {
         }[];
         currentVizConfig: string;
     }) {
-        const isAICustomVizEnabled = await isFeatureFlagEnabled(
-            FeatureFlags.AiCustomViz,
+        const aiCustomVizFlag = await this.featureFlagService.get({
             user,
-            {
-                throwOnTimeout: true,
-            },
-        );
+            featureFlagId: FeatureFlags.AiCustomViz,
+        });
 
-        if (!isAICustomVizEnabled) {
+        if (!aiCustomVizFlag.enabled) {
             throw new Error('AI Custom viz feature not enabled!');
         }
         let openAiResponse: {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -12,7 +12,7 @@ import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';
 import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useDeepCompareEffect } from 'react-use';
-import { useClientFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import DocumentationHelpButton from '../../../DocumentationHelpButton';
 import { isCustomVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -191,7 +191,10 @@ export const ConfigTabs: React.FC = memo(() => {
         EditorProps['options'] | undefined
     >();
 
-    const isAiEnabled = useClientFeatureFlag(FeatureFlags.AiCustomViz);
+    const { data: aiCustomVizFlag } = useServerFeatureFlag(
+        FeatureFlags.AiCustomViz,
+    );
+    const isAiEnabled = aiCustomVizFlag?.enabled ?? false;
     useDeepCompareEffect(() => {
         /** Creates a container that belongs to body, outside of the sidebar
          * so we can place the autocomplete tooltip and it doesn't overflow


### PR DESCRIPTION
Closes:

### Description:
Replaces the client-side `useClientFeatureFlag` hook with `useServerFeatureFlag` for the `AiCustomViz` feature flag in the custom visualization config panel, ensuring the flag is evaluated server-side rather than client-side.

On the backend, the `AiCustomViz` feature flag check in `AiService` is updated to use `featureFlagService.get()` instead of the standalone `isFeatureFlagEnabled` utility function, aligning it with the service-based pattern used elsewhere.