### PR TITLE
chore: migrate `ServiceAccounts` to legacy feature flag

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -842,6 +842,7 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['GROUPS_ENABLED', 'user-groups-enabled'],
         ['SHOW_EXECUTION_TIME', 'show-execution-time'],
         ['EMBEDDING_ENABLED', 'embedding'],
+        ['SERVICE_ACCOUNT_ENABLED', 'service-accounts'],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1562,6 +1562,10 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     // endpoint) and EmbedService (allowAll config). Keep the config field, but
     // translate the env var to the unified allowlist for the flag system.
     ['EMBEDDING_ENABLED', 'embedding'],
+    // SERVICE_ACCOUNT_ENABLED is also read by HealthService (exposed via the
+    // health endpoint). Keep the config field, but translate the env var to
+    // the unified allowlist for the flag system.
+    ['SERVICE_ACCOUNT_ENABLED', 'service-accounts'],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -105,9 +105,11 @@ const Settings: FC = () => {
         (aiOrganizationSettingsQuery.data.isCopilotEnabled ||
             aiOrganizationSettingsQuery.data.isTrial);
 
-    const isServiceAccountFeatureFlagEnabled = useClientFeatureFlag(
+    const { data: serviceAccountsFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.ServiceAccounts,
     );
+    const isServiceAccountFeatureFlagEnabled =
+        serviceAccountsFlag?.enabled ?? false;
 
     const {
         health: {


### PR DESCRIPTION
Closes:

### Description:

Adds `SERVICE_ACCOUNT_ENABLED` to the legacy environment variable translation layer so it maps to the `service-accounts` feature flag, consistent with how other legacy env vars like `GROUPS_ENABLED` are handled.

Additionally, switches the service accounts feature flag check in the Settings page from `useClientFeatureFlag` to `useServerFeatureFlag`, ensuring the flag state is resolved from the server rather than the client.