### PR TITLE
chore: migrate `OrganizationWarehouseCredentials` to legacy feature flag

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -844,6 +844,10 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['EMBEDDING_ENABLED', 'embedding'],
         ['SERVICE_ACCOUNT_ENABLED', 'service-accounts'],
         ['SCIM_ENABLED', 'scim-token-management'],
+        [
+            'ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED',
+            'organization-warehouse-credentials',
+        ],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1564,6 +1564,13 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     // the unified allowlist for the flag system.
     ['SERVICE_ACCOUNT_ENABLED', 'service-accounts'],
     ['SCIM_ENABLED', 'scim-token-management'],
+    // ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED is also read by HealthService
+    // (exposed via the health endpoint). Keep the config field, but translate
+    // the env var to the unified allowlist for the flag system.
+    [
+        'ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED',
+        'organization-warehouse-credentials',
+    ],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -175,9 +175,11 @@ const Settings: FC = () => {
     const isServiceAccountsEnabled =
         health?.isServiceAccountEnabled || isServiceAccountFeatureFlagEnabled;
 
-    const isWarehouseCredentialsFeatureFlagEnabled = useClientFeatureFlag(
+    const { data: warehouseCredentialsFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.OrganizationWarehouseCredentials,
     );
+    const isWarehouseCredentialsFeatureFlagEnabled =
+        warehouseCredentialsFlag?.enabled ?? false;
 
     // This allows us to enable organization warehouse credentials in the UI for on-premise installations
     const isWarehouseCredentialsEnabled =


### PR DESCRIPTION
Closes:

### Description:

Migrates `ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED` to the unified feature flag system by adding it to the `LEGACY_ENABLE_ENV_VARS` list, so the environment variable is translated to the `organization-warehouse-credentials` flag in the allowlist (consistent with how `EMBEDDING_ENABLED` is handled).

On the frontend, the warehouse credentials feature flag check is switched from `useClientFeatureFlag` to `useServerFeatureFlag`, ensuring the flag state is read from the server rather than the client. This allows on-premise installations using the `ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED` env var to correctly enable the warehouse credentials UI.