### PR TITLE
fix(table-calc): harmonise dark-mode colors in formula modal

### DIFF
--- a/packages/frontend/src/components/common/SuggestionList/SuggestionList.module.css
+++ b/packages/frontend/src/components/common/SuggestionList/SuggestionList.module.css
@@ -20,6 +20,14 @@
     }
 
     @mixin dark {
-        background-color: var(--mantine-color-ldDark-5);
+        background-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.itemDescription {
+    color: var(--mantine-color-dimmed);
+
+    @mixin dark {
+        color: var(--mantine-color-ldGray-7);
     }
 }

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.module.css
@@ -91,7 +91,7 @@
 
     @mixin dark {
         background-color: var(--mantine-color-ldDark-3);
-        color: var(--mantine-color-ldGray-5);
+        color: var(--mantine-color-ldGray-7);
         border-color: var(--mantine-color-ldDark-5);
         box-shadow: 0 1px 0 0 var(--mantine-color-ldDark-5);
     }
@@ -121,6 +121,7 @@
 
     @mixin dark {
         color: var(--mantine-color-indigo-3);
+        opacity: 0.7;
     }
 }
 

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/ImproveWithAiSlot.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/ImproveWithAiSlot.module.css
@@ -25,7 +25,7 @@
 
     @mixin dark {
         background-color: var(--mantine-color-ldDark-3);
-        color: var(--mantine-color-ldGray-5);
+        color: var(--mantine-color-ldGray-7);
         border-color: var(--mantine-color-ldDark-5);
         box-shadow: 0 1px 0 0 var(--mantine-color-ldDark-5);
     }

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/generateFunctionSuggestion.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/generateFunctionSuggestion.tsx
@@ -42,7 +42,12 @@ export const generateFunctionSuggestion = (
                     <Text size="xs" fw={500}>
                         {item.label}
                     </Text>
-                    <Text size="xs" c="dimmed" truncate maw={200}>
+                    <Text
+                        size="xs"
+                        truncate
+                        maw={200}
+                        className={suggestionStyles.itemDescription}
+                    >
                         {(item as FunctionSuggestionItem).description}
                     </Text>
                 </Group>


### PR DESCRIPTION
## Summary

Lifts secondary-text contrast and softens the hover state across the **Create/Update Table Calculation** formula modal so dark mode reads cleanly.

| Element | Before (dark) | After (dark) |
|---|---|---|
| Suggestion list hover/select bg | `ldDark-5` (#525252) | `ldDark-4` (#3b3b3b) — subtler |
| Suggestion description text | `c="dimmed"` (~#686868) | `ldGray-7` (#9e9e9e) |
| `⇥ Tab` keycap text | `ldGray-5` (#525252) | `ldGray-7` (#9e9e9e) |
| Inline preview ghost | `indigo-3` × opacity 0.45 | `indigo-3` × opacity 0.7 |
| "Improve with AI" trigger text | `ldGray-5` (#525252) | `ldGray-7` (#9e9e9e) |

Light mode is unchanged — every override is gated on `@mixin dark`.

## Test plan

- [ ] Open the Create Table Calculation modal in dark mode and trigger the `#` suggestions — descriptions are readable, hover/selected row blends rather than glares.
- [ ] Type into the formula editor so the `⇥ Tab` keycap renders — the chip text is legible against the chip background.
- [ ] Trigger an AI preview so the inline ghost (`→ ...`) appears — it reads clearly without losing its ghost feel.
- [ ] Confirm the "Improve with AI" trigger button (bottom-right of the editor) reads clearly in dark mode.
- [ ] Re-check the same flows in light mode — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)