### PR TITLE
fix: drop silent 50-row default in CatalogModel.search

### DIFF
--- a/packages/api-tests/tests/catalog.test.ts
+++ b/packages/api-tests/tests/catalog.test.ts
@@ -875,12 +875,6 @@ describe('Lightdash catalog filter / segment dimensions', () => {
         admin = await login();
     });
 
-    // Regression for PROD-7206: CatalogModel.search defaulted paginateArgs
-    // to pageSize 50, so callers that wanted the full per-table dim list
-    // silently lost any rows past position 50. The events explore is the
-    // only seed explore wide enough (> 50 indexable dimensions) to expose
-    // the truncation. Compute the expected set from the explore directly
-    // so this test stays correct as the YAML evolves.
     const expectedFilterableDimNames = (explore: {
         baseTable: string;
         tables: Record<
@@ -898,16 +892,15 @@ describe('Lightdash catalog filter / segment dimensions', () => {
         >;
     }) => {
         const baseDims = explore.tables[explore.baseTable]?.dimensions ?? {};
-        return new Set(
-            Object.entries(baseDims)
-                .filter(
-                    ([, d]) =>
-                        (d.type === 'string' || d.type === 'boolean') &&
-                        !d.hidden &&
-                        !d.timeIntervalBaseDimensionName,
-                )
-                .map(([name]) => name),
-        );
+        return Object.entries(baseDims)
+            .filter(
+                ([, d]) =>
+                    (d.type === 'string' || d.type === 'boolean') &&
+                    !d.hidden &&
+                    !d.timeIntervalBaseDimensionName,
+            )
+            .map(([name]) => name)
+            .sort();
     };
 
     it('filter-dimensions returns every same-table filterable dimension on a wide explore', async () => {
@@ -918,7 +911,6 @@ describe('Lightdash catalog filter / segment dimensions', () => {
         }>(`${apiUrl}/projects/${projectUuid}/explores/events`);
         expect(exploreResp.status).toBe(200);
         const expected = expectedFilterableDimNames(exploreResp.body.results);
-        // Must exceed the historical 50-row default to actually exercise the regression.
         const totalIndexable = Object.values(
             exploreResp.body.results.tables[exploreResp.body.results.baseTable]
                 ?.dimensions ?? {},
@@ -931,7 +923,7 @@ describe('Lightdash catalog filter / segment dimensions', () => {
             `${apiUrl}/projects/${projectUuid}/dataCatalog/events/filter-dimensions`,
         );
         expect(dimsResp.status).toBe(200);
-        const actual = new Set(dimsResp.body.results.map((d) => d.name));
+        const actual = dimsResp.body.results.map((d) => d.name).sort();
 
         expect(actual).toEqual(expected);
         dimsResp.body.results.forEach((d) => {
@@ -955,7 +947,7 @@ describe('Lightdash catalog filter / segment dimensions', () => {
             `${apiUrl}/projects/${projectUuid}/dataCatalog/events/segment-dimensions`,
         );
         expect(dimsResp.status).toBe(200);
-        const actual = new Set(dimsResp.body.results.map((d) => d.name));
+        const actual = dimsResp.body.results.map((d) => d.name).sort();
 
         expect(actual).toEqual(expected);
     });
@@ -968,10 +960,6 @@ describe('Lightdash catalog metrics list pagination', () => {
         admin = await login();
     });
 
-    // Regression for PROD-7206 follow-up: getMetricsCatalog falls back to
-    // pageSize: 50 at the service layer when the controller doesn't pass
-    // page/pageSize. Without the fallback the endpoint would return every
-    // metric in the project unbounded.
     it('Should cap at 50 metrics when caller omits page/pageSize', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         const resp = await admin.get<{

--- a/packages/api-tests/tests/catalog.test.ts
+++ b/packages/api-tests/tests/catalog.test.ts
@@ -867,3 +867,130 @@ describe('Lightdash analytics - space access filtering', () => {
         expect(chartUuids).not.toContain(privateChartUuid);
     });
 });
+
+describe('Lightdash catalog filter / segment dimensions', () => {
+    let admin: ApiClient;
+
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    // Regression for PROD-7206: CatalogModel.search defaulted paginateArgs
+    // to pageSize 50, so callers that wanted the full per-table dim list
+    // silently lost any rows past position 50. The events explore is the
+    // only seed explore wide enough (> 50 indexable dimensions) to expose
+    // the truncation. Compute the expected set from the explore directly
+    // so this test stays correct as the YAML evolves.
+    const expectedFilterableDimNames = (explore: {
+        baseTable: string;
+        tables: Record<
+            string,
+            {
+                dimensions: Record<
+                    string,
+                    {
+                        type?: string;
+                        hidden?: boolean;
+                        timeIntervalBaseDimensionName?: string;
+                    }
+                >;
+            }
+        >;
+    }) => {
+        const baseDims = explore.tables[explore.baseTable]?.dimensions ?? {};
+        return new Set(
+            Object.entries(baseDims)
+                .filter(
+                    ([, d]) =>
+                        (d.type === 'string' || d.type === 'boolean') &&
+                        !d.hidden &&
+                        !d.timeIntervalBaseDimensionName,
+                )
+                .map(([name]) => name),
+        );
+    };
+
+    it('filter-dimensions returns every same-table filterable dimension on a wide explore', async () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const exploreResp = await admin.get<{
+            results: Parameters<typeof expectedFilterableDimNames>[0];
+        }>(`${apiUrl}/projects/${projectUuid}/explores/events`);
+        expect(exploreResp.status).toBe(200);
+        const expected = expectedFilterableDimNames(exploreResp.body.results);
+        // Must exceed the historical 50-row default to actually exercise the regression.
+        const totalIndexable = Object.values(
+            exploreResp.body.results.tables[exploreResp.body.results.baseTable]
+                ?.dimensions ?? {},
+        ).filter((d) => !d.hidden).length;
+        expect(totalIndexable).toBeGreaterThan(50);
+
+        const dimsResp = await admin.get<{
+            results: Array<{ name: string; type: string; table: string }>;
+        }>(
+            `${apiUrl}/projects/${projectUuid}/dataCatalog/events/filter-dimensions`,
+        );
+        expect(dimsResp.status).toBe(200);
+        const actual = new Set(dimsResp.body.results.map((d) => d.name));
+
+        expect(actual).toEqual(expected);
+        dimsResp.body.results.forEach((d) => {
+            expect(['string', 'boolean']).toContain(d.type);
+            expect(d.table).toBe('events');
+        });
+    });
+
+    it('segment-dimensions returns every same-table filterable dimension on a wide explore', async () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        const exploreResp = await admin.get<{
+            results: Parameters<typeof expectedFilterableDimNames>[0];
+        }>(`${apiUrl}/projects/${projectUuid}/explores/events`);
+        expect(exploreResp.status).toBe(200);
+        const expected = expectedFilterableDimNames(exploreResp.body.results);
+
+        const dimsResp = await admin.get<{
+            results: Array<{ name: string; type: string; table: string }>;
+        }>(
+            `${apiUrl}/projects/${projectUuid}/dataCatalog/events/segment-dimensions`,
+        );
+        expect(dimsResp.status).toBe(200);
+        const actual = new Set(dimsResp.body.results.map((d) => d.name));
+
+        expect(actual).toEqual(expected);
+    });
+});
+
+describe('Lightdash catalog metrics list pagination', () => {
+    let admin: ApiClient;
+
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    // Regression for PROD-7206 follow-up: getMetricsCatalog falls back to
+    // pageSize: 50 at the service layer when the controller doesn't pass
+    // page/pageSize. Without the fallback the endpoint would return every
+    // metric in the project unbounded.
+    it('Should cap at 50 metrics when caller omits page/pageSize', async () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+        const resp = await admin.get<{
+            results: { data: CatalogField[]; pagination: { pageSize: number } };
+        }>(`${apiUrl}/projects/${projectUuid}/dataCatalog/metrics`);
+        expect(resp.status).toBe(200);
+        expect(resp.body.results.pagination.pageSize).toBe(50);
+        expect(resp.body.results.data.length).toBeLessThanOrEqual(50);
+    });
+
+    it('Should respect explicit pageSize when caller provides it', async () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+        const resp = await admin.get<{
+            results: { data: CatalogField[]; pagination: { pageSize: number } };
+        }>(
+            `${apiUrl}/projects/${projectUuid}/dataCatalog/metrics?page=1&pageSize=10`,
+        );
+        expect(resp.status).toBe(200);
+        expect(resp.body.results.pagination.pageSize).toBe(10);
+        expect(resp.body.results.data.length).toBe(10);
+    });
+});

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -1226,10 +1226,7 @@ export class CatalogModel {
             catalogItemsQuery.select<
                 (DbCatalog & { explore: Explore; search_rank: number })[]
             >(),
-            {
-                page: paginateArgs?.page ?? 1,
-                pageSize: paginateArgs?.pageSize ?? 50,
-            },
+            paginateArgs,
         );
 
         const tagsPerItem = await this.getTagsPerItem(

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -976,7 +976,9 @@ export class CatalogService<
                 ownerUserUuids,
             },
             context,
-            paginateArgs,
+            // Explicit cap when caller omits paginateArgs: this is a project-wide
+            // metrics list and could otherwise grow unbounded.
+            paginateArgs: paginateArgs ?? { page: 1, pageSize: 50 },
             sortArgs,
         });
 

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -728,6 +728,9 @@ export class CatalogService<
                 userAttributes,
                 catalogSearch,
                 context,
+                // Explicit cap: this is a project-wide browse search and the result
+                // can otherwise grow unbounded. Preserves the historical 50-row behaviour.
+                paginateArgs: { page: 1, pageSize: 50 },
             });
         }
 
