### PR TITLE
feat: add manual run now button for managed agent autopilot

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -50,7 +50,7 @@
         "@ai-sdk/anthropic": "3.0.36",
         "@ai-sdk/azure": "3.0.26",
         "@ai-sdk/openai": "3.0.25",
-        "@anthropic-ai/sdk": "0.88.0",
+        "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-s3": "3.992.0",
         "@aws-sdk/credential-providers": "3.995.0",
         "@aws-sdk/lib-storage": "3.995.0",

--- a/packages/backend/src/ee/controllers/managedAgentController.ts
+++ b/packages/backend/src/ee/controllers/managedAgentController.ts
@@ -71,6 +71,21 @@ export class ManagedAgentController extends BaseController {
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Post('/run')
+    @OperationId('runManagedAgentHeartbeat')
+    async runHeartbeat(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<{ status: 'ok'; results: undefined }> {
+        await this.getManagedAgentService().startHeartbeat(
+            req.user!,
+            projectUuid,
+        );
+        this.setStatus(202);
+        return { status: 'ok', results: undefined };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @Get('/actions')
     @OperationId('getManagedAgentActions')
     async getActions(

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -432,6 +432,19 @@ export class ManagedAgentService extends BaseService {
         }
     }
 
+    async startHeartbeat(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        await this.assertCanManageProject(user, projectUuid);
+
+        void this.runHeartbeat(projectUuid).catch((error) => {
+            this.logger.error(
+                `Manual heartbeat failed for project ${projectUuid}: ${error instanceof Error ? error.message : 'Unknown'}`,
+            );
+        });
+    }
+
     private async postHeartbeatSummaryToSlack(
         projectUuid: string,
         sessionId: string,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8970,11 +8970,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9452,11 +9452,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9471,11 +9471,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9490,11 +9490,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9509,11 +9509,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9528,11 +9528,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -31953,6 +31953,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateSettings',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsManagedAgentController_runHeartbeat: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/managed-agent/run',
+        ...fetchMiddlewares<RequestHandler>(ManagedAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            ManagedAgentController.prototype.runHeartbeat,
+        ),
+
+        async function ManagedAgentController_runHeartbeat(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsManagedAgentController_runHeartbeat,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ManagedAgentController>(
+                        ManagedAgentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'runHeartbeat',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10423,19 +10423,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -15844,7 +15831,8 @@
             "Pick_Account-at-user.Exclude_keyofAccount-at-user.ability-or-abilityRules__": {
                 "properties": {
                     "id": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
                     },
                     "type": {
                         "type": "string",
@@ -31353,7 +31341,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2849.1",
+        "version": "0.2849.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1,4 +1,6 @@
+import { type ApiError } from '@lightdash/common';
 import {
+    ActionIcon,
     Box,
     Button,
     Group,
@@ -10,6 +12,7 @@ import {
     Table,
     Text,
     Title,
+    Tooltip,
     UnstyledButton,
 } from '@mantine-8/core';
 import {
@@ -20,6 +23,7 @@ import {
     IconDots,
     IconExternalLink,
     IconLayoutDashboard,
+    IconPlayerPlay,
     IconSettings,
     IconX,
 } from '@tabler/icons-react';
@@ -28,10 +32,12 @@ import { useCallback, useEffect, type FC, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
+import MantineIcon from '../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
 import { SlackChannelSelect } from '../../../components/common/SlackChannelSelect';
 import TruncatedText from '../../../components/common/TruncatedText';
 import { useGetSlack } from '../../../hooks/slack/useSlack';
+import useToaster from '../../../hooks/toaster/useToaster';
 import { useSavedQuery } from '../../../hooks/useSavedQuery';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
@@ -59,6 +65,13 @@ const updateSettings = async (
         body: JSON.stringify(body),
     });
 
+const runHeartbeat = async (projectUuid: string) =>
+    lightdashApi<undefined>({
+        url: `/projects/${projectUuid}/managed-agent/run`,
+        method: 'POST',
+        body: undefined,
+    });
+
 const SCHEDULE_OPTIONS = [
     { value: '*/5 * * * *', label: 'Every 5 min' },
     { value: '*/15 * * * *', label: 'Every 15 min' },
@@ -73,7 +86,16 @@ const SetupSection: FC<{
     schedule: string;
     settingsOpen: boolean;
     onOpenSettings: () => void;
-}> = ({ enabled, schedule: initialSchedule, settingsOpen, onOpenSettings }) => {
+    onRunNow: () => void;
+    isRunNowLoading: boolean;
+}> = ({
+    enabled,
+    schedule: initialSchedule,
+    settingsOpen,
+    onOpenSettings,
+    onRunNow,
+    isRunNowLoading,
+}) => {
     const scheduleLabel =
         SCHEDULE_OPTIONS.find(
             (o) => o.value === initialSchedule,
@@ -109,15 +131,37 @@ const SetupSection: FC<{
                         Your project health agent
                     </Text>
                 </Stack>
-                <Button
-                    variant={settingsOpen ? 'light' : 'default'}
-                    color="dark"
-                    size="xs"
-                    leftSection={<IconSettings size={14} />}
-                    onClick={onOpenSettings}
-                >
-                    Settings
-                </Button>
+                <Group gap="xs">
+                    <Tooltip
+                        label={
+                            enabled
+                                ? 'Run Autopilot now'
+                                : 'Enable Autopilot to run now'
+                        }
+                    >
+                        <ActionIcon
+                            aria-label="Run Autopilot now"
+                            variant="default"
+                            color="dark"
+                            size="md"
+                            radius="md"
+                            onClick={onRunNow}
+                            disabled={!enabled || isRunNowLoading}
+                            loading={isRunNowLoading}
+                        >
+                            <MantineIcon icon={IconPlayerPlay} size="sm" />
+                        </ActionIcon>
+                    </Tooltip>
+                    <Button
+                        variant={settingsOpen ? 'light' : 'default'}
+                        color="dark"
+                        size="xs"
+                        leftSection={<IconSettings size={14} />}
+                        onClick={onOpenSettings}
+                    >
+                        Settings
+                    </Button>
+                </Group>
             </Group>
             <Box className={classes.headerDivider} />
         </Stack>
@@ -689,12 +733,33 @@ const ActionRow: FC<{
 // ts-unused-exports:disable-next-line
 export const ManagedAgentActivityPage: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
     const { data: actions, isLoading } = useManagedAgentActions();
     const { data: settings, isLoading: settingsLoading } =
         useManagedAgentSettings();
     const [selected, setSelected] = useState<ManagedAgentAction | null>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
     const filtered = actions ?? [];
+    const runNowMutation = useMutation<undefined, ApiError>({
+        mutationFn: () => runHeartbeat(projectUuid!),
+        onSuccess: () => {
+            showToastSuccess({
+                title: 'Autopilot run started',
+                subtitle:
+                    'Project health checks are running in the background.',
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['managed-agent-actions', projectUuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to start Autopilot',
+                apiError: error,
+            });
+        },
+    });
 
     if (isLoading || settingsLoading) {
         return (
@@ -724,6 +789,8 @@ export const ManagedAgentActivityPage: FC = () => {
                                     settings?.scheduleCron ?? '*/30 * * * *'
                                 }
                                 settingsOpen={settingsOpen}
+                                isRunNowLoading={runNowMutation.isLoading}
+                                onRunNow={() => runNowMutation.mutate()}
                                 onOpenSettings={() => {
                                     setSelected(null);
                                     setSettingsOpen(true);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         specifier: 3.0.25
         version: 3.0.25(zod@3.25.55)
       '@anthropic-ai/sdk':
-        specifier: 0.88.0
-        version: 0.88.0(zod@3.25.55)
+        specifier: 0.91.1
+        version: 0.91.1(zod@3.25.55)
       '@aws-sdk/client-s3':
         specifier: 3.992.0
         version: 3.992.0
@@ -1737,8 +1737,8 @@ packages:
     resolution: {integrity: sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw==}
     engines: {node: '>=18'}
 
-  '@anthropic-ai/sdk@0.88.0':
-    resolution: {integrity: sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -16504,7 +16504,7 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@anthropic-ai/sdk@0.88.0(zod@3.25.55)':
+  '@anthropic-ai/sdk@0.91.1(zod@3.25.55)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
Closes:

### Description:

Adds a "Run Now" button to the Managed Agent (Autopilot) activity page, allowing users to manually trigger a project health agent heartbeat without waiting for the next scheduled run. The button is disabled when Autopilot is not enabled and shows a loading state while the run is in progress. On success, the actions list is refreshed and a toast notification is shown.

A new `POST /projects/:projectUuid/managed-agent/run` endpoint is introduced to support this, which validates project access permissions before firing the heartbeat asynchronously.

Also bumps `@anthropic-ai/sdk` from `0.88.0` to `0.91.1`.