### PR TITLE
feat(permissions): hide SQL custom dim authoring + diff-aware save gate

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -50,7 +50,6 @@ import {
     isCartesianChartConfig,
     isCustomBinDimension,
     isCustomDimension,
-    isCustomSqlDimension,
     isDateItem,
     isExploreError,
     isField,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -83,7 +83,6 @@ import {
     hasWarehouseCredentials,
     IntrinsicUserAttributes,
     isCartesianChartConfig,
-    isCustomSqlDimension,
     isDateItem,
     isExploreError,
     isFilterableDimension,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -1237,23 +1237,6 @@ export class SavedChartService
             throw new ForbiddenError();
         }
 
-        if (
-            savedChart.metricQuery.customDimensions?.some(
-                isCustomSqlDimension,
-            ) &&
-            auditedAbility.cannot(
-                'manage',
-                subject('CustomFields', {
-                    organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'User cannot create charts with custom SQL dimensions',
-            );
-        }
-
         if (!resolvedSpaceUuid && !savedChart.dashboardUuid) {
             throw new Error(
                 'Unable to save chart; no space or dashboard provided.',

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -483,6 +483,7 @@ export class SavedChartService
             metricQuery: {
                 metrics: oldChartMetrics,
                 dimensions: oldChartDimensions,
+                customDimensions: oldCustomDimensions,
             },
         } = await this.savedChartModel.get(savedChartUuid);
 
@@ -508,8 +509,22 @@ export class SavedChartService
             throw new ForbiddenError();
         }
 
+        const oldSqlDimensionsById = new Map(
+            (oldCustomDimensions ?? [])
+                .filter(isCustomSqlDimension)
+                .map((dim) => [dim.id, dim]),
+        );
+        const hasModifiedSqlCustomDimension = (
+            data.metricQuery.customDimensions ?? []
+        )
+            .filter(isCustomSqlDimension)
+            .some((dim) => {
+                const saved = oldSqlDimensionsById.get(dim.id);
+                return !saved || saved.sql !== dim.sql;
+            });
+
         if (
-            data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
+            hasModifiedSqlCustomDimension &&
             auditedAbility.cannot(
                 'manage',
                 subject('CustomFields', {
@@ -520,7 +535,7 @@ export class SavedChartService
             )
         ) {
             throw new ForbiddenError(
-                'User cannot save queries with custom SQL dimensions',
+                'User cannot save queries with modified custom SQL dimensions',
             );
         }
 
@@ -1220,6 +1235,23 @@ export class SavedChartService
             )
         ) {
             throw new ForbiddenError();
+        }
+
+        if (
+            savedChart.metricQuery.customDimensions?.some(
+                isCustomSqlDimension,
+            ) &&
+            auditedAbility.cannot(
+                'manage',
+                subject('CustomFields', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'User cannot create charts with custom SQL dimensions',
+            );
         }
 
         if (!resolvedSpaceUuid && !savedChart.dashboardUuid) {

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/index.tsx
@@ -1,6 +1,8 @@
 import { isCustomBinDimension, isDimension } from '@lightdash/common';
 import { memo } from 'react';
 import { useExplorerSelector } from '../../../features/explorer/store';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useCannotAuthorCustomSql } from '../../../hooks/user/useCannotAuthorCustomSql';
 import { CustomBinDimensionModal } from './CustomBinDimensionModal';
 import { CustomSqlDimensionModal } from './CustomSqlDimensionModal';
 
@@ -8,6 +10,8 @@ export const CustomDimensionModal = memo(() => {
     const { isOpen, isEditing, table, item } = useExplorerSelector(
         (state) => state.explorer.modals.customDimension,
     );
+    const projectUuid = useProjectUuid();
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
 
     if (!isOpen) {
         return null;
@@ -15,6 +19,10 @@ export const CustomDimensionModal = memo(() => {
 
     if (isDimension(item) || isCustomBinDimension(item)) {
         return <CustomBinDimensionModal isEditing={!!isEditing} item={item} />;
+    }
+
+    if (cannotAuthorCustomSql) {
+        return null;
     }
 
     if (!isEditing && table) {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -29,7 +29,9 @@ import { useMemo, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import {
     explorerActions,
+    selectSavedChart,
     useExplorerDispatch,
+    useExplorerSelector,
 } from '../../../../../features/explorer/store';
 import useToaster from '../../../../../hooks/toaster/useToaster';
 import { useFilteredFields } from '../../../../../hooks/useFilters';
@@ -65,6 +67,7 @@ const TreeSingleNodeActions: FC<Props> = ({
 }) => {
     const projectUuid = useProjectUuid();
     const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
+    const savedChart = useExplorerSelector(selectSavedChart);
     const { user } = useApp();
     const { showToastSuccess } = useToaster();
     const { addFilter } = useFilteredFields();
@@ -264,87 +267,102 @@ const TreeSingleNodeActions: FC<Props> = ({
                     </Menu.Item>
                 )}
 
-                {isCustomDimension(item) &&
-                    !(isCustomSqlDimension(item) && cannotAuthorCustomSql) && (
-                        <>
-                            <Menu.Item
-                                component="button"
-                                leftSection={<MantineIcon icon={IconEdit} />}
-                                onClick={(
-                                    e: React.MouseEvent<HTMLButtonElement>,
-                                ) => {
-                                    e.stopPropagation();
-                                    dispatch(
-                                        explorerActions.toggleCustomDimensionModal(
-                                            {
-                                                item,
-                                                isEditing: true,
-                                            },
-                                        ),
-                                    );
-                                }}
-                            >
-                                Edit custom dimension
-                            </Menu.Item>
-                            <Menu.Item
-                                component="button"
-                                leftSection={<MantineIcon icon={IconCopy} />}
-                                onClick={(
-                                    e: React.MouseEvent<HTMLButtonElement>,
-                                ) => {
-                                    e.stopPropagation();
-                                    duplicateCustomDimension(item);
-                                    track({
-                                        name: EventName.ADD_CUSTOM_DIMENSION_CLICKED,
-                                    });
-                                    showToastSuccess({
-                                        title: 'Copy of Custom Dimension added successfully',
-                                    });
-                                }}
-                            >
-                                Duplicate custom dimension
-                            </Menu.Item>
-                            {(isCustomSqlDimension(item) ||
-                                isWriteBackCustomBinDimensionsEnabled) && (
+                {isCustomDimension(item) && (
+                    <>
+                        {!(
+                            isCustomSqlDimension(item) && cannotAuthorCustomSql
+                        ) && (
+                            <>
                                 <Menu.Item
                                     component="button"
                                     leftSection={
-                                        <MantineIcon icon={IconCode} />
+                                        <MantineIcon icon={IconEdit} />
                                     }
                                     onClick={(
                                         e: React.MouseEvent<HTMLButtonElement>,
                                     ) => {
                                         e.stopPropagation();
-                                        if (
-                                            projectUuid &&
-                                            user.data?.organizationUuid
-                                        ) {
-                                            track({
-                                                name: EventName.WRITE_BACK_FROM_CUSTOM_DIMENSION_CLICKED,
-                                                properties: {
-                                                    userId: user.data.userUuid,
-                                                    projectId: projectUuid,
-                                                    organizationId:
-                                                        user.data
-                                                            .organizationUuid,
-                                                    customDimensionsCount: 1,
-                                                },
-                                            });
-                                        }
-
                                         dispatch(
-                                            explorerActions.toggleWriteBackModal(
+                                            explorerActions.toggleCustomDimensionModal(
                                                 {
-                                                    items: [item],
+                                                    item,
+                                                    isEditing: true,
                                                 },
                                             ),
                                         );
                                     }}
                                 >
-                                    Write back to dbt
+                                    Edit custom dimension
                                 </Menu.Item>
-                            )}
+                                <Menu.Item
+                                    component="button"
+                                    leftSection={
+                                        <MantineIcon icon={IconCopy} />
+                                    }
+                                    onClick={(
+                                        e: React.MouseEvent<HTMLButtonElement>,
+                                    ) => {
+                                        e.stopPropagation();
+                                        duplicateCustomDimension(item);
+                                        track({
+                                            name: EventName.ADD_CUSTOM_DIMENSION_CLICKED,
+                                        });
+                                        showToastSuccess({
+                                            title: 'Copy of Custom Dimension added successfully',
+                                        });
+                                    }}
+                                >
+                                    Duplicate custom dimension
+                                </Menu.Item>
+                                {(isCustomSqlDimension(item) ||
+                                    isWriteBackCustomBinDimensionsEnabled) && (
+                                    <Menu.Item
+                                        component="button"
+                                        leftSection={
+                                            <MantineIcon icon={IconCode} />
+                                        }
+                                        onClick={(
+                                            e: React.MouseEvent<HTMLButtonElement>,
+                                        ) => {
+                                            e.stopPropagation();
+                                            if (
+                                                projectUuid &&
+                                                user.data?.organizationUuid
+                                            ) {
+                                                track({
+                                                    name: EventName.WRITE_BACK_FROM_CUSTOM_DIMENSION_CLICKED,
+                                                    properties: {
+                                                        userId: user.data
+                                                            .userUuid,
+                                                        projectId: projectUuid,
+                                                        organizationId:
+                                                            user.data
+                                                                .organizationUuid,
+                                                        customDimensionsCount: 1,
+                                                    },
+                                                });
+                                            }
 
+                                            dispatch(
+                                                explorerActions.toggleWriteBackModal(
+                                                    {
+                                                        items: [item],
+                                                    },
+                                                ),
+                                            );
+                                        }}
+                                    >
+                                        Write back to dbt
+                                    </Menu.Item>
+                                )}
+                            </>
+                        )}
+
+                        {!(
+                            isCustomSqlDimension(item) &&
+                            cannotAuthorCustomSql &&
+                            !!savedChart
+                        ) && (
                             <Menu.Item
                                 color="red"
                                 component="button"
@@ -362,8 +380,9 @@ const TreeSingleNodeActions: FC<Props> = ({
                             >
                                 Remove custom dimension
                             </Menu.Item>
-                        </>
-                    )}
+                        )}
+                    </>
+                )}
 
                 {customMetrics.length > 0 &&
                 (isDimension(item) || isCustomSqlDimension(item)) ? (

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -34,6 +34,7 @@ import {
 import useToaster from '../../../../../hooks/toaster/useToaster';
 import { useFilteredFields } from '../../../../../hooks/useFilters';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
+import { useCannotAuthorCustomSql } from '../../../../../hooks/user/useCannotAuthorCustomSql';
 import {
     useClientFeatureFlag,
     useServerFeatureFlag,
@@ -63,6 +64,7 @@ const TreeSingleNodeActions: FC<Props> = ({
     onViewDescription,
 }) => {
     const projectUuid = useProjectUuid();
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
     const { user } = useApp();
     const { showToastSuccess } = useToaster();
     const { addFilter } = useFilteredFields();
@@ -262,98 +264,106 @@ const TreeSingleNodeActions: FC<Props> = ({
                     </Menu.Item>
                 )}
 
-                {isCustomDimension(item) && (
-                    <>
-                        <Menu.Item
-                            component="button"
-                            leftSection={<MantineIcon icon={IconEdit} />}
-                            onClick={(
-                                e: React.MouseEvent<HTMLButtonElement>,
-                            ) => {
-                                e.stopPropagation();
-                                dispatch(
-                                    explorerActions.toggleCustomDimensionModal({
-                                        item,
-                                        isEditing: true,
-                                    }),
-                                );
-                            }}
-                        >
-                            Edit custom dimension
-                        </Menu.Item>
-                        <Menu.Item
-                            component="button"
-                            leftSection={<MantineIcon icon={IconCopy} />}
-                            onClick={(
-                                e: React.MouseEvent<HTMLButtonElement>,
-                            ) => {
-                                e.stopPropagation();
-                                duplicateCustomDimension(item);
-                                track({
-                                    name: EventName.ADD_CUSTOM_DIMENSION_CLICKED,
-                                });
-                                showToastSuccess({
-                                    title: 'Copy of Custom Dimension added successfully',
-                                });
-                            }}
-                        >
-                            Duplicate custom dimension
-                        </Menu.Item>
-                        {(isCustomSqlDimension(item) ||
-                            isWriteBackCustomBinDimensionsEnabled) && (
+                {isCustomDimension(item) &&
+                    !(isCustomSqlDimension(item) && cannotAuthorCustomSql) && (
+                        <>
                             <Menu.Item
                                 component="button"
-                                leftSection={<MantineIcon icon={IconCode} />}
+                                leftSection={<MantineIcon icon={IconEdit} />}
                                 onClick={(
                                     e: React.MouseEvent<HTMLButtonElement>,
                                 ) => {
                                     e.stopPropagation();
-                                    if (
-                                        projectUuid &&
-                                        user.data?.organizationUuid
-                                    ) {
-                                        track({
-                                            name: EventName.WRITE_BACK_FROM_CUSTOM_DIMENSION_CLICKED,
-                                            properties: {
-                                                userId: user.data.userUuid,
-                                                projectId: projectUuid,
-                                                organizationId:
-                                                    user.data.organizationUuid,
-                                                customDimensionsCount: 1,
-                                            },
-                                        });
-                                    }
-
                                     dispatch(
-                                        explorerActions.toggleWriteBackModal({
-                                            items: [item],
-                                        }),
+                                        explorerActions.toggleCustomDimensionModal(
+                                            {
+                                                item,
+                                                isEditing: true,
+                                            },
+                                        ),
                                     );
                                 }}
                             >
-                                Write back to dbt
+                                Edit custom dimension
                             </Menu.Item>
-                        )}
+                            <Menu.Item
+                                component="button"
+                                leftSection={<MantineIcon icon={IconCopy} />}
+                                onClick={(
+                                    e: React.MouseEvent<HTMLButtonElement>,
+                                ) => {
+                                    e.stopPropagation();
+                                    duplicateCustomDimension(item);
+                                    track({
+                                        name: EventName.ADD_CUSTOM_DIMENSION_CLICKED,
+                                    });
+                                    showToastSuccess({
+                                        title: 'Copy of Custom Dimension added successfully',
+                                    });
+                                }}
+                            >
+                                Duplicate custom dimension
+                            </Menu.Item>
+                            {(isCustomSqlDimension(item) ||
+                                isWriteBackCustomBinDimensionsEnabled) && (
+                                <Menu.Item
+                                    component="button"
+                                    leftSection={
+                                        <MantineIcon icon={IconCode} />
+                                    }
+                                    onClick={(
+                                        e: React.MouseEvent<HTMLButtonElement>,
+                                    ) => {
+                                        e.stopPropagation();
+                                        if (
+                                            projectUuid &&
+                                            user.data?.organizationUuid
+                                        ) {
+                                            track({
+                                                name: EventName.WRITE_BACK_FROM_CUSTOM_DIMENSION_CLICKED,
+                                                properties: {
+                                                    userId: user.data.userUuid,
+                                                    projectId: projectUuid,
+                                                    organizationId:
+                                                        user.data
+                                                            .organizationUuid,
+                                                    customDimensionsCount: 1,
+                                                },
+                                            });
+                                        }
 
-                        <Menu.Item
-                            color="red"
-                            component="button"
-                            leftSection={<MantineIcon icon={IconTrash} />}
-                            onClick={(
-                                e: React.MouseEvent<HTMLButtonElement>,
-                            ) => {
-                                e.stopPropagation();
-                                dispatch(
-                                    explorerActions.removeCustomDimension(
-                                        getItemId(item),
-                                    ),
-                                );
-                            }}
-                        >
-                            Remove custom dimension
-                        </Menu.Item>
-                    </>
-                )}
+                                        dispatch(
+                                            explorerActions.toggleWriteBackModal(
+                                                {
+                                                    items: [item],
+                                                },
+                                            ),
+                                        );
+                                    }}
+                                >
+                                    Write back to dbt
+                                </Menu.Item>
+                            )}
+
+                            <Menu.Item
+                                color="red"
+                                component="button"
+                                leftSection={<MantineIcon icon={IconTrash} />}
+                                onClick={(
+                                    e: React.MouseEvent<HTMLButtonElement>,
+                                ) => {
+                                    e.stopPropagation();
+                                    dispatch(
+                                        explorerActions.removeCustomDimension(
+                                            getItemId(item),
+                                        ),
+                                    );
+                                }}
+                            >
+                                Remove custom dimension
+                            </Menu.Item>
+                        </>
+                    )}
 
                 {customMetrics.length > 0 &&
                 (isDimension(item) || isCustomSqlDimension(item)) ? (

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -11,6 +11,7 @@ import {
     useExplorerSelector,
 } from '../../../../../features/explorer/store';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
+import { useCannotAuthorCustomSql } from '../../../../../hooks/user/useCannotAuthorCustomSql';
 import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
@@ -47,14 +48,7 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
     const isWriteBackCustomBinDimensionsEnabled =
         writeBackCustomBinDimensionsFlag?.enabled ?? false;
 
-    // Filter custom dimensions based on feature flag
-    const customDimensionsToWriteBack = useMemo(() => {
-        if (!allCustomDimensions) return [];
-        return isWriteBackCustomBinDimensionsEnabled
-            ? allCustomDimensions
-            : allCustomDimensions.filter(isCustomSqlDimension);
-    }, [allCustomDimensions, isWriteBackCustomBinDimensionsEnabled]);
-
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
     const canManageCustomFields = user.data?.ability?.can(
         'manage',
         subject('CustomFields', {
@@ -62,6 +56,20 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
             projectUuid,
         }),
     );
+
+    const customDimensionsToWriteBack = useMemo(() => {
+        if (!allCustomDimensions) return [];
+        const baseList = isWriteBackCustomBinDimensionsEnabled
+            ? allCustomDimensions
+            : allCustomDimensions.filter(isCustomSqlDimension);
+        return cannotAuthorCustomSql
+            ? baseList.filter((dim) => !isCustomSqlDimension(dim))
+            : baseList;
+    }, [
+        allCustomDimensions,
+        isWriteBackCustomBinDimensionsEnabled,
+        cannotAuthorCustomSql,
+    ]);
 
     const handleAddCustomDimension = useCallback(() => {
         dispatch(

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -11,7 +11,6 @@ import {
     useExplorerSelector,
 } from '../../../../../features/explorer/store';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
-import { useCannotAuthorCustomSql } from '../../../../../hooks/user/useCannotAuthorCustomSql';
 import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
@@ -48,7 +47,6 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
     const isWriteBackCustomBinDimensionsEnabled =
         writeBackCustomBinDimensionsFlag?.enabled ?? false;
 
-    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
     const canManageCustomFields = user.data?.ability?.can(
         'manage',
         subject('CustomFields', {
@@ -62,13 +60,13 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
         const baseList = isWriteBackCustomBinDimensionsEnabled
             ? allCustomDimensions
             : allCustomDimensions.filter(isCustomSqlDimension);
-        return cannotAuthorCustomSql
-            ? baseList.filter((dim) => !isCustomSqlDimension(dim))
-            : baseList;
+        return canManageCustomFields
+            ? baseList
+            : baseList.filter((dim) => !isCustomSqlDimension(dim));
     }, [
         allCustomDimensions,
         isWriteBackCustomBinDimensionsEnabled,
-        cannotAuthorCustomSql,
+        canManageCustomFields,
     ]);
 
     const handleAddCustomDimension = useCallback(() => {

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -28,6 +28,7 @@ import { useMemo, useState, type FC } from 'react';
 import {
     explorerActions,
     selectAdditionalMetrics,
+    selectSavedChart,
     selectTableCalculations,
     selectTableName,
     useExplorerDispatch,
@@ -75,6 +76,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
     const dispatch = useExplorerDispatch();
     const projectUuid = useProjectUuid();
     const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
+    const savedChart = useExplorerSelector(selectSavedChart);
 
     // Get explore data to check if metrics return date values
     const { data: exploreData } = useExplore(tableName, {
@@ -235,6 +237,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
     } else if (item && isCustomDimension(item)) {
         const hideSqlAuthoringActions =
             isCustomSqlDimension(item) && cannotAuthorCustomSql;
+        const hideRemove = hideSqlAuthoringActions && !!savedChart;
         return (
             <>
                 {isFilterableField(item) && (
@@ -277,7 +280,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
 
                 <ColumnHeaderSortMenuOptions item={item} sort={sort} />
 
-                {!hideSqlAuthoringActions && (
+                {!hideRemove && (
                     <>
                         <Menu.Divider />
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -4,6 +4,7 @@ import {
     getItemLabelWithoutTableName,
     getItemMap,
     isCustomDimension,
+    isCustomSqlDimension,
     isDimension,
     isField,
     isFilterableField,
@@ -38,6 +39,8 @@ import {
 } from '../../../features/tableCalculation';
 import { useExplore } from '../../../hooks/useExplore';
 import { useFilters } from '../../../hooks/useFilters';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useCannotAuthorCustomSql } from '../../../hooks/user/useCannotAuthorCustomSql';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { BetaBadge } from '../../common/BetaBadge';
@@ -70,6 +73,8 @@ const ContextMenu: FC<ContextMenuProps> = ({
     const tableCalculations = useExplorerSelector(selectTableCalculations);
     const tableName = useExplorerSelector(selectTableName);
     const dispatch = useExplorerDispatch();
+    const projectUuid = useProjectUuid();
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
 
     // Get explore data to check if metrics return date values
     const { data: exploreData } = useExplore(tableName, {
@@ -228,6 +233,8 @@ const ContextMenu: FC<ContextMenuProps> = ({
             </>
         );
     } else if (item && isCustomDimension(item)) {
+        const hideSqlAuthoringActions =
+            isCustomSqlDimension(item) && cannotAuthorCustomSql;
         return (
             <>
                 {isFilterableField(item) && (
@@ -249,34 +256,46 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     </>
                 )}
 
-                <Menu.Item
-                    leftSection={<MantineIcon icon={IconPencil} />}
-                    onClick={() => {
-                        dispatch(
-                            explorerActions.toggleCustomDimensionModal({
-                                item,
-                                isEditing: true,
-                            }),
-                        );
-                    }}
-                >
-                    Edit custom dimension
-                </Menu.Item>
-                <Menu.Divider />
+                {!hideSqlAuthoringActions && (
+                    <>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconPencil} />}
+                            onClick={() => {
+                                dispatch(
+                                    explorerActions.toggleCustomDimensionModal({
+                                        item,
+                                        isEditing: true,
+                                    }),
+                                );
+                            }}
+                        >
+                            Edit custom dimension
+                        </Menu.Item>
+                        <Menu.Divider />
+                    </>
+                )}
 
                 <ColumnHeaderSortMenuOptions item={item} sort={sort} />
 
-                <Menu.Divider />
+                {!hideSqlAuthoringActions && (
+                    <>
+                        <Menu.Divider />
 
-                <Menu.Item
-                    leftSection={<MantineIcon icon={IconTrash} />}
-                    color="red"
-                    onClick={() => {
-                        dispatch(explorerActions.removeField(getItemId(item)));
-                    }}
-                >
-                    Remove
-                </Menu.Item>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                            color="red"
+                            onClick={() => {
+                                dispatch(
+                                    explorerActions.removeField(
+                                        getItemId(item),
+                                    ),
+                                );
+                            }}
+                        >
+                            Remove
+                        </Menu.Item>
+                    </>
+                )}
             </>
         );
     } else if (item && isTableCalculation(item)) {

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -1,7 +1,12 @@
 import { subject } from '@casl/ability';
-import { formatSql } from '@lightdash/common';
+import {
+    formatSql,
+    isCustomSqlDimension,
+    isSqlTableCalculation,
+} from '@lightdash/common';
 import {
     ActionIcon,
+    Box,
     CopyButton,
     Group,
     SegmentedControl,
@@ -22,15 +27,18 @@ import {
 import {
     explorerActions,
     selectIsSqlExpanded,
+    selectMetricQuery,
     selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import { useCompiledSql } from '../../../hooks/useCompiledSql';
 import { useProject } from '../../../hooks/useProject';
+import { useCannotAuthorCustomSql } from '../../../hooks/user/useCannotAuthorCustomSql';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
+import Callout from '../../common/Callout';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
 import { type SqlViewType } from '../../RenderedSql';
@@ -55,6 +63,8 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
     const dispatch = useExplorerDispatch();
 
     const unsavedChartVersionTableName = useExplorerSelector(selectTableName);
+    const metricQuery = useExplorerSelector(selectMetricQuery);
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
 
     const toggleExpandedSection = useCallback(
         (section: ExplorerSection) => {
@@ -65,8 +75,14 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
     const { user } = useApp();
     const { data: project } = useProject(projectUuid);
 
+    const hasSqlAuthoredFields =
+        !!metricQuery.customDimensions?.some(isCustomSqlDimension) ||
+        !!metricQuery.tableCalculations?.some(isSqlTableCalculation);
+    const cannotViewSqlAuthoredFields =
+        hasSqlAuthoredFields && cannotAuthorCustomSql;
+
     const { data, isSuccess, isInitialLoading, error } = useCompiledSql({
-        enabled: !!unsavedChartVersionTableName,
+        enabled: !!unsavedChartVersionTableName && !cannotViewSqlAuthoredFields,
     });
 
     const hasPivotQuery = !!data?.pivotQuery;
@@ -90,7 +106,10 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
             onToggle={() => toggleExpandedSection(ExplorerSection.SQL)}
             disabled={!unsavedChartVersionTableName}
             headerElement={
-                (hovered || sqlIsOpen) && data && isSuccess ? (
+                !cannotViewSqlAuthoredFields &&
+                (hovered || sqlIsOpen) &&
+                data &&
+                isSuccess ? (
                     <CopyButton value={formattedSql} timeout={2000}>
                         {({ copied, copy }) => (
                             <Tooltip
@@ -123,7 +142,8 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
                 ) : undefined
             }
             rightHeaderElement={
-                sqlIsOpen && (
+                sqlIsOpen &&
+                !cannotViewSqlAuthoredFields && (
                     <Group spacing="xs">
                         {hasPivotQuery && (
                             <SegmentedControl
@@ -158,9 +178,19 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
                 )
             }
         >
-            <Suspense fallback={<Skeleton height={60} radius="sm" />}>
-                <LazyRenderedSql selectedView={selectedView} />
-            </Suspense>
+            {cannotViewSqlAuthoredFields ? (
+                <Box p="sm">
+                    <Callout variant="info" title="SQL preview unavailable">
+                        This chart contains custom SQL fields. You need the{' '}
+                        <strong>Manage custom fields</strong> permission to view
+                        the compiled SQL.
+                    </Callout>
+                </Box>
+            ) : (
+                <Suspense fallback={<Skeleton height={60} radius="sm" />}>
+                    <LazyRenderedSql selectedView={selectedView} />
+                </Suspense>
+            )}
         </CollapsableCard>
     );
 });

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -23,6 +23,13 @@ import useToaster from './toaster/useToaster';
 import { invalidateContent } from './useContent';
 import useSearchParams from './useSearchParams';
 
+const isCustomSqlDimensionForbiddenError = (
+    error: ApiError['error'],
+): boolean =>
+    error.statusCode === 403 &&
+    typeof error.message === 'string' &&
+    error.message.toLowerCase().includes('custom sql dimensions');
+
 const createSavedQuery = async (
     projectUuid: string,
     payload: CreateSavedChart,
@@ -346,7 +353,8 @@ export const useCreateMutation = ({
     const navigate = useNavigate();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
-    const { showToastSuccess, showToastApiError } = useToaster();
+    const { showToastSuccess, showToastError, showToastApiError } =
+        useToaster();
     return useMutation<SavedChart, ApiError, CreateSavedChart>(
         (data) =>
             projectUuid
@@ -379,6 +387,14 @@ export const useCreateMutation = ({
                 }
             },
             onError: ({ error }) => {
+                if (isCustomSqlDimensionForbiddenError(error)) {
+                    showToastError({
+                        title: "Can't save chart",
+                        subtitle:
+                            "You don't have permission to author custom SQL dimensions. Remove them from your chart to save.",
+                    });
+                    return;
+                }
                 showToastApiError({
                     title: `Failed to save chart`,
                     apiError: error,
@@ -464,7 +480,8 @@ export const useAddVersionMutation = () => {
     const queryClient = useQueryClient();
     const dashboardUuid = useSearchParams('fromDashboard');
 
-    const { showToastSuccess, showToastApiError } = useToaster();
+    const { showToastSuccess, showToastError, showToastApiError } =
+        useToaster();
     return useMutation<
         SavedChart,
         ApiError,
@@ -520,6 +537,14 @@ export const useAddVersionMutation = () => {
             }
         },
         onError: ({ error }) => {
+            if (isCustomSqlDimensionForbiddenError(error)) {
+                showToastError({
+                    title: "Can't update chart",
+                    subtitle:
+                        "You don't have permission to author custom SQL dimensions. Remove them from your chart to save.",
+                });
+                return;
+            }
             showToastApiError({
                 title: `Failed to update chart`,
                 apiError: error,

--- a/packages/frontend/src/hooks/user/useCannotAuthorCustomSql.ts
+++ b/packages/frontend/src/hooks/user/useCannotAuthorCustomSql.ts
@@ -1,0 +1,14 @@
+import { subject } from '@casl/ability';
+import useApp from '../../providers/App/useApp';
+
+export const useCannotAuthorCustomSql = (projectUuid: string | undefined) => {
+    const { user } = useApp();
+
+    return user.data?.ability.cannot(
+        'manage',
+        subject('CustomFields', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+};


### PR DESCRIPTION
## Summary
Re-lands a focused, FE-only set of permission hides for SQL custom dimensions that #22541 reverted, plus a diff-aware backend save gate that protects admin-authored SQL on existing charts.

The full SQL-authoring permissions wave was reverted in #22541 because the strict run-time / read-time gates were breaking editor flows on charts they didn't author. This PR brings back **only** the pieces that are clearly safe and necessary, framed around a tighter mental model:

> **`manage:CustomFields` gates *tampering with admin-authored SQL on the chart they wrote*. It does not block editors from running, exporting, or reusing those charts elsewhere.**

The broader run-time / read-time gates remain reverted pending a more deliberate design pass.

## What's gated

**Frontend** (only for users without `manage:CustomFields`):
- `TreeSingleNodeActions` — hide Edit / Duplicate / Write back to dbt on SQL custom dims in the dimension tree's `...` menu
- `ColumnHeaderContextMenu` — hide Edit on SQL custom dims in the column header dropdown
- Remove on SQL custom dims is hidden **only when a saved chart is loaded** (protects the admin's dim from being deleted out of the saved chart). In explore-from-here / draft contexts, Remove is shown so editors aren't trapped with a SQL dim they don't want.
- `CustomDimensionModal` — early-return `null` on the SQL variant as defense-in-depth
- `VirtualSectionHeader` — filter SQL dims out of the bulk Write-back list
- `SqlCard` — render a subtle blue "SQL preview unavailable" callout instead of the compiled SQL when the chart contains SQL-authored fields

**Backend**:
- `SavedChartService.createVersion`: changes the existing strict gate from *"any save of a chart with a SQL custom dim → 403"* to *"only **modified or added** SQL custom dims trigger 403"*. Editors can now save filter / sort / vis tweaks on charts containing admin-authored SQL they didn't touch (restores the diff-aware behavior from #22451).
- `AsyncQueryService` / `ProjectService` / `GdriveService`: drop dead `isCustomSqlDimension` imports left over from the wave revert.

**Toast UX**:
- `useCreateMutation` / `useAddVersionMutation` detect the SQL-custom-dim 403 (matches `error.message` against `"custom sql dimensions"`) and render an actionable toast: *"You don't have permission to author custom SQL dimensions. Remove them from your chart to save."* — instead of the generic *"Failed to save chart — User cannot save queries with modified custom SQL dimensions"* raw API toast.

## What's intentionally **not** gated

- **`SavedChartService.create` (new chart)**: editors can save a new chart whose metricQuery contains SQL custom dimensions. This unblocks legitimate flows like saving an explore-from-here as a new chart, copying an admin's chart, or building a variation on existing analytics. Whether that SQL came from explore-from-here, a copy, or fresh authoring is not distinguishable at the API surface without provenance tracking — and the run path is already ungated post-revert, so persistence is now symmetric with execution.
- **`AsyncQueryService.executeAsyncMetricQuery` (run-time)**: not gated. Editors can run charts containing SQL custom dimensions, refresh, drill, export, etc. — same as today.
- **Content-as-code (`CoderService.upsertChart`)**: not gated separately — matches the "create" semantics above. The original gate proposal (#22556) was closed.

## Regression analysis
- **Editors without `manage:CustomFields`**:
  - Cannot Edit / Duplicate / Write back SQL custom dims via the UI
  - Cannot **modify** an existing SQL custom dim's SQL on a saved chart they're updating (`createVersion` 403)
  - Cannot **add** a new SQL custom dim to an existing chart they're updating (`createVersion` 403)
  - **Can** save unrelated changes (filters, vis, sort) on charts that contain admin-authored SQL custom dims they didn't touch (diff-aware exemption)
  - **Can** save a new chart that contains SQL custom dims (e.g. saving an explore-from-here)
  - **Can** remove a SQL custom dim from their working state in explore-from-here / draft contexts
- **Editors with `manage:CustomFields`**: unchanged
- **Developers / admins / service accounts**: unchanged

## Test plan
- [ ] As an editor (no `manage:CustomFields`) editing a saved chart with an admin-authored SQL custom dim:
  - [ ] `...` menu hides Edit / Duplicate / Write back / Remove on the SQL dim
  - [ ] Column header hides Edit and Remove on the SQL dim
  - [ ] SQL card shows the "SQL preview unavailable" callout
  - [ ] Adding a filter and clicking Save **succeeds**
  - [ ] Modifying the SQL via the API still **403**s with the actionable toast
  - [ ] Adding a new SQL dim to the chart via the API **403**s with the actionable toast
- [ ] As the same editor in explore-from-here from that chart:
  - [ ] `...` menu hides Edit / Duplicate / Write back, but **shows** Remove
  - [ ] Column header hides Edit but **shows** Remove
  - [ ] Saving as a new chart **succeeds**, including the SQL custom dim
  - [ ] Removing the SQL dim and saving also succeeds
- [ ] As a developer / admin, all flows behave as before
- [ ] As an editor with `manage:CustomFields`, all flows behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
