### PR TITLE
fix(scheduler): translate Slack errors to actionable messages in scheduler log [PROD-7211]

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -82,6 +82,7 @@ import {
     ThresholdOperator,
     ThresholdOptions,
     TimeZone,
+    translateSlackError,
     UnexpectedGoogleSheetsError,
     UnexpectedServerError,
     UploadMetricGsheetPayload,
@@ -1282,6 +1283,7 @@ export default class SchedulerTask {
                 },
             });
 
+            const translatedSlackError = translateSlackError(e);
             await this.schedulerService.logSchedulerJob({
                 task: SCHEDULER_TASKS.SEND_SLACK_NOTIFICATION,
                 schedulerUuid,
@@ -1292,7 +1294,10 @@ export default class SchedulerTask {
                 targetType: 'slack',
                 status: SchedulerJobStatus.ERROR,
                 details: {
-                    error: getErrorMessage(e),
+                    error: translatedSlackError?.error ?? getErrorMessage(e),
+                    ...(translatedSlackError && {
+                        slackErrorCode: translatedSlackError.slackErrorCode,
+                    }),
                     projectUuid: notification.projectUuid,
                     organizationUuid: notification.organizationUuid,
                     createdByUserUuid: notification.userUuid,
@@ -3636,6 +3641,7 @@ export default class SchedulerTask {
                     error: `${e}`,
                 },
             });
+            const translatedSlackError = translateSlackError(e);
             await this.schedulerService.logSchedulerJob({
                 task: SCHEDULER_TASKS.HANDLE_SCHEDULED_DELIVERY,
                 schedulerUuid,
@@ -3644,7 +3650,10 @@ export default class SchedulerTask {
                 scheduledTime,
                 status: SchedulerJobStatus.ERROR,
                 details: {
-                    error: getErrorMessage(e),
+                    error: translatedSlackError?.error ?? getErrorMessage(e),
+                    ...(translatedSlackError && {
+                        slackErrorCode: translatedSlackError.slackErrorCode,
+                    }),
                     projectUuid: schedulerPayload.projectUuid,
                     organizationUuid: schedulerPayload.organizationUuid,
                     createdByUserUuid: schedulerPayload.userUuid,
@@ -4491,6 +4500,20 @@ export default class SchedulerTask {
             });
         } else if (succeeded === 0) {
             // All failed - total failure
+            const translatedByCode = new Map<string, string>();
+            for (const r of settledResults) {
+                if (r.status === 'rejected') {
+                    const t = translateSlackError(r.reason);
+                    if (t) translatedByCode.set(t.slackErrorCode, t.error);
+                }
+            }
+            const batchErrorMessage =
+                translatedByCode.size > 0
+                    ? `All Slack deliveries failed: ${[
+                          ...translatedByCode.values(),
+                      ].join(' ')}`
+                    : 'All Slack deliveries failed';
+            const slackErrorCodes = [...translatedByCode.keys()];
             this.analytics.track({
                 event: 'scheduler_notification_job.failed',
                 anonymousId: LightdashAnalytics.anonymousId,
@@ -4507,7 +4530,7 @@ export default class SchedulerTask {
                     failed,
                     sendNow: false,
                     isThresholdAlert: scheduler.thresholds !== undefined,
-                    error: 'All Slack deliveries failed',
+                    error: batchErrorMessage,
                 },
             });
             await this.schedulerService.logSchedulerJob({
@@ -4522,7 +4545,8 @@ export default class SchedulerTask {
                     projectUuid: notification.projectUuid,
                     organizationUuid: notification.organizationUuid,
                     createdByUserUuid: notification.userUuid,
-                    error: 'All Slack deliveries failed',
+                    error: batchErrorMessage,
+                    ...(slackErrorCodes.length > 0 && { slackErrorCodes }),
                     batchResult,
                 },
             });

--- a/packages/common/src/utils/slack.test.ts
+++ b/packages/common/src/utils/slack.test.ts
@@ -1,0 +1,87 @@
+import {
+    getSlackErrorCode,
+    isSlackRateLimitedError,
+    isUnrecoverableSlackError,
+    SLACK_USER_FACING_ERROR_MESSAGES,
+    translateSlackError,
+} from './slack';
+
+describe('getSlackErrorCode', () => {
+    it('returns the error code from a Slack API error shape', () => {
+        expect(getSlackErrorCode({ data: { error: 'invalid_blocks' } })).toBe(
+            'invalid_blocks',
+        );
+    });
+
+    it('returns undefined for non-Slack errors', () => {
+        expect(getSlackErrorCode(new Error('boom'))).toBeUndefined();
+        expect(getSlackErrorCode(undefined)).toBeUndefined();
+        expect(getSlackErrorCode(null)).toBeUndefined();
+        expect(getSlackErrorCode('string')).toBeUndefined();
+        expect(getSlackErrorCode({ data: {} })).toBeUndefined();
+    });
+});
+
+describe('isUnrecoverableSlackError', () => {
+    it('returns true for known unrecoverable codes', () => {
+        expect(
+            isUnrecoverableSlackError({ data: { error: 'channel_not_found' } }),
+        ).toBe(true);
+        expect(
+            isUnrecoverableSlackError({ data: { error: 'invalid_auth' } }),
+        ).toBe(true);
+    });
+
+    it('returns false for recoverable or unknown codes', () => {
+        expect(
+            isUnrecoverableSlackError({ data: { error: 'invalid_blocks' } }),
+        ).toBe(false);
+        expect(isUnrecoverableSlackError(new Error('boom'))).toBe(false);
+    });
+});
+
+describe('isSlackRateLimitedError', () => {
+    it('returns true for the @slack/web-api rate limit error', () => {
+        const error = Object.assign(new Error('rate limited'), {
+            code: 'slack_webapi_rate_limited_error',
+        });
+        expect(isSlackRateLimitedError(error)).toBe(true);
+    });
+
+    it('returns false for other errors', () => {
+        expect(isSlackRateLimitedError(new Error('boom'))).toBe(false);
+        expect(
+            isSlackRateLimitedError({ data: { error: 'invalid_blocks' } }),
+        ).toBe(false);
+    });
+});
+
+describe('translateSlackError', () => {
+    it.each(Object.entries(SLACK_USER_FACING_ERROR_MESSAGES))(
+        'translates %s to its user-facing message',
+        (slackErrorCode, message) => {
+            expect(
+                translateSlackError({ data: { error: slackErrorCode } }),
+            ).toEqual({
+                error: message,
+                slackErrorCode,
+            });
+        },
+    );
+
+    it('returns null for unknown Slack error codes', () => {
+        expect(
+            translateSlackError({ data: { error: 'rate_limited' } }),
+        ).toBeNull();
+        expect(
+            translateSlackError({ data: { error: 'something_new' } }),
+        ).toBeNull();
+    });
+
+    it('returns null for non-Slack errors', () => {
+        expect(translateSlackError(new Error('boom'))).toBeNull();
+        expect(translateSlackError(undefined)).toBeNull();
+        expect(translateSlackError(null)).toBeNull();
+        expect(translateSlackError('invalid_blocks')).toBeNull();
+    });
+});

--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -61,3 +61,44 @@ export const isSlackRateLimitedError = (error: unknown): boolean =>
     error instanceof Error &&
     'code' in error &&
     error.code === 'slack_webapi_rate_limited_error';
+
+/**
+ * User-facing translations for common Slack API error codes. Surfaced in
+ * scheduler logs so the delivery recipient gets an actionable explanation
+ * instead of a raw API code. The raw code is also recorded as
+ * `details.slackErrorCode` for debugging.
+ */
+export const SLACK_USER_FACING_ERROR_MESSAGES: Record<string, string> = {
+    invalid_blocks:
+        "Slack rejected this message because it exceeds Slack's size or formatting limits (e.g. dashboard has too many charts, or very long names/descriptions). Please reach out to support if the issue persists.",
+    channel_not_found:
+        'The Slack channel for this delivery no longer exists. Edit this delivery to choose another channel.',
+    not_in_channel:
+        "The Lightdash Slack app isn't a member of this channel. Invite the app to the channel or choose a different one.",
+    is_archived:
+        'This Slack channel has been archived. Edit this delivery to choose another channel.',
+    account_inactive:
+        'The Lightdash Slack app has been deactivated for your workspace. Ask your admin to reconnect Slack in organization settings, or contact support.',
+    invalid_auth:
+        'Slack authentication is invalid for your workspace. Ask your admin to reconnect Slack in organization settings, or contact support.',
+    missing_scope:
+        'The Lightdash Slack app is missing required permissions. Ask your admin to reconnect Slack to grant the new scopes, or contact support.',
+};
+
+/**
+ * Translates a Slack error into an actionable, user-facing message.
+ * Returns null when no translation applies — callers should fall back to their
+ * default error message in that case.
+ */
+export const translateSlackError = (
+    error: unknown,
+): { error: string; slackErrorCode: string } | null => {
+    const slackErrorCode = getSlackErrorCode(error);
+    if (slackErrorCode && slackErrorCode in SLACK_USER_FACING_ERROR_MESSAGES) {
+        return {
+            error: SLACK_USER_FACING_ERROR_MESSAGES[slackErrorCode],
+            slackErrorCode,
+        };
+    }
+    return null;
+};


### PR DESCRIPTION
## Summary

Slack API error codes like \`invalid_blocks\` or \`channel_not_found\` were surfaced verbatim in \`scheduler_log.details.error\`, leaving the recipient of a failed delivery with no way to act on it. This adds a \`translateSlackError\` helper in \`@lightdash/common\` that maps the most common codes to user-facing messages, while keeping the raw code under \`details.slackErrorCode\` for debugging.

- New helper + lookup table in \`packages/common/src/utils/slack.ts\` covering \`invalid_blocks\`, \`channel_not_found\`, \`not_in_channel\`, \`is_archived\`, \`account_inactive\`, \`invalid_auth\`, \`missing_scope\`. Returns \`null\` when no translation applies so callers fall back to the original \`getErrorMessage(e)\`.
- Applied at all three error paths in \`SchedulerTask.ts\`: \`sendSlackNotification\` catch, scheduled-delivery wrapper, and the batch-failure path. The batch path keeps the \`All Slack deliveries failed\` prefix and appends translated messages, deduplicated by error code so a fan-out failure doesn't repeat the same explanation N times. Unique codes are recorded as \`details.slackErrorCodes\` (plural array) to disambiguate from the single-target \`slackErrorCode\` field.
- No DB migration: \`scheduler_log.details\` is a JSON column. No frontend change: the toast at \`useScheduler.ts\` already renders \`details.error\` verbatim.

Closes #22424
Linear: [PROD-7211](https://linear.app/lightdash/issue/PROD-7211), [SPK-417](https://linear.app/lightdash/issue/SPK-417)

## Test plan

- [x] \`pnpm -F common test src/utils/slack.test.ts\` — 15 passed (one parameterised test per code)
- [x] \`pnpm -F backend exec jest src/scheduler/SchedulerTask.test.ts\` — 5 passed (no regressions)
- [x] \`pnpm -F common typecheck\`, \`pnpm -F backend typecheck\`
- [x] \`pnpm -F common lint\`, \`pnpm -F backend lint\`
- [ ] Manual: trigger \`invalid_blocks\` (e.g. force a too-long button URL), then \`psql -c "SELECT details FROM scheduler_log WHERE status='error' ORDER BY created_at DESC LIMIT 1;"\` and confirm the friendly message + raw code are both present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)