### PR TITLE
fix: use RFC 5987 encoding for Content-Disposition to handle non-ASCII filenames (PROD-7227)

### DIFF
--- a/packages/backend/src/controllers/fileController.ts
+++ b/packages/backend/src/controllers/fileController.ts
@@ -11,6 +11,7 @@ import {
 import express from 'express';
 import path from 'path';
 import { pipeline } from 'stream/promises';
+import { createContentDispositionHeader } from '../utils/FileDownloadUtils/FileDownloadUtils';
 import { BaseController } from './baseController';
 
 const NANOID_REGEX = /^[\w-]{21}$/;
@@ -62,9 +63,13 @@ export class FileController extends BaseController {
         const filename = path.basename(s3Key);
 
         res.setHeader('Content-Type', contentType);
+        // Use RFC 5987 encoding so non-ASCII characters in the filename
+        // (em-dashes, accented letters, emojis from dashboard names) don't
+        // make Node throw `ERR_INVALID_CHAR` on setHeader, which would turn
+        // the download into a ~200-byte JSON error response (PROD-7227).
         res.setHeader(
             'Content-Disposition',
-            `attachment; filename="${filename.replace(/"/g, '')}"`,
+            createContentDispositionHeader(filename),
         );
         res.setHeader('X-Robots-Tag', 'noindex, nofollow');
 


### PR DESCRIPTION
Closes:  https://linear.app/lightdash/issue/PROD-7227/exports-dashboard-csv-zip-download-broken-returns-tiny-corrupted-files

  BUG FIX REPORT
════════════════════════════════════════
Issue:           PROD-7227 — Dashboard CSV ZIP "tiny corrupted file" / "Site wasn't available"
Root cause:      fileController.getFile interpolated the s3Key filename directly into
Content-Disposition. Non-ASCII bytes (emoji, em-dash, accented chars from
dashboard names) made Node.setHeader throw ERR_INVALID_CHAR. TSOA turned
the throw into a ~200-byte JSON error response while Content-Type was
already application/zip, so the browser saved JSON as the .zip filename.
Fix:             Use the existing createContentDispositionHeader helper (RFC 5987 ASCII
fallback + filename* UTF-8 form). 5 lines in 1 file.
Verified:        Reproduced locally with the same stack trace as Cloud, fix works on
user's "🚀 Dashboard with emojis" branch.
Status:          DONE
════════════════════════════════════════



Before

only with `PERSISTENT_DOWNLOAD_URLS_ENABLED=true` enabled

```
wed)
packages/backend dev: 2026-04-30 09:49:34 [Lightdash][WEB:0.2847.0] http: GET /api/v1/schedulers/job/9609/status 200 - 4 ms
packages/backend dev: 2026-04-30 09:49:34 [Lightdash][PersistentDownloadFileService] info: Serving persistent download (stream): nanoid=2bmNHuFAezYb6CjL_Hiby, ip=::1, userAgent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36
packages/backend dev: TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Content-Disposition"]
packages/backend dev:     at ServerResponse.setHeader (node:_http_outgoing:658:3)
packages/backend dev:     at FileController.getFile (/Users/javier/work/lightdash/packages/backend/src/controllers/fileController.ts:65:13)
packages/backend dev:     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
packages/backend dev:     at async ExpressTemplateService.apiHandler (/Users/javier/work/lightdash/node_modules/.pnpm/@tsoa+runtime@6.6.0/node_modules/@tsoa/runtime/src/routeGeneration/templates/express/expressTemplateService.ts:37:20)
packages/backend dev:     at async FileController_getFile (/Users/javier/work/lightdash/packages/backend/src/generated/routes.ts:52871:17) {
packages/backend dev:   code: 'ERR_INVALID_CHAR'
packages/backend dev: }
packages/backend dev: 2026-04-30 09:49:34 [Lightdash] error: Handled error of type UnexpectedServerError on [GET] /api/v1/file/2bmNHuFAezYb6CjL_Hiby Something went wrong.
packages/backend dev: 2026-04-30 09:49:34 [Lightdash] error: TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Content-Disposition"]
packages/backend dev:     at ServerResponse.setHeader (node:_http_outgoing:658:3)
packages/backend dev:     at FileController.getFile (/Users/javier/work/lightdash/packages/backend/src/controllers/fileController.ts:65:13)
packages/backend dev:     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
packages/backend dev:     at async ExpressTemplateService.apiHandler (/Users/javier/work/lightdash/node_modules/.pnpm/@tsoa+runtime@6.6.0/node_modules/@tsoa/runtime/src/routeGeneration/templates/express/expressTemplateService.ts:37:20)
packages/backend dev:     at async FileController_getFile (/Users/javier/work/lightdash/packages/backend/src/generated/routes.ts:52871:17)
packages/backend dev: 2026-04-30 09:49:34 [Lightdash] http: GET /api/v1/file/2bmNHuFAezYb6CjL_Hiby 500 - 110 ms
```

![CleanShot 2026-04-30 at 09.50.13.png](https://app.graphite.com/user-attachments/assets/e0d519ad-706a-4287-94e8-ea6bc053f203.png)



After



![CleanShot 2026-04-30 at 09.51.05.png](https://app.graphite.com/user-attachments/assets/61231b53-826a-4693-90ef-bc68a84562ba.png)



### Description:

When downloading files whose names contain non-ASCII characters (e.g. em-dashes, accented letters, or emojis from dashboard names), Node would throw an `ERR_INVALID_CHAR` error when setting the `Content-Disposition` header. This caused the download to fail and return a ~200-byte JSON error response instead of the file.

The fix replaces the inline `Content-Disposition` header construction with a `createContentDispositionHeader` utility that uses RFC 5987 encoding, ensuring non-ASCII filenames are safely encoded and the header is set without errors.