### PR TITLE
chore: migrate `Scim` to legacy feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -252,9 +252,6 @@ export const lightdashConfigMock: LightdashConfig = {
         },
         events: undefined,
     },
-    scim: {
-        enabled: false,
-    },
     security: {
         contentSecurityPolicy: {
             reportOnly: false,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -843,6 +843,7 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['SHOW_EXECUTION_TIME', 'show-execution-time'],
         ['EMBEDDING_ENABLED', 'embedding'],
         ['SERVICE_ACCOUNT_ENABLED', 'service-accounts'],
+        ['SCIM_ENABLED', 'scim-token-management'],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1127,9 +1127,6 @@ export type LightdashConfig = {
             enablePostMessage: boolean;
         };
     };
-    scim: {
-        enabled: boolean;
-    };
     serviceAccount: {
         enabled: boolean;
     };
@@ -1566,6 +1563,7 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     // health endpoint). Keep the config field, but translate the env var to
     // the unified allowlist for the flag system.
     ['SERVICE_ACCOUNT_ENABLED', 'service-accounts'],
+    ['SCIM_ENABLED', 'scim-token-management'],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
@@ -2191,9 +2189,6 @@ export const parseConfig = (): LightdashConfig => {
                     process.env.EMBED_EVENT_SYSTEM_POST_MESSAGE_ENABLED ===
                     'true',
             },
-        },
-        scim: {
-            enabled: process.env.SCIM_ENABLED === 'true',
         },
         serviceAccount: {
             enabled: process.env.SERVICE_ACCOUNT_ENABLED === 'true',

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -17,30 +17,8 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
         this.featureFlagHandlers = {
             ...this.featureFlagHandlers, // Inherit parent handlers
             // Add new commercial handlers
-            [CommercialFeatureFlags.Scim]: this.getScimFlag.bind(this),
             [CommercialFeatureFlags.AiCopilot]:
                 this.getAiCopilotFlag.bind(this),
-        };
-    }
-
-    private async getScimFlag({ user, featureFlagId }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.scim.enabled ||
-            (user
-                ? await isFeatureFlagEnabled(
-                      CommercialFeatureFlags.Scim as AnyType as FeatureFlags,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                      },
-                  )
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
         };
     }
 


### PR DESCRIPTION
Closes:

### Description:
Migrates the `SCIM_ENABLED` environment variable from a dedicated `scim.enabled` config field to the unified feature flag system, consistent with how other legacy feature flags (e.g. `SERVICE_ACCOUNT_ENABLED`) are handled.

The `scim` config block has been removed, and `SCIM_ENABLED=true` now translates to enabling the `scim-token-management` feature flag via the legacy env var translation layer. The custom `getScimFlag` handler in `CommercialFeatureFlagModel` has also been removed, as the flag is now resolved through the standard feature flag mechanism.