### PR TITLE
fix: show "Change explore" menu in edit mode

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -740,8 +740,7 @@ const SavedChartsHeader: FC = () => {
                                     </Menu.Item>
                                 )}
                                 {changeChartExploreEnabled &&
-                                    userCanManageChart &&
-                                    !isEditMode && (
+                                    userCanManageChart && (
                                         <Menu.Item
                                             leftSection={
                                                 <MantineIcon
@@ -1069,6 +1068,7 @@ const SavedChartsHeader: FC = () => {
                         projectUuid={projectUuid}
                         chartUuid={savedChart.uuid}
                         currentExploreName={savedChart.tableName}
+                        hasUnsavedChanges={hasUnsavedChanges && isEditMode}
                     />
                 )}
         </TrackSection>

--- a/packages/frontend/src/components/common/modal/ChangeChartExploreModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChangeChartExploreModal.tsx
@@ -25,6 +25,7 @@ import { pollJobStatus } from '../../../features/scheduler/hooks/useScheduler';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useExplores } from '../../../hooks/useExplores';
 import useApp from '../../../providers/App/useApp';
+import Callout from '../Callout';
 import MantineModal from '../MantineModal';
 
 const renameChartExplore = async ({
@@ -59,6 +60,7 @@ interface ChangeChartExploreModalProps extends Pick<
     projectUuid: string;
     chartUuid: string;
     currentExploreName: string;
+    hasUnsavedChanges: boolean;
 }
 
 const FORM_ID = 'change-chart-explore-form';
@@ -69,6 +71,7 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
     projectUuid,
     chartUuid,
     currentExploreName,
+    hasUnsavedChanges,
 }) => {
     const queryClient = useQueryClient();
     const { user } = useApp();
@@ -204,6 +207,13 @@ const ChangeChartExploreModal: FC<ChangeChartExploreModalProps> = ({
         >
             <form id={FORM_ID} onSubmit={handleSubmit}>
                 <Stack>
+                    {hasUnsavedChanges && (
+                        <Callout variant="warning">
+                            You have unsaved changes to this chart. They will be
+                            discarded when the explore is changed.
+                        </Callout>
+                    )}
+
                     <Text fz="sm" c="dimmed">
                         Change which explore this chart uses. All field
                         references will be remapped to the new explore.


### PR DESCRIPTION
## Summary

- Drop the `!isEditMode` guard so the **Change explore** menu item is visible in both view *and* edit mode (still gated by the `ChangeChartExplore` feature flag and chart-manage permission).
- Add a yellow warning callout in `ChangeChartExploreModal` when the user has unsaved chart edits, so they know the rename will discard them. The discard itself happens automatically — the rename mutation invalidates the `saved_query` cache, the refetch lands in `SavedExplorer`'s effect which detects `tableName` changed and rebuilds explorer state from the fresh saved chart.

### Why

When a chart's underlying explore is renamed or removed, the chart breaks. Users naturally click **Edit chart** to fix it, but the only UI to remap the explore was hidden behind `!isEditMode` — leaving broken charts un-fixable from the place users go to repair them.

## Tested

Manually verified via Chrome DevTools against a local instance with the demo dataset. All checks evidenced with screenshots, DOM assertions, network logs, or DB queries.

- [x] **Edit mode shows the menu item** — a11y snapshot confirms `menuitem "Change explore"` present in the `⋮` menu at URL `/edit`.
- [x] **Warning callout renders correctly when dirty** — `role="alert"` with the expected text, color `#fab005` (Mantine yellow.6), background `rgba(250,176,5,0.1)` (light variant), Mantine v8 `Alert` classes.
- [x] **End-to-end rename + implicit discard** — submitted a rename in edit mode after adding an `Industry` dimension as an unsaved edit. Network sequence confirmed: `POST /rename/chart/<uuid>` → 200, `GET /saved/<uuid>` refetch → 200, `GET /explores/<new>` → 200. Sidebar header switched from old explore to new. The pre-rename `Industry` dimension was discarded. DB version history shows the new `explore_name` on the latest row, the old one on the previous row.
- [x] **Cancel preserves unsaved changes** — opening the modal then clicking Cancel issues no `/rename/` request and leaves the explorer's dirty state intact.
- [x] **View mode still shows the menu item** — regression check; pre-existing visibility unchanged.
- [x] **`isEditMode` gate suppresses the callout in view mode** — opening the modal in view mode renders the body without the alert (the `&& isEditMode` portion of the prop expression).
- [x] **Feature flag off hides the menu** — toggling `feature_flag_overrides.enabled = false` for the org and reloading: menu renders with 10 items, no "Change explore" entry. Re-enabled afterwards.

### Not covered in this run

- **No chart-manage permission** — would require a viewer-role user setup. The `userCanManageChart` predicate is unchanged by this PR.
- **`isEditMode=true && !hasUnsavedChanges` branch of the callout gate** — `selectHasUnsavedChanges` returns true on chart load even before any user edit (pre-existing explorer quirk, not a regression from this PR), so a clean dirty-state-false case wasn't reproducible on the test chart. The opposite branch (`isEditMode=false`) is verified above.
- **Refetch race under network throttling** — residual risk only, not a regression candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)