### PR TITLE
chore: simplify `AiCopilot` feature flag logic to use DB-backed overrides

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -77,34 +77,24 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
         featureFlagId,
         user,
     }: FeatureFlagLogicArgs) {
-        let enabled = false;
+        const { enabled: copilotConfigEnabled, requiresFeatureFlag } =
+            this.lightdashConfig.ai.copilot;
 
-        if (
-            this.lightdashConfig.ai.copilot.enabled &&
-            this.lightdashConfig.ai.copilot.requiresFeatureFlag
-        ) {
-            if (!user) {
-                throw new Error(
-                    'User is required to check if AI copilot is enabled',
-                );
-            }
-
-            enabled = await isFeatureFlagEnabled(
-                CommercialFeatureFlags.AiCopilot as AnyType as FeatureFlags,
-                {
-                    userUuid: user.userUuid,
-                    organizationUuid: user.organizationUuid,
-                    organizationName: user.organizationName,
-                },
-            );
-        } else {
-            enabled = this.lightdashConfig.ai.copilot.enabled;
+        // Dedicated instances (per the AI Copilot tenant docs) bypass the
+        // flag system entirely. Shared tenants (app/eu1) set
+        // requiresFeatureFlag=true and gate per-org via DB-backed overrides.
+        if (!copilotConfigEnabled || !requiresFeatureFlag) {
+            return { id: featureFlagId, enabled: copilotConfigEnabled };
         }
 
-        return {
-            id: featureFlagId,
-            enabled,
-        };
+        if (!user) {
+            throw new Error(
+                'User is required to check if AI copilot is enabled',
+            );
+        }
+
+        const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });
+        return dbResult ?? { id: featureFlagId, enabled: false };
     }
 
     private static async getAgentReasoningFlag({

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -166,7 +166,7 @@ export class FeatureFlagModel {
         return dbResult ?? { id: args.featureFlagId, enabled: false };
     }
 
-    private async tryGetFromDatabase(
+    protected async tryGetFromDatabase(
         args: FeatureFlagLogicArgs,
     ): Promise<FeatureFlag | null> {
         try {


### PR DESCRIPTION
Closes:

### Description:

Refactors the AI Copilot feature flag logic to simplify the enabled/disabled branching and align with how dedicated vs. shared tenants are configured.

Previously, the logic checked both `copilot.enabled` and `copilot.requiresFeatureFlag` before deciding whether to call `isFeatureFlagEnabled`, falling back to the config value otherwise. This has been replaced with an early return: if `copilotConfigEnabled` is false or `requiresFeatureFlag` is not set, the config value is returned directly without hitting the database. This correctly handles dedicated instances, which bypass the flag system entirely.

For shared tenants (e.g. `app`/`eu1`) where `requiresFeatureFlag=true`, the logic now delegates to `tryGetFromDatabase` (previously `private`, now `protected` to allow subclass access) to resolve per-org overrides stored in the database.