### PR TITLE
fix: big number compact style respects metric round (PROD-7229)

### DIFF
--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -83,12 +83,13 @@ const formatComparisonValue = (
                 )}`;
             }
 
+            const metricRoundRaw = isField(item) ? item.round : undefined;
             const formattedValue = bigNumberComparisonStyle
                 ? applyCustomFormat(
                       value,
                       getCustomFormatFromLegacy({
                           format: isField(item) ? item.format : undefined,
-                          round: 2,
+                          round: metricRoundRaw ?? 2,
                           compact: bigNumberComparisonStyle,
                       }),
                   )
@@ -105,12 +106,13 @@ const formatComparisonValue = (
                     timezone,
                 );
             }
+            const metricRoundDefault = isField(item) ? item.round : undefined;
             return bigNumberComparisonStyle
                 ? applyCustomFormat(
                       value,
                       getCustomFormatFromLegacy({
                           format: isField(item) ? item.format : undefined,
-                          round: 2,
+                          round: metricRoundDefault ?? 2,
                           compact: bigNumberComparisonStyle,
                       }),
                   )
@@ -355,15 +357,13 @@ const useBigNumberConfig = (
                 compact: bigNumberStyle ?? item.formatOptions?.compact,
             });
         } else {
+            const metricRound = isField(item) ? item.round : undefined;
+            const compactStyleDefault = bigNumberStyle ? 2 : undefined;
             return applyCustomFormat(
                 firstRowValueRaw,
                 getCustomFormatFromLegacy({
                     format: isField(item) ? item.format : undefined,
-                    round: bigNumberStyle
-                        ? 2
-                        : isField(item)
-                          ? item.round
-                          : undefined,
+                    round: metricRound ?? compactStyleDefault,
                     compact: bigNumberStyle,
                 }),
             );


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/22533

## Summary

Chart-level compact style on Big Value charts was hardcoding `round: 2` and ignoring the metric's `round` setting. A metric defined with `round: 0` would render with 2 decimals (e.g. `648.82M` instead of `649M`) once the chart's compact style was set.

Falls back to the metric's `round` first, only defaulting to `2` when the metric has no `round` set. Same fix applied to the two comparison value branches in `formatComparisonValue`.

### Before
**Metric with `round: 0`**

```yaml
          avg_systolic_bp:
            type: average
            sql: blood_pressure_systolic
            round: 0
            label: "Average Systolic BP"
```

**No Compact**
<img width="2133" height="1075" alt="before_no_compact" src="https://github.com/user-attachments/assets/4cc45a3a-2d63-404c-b30a-5f3237ec9351" />

**Compact set to K**
<img width="2109" height="1060" alt="before_with_compact" src="https://github.com/user-attachments/assets/45757408-b3ef-40bc-b157-67643103de7c" />

### After
**Metric with `round: 0`**

```yaml
          avg_systolic_bp:
            type: average
            sql: blood_pressure_systolic
            round: 0
            label: "Average Systolic BP"
```
**No Compact**
<img width="2071" height="796" alt="CleanShot 2026-04-30 at 11 03 29" src="https://github.com/user-attachments/assets/5ff573e8-112f-422c-bc8c-c1bd851f5477" />

**Compact set to K**
<img width="2110" height="1067" alt="after_with_compact" src="https://github.com/user-attachments/assets/0444bda9-ad3c-4165-ba66-c95a4b1c805e" />
<img width="2126" height="619" alt="after_compact_comparison" src="https://github.com/user-attachments/assets/cbed04f8-0c7e-48bd-9ae8-62c03a6d333f" />

**Metric with no round setting**

```yaml
              unique_order_count:
                type: count_distinct
                spotlight:
                  categories: ["revenue_growth"]
```

**Compact set to K**
<img width="2109" height="1066" alt="after_with_compact_no_round" src="https://github.com/user-attachments/assets/b97be6f9-fa51-42af-8e2b-1805ada504cc" />
<img width="2123" height="693" alt="after_compact_no_round_comparison" src="https://github.com/user-attachments/assets/2800bd6d-0771-4a7c-8878-c52470259a19" />


