### PR TITLE
refactor: move ManagedAgentClient config to use LightdashConfig and session-scoped resources

### DIFF
--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -1,14 +1,16 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { AnyType } from '@lightdash/common';
+import { ParameterError } from '@lightdash/common/src';
+import type { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { CUSTOM_TOOL_DEFINITIONS } from '../services/ManagedAgentService/managedAgentTools';
 
 type ManagedAgentClientConfig = {
-    anthropicApiKey: string;
-    siteUrl: string;
+    lightdashConfig: LightdashConfig;
+};
+
+export type ManagedAgentSessionConfig = {
     serviceAccountPat: string;
-    sessionTimeoutMs: number;
-    agentId: string | null;
+    resourceName: string;
     persistedEnvironmentId: string | null;
     persistedVaultId: string | null;
     onResourcesCreated: (
@@ -25,33 +27,31 @@ type CustomToolHandler = (
 export class ManagedAgentClient {
     private readonly config: ManagedAgentClientConfig;
 
-    private client: Anthropic;
-
-    private agentId: string | null = null;
-
-    private environmentId: string | null = null;
-
-    private vaultId: string | null = null;
-
     constructor(config: ManagedAgentClientConfig) {
         this.config = config;
-        this.client = new Anthropic({ apiKey: config.anthropicApiKey });
     }
 
-    private async ensureAgentAndEnvironment(): Promise<{
+    private getAnthropicClient(): Anthropic {
+        const { anthropicApiKey } = this.config.lightdashConfig.managedAgent;
+        if (!anthropicApiKey) {
+            throw new ParameterError(
+                'ANTHROPIC_API_KEY is required for managed agent',
+            );
+        }
+
+        return new Anthropic({ apiKey: anthropicApiKey });
+    }
+
+    private async ensureAgentAndEnvironment(
+        client: Anthropic,
+        sessionConfig: ManagedAgentSessionConfig,
+    ): Promise<{
         agentId: string;
         environmentId: string;
         vaultId: string;
     }> {
-        if (this.agentId && this.environmentId && this.vaultId) {
-            return {
-                agentId: this.agentId,
-                environmentId: this.environmentId,
-                vaultId: this.vaultId,
-            };
-        }
-
-        const { agentId: configAgentId } = this.config;
+        const { agentId: configAgentId } =
+            this.config.lightdashConfig.managedAgent;
         if (!configAgentId) {
             throw new Error(
                 'MANAGED_AGENT_AGENT_ID is required. Create an agent at https://platform.claude.com and set the ID.',
@@ -62,15 +62,12 @@ export class ManagedAgentClient {
 
         // Reuse persisted Anthropic resource IDs when available to avoid
         // creating duplicate environments and vaults on every restart.
-        const { persistedEnvironmentId, persistedVaultId } = this.config;
+        const { persistedEnvironmentId, persistedVaultId } = sessionConfig;
 
         if (persistedEnvironmentId && persistedVaultId) {
             Logger.info(
                 `[ManagedAgent] Reusing persisted resources: env=${persistedEnvironmentId}, vault=${persistedVaultId}`,
             );
-            this.agentId = configAgentId;
-            this.environmentId = persistedEnvironmentId;
-            this.vaultId = persistedVaultId;
             return {
                 agentId: configAgentId,
                 environmentId: persistedEnvironmentId,
@@ -78,20 +75,17 @@ export class ManagedAgentClient {
             };
         }
 
-        const betaAny = this.client.beta as AnyType;
-
         // Reuse existing environment if one exists, otherwise create
-        const environment = await this.findOrCreateEnvironment(betaAny);
+        const environment = await this.findOrCreateEnvironment(
+            client.beta,
+            sessionConfig.resourceName,
+        );
 
         // Reuse existing vault if one exists, otherwise create with credentials
-        const vault = await this.findOrCreateVault(betaAny);
-
-        this.agentId = configAgentId;
-        this.environmentId = environment.id;
-        this.vaultId = vault.id;
+        const vault = await this.createVault(client.beta, sessionConfig);
 
         // Persist the IDs so they survive service restarts
-        await this.config.onResourcesCreated(environment.id, vault.id);
+        await sessionConfig.onResourcesCreated(environment.id, vault.id);
 
         Logger.info(
             `Managed agent ready: agentId=${configAgentId}, environmentId=${environment.id}, vaultId=${vault.id}`,
@@ -106,13 +100,14 @@ export class ManagedAgentClient {
 
     // eslint-disable-next-line class-methods-use-this
     private async findOrCreateEnvironment(
-        betaAny: AnyType,
+        beta: Anthropic.Beta,
+        resourceName: string,
     ): Promise<{ id: string }> {
-        const ENV_NAME = 'lightdash-agent-env';
+        const envName = `Env ${resourceName}`;
         try {
-            const list = await betaAny.environments.list();
+            const list = await beta.environments.list();
             const existing = list?.data?.find(
-                (e: { name: string }) => e.name === ENV_NAME,
+                (e: { name: string }) => e.name === envName,
             );
             if (existing) {
                 Logger.info(
@@ -127,8 +122,8 @@ export class ManagedAgentClient {
         }
 
         Logger.info('[ManagedAgent] Creating new environment');
-        return betaAny.environments.create({
-            name: ENV_NAME,
+        return beta.environments.create({
+            name: envName,
             config: {
                 type: 'cloud',
                 networking: { type: 'limited', allow_mcp_servers: true },
@@ -136,14 +131,20 @@ export class ManagedAgentClient {
         });
     }
 
-    private async findOrCreateVault(betaAny: AnyType): Promise<{ id: string }> {
-        const VAULT_NAME = 'Lightdash MCP Auth';
+    private async createVault(
+        beta: Anthropic.Beta,
+        sessionConfig: Pick<
+            ManagedAgentSessionConfig,
+            'resourceName' | 'serviceAccountPat'
+        >,
+    ): Promise<{ id: string }> {
+        const vaultName = `Vault ${sessionConfig.resourceName}`;
         const credPayload = {
             display_name: 'Lightdash PAT',
             auth: {
-                type: 'static_bearer',
-                mcp_server_url: `${this.config.siteUrl}/api/v1/mcp`,
-                token: this.config.serviceAccountPat,
+                type: 'static_bearer' as const,
+                mcp_server_url: `${this.config.lightdashConfig.siteUrl}/api/v1/mcp`,
+                token: sessionConfig.serviceAccountPat,
             },
         };
 
@@ -152,26 +153,26 @@ export class ManagedAgentClient {
         // delete+recreate, so we create a new vault each time
         // instead of trying to update an existing one's credentials.
         Logger.info('[ManagedAgent] Creating new vault');
-        const vault = await betaAny.vaults.create({
-            display_name: VAULT_NAME,
+        const vault = await beta.vaults.create({
+            display_name: vaultName,
         });
 
-        await betaAny.vaults.credentials.create(vault.id, credPayload);
+        await beta.vaults.credentials.create(vault.id, credPayload);
 
         return vault;
     }
 
     async runSession(
+        sessionConfig: ManagedAgentSessionConfig,
         projectName: string,
         onCustomToolUse: CustomToolHandler,
         onSessionCreated?: (sessionId: string) => void,
     ): Promise<{ sessionId: string; summary: string }> {
+        const client = this.getAnthropicClient();
         const { agentId, environmentId, vaultId } =
-            await this.ensureAgentAndEnvironment();
+            await this.ensureAgentAndEnvironment(client, sessionConfig);
 
-        const betaAny = this.client.beta as AnyType;
-
-        const session = await betaAny.sessions.create({
+        const session = await client.beta.sessions.create({
             agent: agentId,
             environment_id: environmentId,
             vault_ids: [vaultId],
@@ -181,9 +182,9 @@ export class ManagedAgentClient {
         Logger.info(`[ManagedAgent] Session created: ${session.id}`);
         onSessionCreated?.(session.id);
 
-        const stream = await betaAny.sessions.events.stream(session.id);
+        const stream = await client.beta.sessions.events.stream(session.id);
 
-        await betaAny.sessions.events.send(session.id, {
+        await client.beta.sessions.events.send(session.id, {
             events: [
                 {
                     type: 'user.message',
@@ -197,7 +198,7 @@ export class ManagedAgentClient {
             ],
         });
 
-        const { sessionTimeoutMs } = this.config;
+        const { sessionTimeoutMs } = this.config.lightdashConfig.managedAgent;
 
         // Wrap the event loop in a timeout to prevent the scheduler from
         // blocking indefinitely if the agent stalls or loops.
@@ -241,7 +242,7 @@ export class ManagedAgentClient {
                         Logger.info(
                             `[ManagedAgent] Sending result for: ${event.name} (event_id: ${event.id})`,
                         );
-                        await betaAny.sessions.events.send(session.id, {
+                        await client.beta.sessions.events.send(session.id, {
                             events: [
                                 {
                                     type: 'user.custom_tool_result',
@@ -258,7 +259,7 @@ export class ManagedAgentClient {
                         Logger.error(
                             `[ManagedAgent] Tool error: ${event.name}: ${errorMessage}`,
                         );
-                        await betaAny.sessions.events.send(session.id, {
+                        await client.beta.sessions.events.send(session.id, {
                             events: [
                                 {
                                     type: 'user.custom_tool_result',
@@ -278,7 +279,10 @@ export class ManagedAgentClient {
                     }
                 } else if (event.type === 'session.status_idle') {
                     const stopReason = event.stop_reason?.type;
-                    const eventIds = event.stop_reason?.event_ids ?? [];
+                    const eventIds =
+                        event.stop_reason?.type === 'requires_action'
+                            ? event.stop_reason.event_ids
+                            : [];
                     if (stopReason === 'end_turn') {
                         Logger.info(
                             '[ManagedAgent] Session complete (end_turn)',

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -12,6 +12,7 @@ import { ProjectService } from '../services/ProjectService/ProjectService';
 import { RolesService } from '../services/RolesService/RolesService';
 import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
 import LicenseClient from './clients/License/LicenseClient';
+import { ManagedAgentClient } from './clients/ManagedAgentClient';
 import OpenAi from './clients/OpenAi';
 import { CommercialSlackClient } from './clients/Slack/SlackClient';
 import { AiAgentModel } from './models/AiAgentModel';
@@ -420,6 +421,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     serviceAccountModel: models.getServiceAccountModel(),
                     schedulerClient: clients.getSchedulerClient(),
                     slackClient: clients.getSlackClient(),
+                    managedAgentClient: new ManagedAgentClient({
+                        lightdashConfig: context.lightdashConfig,
+                    }),
                 }),
             deployService: ({ models, clients, repository, context }) =>
                 new DeployService({

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -28,7 +28,10 @@ import type { UserModel } from '../../../models/UserModel';
 import type { ValidationModel } from '../../../models/ValidationModel/ValidationModel';
 import { SchedulerClient } from '../../../scheduler/SchedulerClient';
 import { BaseService } from '../../../services/BaseService';
-import { ManagedAgentClient } from '../../clients/ManagedAgentClient';
+import {
+    ManagedAgentClient,
+    type ManagedAgentSessionConfig,
+} from '../../clients/ManagedAgentClient';
 import { ManagedAgentModel } from '../../models/ManagedAgentModel';
 import type { ServiceAccountModel } from '../../models/ServiceAccountModel';
 
@@ -45,6 +48,7 @@ type ManagedAgentServiceDependencies = {
     serviceAccountModel: ServiceAccountModel;
     schedulerClient: SchedulerClient;
     slackClient: SlackClient;
+    managedAgentClient: ManagedAgentClient;
 };
 
 export class ManagedAgentService extends BaseService {
@@ -72,7 +76,7 @@ export class ManagedAgentService extends BaseService {
 
     private readonly slackClient: SlackClient;
 
-    private client: ManagedAgentClient | null = null;
+    private readonly managedAgentClient: ManagedAgentClient;
 
     constructor(deps: ManagedAgentServiceDependencies) {
         super();
@@ -88,6 +92,7 @@ export class ManagedAgentService extends BaseService {
         this.serviceAccountModel = deps.serviceAccountModel;
         this.schedulerClient = deps.schedulerClient;
         this.slackClient = deps.slackClient;
+        this.managedAgentClient = deps.managedAgentClient;
     }
 
     // --- Validation helpers ---
@@ -164,27 +169,17 @@ export class ManagedAgentService extends BaseService {
         }
     }
 
-    private async getClient(
+    private async getSessionConfig(
         projectUuid: string,
         serviceAccountToken: string,
-    ): Promise<ManagedAgentClient> {
-        // Always create a fresh client per heartbeat run — persisted resource
-        // IDs are loaded from the DB each time so they stay in sync.
-        const { anthropicApiKey, sessionTimeoutMs, agentId } =
-            this.lightdashConfig.managedAgent;
-        if (!anthropicApiKey) {
-            throw new Error('ANTHROPIC_API_KEY is required for managed agent');
-        }
-
+    ): Promise<ManagedAgentSessionConfig> {
         const { environmentId, vaultId } =
             await this.managedAgentModel.getAnthropicResourceIds(projectUuid);
+        const project = await this.projectModel.getSummary(projectUuid);
 
-        this.client = new ManagedAgentClient({
-            anthropicApiKey,
-            siteUrl: this.lightdashConfig.siteUrl,
+        return {
             serviceAccountPat: serviceAccountToken,
-            sessionTimeoutMs,
-            agentId,
+            resourceName: `${project.organizationUuid}:${project.name}:${project.projectUuid}`,
             persistedEnvironmentId: environmentId,
             persistedVaultId: vaultId,
             onResourcesCreated: async (newEnvId, newVaultId) => {
@@ -194,8 +189,7 @@ export class ManagedAgentService extends BaseService {
                     newVaultId,
                 );
             },
-        });
-        return this.client;
+        };
     }
 
     // --- Authorization ---
@@ -390,7 +384,10 @@ export class ManagedAgentService extends BaseService {
 
         this.logger.info(`Running heartbeat for project: ${projectUuid}`);
 
-        const client = await this.getClient(projectUuid, serviceAccountToken);
+        const sessionConfig = await this.getSessionConfig(
+            projectUuid,
+            serviceAccountToken,
+        );
         let sessionId = '';
         let agentSummary = '';
 
@@ -405,7 +402,8 @@ export class ManagedAgentService extends BaseService {
         };
 
         try {
-            const result = await client.runSession(
+            const result = await this.managedAgentClient.runSession(
+                sessionConfig,
                 projectUuid,
                 onToolCall,
                 onSessionCreated,


### PR DESCRIPTION
Closes:

### Description:

Refactors `ManagedAgentClient` to be a long-lived singleton rather than being recreated on every heartbeat run. Previously, the client was instantiated fresh each time with config values (API key, site URL, session timeout, agent ID) passed directly into the constructor. Now, the client is constructed once with the full `LightdashConfig` and reads those values lazily at runtime.

Session-specific state (service account PAT, persisted environment/vault IDs, resource name, and callbacks) has been extracted into a new `ManagedAgentSessionConfig` type, which is passed into `runSession` instead of being baked into the client at construction time.

The Anthropic client instance is also now created per-session via `getAnthropicClient()`, and all previously cached instance-level state (`agentId`, `environmentId`, `vaultId`) has been removed in favour of passing values through method arguments.

Additionally, environment and vault names are now derived from the project's organization UUID, name, and project UUID (e.g. `Env org:project:uuid`) rather than using hardcoded constants, and `findOrCreateVault` has been simplified to always create a new vault rather than attempting to find an existing one.