### PR TITLE
refactor(audited-ability): widen SpacePermissionService to Account | SessionUser [SPK-416]

### DIFF
--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -1,9 +1,11 @@
 import { subject } from '@casl/ability';
 import {
     getHighestSpaceRole,
+    isAccount,
     NotFoundError,
     resolveSpaceAccess,
     type AbilityAction,
+    type Account,
     type OrganizationSpaceAccess,
     type ProjectSpaceAccess,
     type SessionUser,
@@ -31,15 +33,15 @@ export class SpacePermissionService extends BaseService {
     }
 
     /**
-     * Checks if the user has access to all the space uuids
+     * Checks if the actor has access to all the space uuids
      * @param action - The action to check permissions for
-     * @param user - The session user to check permissions for
+     * @param actor - The account or session user to check permissions for
      * @param spaceUuids - The space uuids to check permissions for
      * @returns The access context for the given space uuids
      */
     async can(
         action: AbilityAction,
-        user: SessionUser,
+        actor: Account | SessionUser,
         spaceUuids: string[] | string,
     ): Promise<boolean> {
         const spaceUuidsArray = Array.isArray(spaceUuids)
@@ -47,32 +49,32 @@ export class SpacePermissionService extends BaseService {
             : [spaceUuids];
 
         const accessContext = await this.getSpacesCaslContext(spaceUuidsArray, {
-            userUuid: user.userUuid,
+            userUuid: isAccount(actor) ? actor.user.id : actor.userUuid,
         });
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(actor);
         return Object.values(accessContext).every((access) =>
             auditedAbility.can(action, subject('Space', access)),
         );
     }
 
     /**
-     * Gets the accessible space uuids for a given action and user
+     * Gets the accessible space uuids for a given action and actor
      * @param action - The action to check permissions for
-     * @param user - The session user to check permissions for
+     * @param actor - The account or session user to check permissions for
      * @param spaceUuids - The space uuids to get the accessible space uuids for
      * @returns The accessible space uuids
      */
     async getAccessibleSpaceUuids(
         action: AbilityAction,
-        user: SessionUser,
+        actor: Account | SessionUser,
         spaceUuids: string[],
     ): Promise<string[]> {
         const accessContext = await this.getSpacesCaslContext(spaceUuids, {
-            userUuid: user.userUuid,
+            userUuid: isAccount(actor) ? actor.user.id : actor.userUuid,
         });
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(actor);
         return Object.entries(accessContext)
             .filter(([_, access]) =>
                 auditedAbility.can(action, subject('Space', access)),
@@ -256,18 +258,18 @@ export class SpacePermissionService extends BaseService {
     }
 
     /**
-     * Returns the UUID of the first root space the user can view in the project.
+     * Returns the UUID of the first root space the actor can view in the project.
      * Uses CASL-based permission checking via getAccessibleSpaceUuids.
      */
     async getFirstViewableSpaceUuid(
-        user: SessionUser,
+        actor: Account | SessionUser,
         projectUuid: string,
     ): Promise<string> {
         const allRootSpaceUuids =
             await this.spaceModel.getRootSpaceUuidsForProject(projectUuid);
         const accessible = await this.getAccessibleSpaceUuids(
             'view',
-            user,
+            actor,
             allRootSpaceUuids,
         );
         if (accessible.length === 0) {


### PR DESCRIPTION
## Summary

Part of [SPK-416](https://linear.app/lightdash/issue/SPK-416). Widens `SpacePermissionService`'s 3 audited methods to accept `Account | SessionUser`, mirroring `BaseService.createAuditedAbility`'s existing union signature. Final narrowing to `Account`-only happens in the last PR of the stack alongside `BaseService.createAuditedAbility`.

Stacked on #22516.

## Why a union (not `Account`-only)

`SpacePermissionService` is the chokepoint service called by ~13 other services. Migrating it ahead of those callers requires **either**:

1. **Account-only signature + `fromSession(user)` shims at every call site** (the original approach in this PR), or
2. **`Account | SessionUser` union — callers pass whatever they already have** (this approach).

Option 1 has two latent regressions:

- **`requestContext` is dropped.** `sessionAccountMiddleware` only attaches `requestContext` (ip/userAgent/requestId) to the original `req.account` and `req.user`. `fromSession()` synthesizes a fresh account that doesn't carry it forward, so audit events fired from `SpacePermissionService.can` lose those fields for the duration of the migration (PRs 4, 6, 8, 9, 10).
- **`authentication.type` is misreported.** `fromSession()` hard-codes `type: 'session'`. ApiKey, OAuth, and service-account requests would be relabeled as session-authenticated for every space CASL check.

Option 2 — the union — sidesteps both. Each downstream service migrates in its own scoped PR (PR4: `SpaceService`/`ContentService`/`ValidationService`/`CommentService`; PR6: `CoderService`/`SavedSqlService`; PR8: `DashboardService`/`SavedChartService`; PR9: `CatalogService`; PR10: `ProjectService`) and `SpacePermissionService` accepts whatever shape they pass.

## Method changes

`SpacePermissionService`:
- `can(action, actor, spaceUuids)` — `actor: Account | SessionUser`
- `getAccessibleSpaceUuids(action, actor, spaceUuids)` — `actor: Account | SessionUser`
- `getFirstViewableSpaceUuid(actor, projectUuid)` — `actor: Account | SessionUser`

Internal:
- `userUuid` extraction via `isAccount(actor) ? actor.user.id : actor.userUuid`
- `actor` passed through to `createAuditedAbility` unchanged (it already accepts the same union)

No caller-side changes — every existing `user`-passing call site continues to work.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [ ] CI green

## Diff size

1 file, +15 / -13.