### PR TITLE
fix: fallback to `ANTHROPIC_API_KEY` for managed agent config

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2239,7 +2239,9 @@ export const parseConfig = (): LightdashConfig => {
         managedAgent: {
             enabled: process.env.MANAGED_AGENT_ENABLED === 'true',
             anthropicApiKey:
-                process.env.MANAGED_AGENT_ANTHROPIC_API_KEY || null,
+                process.env.MANAGED_AGENT_ANTHROPIC_API_KEY ||
+                process.env.ANTHROPIC_API_KEY ||
+                null,
             schedule: process.env.MANAGED_AGENT_SCHEDULE || '*/30 * * * *',
             sessionTimeoutMs: parseInt(
                 process.env.MANAGED_AGENT_SESSION_TIMEOUT_MS || '300000',


### PR DESCRIPTION
Closes:

### Description:
The managed agent now falls back to the `ANTHROPIC_API_KEY` environment variable if `MANAGED_AGENT_ANTHROPIC_API_KEY` is not set. This allows users to use a single shared Anthropic API key across the application without needing to define a separate key specifically for the managed agent.