### PR TITLE
fix(saved-charts): allow saving chart edits when SQL TC/dim is unchanged

### DIFF
--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -20,16 +20,15 @@ import {
     ExploreType,
     ForbiddenError,
     generateSlug,
+    getModifiedSqlAuthoredFields,
     getSchedulerResourceTypeAndId,
     getTimezoneLabel,
     GoogleSheetsTransientError,
     isConditionalFormattingConfigWithColorRange,
     isConditionalFormattingConfigWithSingleColor,
-    isCustomSqlDimension,
     isFormulaTableCalculation,
     isJwtUser,
     isSchedulerGsheetsOptions,
-    isSqlTableCalculation,
     isUserWithOrg,
     isValidFrequency,
     isValidTimezone,
@@ -485,11 +484,10 @@ export class SavedChartService
             organizationUuid,
             projectUuid,
             spaceUuid,
-            metricQuery: {
-                metrics: oldChartMetrics,
-                dimensions: oldChartDimensions,
-            },
+            metricQuery: oldMetricQuery,
         } = await this.savedChartModel.get(savedChartUuid);
+        const { metrics: oldChartMetrics, dimensions: oldChartDimensions } =
+            oldMetricQuery;
 
         const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getSpaceAccessContext(
@@ -513,16 +511,22 @@ export class SavedChartService
             throw new ForbiddenError();
         }
 
+        const modifiedSqlFields = getModifiedSqlAuthoredFields(
+            data.metricQuery,
+            oldMetricQuery,
+        );
+        const cannotManageCustomFields = auditedAbility.cannot(
+            'manage',
+            subject('CustomFields', {
+                organizationUuid,
+                projectUuid,
+                metadata: { savedChartUuid },
+            }),
+        );
+
         if (
-            data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            auditedAbility.cannot(
-                'manage',
-                subject('CustomFields', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: { savedChartUuid },
-                }),
-            )
+            modifiedSqlFields.customDimensions.length > 0 &&
+            cannotManageCustomFields
         ) {
             throw new ForbiddenError(
                 'User cannot save queries with custom SQL dimensions',
@@ -530,15 +534,8 @@ export class SavedChartService
         }
 
         if (
-            data.metricQuery.tableCalculations.some(isSqlTableCalculation) &&
-            auditedAbility.cannot(
-                'manage',
-                subject('CustomFields', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: { savedChartUuid },
-                }),
-            )
+            modifiedSqlFields.tableCalculations.length > 0 &&
+            cannotManageCustomFields
         ) {
             throw new ForbiddenError(
                 'User cannot save queries with custom SQL table calculations',


### PR DESCRIPTION
## Summary

Editors without `manage CustomFields` permission could not save **any** edit to a chart that contained a SQL table calculation or SQL custom dimension authored by someone else — even when they did not touch those fields. They saw:

> User cannot save queries with custom SQL table calculations

(or the matching `…custom SQL dimensions` variant).

The save-time gate threw on the *presence* of any SQL-authored field instead of on its *modification*. So an admin creating a chart with a SQL TC effectively locked everyone else out of editing literally anything else on that chart — adding a dimension, changing a filter, renaming the chart — all blocked.

## Fix

Switch `SavedChartService.createVersion` to use `getModifiedSqlAuthoredFields` — the same helper `AsyncQueryService` already uses on the query/read side (`AsyncQueryService.ts:3609`) for exactly this "carry-over fine, modification gated" rule. The save gate now fires **only** when the editor actually adds, removes, or changes a SQL TC / SQL custom dimension. Carrying an unchanged SQL field over from the saved chart is allowed.

The two distinct error messages (dimensions vs. table calculations) are preserved so the UX still tells you *which* kind of SQL field is the problem when you do hit the gate.

## Regression analysis — who's affected, who isn't

| Case | Before | After |
|---|---|---|
| Editor (no `CustomFields`) saves chart that has SQL TC, **doesn't touch SQL TC** | ❌ blocked | ✅ allowed |
| Editor (no `CustomFields`) **modifies** an existing SQL TC's body | ❌ blocked | ❌ blocked |
| Editor (no `CustomFields`) **adds** a new SQL TC | ❌ blocked | ❌ blocked |
| Editor (no `CustomFields`) **renames** a SQL TC (treated as new id) | ❌ blocked | ❌ blocked |
| Admin (with `CustomFields`) anything | ✅ allowed | ✅ allowed |
| Service accounts / CI | already had `CustomFields` via `ORG_ADMIN` | unchanged |
| Custom roles | gated entirely on the same `manage CustomFields` scope | unchanged behaviour, just precision-gated |
| `createSavedChart` (new chart creation, line 1255) | strict `assertCanAccessSqlAuthoredFields` | unchanged — correct for creates because there's no saved baseline to diff against |
| Stripped-SQL round-trips (incoming `sql=''` because transport scrubbed it) | the old hand-rolled `.some(isSqlTableCalculation)` would return false (empty `sql` fails the type guard), so saves slipped through; this was a latent inconsistency | now treated as *preserved* by `getModifiedSqlAuthoredFields` (which has explicit logic for this case) — same outcome, intentional |

The only behaviour that changes is the customer-reported case: an editor without `CustomFields` can now save edits to charts with SQL fields they didn't touch, which is what the permission was always meant to gate on (authoring SQL, not glancing at it).

## Test plan

- [ ] As admin, create a chart in an explore that contains a SQL table calculation. Save it.
- [ ] As an editor without `manage CustomFields` (e.g. a custom role missing the `CustomFields:manage` scope), open that chart, add a dimension and save → should succeed.
- [ ] Same editor opens the chart and edits the SQL TC body → save should be blocked with the existing error message.
- [ ] Same editor adds a brand-new SQL TC → blocked with the existing error message.
- [ ] Repeat all three for SQL custom dimensions, expecting the matching `…custom SQL dimensions` error message in the blocked cases.
- [ ] Admin still saves any of the above without issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)