@@ -1469,6 +1472,9 @@ export class CatalogService<
             tablesConfiguration:
                 await this.projectModel.getTablesConfiguration(projectUuid),
             hasTimeDimension: true,
+            // Explicit cap: this v1 endpoint is project-wide when tableName is omitted
+            // and could otherwise grow unbounded. Use the v2 paginated endpoint for full results.
+            paginateArgs: { page: 1, pageSize: 50 },
         });
 
         const filteredMetrics = allCatalogMetrics.data.filter(


### PR DESCRIPTION
## Summary

`CatalogModel.search` defaulted `pageSize` to 50 when callers omitted `paginateArgs`, silently truncating per-table dim lists. The Metrics Catalog filter dropdown lost dimensions on tables with more than 50 catalog rows.

The truncation was made worse by `getFilterDimensions` applying its in-memory `string|boolean only / exclude time-derived` filter *after* the DB pagination — so up to 50 catalog rows came back, and the type filter could shrink the visible result further.

Drops the silent default and adds explicit `{ pageSize: 50 }` to the project-wide callers that relied on it (`getCatalog` search, `getMetricsCatalog`, v1 metrics-with-time-dimensions). `getFilterDimensions` and `getSegmentDimensions` now return the full per-table list, bounded by their `exploreName` filter.

## Test plan

- [x] New API regression tests in `catalog.test.ts` against the seeded `events` explore (the only seed wide enough to hit the cap)
- [x] Backend lint + typecheck clean

Closes: https://github.com/lightdash/lightdash/issues/22497