### PR TITLE
fix(promote): allow content overwrite without manage Space (PROD-7288)

### DIFF
--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -1263,18 +1263,6 @@ describe('PromoteService permission checks', () => {
         return new CaslAuditWrapper(developerUser.ability, developerUser);
     };
 
-    // Static helper that bypasses TypeScript's `private` to exercise the chart
-    // and SQL chart wrappers from tests. checkPromoteSpacePermissions is shared
-    // by all three flows, so testing one flow exhaustively + a smoke test on
-    // the others is enough.
-    const callCheckPromoteChartPermissions = (...args: unknown[]): void => {
-        (
-            PromoteService as unknown as {
-                checkPromoteChartPermissions: (...a: unknown[]) => void;
-            }
-        ).checkPromoteChartPermissions(...args);
-    };
-
     test('PROD-7288: allows overwrite of an existing dashboard in an unchanged existing space when user has promote Dashboard but not manage Space', () => {
         const auditedAbility = buildAuditedAbility([
             { subject: 'Dashboard', action: ['promote'] },
@@ -1286,21 +1274,6 @@ describe('PromoteService permission checks', () => {
                 'organization-uuid',
                 promotedDashboard,
                 existingUpstreamDashboard,
-            ),
-        ).not.toThrow();
-    });
-
-    test('PROD-7288: allows overwrite of an existing chart in an unchanged existing space when user has promote SavedChart but not manage Space', () => {
-        const auditedAbility = buildAuditedAbility([
-            { subject: 'SavedChart', action: ['promote'] },
-        ]);
-
-        expect(() =>
-            callCheckPromoteChartPermissions(
-                auditedAbility,
-                'organization-uuid',
-                promotedChart,
-                existingUpstreamChart,
             ),
         ).not.toThrow();
     });

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -1,6 +1,14 @@
-import { DashboardTileTypes, PromotionAction } from '@lightdash/common';
+import { Ability } from '@casl/ability';
+import {
+    DashboardTileTypes,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    PromotionAction,
+    SessionUser,
+} from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
@@ -1240,5 +1248,113 @@ describe('PromoteService promoting and mutating changes', () => {
                 },
             },
         ]);
+    });
+});
+
+describe('PromoteService permission checks', () => {
+    const buildAuditedAbility = (
+        rules: ConstructorParameters<typeof Ability<PossibleAbilities>>[0],
+    ) => {
+        const developerUser: SessionUser = {
+            ...user,
+            role: OrganizationMemberRole.DEVELOPER,
+            ability: new Ability<PossibleAbilities>(rules),
+        };
+        return new CaslAuditWrapper(developerUser.ability, developerUser);
+    };
+
+    // Static helper that bypasses TypeScript's `private` to exercise the chart
+    // and SQL chart wrappers from tests. checkPromoteSpacePermissions is shared
+    // by all three flows, so testing one flow exhaustively + a smoke test on
+    // the others is enough.
+    const callCheckPromoteChartPermissions = (...args: unknown[]): void => {
+        (
+            PromoteService as unknown as {
+                checkPromoteChartPermissions: (...a: unknown[]) => void;
+            }
+        ).checkPromoteChartPermissions(...args);
+    };
+
+    test('PROD-7288: allows overwrite of an existing dashboard in an unchanged existing space when user has promote Dashboard but not manage Space', () => {
+        const auditedAbility = buildAuditedAbility([
+            { subject: 'Dashboard', action: ['promote'] },
+        ]);
+
+        expect(() =>
+            PromoteService.checkPromoteDashboardPermissions(
+                auditedAbility,
+                'organization-uuid',
+                promotedDashboard,
+                existingUpstreamDashboard,
+            ),
+        ).not.toThrow();
+    });
+
+    test('PROD-7288: allows overwrite of an existing chart in an unchanged existing space when user has promote SavedChart but not manage Space', () => {
+        const auditedAbility = buildAuditedAbility([
+            { subject: 'SavedChart', action: ['promote'] },
+        ]);
+
+        expect(() =>
+            callCheckPromoteChartPermissions(
+                auditedAbility,
+                'organization-uuid',
+                promotedChart,
+                existingUpstreamChart,
+            ),
+        ).not.toThrow();
+    });
+
+    test('throws when promotion would rename the upstream space and user lacks manage Space', () => {
+        const auditedAbility = buildAuditedAbility([
+            { subject: 'Dashboard', action: ['promote'] },
+        ]);
+        const renamedSource = {
+            ...promotedDashboard,
+            space: {
+                ...promotedDashboard.space,
+                name: 'Renamed jaffle shop',
+            },
+        };
+
+        expect(() =>
+            PromoteService.checkPromoteDashboardPermissions(
+                auditedAbility,
+                'organization-uuid',
+                renamedSource,
+                existingUpstreamDashboard,
+            ),
+        ).toThrow(/do not have access to modify this space/);
+    });
+
+    test('throws when promoting into a brand-new upstream space and user lacks create Space', () => {
+        const auditedAbility = buildAuditedAbility([
+            { subject: 'Dashboard', action: ['promote', 'manage'] },
+        ]);
+
+        expect(() =>
+            PromoteService.checkPromoteDashboardPermissions(
+                auditedAbility,
+                'organization-uuid',
+                promotedDashboard,
+                missingUpstreamDashboard,
+            ),
+        ).toThrow(/do not have access to create a space/);
+    });
+
+    test('allows promoting into a brand-new upstream space when user has create Space and manage Dashboard', () => {
+        const auditedAbility = buildAuditedAbility([
+            { subject: 'Dashboard', action: ['promote', 'manage'] },
+            { subject: 'Space', action: ['create'] },
+        ]);
+
+        expect(() =>
+            PromoteService.checkPromoteDashboardPermissions(
+                auditedAbility,
+                'organization-uuid',
+                promotedDashboard,
+                missingUpstreamDashboard,
+            ),
+        ).not.toThrow();
     });
 });

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -362,22 +362,9 @@ export class PromoteService extends BaseService {
             UpstreamChart | UpstreamDashboard | UpstreamSqlChart,
             'space' | 'projectUuid' | 'spaceAccessContext'
         >,
-        promotedSpace: Pick<PromotedSpace, 'name'> | undefined,
     ) {
         if (upstreamContent.space) {
-            // The only space-level mutation promotion performs on an existing
-            // upstream space is a rename (see isSpaceUpdated). When the source
-            // and upstream space match, the entity-level checks above already
-            // gate the actual operation — no `manage Space` required.
-            const willRenameSpace =
-                promotedSpace !== undefined &&
-                PromoteService.isSpaceUpdated(
-                    promotedSpace,
-                    upstreamContent.space,
-                );
-            if (!willRenameSpace) {
-                return;
-            }
+            // If upstreamContent has a matching space, we check if we have access
             if (
                 auditedAbility.cannot(
                     'manage',
@@ -529,12 +516,23 @@ export class PromoteService extends BaseService {
             }
         }
 
-        PromoteService.checkPromoteSpacePermissions(
-            auditedAbility,
-            organizationUuid,
-            upstreamChart,
-            promotedChart.space,
-        );
+        // Promotion only mutates the upstream space when creating a new one or
+        // renaming an existing one (see isSpaceUpdated). When the upstream
+        // space already exists and won't be renamed, the entity-level checks
+        // above already gate the operation — no `manage Space` required.
+        const promotionWillModifyChartSpace =
+            !upstreamChart.space ||
+            PromoteService.isSpaceUpdated(
+                promotedChart.space,
+                upstreamChart.space,
+            );
+        if (promotionWillModifyChartSpace) {
+            PromoteService.checkPromoteSpacePermissions(
+                auditedAbility,
+                organizationUuid,
+                upstreamChart,
+            );
+        }
     }
 
     private static checkPromoteSqlChartPermissions(
@@ -631,12 +629,19 @@ export class PromoteService extends BaseService {
             }
         }
 
-        PromoteService.checkPromoteSpacePermissions(
-            auditedAbility,
-            organizationUuid,
-            upstreamSqlChart,
-            promotedSqlChart.space,
-        );
+        const promotionWillModifySqlChartSpace =
+            !upstreamSqlChart.space ||
+            PromoteService.isSpaceUpdated(
+                promotedSqlChart.space,
+                upstreamSqlChart.space,
+            );
+        if (promotionWillModifySqlChartSpace) {
+            PromoteService.checkPromoteSpacePermissions(
+                auditedAbility,
+                organizationUuid,
+                upstreamSqlChart,
+            );
+        }
     }
 
     static checkPromoteDashboardPermissions(
@@ -726,12 +731,19 @@ export class PromoteService extends BaseService {
                 );
             }
         }
