### PR TITLE
refactor(backend): assertRegisteredAccount in registered-only controllers [SPK-424]

### DIFF
--- a/packages/backend/src/controllers/OrganizationRolesController.ts
+++ b/packages/backend/src/controllers/OrganizationRolesController.ts
@@ -4,6 +4,7 @@ import {
     ApiRoleAssignmentListResponse,
     ApiRoleAssignmentResponse,
     ApiRoleWithScopesResponse,
+    assertRegisteredAccount,
     CreateRole,
 } from '@lightdash/common';
 import {
@@ -65,9 +66,10 @@ export class OrganizationRolesController extends BaseController {
         @Query() load?: string,
         @Query() roleTypeFilter?: string,
     ): Promise<ApiGetRolesResponse | ApiRoleWithScopesResponse> {
+        assertRegisteredAccount(req.account);
         const loadScopes = load === 'scopes';
         const roles = await this.getRolesService().getRolesByOrganizationUuid(
-            req.account!,
+            req.account,
             orgUuid,
             loadScopes,
             roleTypeFilter,
@@ -92,9 +94,10 @@ export class OrganizationRolesController extends BaseController {
         @Request() req: express.Request,
         @Path() orgUuid: string,
     ): Promise<ApiRoleAssignmentListResponse> {
+        assertRegisteredAccount(req.account);
         const assignments =
             await this.getRolesService().getOrganizationRoleAssignments(
-                req.account!,
+                req.account,
                 orgUuid,
             );
 
@@ -118,8 +121,9 @@ export class OrganizationRolesController extends BaseController {
         @Path() orgUuid: string,
         @Path() roleUuid: string,
     ): Promise<ApiRoleWithScopesResponse> {
+        assertRegisteredAccount(req.account);
         const role = await this.getRolesService().getRoleByUuid(
-            req.account!,
+            req.account,
             roleUuid,
         );
 
@@ -148,9 +152,10 @@ export class OrganizationRolesController extends BaseController {
         @Path() userId: string,
         @Body() body: { roleId: string },
     ): Promise<ApiRoleAssignmentResponse> {
+        assertRegisteredAccount(req.account);
         const assignment =
             await this.getRolesService().upsertOrganizationUserRoleAssignment(
-                req.account!,
+                req.account,
                 orgUuid,
                 userId,
                 body,
@@ -181,8 +186,9 @@ export class OrganizationRolesController extends BaseController {
         @Path() roleId: string,
         @Body() body: CreateRole,
     ): Promise<ApiRoleWithScopesResponse> {
+        assertRegisteredAccount(req.account);
         const duplicatedRole = await this.getRolesService().duplicateRole(
-            req.account!,
+            req.account,
             orgUuid,
             roleId,
             body,

--- a/packages/backend/src/controllers/ProjectRolesController.ts
+++ b/packages/backend/src/controllers/ProjectRolesController.ts
@@ -3,6 +3,7 @@ import {
     ApiRoleAssignmentListResponse,
     ApiRoleAssignmentResponse,
     ApiUnassignRoleFromUserResponse,
+    assertRegisteredAccount,
     CreateGroupRoleAssignmentRequest,
     CreateUserRoleAssignmentRequest,
     UpdateRoleAssignmentRequest,
@@ -71,9 +72,10 @@ export class ProjectRolesController extends BaseController {
         @Request() req: express.Request,
         @Path() projectId: string,
     ): Promise<ApiRoleAssignmentListResponse> {
+        assertRegisteredAccount(req.account);
         const assignments =
             await this.getRolesService().getProjectRoleAssignments(
-                req.account!,
+                req.account,
                 projectId,
             );
 
@@ -102,9 +104,10 @@ export class ProjectRolesController extends BaseController {
         @Path() userId: string,
         @Body() body: UpsertUserRoleAssignmentRequest,
     ): Promise<ApiRoleAssignmentResponse> {
+        assertRegisteredAccount(req.account);
         const assignment =
             await this.getRolesService().upsertProjectUserRoleAssignment(
-                req.account!,
+                req.account,
                 projectId,
                 userId,
                 body,
@@ -135,9 +138,10 @@ export class ProjectRolesController extends BaseController {
         @Path() groupId: string,
         @Body() body: UpsertUserRoleAssignmentRequest,
     ): Promise<ApiRoleAssignmentResponse> {
+        assertRegisteredAccount(req.account);
         const assignment =
             await this.getRolesService().upsertProjectGroupRoleAssignment(
-                req.account!,
+                req.account,
                 projectId,
                 groupId,
                 body,
@@ -168,9 +172,10 @@ export class ProjectRolesController extends BaseController {
         @Path() groupId: string,
         @Body() body: UpdateRoleAssignmentRequest,
     ): Promise<ApiRoleAssignmentResponse> {
+        assertRegisteredAccount(req.account);
         const assignment =
             await this.getRolesService().updateProjectRoleAssignment(
-                req.account!,
+                req.account,
                 projectId,
                 groupId,
                 'group',
@@ -201,8 +206,9 @@ export class ProjectRolesController extends BaseController {
         @Path() projectId: string,
         @Path() userId: string,
     ): Promise<ApiUnassignRoleFromUserResponse> {
+        assertRegisteredAccount(req.account);
         await this.getRolesService().deleteProjectRoleAssignment(
-            req.account!,
+            req.account,
             projectId,
             userId,
             'user',
@@ -232,8 +238,9 @@ export class ProjectRolesController extends BaseController {
         @Path() projectId: string,
         @Path() groupId: string,
     ): Promise<ApiUnassignRoleFromUserResponse> {
+        assertRegisteredAccount(req.account);
         await this.getRolesService().deleteProjectRoleAssignment(
-            req.account!,
+            req.account,
             projectId,
             groupId,
             'group',

--- a/packages/backend/src/controllers/googleDriveController.ts
+++ b/packages/backend/src/controllers/googleDriveController.ts
@@ -2,6 +2,7 @@ import {
     ApiErrorPayload,
     ApiGdriveAccessTokenResponse,
     ApiJobScheduledResponse,
+    assertRegisteredAccount,
     UploadMetricGsheet,
 } from '@lightdash/common';
 import {
@@ -60,11 +61,12 @@ export class GoogleDriveController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiJobScheduledResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await req.services
                 .getGdriveService()
-                .scheduleUploadGsheet(req.account!, body),
+                .scheduleUploadGsheet(req.account, body),
         };
     }
 }

--- a/packages/backend/src/controllers/projectCompileLogController.ts
+++ b/packages/backend/src/controllers/projectCompileLogController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    assertRegisteredAccount,
     KnexPaginateArgs,
     type ApiProjectCompileLogResponse,
     type ApiProjectCompileLogsResponse,
@@ -50,7 +51,7 @@ export class ProjectCompileLogController extends BaseController {
         @Query() source?: 'cli_deploy' | 'refresh_dbt' | 'create_project',
     ): Promise<ApiProjectCompileLogsResponse> {
         this.setStatus(200);
-
+        assertRegisteredAccount(req.account);
         let paginateArgs: KnexPaginateArgs | undefined;
         if (pageSize && page) {
             paginateArgs = {
@@ -73,7 +74,7 @@ export class ProjectCompileLogController extends BaseController {
             results: await this.services
                 .getProjectCompileLogService()
                 .getProjectCompileLogs(
-                    req.account!,
+                    req.account,
                     projectUuid,
                     paginateArgs,
                     sort,
@@ -99,14 +100,14 @@ export class ProjectCompileLogController extends BaseController {
         @Path() jobUuid: string,
     ): Promise<ApiProjectCompileLogResponse> {
         this.setStatus(200);
-
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: {
                 log: await this.services
                     .getProjectCompileLogService()
                     .getProjectCompileLogByJob(
-                        req.account!,
+                        req.account,
                         projectUuid,
                         jobUuid,
                     ),

--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -10,6 +10,7 @@ import {
     ApiSchedulerRunsResponse,
     ApiSchedulersResponse,
     ApiTestSchedulerResponse,
+    assertRegisteredAccount,
     AuthorizationError,
     KnexPaginateArgs,
     ReassignSchedulerOwnerRequest,
@@ -566,9 +567,10 @@ export class SchedulerController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiJobStatusResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const { status, details } = await this.services
             .getSchedulerService()
-            .getJobStatus(req.account!, jobId);
+            .getJobStatus(req.account, jobId);
         return {
             status: 'ok',
             results: {

--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -5,6 +5,7 @@ import {
     ApiSlackCustomSettingsResponse,
     ApiSlackGetInstallationResponse,
     ApiSuccessEmpty,
+    assertRegisteredAccount,
     getErrorMessage,
     NotFoundError,
     OpenIdIdentityIssuerType,
@@ -280,9 +281,10 @@ export class SlackController extends BaseController {
     async deleteInstallation(
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getSlackIntegrationService()
-            .deleteInstallationFromOrganizationUuid(req.account!);
+            .deleteInstallationFromOrganizationUuid(req.account);
 
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/userActivityController.ts
+++ b/packages/backend/src/controllers/userActivityController.ts
@@ -6,6 +6,7 @@ import {
     ApiUserActivityDownloadCsv,
     ApiValidateResponse,
     ApiValidationDismissResponse,
+    assertRegisteredAccount,
     getRequestMethod,
     LightdashRequestMethodHeader,
     ValidationTarget,
@@ -54,9 +55,10 @@ export class UserActivityController extends BaseController {
         @Path() projectUuid: string,
     ): Promise<ApiUserActivity> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const userActivity = await req.services
             .getAnalyticsService()
-            .getUserActivity(projectUuid, req.account!);
+            .getUserActivity(projectUuid, req.account);
         return {
             status: 'ok',
             results: userActivity,
@@ -80,9 +82,10 @@ export class UserActivityController extends BaseController {
         @Path() projectUuid: string,
     ): Promise<ApiUserActivityDownloadCsv> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const userActivity = await req.services
             .getAnalyticsService()
-            .exportUserActivityRawCsv(projectUuid, req.account!);
+            .exportUserActivityRawCsv(projectUuid, req.account);
         return {
             status: 'ok',
             results: userActivity,

--- a/packages/backend/src/controllers/userAttributesController.ts
+++ b/packages/backend/src/controllers/userAttributesController.ts
@@ -3,6 +3,7 @@ import {
     ApiErrorPayload,
     ApiSuccessEmpty,
     ApiUserAttributesResponse,
+    assertRegisteredAccount,
     CreateUserAttribute,
     getRequestMethod,
     LightdashRequestMethodHeader,
@@ -45,6 +46,7 @@ export class UserAttributesController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiUserAttributesResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const context = getRequestMethod(
             req.header(LightdashRequestMethodHeader),
         );
@@ -52,7 +54,7 @@ export class UserAttributesController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getUserAttributesService()
-                .getAll(req.account!, context),
+                .getAll(req.account, context),
         };
     }
 
@@ -74,12 +76,12 @@ export class UserAttributesController extends BaseController {
         @Body() body: CreateUserAttribute,
     ): Promise<ApiCreateUserAttributeResponse> {
         this.setStatus(201);
-
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getUserAttributesService()
-                .create(req.account!, body),
+                .create(req.account, body),
         };
     }
 
@@ -103,12 +105,12 @@ export class UserAttributesController extends BaseController {
         @Body() body: CreateUserAttribute,
     ): Promise<ApiCreateUserAttributeResponse> {
         this.setStatus(201);
-
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getUserAttributesService()
-                .update(req.account!, userAttributeUuid, body),
+                .update(req.account, userAttributeUuid, body),
         };
     }
 
@@ -130,10 +132,10 @@ export class UserAttributesController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-
+        assertRegisteredAccount(req.account);
         await this.services
             .getUserAttributesService()
-            .delete(req.account!, userAttributeUuid);
+            .delete(req.account, userAttributeUuid);
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -7,6 +7,7 @@ import {
     ApiRegisterUserResponse,
     ApiSuccessEmpty,
     ApiUserAllowedOrganizationsResponse,
+    assertRegisteredAccount,
     AuthorizationError,
     CreatePersonalAccessToken,
     getRequestMethod,
@@ -383,11 +384,12 @@ export class UserController extends BaseController {
         results: PersonalAccessToken[];
     }> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getPersonalAccessTokenService()
-                .getAllPersonalAccessTokens(req.account!),
+                .getAllPersonalAccessTokens(req.account),
         };
     }
 
@@ -411,12 +413,13 @@ export class UserController extends BaseController {
         results: PersonalAccessTokenWithToken;
     }> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getPersonalAccessTokenService()
                 .createPersonalAccessToken(
-                    req.account!,
+                    req.account,
                     body,
                     getRequestMethod(req.header(LightdashRequestMethodHeader)),
                 ),
@@ -436,9 +439,10 @@ export class UserController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         await this.services
             .getPersonalAccessTokenService()
-            .deletePersonalAccessToken(req.account!, personalAccessTokenUuid);
+            .deletePersonalAccessToken(req.account, personalAccessTokenUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -469,12 +473,13 @@ export class UserController extends BaseController {
         results: PersonalAccessTokenWithToken;
     }> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getPersonalAccessTokenService()
                 .rotatePersonalAccessToken(
-                    req.account!,
+                    req.account,
                     personalAccessTokenUuid,
                     body,
                 ),


### PR DESCRIPTION
## Summary

[SPK-424](https://linear.app/lightdash/issue/SPK-424) **PR 1 of 5** — stacked on top of #22543.

Adds `assertRegisteredAccount(req.account)` to 9 registered-only controllers and drops the `req.account!` non-null assertion (the assertion narrows away `undefined`).

**Controllers touched:**
- `OrganizationRolesController` (5 methods)
- `ProjectRolesController` (6 methods)
- `userController` (4 PAT methods — `getAccount` left on `Account` since it returns the account shape directly)
- `userAttributesController` (4 methods)
- `userActivityController` (2 methods)
- `googleDriveController` (1 method — gsheet upload)
- `slackController` (1 method — delete installation)
- `schedulerController` (1 method — get job status)
- `projectCompileLogController` (2 methods)

**Skipped:** `impersonationController` — uses `req.user` rather than passing `req.account` to a service. The `req.account?.authentication.type === 'session'` check is a feature gate, not an account assertion.

## Why

Each method on these controllers already required a registered user (no embed/JWT path). The non-null assertion (`req.account!`) silently accepted `undefined` at compile time; replacing it with `assertRegisteredAccount` enforces the precondition at runtime with a clear `ForbiddenError`, and primes the controllers for the type-narrowing rollout in PR 2 onward.

## What's next

Service signatures still take `Account`. PR 2 will start narrowing service params to `RegisteredAccount` and migrate `account.user.id` → `account.user.userUuid` in the long tail of low-touch services.

## Test plan

- [ ] `pnpm -F backend typecheck` passes (verified locally)
- [ ] `pnpm -F backend lint` passes
- [ ] Backend test suite green
- [ ] Manual: hit each migrated endpoint with a session cookie / API key — should still 200
- [ ] Manual: hit `/api/v1/user/me/personal-access-tokens` without auth → 403 `Account is required` (instead of 500 from undefined access)