### PR TITLE
fix: redirect bare /projects/:projectUuid to /home

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -285,6 +285,7 @@ const APP_ROUTES: RouteObject[] = [
                     </ProjectRoute>
                 ),
                 children: [
+                    { index: true, element: <Navigate to="home" replace /> },
                     {
                         path: '/projects/:projectUuid/home',
                         element: (

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -401,6 +401,7 @@ const APP_ROUTES: RouteObject[] = [
                     </ProjectRoute>
                 ),
                 children: [
+                    { index: true, element: <Navigate to="home" replace /> },
                     // Legacy sqlRunner redirect (no layout needed)
                     {
                         path: 'sqlRunner',


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/22515
Closes: [PROD-7219](https://linear.app/lightdash/issue/PROD-7219/routing-bare-projectsprojectuuid-url-renders-blank-page-instead-of).

## Summary

- Navigating directly to `/projects/<projectUuid>` rendered a blank page: the route had `<Outlet />` but no `index` child to fill it.
- Adds an `index` route in both `Routes.tsx` and `MobileRoutes.tsx` that redirects to `home`, the existing default landing page.



## Test plan

- [ ] Log in, visit `/projects/<valid-uuid>` directly — browser is redirected to `/projects/<uuid>/home` and the home page renders.
- [ ] Existing sub-routes (`/saved`, `/dashboards`, `/spaces`, `/sqlRunner`, etc.) still resolve normally.
- [ ] Same check on mobile viewport for `MobileRoutes.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)