### PR TITLE
feat(permissions): gate SQL custom dim authoring in content-as-code upload

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -20,6 +20,7 @@ import {
     friendlyName,
     getContentAsCodePathFromLtreePath,
     getLtreePathFromContentAsCodePath,
+    isCustomSqlDimension,
     NotFoundError,
     Project,
     PromotionAction,
@@ -1095,6 +1096,23 @@ export class CoderService extends BaseService {
             )
         ) {
             throw new ForbiddenError();
+        }
+
+        if (
+            chartAsCode.metricQuery.customDimensions?.some(
+                isCustomSqlDimension,
+            ) &&
+            auditedAbility.cannot(
+                'manage',
+                subject('CustomFields', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid: project.projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'User cannot upload charts with custom SQL dimensions',
+            );
         }
 
         // Default optional fields when missing (e.g. user-authored YAML)


### PR DESCRIPTION
## Summary
Mirrors the `SavedChartService` save gate in `CoderService.upsertChart` so the same `manage:CustomFields` restriction applies to `lightdash upload` and the underlying `POST /api/v1/projects/{uuid}/charts/{slug}/code` endpoint.

Stacked on top of #22555.

## Why
After #22555, an editor without `manage:CustomFields` cannot author SQL custom dimensions through the explorer save / create paths. Content-as-code is a separate write surface — without this PR, the same editor (or a service account / custom role with `manage:ContentAsCode` but no `manage:CustomFields`) could still upload arbitrary SQL custom dims via the API and bypass everything #22555 set up.

## Regression analysis
- **System roles**: no-op. `manage:ContentAsCode` and `manage:CustomFields` are granted to the **same tier** (developer + admin) at the project, organization, and service-account levels. Anyone who can use content-as-code today already has the right to author SQL custom dims.
- **Custom roles**: this is the case the gate exists for. An org could define a custom role with `manage:ContentAsCode` but no `manage:CustomFields` — without this gate, that user could upload SQL custom dimensions through the API while being unable to author them via the explorer. Now both paths are consistent.

## Test plan
- [ ] As a developer, `lightdash upload` of a chart containing a SQL custom dim succeeds (unchanged).
- [ ] As a custom role with `manage:ContentAsCode` but **without** `manage:CustomFields`, `POST /charts/{slug}/code` with a SQL custom dim returns 403 with `User cannot upload charts with custom SQL dimensions`.
- [ ] As the same custom role, uploading a chart **without** SQL custom dims still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
