### PR TITLE
chore: migrate `UserGroupsEnabled` to legacy feature flag

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -839,6 +839,7 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['GOOGLE_CHAT_ENABLED', 'google-chat-enabled'],
         ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
         ['USER_IMPERSONATION_ENABLED', 'user-impersonation'],
+        ['GROUPS_ENABLED', 'user-groups-enabled'],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1554,6 +1554,10 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     // bootstrapping.
     ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
     ['USER_IMPERSONATION_ENABLED', 'user-impersonation'],
+    // GROUPS_ENABLED is also read by UserService for group-sync logic (separate
+    // from the feature flag) — keep the config field, but translate the env
+    // var to the unified allowlist for the flag system too.
+    ['GROUPS_ENABLED', 'user-groups-enabled'],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -36,8 +36,6 @@ export class FeatureFlagModel {
         this.lightdashConfig = args.lightdashConfig;
         // Initialize the handlers for feature flag logic
         this.featureFlagHandlers = {
-            [FeatureFlags.UserGroupsEnabled]:
-                this.getUserGroupsEnabled.bind(this),
             [FeatureFlags.EditYamlInUi]: this.getEditYamlInUiEnabled.bind(this),
             [FeatureFlags.ShowExecutionTime]:
                 this.getShowExecutionTimeEnabled.bind(this),
@@ -97,33 +95,6 @@ export class FeatureFlagModel {
             userUuid: user.userUuid,
             organizationUuid: user.organizationUuid,
         });
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private async getUserGroupsEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.groups.enabled ??
-            (user
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.UserGroupsEnabled,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          // because we are checking this in the health check, we don't want to throw an error
-                          // nor do we want to wait too long
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
-                : false);
         return {
             id: featureFlagId,
             enabled,


### PR DESCRIPTION
Closes:

### Description:

The `GROUPS_ENABLED` environment variable is now included in the legacy env var translation layer, mapping it to the `user-groups-enabled` feature flag through the unified flag system. This means setting `GROUPS_ENABLED=true` will correctly enable the `user-groups-enabled` feature flag alongside the existing config field that `UserService` reads for group-sync logic.

As part of this change, the custom `getUserGroupsEnabled` handler in `FeatureFlagModel` has been removed. Previously, this handler had its own logic that checked `lightdashConfig.groups.enabled` and fell back to a LaunchDarkly lookup with a timeout. Now that `GROUPS_ENABLED` feeds directly into the standard feature flag allowlist, the dedicated handler is no longer needed and the flag resolves through the same path as all other feature flags.