-        PromoteService.checkPromoteSpacePermissions(
-            auditedAbility,
-            organizationUuid,
-            upstreamDashboard,
-            promotedDashboard.space,
-        );
+        const promotionWillModifyDashboardSpace =
+            !upstreamDashboard.space ||
+            PromoteService.isSpaceUpdated(
+                promotedDashboard.space,
+                upstreamDashboard.space,
+            );
+        if (promotionWillModifyDashboardSpace) {
+            PromoteService.checkPromoteSpacePermissions(
+                auditedAbility,
+                organizationUuid,
+                upstreamDashboard,
+            );
+        }
     }
 
     private static isSpaceUpdated(

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -362,9 +362,22 @@ export class PromoteService extends BaseService {
             UpstreamChart | UpstreamDashboard | UpstreamSqlChart,
             'space' | 'projectUuid' | 'spaceAccessContext'
         >,
+        promotedSpace: Pick<PromotedSpace, 'name'> | undefined,
     ) {
         if (upstreamContent.space) {
-            // If upstreamContent has a matching space, we check if we have access
+            // The only space-level mutation promotion performs on an existing
+            // upstream space is a rename (see isSpaceUpdated). When the source
+            // and upstream space match, the entity-level checks above already
+            // gate the actual operation — no `manage Space` required.
+            const willRenameSpace =
+                promotedSpace !== undefined &&
+                PromoteService.isSpaceUpdated(
+                    promotedSpace,
+                    upstreamContent.space,
+                );
+            if (!willRenameSpace) {
+                return;
+            }
             if (
                 auditedAbility.cannot(
                     'manage',
@@ -520,6 +533,7 @@ export class PromoteService extends BaseService {
             auditedAbility,
             organizationUuid,
             upstreamChart,
+            promotedChart.space,
         );
     }
 
@@ -621,6 +635,7 @@ export class PromoteService extends BaseService {
             auditedAbility,
             organizationUuid,
             upstreamSqlChart,
+            promotedSqlChart.space,
         );
     }
 
@@ -715,6 +730,7 @@ export class PromoteService extends BaseService {
             auditedAbility,
             organizationUuid,
             upstreamDashboard,
+            promotedDashboard.space,
         );
     }
 


### PR DESCRIPTION
## Summary

`lightdash upload` (and any promote-overwrite flow) of an existing dashboard / chart / SQL chart was failing for users who can edit that same content directly in the UI. The promote permission check required `manage` on the upstream **Space**, while in-UI editing only requires `update` on the **Dashboard** / **Chart** — which a developer-role user with `EDITOR` ("Can edit") access on the destination space already has.

`checkPromoteSpacePermissions` now only requires `manage Space` when promotion will actually rename the upstream space (using the existing `isSpaceUpdated` comparator). When the upstream space exists and won't be modified, the entity-level `promote SavedChart` / `promote Dashboard` checks above already gate the operation. The `create Space` branch (new upstream space) is unchanged.

- Aligns the upload/promote gate with the in-UI edit gate.
- Removes the surprising "move dashboard to a personal space to upload" workaround.
- New regression tests cover overwrite, rename, and new-space scenarios.

Closes PROD-7288
Closes #22544

## Test plan
- [x] `pnpm -F backend exec jest src/services/PromoteService/PromoteService.test.ts` — 30/30 passing (5 new permission tests)
- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend run linter src/services/PromoteService/...` — clean
- [ ] Manual: as a developer-role user with `EDITOR` on a non-personal space, `lightdash download` then `lightdash upload --include-charts` an existing dashboard — must succeed (today errors with `Failed to promote: you do not have access to modify this space …`)
- [ ] Manual: same user attempting an upload that **renames** the destination space — must still fail with the same error (rename gate preserved)
- [ ] Manual: same flow as a space `ADMIN` (or org `editor`) — must continue to succeed in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)