### PR TITLE
chore: migrate `Embedding` to legacy feature flag

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -841,6 +841,7 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['USER_IMPERSONATION_ENABLED', 'user-impersonation'],
         ['GROUPS_ENABLED', 'user-groups-enabled'],
         ['SHOW_EXECUTION_TIME', 'show-execution-time'],
+        ['EMBEDDING_ENABLED', 'embedding'],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1558,6 +1558,10 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     // var to the unified allowlist for the flag system too.
     ['GROUPS_ENABLED', 'user-groups-enabled'],
     ['SHOW_EXECUTION_TIME', 'show-execution-time'],
+    // EMBEDDING_ENABLED is also read by HealthService (exposed via the health
+    // endpoint) and EmbedService (allowAll config). Keep the config field, but
+    // translate the env var to the unified allowlist for the flag system.
+    ['EMBEDDING_ENABLED', 'embedding'],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -17,36 +17,9 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
         this.featureFlagHandlers = {
             ...this.featureFlagHandlers, // Inherit parent handlers
             // Add new commercial handlers
-            [CommercialFeatureFlags.Embedding]:
-                this.getEmbeddingFlag.bind(this),
             [CommercialFeatureFlags.Scim]: this.getScimFlag.bind(this),
             [CommercialFeatureFlags.AiCopilot]:
                 this.getAiCopilotFlag.bind(this),
-        };
-    }
-
-    private async getEmbeddingFlag({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.embedding.enabled ||
-            (user
-                ? await isFeatureFlagEnabled(
-                      CommercialFeatureFlags.Embedding as AnyType as FeatureFlags,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                          organizationName: user.organizationName,
-                      },
-                      {
-                          throwOnTimeout: false,
-                      },
-                  )
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
         };
     }
 


### PR DESCRIPTION
Closes:

### Description:

The `EMBEDDING_ENABLED` environment variable is now registered as a legacy feature flag translation, mapping it to the unified `embedding` feature flag ID. This brings it in line with how other legacy env vars (e.g. `GROUPS_ENABLED`) are handled — the config field is preserved for use by `HealthService` and `EmbedService`, while the env var is also translated into the feature flag allowlist.

As a result, the custom `getEmbeddingFlag` handler in `CommercialFeatureFlagModel` has been removed, since the embedding flag no longer requires special resolution logic and can rely on the standard flag system instead.