### PR TITLE
refactor(common): add RegisteredAccount type and assertRegisteredAccount [SPK-424]

### DIFF
--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -201,6 +201,8 @@ export type Account =
     | ServiceAcctAccount
     | OauthAccount;
 
+export type RegisteredAccount = Exclude<Account, AnonymousAccount>;
+
 export type AccountWithoutHelpers<T extends Account> = Omit<
     T,
     keyof AccountHelpers
@@ -223,6 +225,17 @@ export function assertSessionAuth(
         throw new ForbiddenError(
             `${account?.authentication.type} Account is not session auth`,
         );
+    }
+}
+
+export function assertRegisteredAccount(
+    account: Account | undefined,
+): asserts account is RegisteredAccount {
+    if (!account) {
+        throw new ForbiddenError('Account is required');
+    }
+    if (account.user.type !== 'registered') {
+        throw new ForbiddenError('Account is not a registered user');
     }
 }
 

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -5,6 +5,10 @@ import { type OpenIdIdentityIssuerType } from './openIdIdentity';
 import { type OrganizationMemberRole } from './organizationMemberProfile';
 
 export type AccountUser = {
+    /**
+     * @deprecated Use `userUuid` for registered users. This field should only
+     * be used for anonymous users (where no `userUuid` exists).
+     */
     id: string;
     email: string | undefined;
     /* Whether the user can login */


### PR DESCRIPTION
## Summary

Foundation for [SPK-424](https://linear.app/lightdash/issue/SPK-424/migrate-account-registeredaccount-across-controllers-and-services) — migrating registered-only code paths off `Account` and `account.user.id` onto a stricter type.

- Adds `RegisteredAccount = Exclude<Account, AnonymousAccount>` — covers `SessionAccount | ApiKeyAccount | ServiceAcctAccount | OauthAccount`.
- Adds `assertRegisteredAccount()` — throws `ForbiddenError` if the account is missing or anonymous; narrows to `RegisteredAccount` otherwise.
- Marks `AccountUser.id` as `@deprecated`. Registered users should narrow to `LightdashSessionUser` and read `userUuid`. The field stays valid for `ExternalUser` (anonymous embed) where no `userUuid` exists.

No call sites are migrated in this PR. The deprecation will surface IDE warnings on ~99 `account.user.id` usages — these are migrated incrementally in follow-up PRs per the SPK-424 plan.

## Why

`account.user.id` is a duplicate of `userUuid` for registered users and an external string for anonymous users. The shared field forces every caller into duck-typing. Splitting registered vs anonymous at the type level lets the compiler enforce the right access pattern and removes a foot-gun where backend code accidentally passes an `external::xxx` ID into a UUID column.

## Test plan

- [ ] `pnpm -F common typecheck` passes
- [ ] `pnpm -F common lint` passes
- [ ] `pnpm -F backend typecheck` passes (no behavioral change; only verifies the new exports compile against existing call sites)
- [ ] `pnpm -F common test` passes

## Follow-ups (SPK-424)

5-PR migration tracked in [SPK-424](https://linear.app/lightdash/issue/SPK-424):
1. Foundation + 10 low-risk controllers (this PR is the type prep)
2. Tail services + small models (`id` → `userUuid`)
3. Scheduler + QueryHistoryModel + SavedChartService
4. ProjectService split (registered vs embed)
5. AsyncQueryService + v2/QueryController + cleanup