### PR TITLE
refactor(backend): tail services + 6 controllers to RegisteredAccount [SPK-424]

### DIFF
--- a/packages/backend/src/controllers/ChangesetController.ts
+++ b/packages/backend/src/controllers/ChangesetController.ts
@@ -3,6 +3,7 @@ import {
     ApiErrorPayload,
     ApiGetChangeResponseTSOACompat,
     ApiRevertChangeResponse,
+    assertRegisteredAccount,
 } from '@lightdash/common';
 import {
     Get,
@@ -36,10 +37,11 @@ export class ChangesetController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiChangesetsResponseTSOACompat> {
+        assertRegisteredAccount(req.account);
         const changesets = await this.services
             .getChangesetService()
             .findActiveChangesetWithChangesByProjectUuid(
-                req.account!,
+                req.account,
                 projectUuid,
             );
 
@@ -63,9 +65,10 @@ export class ChangesetController extends BaseController {
         @Path() changeUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetChangeResponseTSOACompat> {
+        assertRegisteredAccount(req.account);
         const change = await this.services
             .getChangesetService()
-            .getChange(req.account!, projectUuid, changeUuid);
+            .getChange(req.account, projectUuid, changeUuid);
 
         return {
             status: 'ok',
@@ -87,9 +90,10 @@ export class ChangesetController extends BaseController {
         @Path() changeUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiRevertChangeResponse> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getChangesetService()
-            .revertChange(req.account!, projectUuid, changeUuid);
+            .revertChange(req.account, projectUuid, changeUuid);
 
         return {
             status: 'ok',
@@ -109,9 +113,10 @@ export class ChangesetController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiRevertChangeResponse> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getChangesetService()
-            .revertAllChanges(req.account!, projectUuid);
+            .revertAllChanges(req.account, projectUuid);
 
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -14,6 +14,7 @@ import {
     ApiReassignUserSchedulersResponse,
     ApiSuccessEmpty,
     ApiUserSchedulersSummaryResponse,
+    assertRegisteredAccount,
     AuthorizationError,
     CreateColorPalette,
     CreateGroup,
@@ -72,11 +73,12 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiOrganization> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .get(req.account!),
+                .get(req.account),
         };
     }
 
@@ -179,11 +181,12 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiOrganizationProjects> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .getProjects(req.account!),
+                .getProjects(req.account),
         };
     }
 
@@ -534,11 +537,12 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiColorPalettesResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .getColorPalettes(req.account!),
+                .getColorPalettes(req.account),
         };
     }
 

--- a/packages/backend/src/controllers/spotlightController.ts
+++ b/packages/backend/src/controllers/spotlightController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    assertRegisteredAccount,
     NotFoundError,
     type ApiGetSpotlightTableConfig,
     type ApiSuccessEmpty,
@@ -48,9 +49,10 @@ export class SpotlightController extends BaseController {
         @Body() body: Pick<SpotlightTableConfig, 'columnConfig'>,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getSpotlightService()
-            .createSpotlightTableConfig(req.account!, projectUuid, body);
+            .createSpotlightTableConfig(req.account, projectUuid, body);
 
         this.setStatus(201);
         return {
@@ -71,9 +73,10 @@ export class SpotlightController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetSpotlightTableConfig> {
+        assertRegisteredAccount(req.account);
         const { columnConfig } = await this.services
             .getSpotlightService()
-            .getSpotlightTableConfig(req.account!, projectUuid);
+            .getSpotlightTableConfig(req.account, projectUuid);
 
         this.setStatus(200);
         return {
@@ -100,9 +103,10 @@ export class SpotlightController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getSpotlightService()
-            .resetSpotlightTableConfig(req.account!, projectUuid);
+            .resetSpotlightTableConfig(req.account, projectUuid);
 
         this.setStatus(200);
         return {

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -12,6 +12,7 @@ import {
     ApiUpdateSqlChart,
     ApiWarehouseTableFields,
     ApiWarehouseTablesCatalog,
+    assertRegisteredAccount,
     CreateSchedulerAndTargetsWithoutIds,
     CreateSqlChart,
     CreateVirtualViewPayload,
@@ -518,11 +519,12 @@ export class SqlRunnerController extends BaseController {
         @Body() body: CreateVirtualViewPayload,
     ): Promise<ApiCreateVirtualView> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const { name, sql, columns, parameterValues } = body;
 
         const virtualViewName = await this.services
             .getProjectService()
-            .createVirtualView(req.account!, projectUuid, {
+            .createVirtualView(req.account, projectUuid, {
                 name,
                 sql,
                 columns,
@@ -550,9 +552,10 @@ export class SqlRunnerController extends BaseController {
         @Body() body: UpdateVirtualViewPayload,
     ): Promise<ApiCreateVirtualView> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const { name: virtualViewName } = await this.services
             .getProjectService()
-            .updateVirtualView(req.account!, projectUuid, name, body);
+            .updateVirtualView(req.account, projectUuid, name, body);
 
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/v2/DeployController.ts
+++ b/packages/backend/src/controllers/v2/DeployController.ts
@@ -5,6 +5,7 @@ import {
     ApiErrorPayload,
     ApiFinalizeDeployResponse,
     ApiStartDeploySessionResponse,
+    assertRegisteredAccount,
 } from '@lightdash/common';
 import {
     Body,
@@ -47,9 +48,10 @@ export class DeployController extends BaseController {
         @Path() projectUuid: string,
     ): Promise<ApiStartDeploySessionResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const result = await this.services
             .getDeployService()
-            .startDeploySession(req.account!, projectUuid);
+            .startDeploySession(req.account, projectUuid);
         return {
             status: 'ok',
             results: result,

--- a/packages/backend/src/controllers/v2/ProjectDefaultsController.ts
+++ b/packages/backend/src/controllers/v2/ProjectDefaultsController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiSuccess,
+    assertRegisteredAccount,
     ProjectDefaults,
 } from '@lightdash/common';
 import {
@@ -40,9 +41,10 @@ export class ProjectDefaultsController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccess<ProjectDefaults | undefined>> {
+        assertRegisteredAccount(req.account);
         const project = await this.services
             .getProjectService()
-            .getProject(projectUuid, req.account!);
+            .getProject(projectUuid, req.account);
 
         return {
             status: 'ok',

--- a/packages/backend/src/ee/controllers/OrganizationWarehouseCredentialsController.ts
+++ b/packages/backend/src/ee/controllers/OrganizationWarehouseCredentialsController.ts
@@ -4,6 +4,7 @@ import {
     ApiOrganizationWarehouseCredentialsResponse,
     ApiOrganizationWarehouseCredentialsSummaryListResponse,
     ApiSuccessEmpty,
+    assertRegisteredAccount,
     CreateOrganizationWarehouseCredentials,
     UpdateOrganizationWarehouseCredentials,
 } from '@lightdash/common';
@@ -52,13 +53,14 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         | ApiOrganizationWarehouseCredentialsSummaryListResponse
     > {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
 
         if (summary) {
             return {
                 status: 'ok',
                 results:
                     await this.getOrganizationWarehouseCredentialsService().getAllSummaries(
-                        req.account!,
+                        req.account,
                     ),
             };
         }
@@ -67,7 +69,7 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
             status: 'ok',
             results:
                 await this.getOrganizationWarehouseCredentialsService().getAll(
-                    req.account!,
+                    req.account,
                 ),
         };
     }
@@ -86,11 +88,12 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         @Path() credentialsUuid: string,
     ): Promise<ApiOrganizationWarehouseCredentialsResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results:
                 await this.getOrganizationWarehouseCredentialsService().get(
-                    req.account!,
+                    req.account,
                     credentialsUuid,
                 ),
         };
@@ -114,11 +117,12 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         @Body() body: CreateOrganizationWarehouseCredentials,
     ): Promise<ApiOrganizationWarehouseCredentialsResponse> {
         this.setStatus(201);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results:
                 await this.getOrganizationWarehouseCredentialsService().create(
-                    req.account!,
+                    req.account,
                     body,
                 ),
         };
@@ -144,11 +148,12 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         @Body() body: UpdateOrganizationWarehouseCredentials,
     ): Promise<ApiOrganizationWarehouseCredentialsResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results:
                 await this.getOrganizationWarehouseCredentialsService().update(
-                    req.account!,
+                    req.account,
                     credentialsUuid,
                     body,
                 ),
@@ -172,8 +177,9 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         @Request() req: express.Request,
         @Path() credentialsUuid: string,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.getOrganizationWarehouseCredentialsService().delete(
-            req.account!,
+            req.account,
             credentialsUuid,
         );
         this.setStatus(200);

--- a/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
+++ b/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    Account,
     CreateOrganizationWarehouseCredentials,
     CreateWarehouseCredentials,
     ForbiddenError,
@@ -8,6 +7,7 @@ import {
     OpenIdIdentityIssuerType,
     OrganizationWarehouseCredentials,
     OrganizationWarehouseCredentialsSummary,
+    RegisteredAccount,
     SnowflakeAuthenticationType,
     UpdateOrganizationWarehouseCredentials,
     WarehouseTypes,
@@ -43,7 +43,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         this.userModel = userModel;
     }
 
-    private canManage(account: Account) {
+    private canManage(account: RegisteredAccount) {
         const auditedAbility = this.createAuditedAbility(account);
         const { organizationUuid } = account.organization;
         if (!organizationUuid) {
@@ -64,7 +64,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async getAll(
-        account: Account,
+        account: RegisteredAccount,
     ): Promise<OrganizationWarehouseCredentials[]> {
         this.canManage(account);
         const organizationUuid = account.organization.organizationUuid!;
@@ -79,7 +79,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
      * Returns only non-sensitive information: name, description, and warehouse type
      */
     async getAllSummaries(
-        account: Account,
+        account: RegisteredAccount,
     ): Promise<OrganizationWarehouseCredentialsSummary[]> {
         const auditedAbility = this.createAuditedAbility(account);
         const { organizationUuid } = account.organization;
@@ -116,7 +116,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async get(
-        account: Account,
+        account: RegisteredAccount,
         credentialsUuid: string,
     ): Promise<OrganizationWarehouseCredentials> {
         this.canManage(account);
@@ -172,12 +172,12 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async create(
-        account: Account,
+        account: RegisteredAccount,
         data: CreateOrganizationWarehouseCredentials,
     ): Promise<OrganizationWarehouseCredentials> {
         this.canManage(account);
         const organizationUuid = account.organization.organizationUuid!;
-        const userUuid = account.user.id;
+        const { userUuid } = account.user;
         const credentialsWithTokens = await this.updateCredentialTokens(
             userUuid,
             data,
@@ -204,13 +204,13 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async update(
-        account: Account,
+        account: RegisteredAccount,
         credentialsUuid: string,
         data: UpdateOrganizationWarehouseCredentials,
     ): Promise<OrganizationWarehouseCredentials> {
         this.canManage(account);
         const organizationUuid = account.organization.organizationUuid!;
-        const userUuid = account.user.id;
+        const { userUuid } = account.user;
 
         // Verify ownership before update
         const existing =
@@ -249,10 +249,13 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         return updated;
     }
 
-    async delete(account: Account, credentialsUuid: string): Promise<void> {
+    async delete(
+        account: RegisteredAccount,
+        credentialsUuid: string,
+    ): Promise<void> {
         this.canManage(account);
         const organizationUuid = account.organization.organizationUuid!;
-        const userUuid = account.user.id;
+        const { userUuid } = account.user;
 
         // Verify ownership before delete
         const existing =

--- a/packages/backend/src/services/ChangesetService.ts
+++ b/packages/backend/src/services/ChangesetService.ts
@@ -1,9 +1,9 @@
 import { subject } from '@casl/ability';
 import {
-    Account,
     Change,
     ChangesetWithChanges,
     ForbiddenError,
+    RegisteredAccount,
 } from '@lightdash/common';
 import { CatalogModel } from '../models/CatalogModel/CatalogModel';
 import { ChangesetModel } from '../models/ChangesetModel';
@@ -31,7 +31,7 @@ export class ChangesetService extends BaseService {
     }
 
     async findActiveChangesetWithChangesByProjectUuid(
-        account: Account,
+        account: RegisteredAccount,
         projectUuid: string,
     ): Promise<ChangesetWithChanges | undefined> {
         const auditedAbility = this.createAuditedAbility(account);
@@ -55,7 +55,7 @@ export class ChangesetService extends BaseService {
     }
 
     async getChange(
-        account: Account,
+        account: RegisteredAccount,
         projectUuid: string,
         changeUuid: string,
     ): Promise<Change> {
@@ -79,7 +79,7 @@ export class ChangesetService extends BaseService {
     }
 
     async revertChange(
-        account: Account,
+        account: RegisteredAccount,
         projectUuid: string,
         changeUuid: string,
     ): Promise<void> {
@@ -132,7 +132,7 @@ export class ChangesetService extends BaseService {
     }
 
     async revertAllChanges(
-        account: Account,
+        account: RegisteredAccount,
         projectUuid: string,
     ): Promise<void> {
         const auditedAbility = this.createAuditedAbility(account);

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    Account,
     calculateExploreWarningReport,
     DeploySessionStatus,
     Explore,
@@ -8,6 +7,7 @@ import {
     ForbiddenError,
     NotFoundError,
     ProjectType,
+    RegisteredAccount,
     SessionUser,
     type ApiDeployExploresResults,
 } from '@lightdash/common';
@@ -60,7 +60,7 @@ export class DeployService extends BaseService {
     }
 
     async startDeploySession(
-        account: Account,
+        account: RegisteredAccount,
         projectUuid: string,
     ): Promise<{ deploySessionUuid: string }> {
         // Check deploy permission
@@ -93,7 +93,7 @@ export class DeployService extends BaseService {
         // Create a new deploy session
         const sessionUuid = await this.deploySessionModel.createSession(
             projectUuid,
-            account.user.id,
+            account.user.userUuid,
         );
 
         this.logger.info(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    Account,
     AllowedEmailDomains,
     assertIsAccountWithOrg,
     convertProjectRoleToOrganizationRole,
@@ -26,6 +25,7 @@ import {
     OrganizationMemberRole,
     OrganizationProject,
     ParameterError,
+    RegisteredAccount,
     SessionUser,
     UpdateAllowedEmailDomains,
     UpdateColorPalette,
@@ -107,7 +107,7 @@ export class OrganizationService extends BaseService {
         this.featureFlagModel = featureFlagModel;
     }
 
-    async get(account: Account): Promise<Organization> {
+    async get(account: RegisteredAccount): Promise<Organization> {
         assertIsAccountWithOrg(account);
 
         const needsProject = !(await this.projectModel.hasProjects(
@@ -301,7 +301,9 @@ export class OrganizationService extends BaseService {
         };
     }
 
-    async getProjects(account: Account): Promise<OrganizationProject[]> {
+    async getProjects(
+        account: RegisteredAccount,
+    ): Promise<OrganizationProject[]> {
         const { organizationUuid } = account.organization;
         if (organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');
@@ -693,7 +695,7 @@ export class OrganizationService extends BaseService {
     }
 
     async getColorPalettes(
-        account: Account,
+        account: RegisteredAccount,
     ): Promise<OrganizationColorPaletteWithIsActive[]> {
         const { organizationUuid } = account.organization;
 

--- a/packages/backend/src/services/SpotlightService/SpotlightService.ts
+++ b/packages/backend/src/services/SpotlightService/SpotlightService.ts
@@ -2,7 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     NotFoundError,
-    type Account,
+    type RegisteredAccount,
     type SpotlightTableConfig,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -35,7 +35,7 @@ export class SpotlightService extends BaseService {
     }
 
     async createSpotlightTableConfig(
-        account: Account,
+        account: RegisteredAccount,
         projectUuid: string,
         tableConfig: Pick<SpotlightTableConfig, 'columnConfig'>,
     ): Promise<void> {
@@ -64,7 +64,7 @@ export class SpotlightService extends BaseService {
     }
 
     async getSpotlightTableConfig(
-        account: Account,
+        account: RegisteredAccount,
         projectUuid: string,
     ): Promise<SpotlightTableConfig> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
@@ -100,7 +100,7 @@ export class SpotlightService extends BaseService {
     }
 
     async resetSpotlightTableConfig(
-        account: Account,
+        account: RegisteredAccount,
         projectUuid: string,
     ): Promise<void> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);


### PR DESCRIPTION
## Summary

[SPK-424](https://linear.app/lightdash/issue/SPK-424) — continues the migration started in #22547. Stacked on #22547.

Adds `assertRegisteredAccount(req.account)` to 6 more registered-only controllers and narrows the corresponding services from `Account` → `RegisteredAccount`. Also migrates `account.user.id` → `account.user.userUuid` where applicable.

## Controllers (6 + 1 EE)

Each gets `assertRegisteredAccount(req.account)` at method entry and drops the `req.account!` non-null assertion:

- `ChangesetController` (4 methods — list/get/revert/revert-all)
- `spotlightController` (3 methods — create/get/reset table config)
- `organizationController` (3 methods — `get`, `getProjects`, `getColorPalettes`; the rest already used `req.user!`)
- `sqlRunnerController` (2 methods — `createVirtualView`, `updateVirtualView`)
- `v2/DeployController.startDeploySession`
- `v2/ProjectDefaultsController.getProjectDefaults`
- **EE:** `OrganizationWarehouseCredentialsController` (5 methods — getAll/get/create/update/delete)

## Services migrated

| Service | Signatures | `id` → `userUuid` |
|---|---:|---:|
| `ChangesetService` (4 methods, typing-only) | 4 | 0 |
| `SpotlightService` (3 methods, typing-only) | 3 | 0 |
| `OrganizationService.get` / `.getProjects` / `.getColorPalettes` | 3 | 0 |
| `DeployService.startDeploySession` | 1 | 1 |
| **EE:** `OrganizationWarehouseCredentialsService` (canManage + 5 public methods) | 6 | 3 |

`OrganizationService` other methods (`updateOrg`, `delete`, `getUsers`, etc.) already use `SessionUser`, so no migration needed.

`v2/DeployController.addDeployBatch` / `.finalizeDeploySession` use `req.user!` directly (SessionUser path) — out of scope.

## What's NOT in this PR

Services left for later PRs because their callers are still on `Account` (mixed with anonymous/embed paths in PR4+):

- `ShareService` — `shareController` is mixed (PR4)
- `OAuthService.listClients/createAdminClient/updateClient/deleteClient` — `oauthRouter` mixes auth flows
- `CsvService.scheduleExportCsvDashboard` — `dashboardRouter` (Express, not TSOA)
- `AdminNotificationService` — called from `ProjectService` (PR4) which still passes `Account`
- `ProjectParametersService` — called from `v2/ParametersController` (PR4)
- `LightdashAnalyticsService` — does not use `Account` directly

## Test plan

- [x] `pnpm -F backend typecheck` passes (verified locally)
- [x] `pnpm -F backend lint` passes (verified locally)
- [x] `pnpm -F backend test:dev:nowatch` for changed files passes (verified locally — 3 suites, 12 tests)
- [ ] Manual: changeset list / revert flow
- [ ] Manual: spotlight table config CRUD
- [ ] Manual: organization detail / projects list / color palettes list
- [ ] Manual: SQL Runner virtual view create/update
- [ ] Manual: `lightdash deploy` (start deploy session via v2 endpoint)
- [ ] Manual: project defaults v2 GET
- [ ] Manual: EE org warehouse credentials CRUD (admin)
- [ ] Manual: hit any migrated endpoint without auth → 403 \`Account is required\` (instead of 500)