### PR TITLE
feat: auto-provision and sync Anthropic agent from config instead of requiring manual agent ID

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -349,6 +349,12 @@ import {
     DashboardSummariesTableName,
 } from '../ee/database/entities/dashboardSummaries';
 import {
+    ManagedAgentActionsTable,
+    ManagedAgentActionsTableName,
+    ManagedAgentSettingsTable,
+    ManagedAgentSettingsTableName,
+} from '../ee/database/entities/managedAgent';
+import {
     PreAggregateDailyStatsTable,
     PreAggregateDailyStatsTableName,
 } from '../ee/database/entities/preAggregateDailyStats';
@@ -493,6 +499,8 @@ declare module 'knex/types/tables' {
         [AiEvalRunResultAssessmentTableName]: AiEvalRunResultAssessmentTable;
         [ChangesetsTableName]: ChangesetsTable;
         [ChangesTableName]: ChangesTable;
+        [ManagedAgentSettingsTableName]: ManagedAgentSettingsTable;
+        [ManagedAgentActionsTableName]: ManagedAgentActionsTable;
         [UserFavoritesTableName]: UserFavoritesTable;
         [ContentVerificationTableName]: ContentVerificationTable;
         [AppsTableName]: AppsTable;

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -308,7 +308,6 @@ export const lightdashConfigMock: LightdashConfig = {
         anthropicApiKey: null,
         schedule: '*/30 * * * *',
         sessionTimeoutMs: 300000,
-        agentId: null,
     },
     mcp: {
         enabled: true,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1165,7 +1165,6 @@ export type LightdashConfig = {
         anthropicApiKey: string | null;
         schedule: string;
         sessionTimeoutMs: number;
-        agentId: string | null;
     };
 
     initialSetup?: {
@@ -2247,7 +2246,6 @@ export const parseConfig = (): LightdashConfig => {
                 process.env.MANAGED_AGENT_SESSION_TIMEOUT_MS || '300000',
                 10,
             ), // 5 minutes default
-            agentId: process.env.MANAGED_AGENT_AGENT_ID || null,
         },
         initialSetup: getInitialSetupConfig(),
         updateSetup: getUpdateSetupConfig(),

--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -1,8 +1,17 @@
 import Anthropic from '@anthropic-ai/sdk';
+import type {
+    AgentCreateParams,
+    AgentUpdateParams,
+    BetaManagedAgentsAgent,
+} from '@anthropic-ai/sdk/resources/beta/agents';
 import { ParameterError } from '@lightdash/common/src';
+import { produce } from 'immer';
 import type { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
-import { CUSTOM_TOOL_DEFINITIONS } from '../services/ManagedAgentService/managedAgentTools';
+import {
+    agentConfigHash,
+    managedAgentConfig,
+} from '../services/ManagedAgentService/config/agent';
 
 type ManagedAgentClientConfig = {
     lightdashConfig: LightdashConfig;
@@ -11,8 +20,16 @@ type ManagedAgentClientConfig = {
 export type ManagedAgentSessionConfig = {
     serviceAccountPat: string;
     resourceName: string;
+    persistedAgentId: string | null;
+    persistedAgentConfigHash: string | null;
+    persistedAgentVersion: number | null;
     persistedEnvironmentId: string | null;
     persistedVaultId: string | null;
+    onAgentSynced: (
+        agentId: string,
+        agentConfigHash: string,
+        agentVersion: number,
+    ) => Promise<void>;
     onResourcesCreated: (
         environmentId: string,
         vaultId: string,
@@ -27,8 +44,11 @@ type CustomToolHandler = (
 export class ManagedAgentClient {
     private readonly config: ManagedAgentClientConfig;
 
+    private readonly renderedAgentConfig: AgentCreateParams;
+
     constructor(config: ManagedAgentClientConfig) {
         this.config = config;
+        this.renderedAgentConfig = this.renderAgentConfigTemplate();
     }
 
     private getAnthropicClient(): Anthropic {
@@ -42,6 +62,106 @@ export class ManagedAgentClient {
         return new Anthropic({ apiKey: anthropicApiKey });
     }
 
+    private renderAgentConfigTemplate(): AgentCreateParams {
+        return produce(managedAgentConfig, (draft) => {
+            // eslint-disable-next-line no-param-reassign
+            draft.mcp_servers[0].url = draft.mcp_servers[0].url.replace(
+                '{{LIGHTDASH_SITE_URL}}',
+                this.config.lightdashConfig.siteUrl,
+            );
+        });
+    }
+
+    private getRenderedAgentConfig(resourceName: string): AgentCreateParams {
+        return {
+            ...this.renderedAgentConfig,
+            name: `${this.renderedAgentConfig.name} (${resourceName})`,
+            metadata: {
+                ...this.renderedAgentConfig.metadata,
+                lightdash_resource: resourceName,
+            },
+        };
+    }
+
+    private async ensureAgent(
+        beta: Anthropic.Beta,
+        sessionConfig: ManagedAgentSessionConfig,
+    ): Promise<string> {
+        const desiredAgent = this.getRenderedAgentConfig(
+            sessionConfig.resourceName,
+        );
+        const desiredHash = agentConfigHash;
+
+        if (
+            sessionConfig.persistedAgentId &&
+            sessionConfig.persistedAgentConfigHash === desiredHash &&
+            sessionConfig.persistedAgentVersion
+        ) {
+            Logger.info(
+                `[ManagedAgent] Reusing persisted agent: ${sessionConfig.persistedAgentId}`,
+            );
+            return sessionConfig.persistedAgentId;
+        }
+
+        if (sessionConfig.persistedAgentId) {
+            try {
+                const current = await beta.agents.retrieve(
+                    sessionConfig.persistedAgentId,
+                );
+                const updated = await this.updateAgent(
+                    beta,
+                    current,
+                    desiredAgent,
+                );
+                await sessionConfig.onAgentSynced(
+                    updated.id,
+                    desiredHash,
+                    updated.version,
+                );
+                Logger.info(
+                    `[ManagedAgent] Updated agent ${updated.id} to version ${updated.version}`,
+                );
+                return updated.id;
+            } catch (error) {
+                Logger.warn(
+                    `[ManagedAgent] Could not update persisted agent ${sessionConfig.persistedAgentId}, creating a new one: ${error instanceof Error ? error.message : 'Unknown'}`,
+                );
+            }
+        }
+
+        const created = await beta.agents.create(desiredAgent);
+        await sessionConfig.onAgentSynced(
+            created.id,
+            desiredHash,
+            created.version,
+        );
+        Logger.info(
+            `[ManagedAgent] Created agent ${created.id} at version ${created.version}`,
+        );
+        return created.id;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private async updateAgent(
+        beta: Anthropic.Beta,
+        current: BetaManagedAgentsAgent,
+        desiredAgent: AgentCreateParams,
+    ): Promise<BetaManagedAgentsAgent> {
+        const update: AgentUpdateParams = {
+            version: current.version,
+            description: desiredAgent.description,
+            mcp_servers: desiredAgent.mcp_servers ?? [],
+            metadata: desiredAgent.metadata ?? {},
+            model: desiredAgent.model,
+            name: desiredAgent.name,
+            skills: desiredAgent.skills ?? [],
+            system: desiredAgent.system,
+            tools: desiredAgent.tools ?? [],
+        };
+
+        return beta.agents.update(current.id, update);
+    }
+
     private async ensureAgentAndEnvironment(
         client: Anthropic,
         sessionConfig: ManagedAgentSessionConfig,
@@ -50,15 +170,7 @@ export class ManagedAgentClient {
         environmentId: string;
         vaultId: string;
     }> {
-        const { agentId: configAgentId } =
-            this.config.lightdashConfig.managedAgent;
-        if (!configAgentId) {
-            throw new Error(
-                'MANAGED_AGENT_AGENT_ID is required. Create an agent at https://platform.claude.com and set the ID.',
-            );
-        }
-
-        Logger.info(`[ManagedAgent] Using agent: ${configAgentId}`);
+        const agentId = await this.ensureAgent(client.beta, sessionConfig);
 
         // Reuse persisted Anthropic resource IDs when available to avoid
         // creating duplicate environments and vaults on every restart.
@@ -69,7 +181,7 @@ export class ManagedAgentClient {
                 `[ManagedAgent] Reusing persisted resources: env=${persistedEnvironmentId}, vault=${persistedVaultId}`,
             );
             return {
-                agentId: configAgentId,
+                agentId,
                 environmentId: persistedEnvironmentId,
                 vaultId: persistedVaultId,
             };
@@ -88,11 +200,11 @@ export class ManagedAgentClient {
         await sessionConfig.onResourcesCreated(environment.id, vault.id);
 
         Logger.info(
-            `Managed agent ready: agentId=${configAgentId}, environmentId=${environment.id}, vaultId=${vault.id}`,
+            `Managed agent ready: agentId=${agentId}, environmentId=${environment.id}, vaultId=${vault.id}`,
         );
 
         return {
-            agentId: configAgentId,
+            agentId,
             environmentId: environment.id,
             vaultId: vault.id,
         };

--- a/packages/backend/src/ee/database/entities/managedAgent.ts
+++ b/packages/backend/src/ee/database/entities/managedAgent.ts
@@ -9,6 +9,9 @@ export type DbManagedAgentSettings = {
     schedule_cron: string;
     enabled_by_user_uuid: string | null;
     service_account_token: Buffer | null;
+    anthropic_agent_id: string | null;
+    anthropic_agent_config_hash: string | null;
+    anthropic_agent_version: number | null;
     anthropic_environment_id: string | null;
     anthropic_vault_id: string | null;
     slack_channel_id: string | null;
@@ -27,9 +30,13 @@ export type DbManagedAgentSettingsCreate = Pick<
             | 'schedule_cron'
             | 'enabled_by_user_uuid'
             | 'service_account_token'
+            | 'anthropic_agent_id'
+            | 'anthropic_agent_config_hash'
+            | 'anthropic_agent_version'
             | 'anthropic_environment_id'
             | 'anthropic_vault_id'
             | 'slack_channel_id'
+            | 'updated_at'
         >
     >;
 
@@ -40,6 +47,9 @@ export type DbManagedAgentSettingsUpdate = Partial<
         | 'schedule_cron'
         | 'enabled_by_user_uuid'
         | 'service_account_token'
+        | 'anthropic_agent_id'
+        | 'anthropic_agent_config_hash'
+        | 'anthropic_agent_version'
         | 'anthropic_environment_id'
         | 'anthropic_vault_id'
         | 'slack_channel_id'
@@ -73,7 +83,12 @@ export type DbManagedAgentActionCreate = Omit<
     'action_uuid' | 'reversed_at' | 'reversed_by_user_uuid' | 'created_at'
 >;
 
+export type DbManagedAgentActionUpdate = Partial<
+    Pick<DbManagedAgentAction, 'reversed_at' | 'reversed_by_user_uuid'>
+>;
+
 export type ManagedAgentActionsTable = Knex.CompositeTableType<
     DbManagedAgentAction,
-    DbManagedAgentActionCreate
+    DbManagedAgentActionCreate,
+    DbManagedAgentActionUpdate
 >;

--- a/packages/backend/src/ee/database/migrations/20260430115535_add_managed_agent_agent_id.ts
+++ b/packages/backend/src/ee/database/migrations/20260430115535_add_managed_agent_agent_id.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+const ManagedAgentSettingsTableName = 'managed_agent_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ManagedAgentSettingsTableName, (table) => {
+        table.text('anthropic_agent_id').nullable();
+        table.text('anthropic_agent_config_hash').nullable();
+        table.integer('anthropic_agent_version').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ManagedAgentSettingsTableName, (table) => {
+        table.dropColumn('anthropic_agent_version');
+        table.dropColumn('anthropic_agent_config_hash');
+        table.dropColumn('anthropic_agent_id');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -412,6 +412,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig: context.lightdashConfig,
                     managedAgentModel: models.getManagedAgentModel(),
                     analyticsModel: models.getAnalyticsModel(),
+                    organizationModel: models.getOrganizationModel(),
                     projectModel: models.getProjectModel(),
                     validationModel: models.getValidationModel(),
                     savedChartModel: models.getSavedChartModel(),

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -65,17 +65,45 @@ export class ManagedAgentModel {
             .update({ service_account_token: encrypted });
     }
 
-    async getAnthropicResourceIds(
-        projectUuid: string,
-    ): Promise<{ environmentId: string | null; vaultId: string | null }> {
+    async getAnthropicResourceIds(projectUuid: string): Promise<{
+        agentId: string | null;
+        agentConfigHash: string | null;
+        agentVersion: number | null;
+        environmentId: string | null;
+        vaultId: string | null;
+    }> {
         const row = await this.database(ManagedAgentSettingsTableName)
             .where({ project_uuid: projectUuid })
-            .select('anthropic_environment_id', 'anthropic_vault_id')
+            .select(
+                'anthropic_agent_id',
+                'anthropic_agent_config_hash',
+                'anthropic_agent_version',
+                'anthropic_environment_id',
+                'anthropic_vault_id',
+            )
             .first();
         return {
+            agentId: row?.anthropic_agent_id ?? null,
+            agentConfigHash: row?.anthropic_agent_config_hash ?? null,
+            agentVersion: row?.anthropic_agent_version ?? null,
             environmentId: row?.anthropic_environment_id ?? null,
             vaultId: row?.anthropic_vault_id ?? null,
         };
+    }
+
+    async setAnthropicAgentState(
+        projectUuid: string,
+        agentId: string,
+        agentConfigHash: string,
+        agentVersion: number,
+    ): Promise<void> {
+        await this.database(ManagedAgentSettingsTableName)
+            .where({ project_uuid: projectUuid })
+            .update({
+                anthropic_agent_id: agentId,
+                anthropic_agent_config_hash: agentConfigHash,
+                anthropic_agent_version: agentVersion,
+            });
     }
 
     async setAnthropicResourceIds(
@@ -168,7 +196,7 @@ export class ManagedAgentModel {
                 target_uuid: action.targetUuid,
                 target_name: action.targetName,
                 description: action.description,
-                metadata: JSON.stringify(action.metadata),
+                metadata: action.metadata,
             })
             .returning('*');
         return ManagedAgentModel.mapDbAction(row);

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -21,6 +21,7 @@ import type { SlackClient } from '../../../clients/Slack/SlackClient';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import type { AnalyticsModel } from '../../../models/AnalyticsModel';
 import type { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
+import type { OrganizationModel } from '../../../models/OrganizationModel';
 import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import type { SavedChartModel } from '../../../models/SavedChartModel';
 import type { SpaceModel } from '../../../models/SpaceModel';
@@ -39,6 +40,7 @@ type ManagedAgentServiceDependencies = {
     lightdashConfig: LightdashConfig;
     managedAgentModel: ManagedAgentModel;
     analyticsModel: AnalyticsModel;
+    organizationModel: OrganizationModel;
     projectModel: ProjectModel;
     validationModel: ValidationModel;
     savedChartModel: SavedChartModel;
@@ -57,6 +59,8 @@ export class ManagedAgentService extends BaseService {
     private readonly managedAgentModel: ManagedAgentModel;
 
     private readonly analyticsModel: AnalyticsModel;
+
+    private readonly organizationModel: OrganizationModel;
 
     private readonly projectModel: ProjectModel;
 
@@ -83,6 +87,7 @@ export class ManagedAgentService extends BaseService {
         this.lightdashConfig = deps.lightdashConfig;
         this.managedAgentModel = deps.managedAgentModel;
         this.analyticsModel = deps.analyticsModel;
+        this.organizationModel = deps.organizationModel;
         this.projectModel = deps.projectModel;
         this.validationModel = deps.validationModel;
         this.savedChartModel = deps.savedChartModel;
@@ -173,15 +178,38 @@ export class ManagedAgentService extends BaseService {
         projectUuid: string,
         serviceAccountToken: string,
     ): Promise<ManagedAgentSessionConfig> {
-        const { environmentId, vaultId } =
-            await this.managedAgentModel.getAnthropicResourceIds(projectUuid);
+        const {
+            agentId,
+            agentConfigHash,
+            agentVersion,
+            environmentId,
+            vaultId,
+        } = await this.managedAgentModel.getAnthropicResourceIds(projectUuid);
         const project = await this.projectModel.getSummary(projectUuid);
+        const organization = await this.organizationModel.get(
+            project.organizationUuid,
+        );
 
         return {
             serviceAccountPat: serviceAccountToken,
-            resourceName: `${project.organizationUuid}:${project.name}:${project.projectUuid}`,
+            resourceName: `${organization.name}:${organization.organizationUuid}:${project.projectUuid}`,
+            persistedAgentId: agentId,
+            persistedAgentConfigHash: agentConfigHash,
+            persistedAgentVersion: agentVersion,
             persistedEnvironmentId: environmentId,
             persistedVaultId: vaultId,
+            onAgentSynced: async (
+                newAgentId,
+                newAgentConfigHash,
+                newAgentVersion,
+            ) => {
+                await this.managedAgentModel.setAnthropicAgentState(
+                    projectUuid,
+                    newAgentId,
+                    newAgentConfigHash,
+                    newAgentVersion,
+                );
+            },
             onResourcesCreated: async (newEnvId, newVaultId) => {
                 await this.managedAgentModel.setAnthropicResourceIds(
                     projectUuid,

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -1,0 +1,428 @@
+import type { AgentCreateParams } from '@anthropic-ai/sdk/resources/beta/agents';
+import { createHash } from 'crypto';
+
+export const managedAgentConfig = {
+    name: 'Lightdash Autopilot Agent',
+    description: null,
+    model: {
+        id: 'claude-opus-4-6',
+        speed: 'standard',
+    },
+    system: 'You are Autopilot, a Lightdash project health agent. You run on a schedule to keep this project clean and useful.\n\n## Skills\n\nYou have the **"Developing in Lightdash"** skill attached. Use it when creating or fixing charts:\n- It contains the full chart-as-code YAML reference, chart type guide, and field ID conventions\n- When creating charts via create_content_from_code, follow the YAML structure from the skill (sorted keys, correct chartConfig.type, contentType:        chart)\n- When fixing broken charts via fix_broken_chart, reference the skill for valid metricQuery and chartConfig shapes\n- CRITICAL: chartConfig.type must be "cartesian" for line/bar/area/scatter charts — never use "line" or "bar"\n\n## Rules\n- ALWAYS explain WHY you\'re taking an action in the description field\n- NEVER flag or soft-delete content created in the last 30 days, regardless of view count\n- NEVER flag or soft-delete content that YOU created (check get_recent_actions for created_content actions, or if the slug starts with "agent-")\n- NEVER soft-delete content if it\'s the only chart on a dashboard\n- "3+ months" means the last_viewed_at date is MORE than 90 days before today\'s date (provided in the first message). Calculate this carefully.\n- Prefer flagging over deleting when in doubt\n- For insights, only surface actionable observations\n- Check get_recent_actions first to avoid repeating yourself\n- Escalate: if you flagged something more than 24 hours ago and it hasn\'t been reversed, consider soft-deleting\n- When writing your final summary, use the "lightdash-agent-slack-messaging" skill to match Lightdash\'s Slack tone of voice\n\n## Checklist (follow in order)\n\n### 0. Context & Recovery\nCall get_recent_actions to understand what you\'ve already done.\nDon\'t re-flag content you\'ve already flagged. Escalate flagged content that\'s been ignored for 24+ hours.\n\n**Recovery check:** Review your recent soft_deleted and flagged_stale actions. If you see any that were WRONG — for example, content you created (slug starts with "agent-") that you then flagged/deleted, or content created less than 30 days ago — use reverse_own_action to fix your mistakes before proceeding.\n\n### 1. Preview Project Cleanup\nCall get_preview_projects. Flag any older than 3 months.\n\n### 2. Stale Content Detection\nCall get_stale_charts and get_stale_dashboards.\nUse today\'s date (from the first message) to calculate whether content is truly 3+ months old.\n- Content with 0 views AND created more than 30 days ago → soft_delete_content\n- Content with some views but last viewed 3+ months ago → flag_content\n- Content created in the last 30 days → SKIP regardless of views (it\'s new)\n- Content YOU created (slug starts with "agent-") → NEVER flag or delete\nInclude last_viewed_at, views_count, and created_at in the description.\n\n### 3. Broken Content\nCall get_broken_content. For each broken chart:\n- Call get_chart_details to understand the current state\n- If the fix is clear (removed field has an obvious replacement, or invalid fields can be dropped without changing the chart\'s purpose), use fix_broken_chart\n- If the fix is ambiguous or would change what the chart shows, flag it instead\n- Reference the "Developing in Lightdash" skill for valid metricQuery and chartConfig structure\n\n### 4. Content Suggestions (demand-driven)\nCreate charts when there\'s a clear signal — user demand or content gaps.\n\n**Demand-driven creation:** Call get_user_questions to see what users have been asking the AI assistant. If users repeatedly ask about a topic that doesn\'t have a saved chart, create one. This is the strongest signal for what charts to build.\n\nAlso create when you notice a gap:\n- If you soft-deleted or fixed a chart, consider whether a replacement would help\n- If get_popular_content shows heavy use of an explore with few charts, suggest one\n- If a broken chart was unfixable, create a simpler replacement\n- If the project is quite empty, create useful starter charts\n\nWhen creating, use create_content_from_code:\n1. Call get_user_questions to see what users are asking about\n2. Call get_chart_schema for the exact JSON format\n3. Use MCP tools (set_project, list_explores, find_fields) to discover the data model\n4. Use find_content (MCP) to check if a chart already exists for the topic\n5. Call run_metric_query to validate the data before creating\n6. Prefix slugs with "agent-" to identify agent-created content\n7. Place all charts in the "Agent Suggestions" space for admin review\n\nCRITICAL: chartConfig.type must be "cartesian" (for line/bar/area), "table", "big_number", or "pie". Do NOT use "line" or "bar" as the type.\n\nMax 3 charts per run. Skip if nothing warrants creation.\n\n### 5. Insights\nCall get_popular_content.\n- Surface content that is popular but not pinned\n- Surface content with high views but restricted access (private space)\n- If nothing noteworthy, skip this step\n',
+    mcp_servers: [
+        {
+            name: 'lightdash',
+            type: 'url',
+            url: '{{LIGHTDASH_SITE_URL}}/api/v1/mcp',
+        },
+    ],
+    metadata: {},
+    skills: [
+        {
+            skill_id: 'skill_01BV6ecNgXFXtSFAMhK9t6Ci',
+            type: 'custom',
+            version: 'latest',
+        },
+        {
+            skill_id: 'skill_01Dj8ukzto5pSMkf99x4nZGH',
+            type: 'custom',
+            version: 'latest',
+        },
+    ],
+    tools: [
+        {
+            configs: [
+                {
+                    enabled: true,
+                    name: 'read',
+                    permission_policy: {
+                        type: 'always_allow',
+                    },
+                },
+                {
+                    enabled: true,
+                    name: 'write',
+                    permission_policy: {
+                        type: 'always_allow',
+                    },
+                },
+            ],
+            default_config: {
+                enabled: false,
+                permission_policy: {
+                    type: 'always_allow',
+                },
+            },
+            type: 'agent_toolset_20260401',
+        },
+        {
+            configs: [],
+            default_config: {
+                enabled: true,
+                permission_policy: {
+                    type: 'always_allow',
+                },
+            },
+            mcp_server_name: 'lightdash',
+            type: 'mcp_toolset',
+        },
+        {
+            description:
+                'Get the most recent actions taken by this agent on the project. Call this first to understand what you have already done in previous runs and avoid repeating yourself.',
+            input_schema: {
+                properties: {
+                    limit: {
+                        description: 'Max actions to return (default 50)',
+                        type: 'number',
+                    },
+                },
+                required: [],
+                type: 'object',
+            },
+            name: 'get_recent_actions',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get charts that have not been viewed in 3+ months. Returns uuid, name, space, last_viewed_at, views_count, and created_by.',
+            input_schema: {
+                properties: {},
+                required: [],
+                type: 'object',
+            },
+            name: 'get_stale_charts',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get dashboards that have not been viewed in 3+ months. Returns uuid, name, space, last_viewed_at, views_count, and created_by.',
+            input_schema: {
+                properties: {},
+                required: [],
+                type: 'object',
+            },
+            name: 'get_stale_dashboards',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get charts and dashboards with validation errors (e.g., referencing fields that no longer exist). Returns uuid, name, type, and the specific errors.',
+            input_schema: {
+                properties: {},
+                required: [],
+                type: 'object',
+            },
+            name: 'get_broken_content',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get preview projects older than 3 months. Returns uuid, name, created_at, and the project they were copied from.',
+            input_schema: {
+                properties: {},
+                required: [],
+                type: 'object',
+            },
+            name: 'get_preview_projects',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get the most viewed charts and dashboards in the last 30 days. Returns uuid, name, type, views_count, unique_viewers, space name, and whether it is pinned.',
+            input_schema: {
+                properties: {},
+                required: [],
+                type: 'object',
+            },
+            name: 'get_popular_content',
+            type: 'custom',
+        },
+        {
+            description:
+                'Flag a chart, dashboard, or project in the action log. Does NOT delete or modify the content — only records an observation. Use for stale content, broken content, or old preview projects.',
+            input_schema: {
+                properties: {
+                    description: {
+                        description:
+                            'Human-readable explanation of WHY you are flagging this content',
+                        type: 'string',
+                    },
+                    flag_type: {
+                        description: 'Why this content is being flagged',
+                        enum: ['flagged_stale', 'flagged_broken'],
+                        type: 'string',
+                    },
+                    metadata: {
+                        description:
+                            'Additional data (e.g., last_viewed_at, views_count, errors)',
+                        type: 'object',
+                    },
+                    target_name: {
+                        description: 'Name of the content',
+                        type: 'string',
+                    },
+                    target_type: {
+                        description: 'Type of content',
+                        enum: ['chart', 'dashboard', 'project'],
+                        type: 'string',
+                    },
+                    target_uuid: {
+                        description: 'UUID of the content to flag',
+                        type: 'string',
+                    },
+                },
+                required: [
+                    'target_uuid',
+                    'target_type',
+                    'target_name',
+                    'flag_type',
+                    'description',
+                ],
+                type: 'object',
+            },
+            name: 'flag_content',
+            type: 'custom',
+        },
+        {
+            description:
+                'Soft-delete a chart or dashboard. The content can be restored by an admin. Do NOT use for content created in the last 30 days. Do NOT use for agent-created content (slug starts with agent-). Do NOT use if the chart is the only chart on a dashboard.',
+            input_schema: {
+                properties: {
+                    description: {
+                        description:
+                            'Human-readable explanation of WHY you are deleting this content',
+                        type: 'string',
+                    },
+                    metadata: {
+                        description:
+                            'Additional data (e.g., last_viewed_at, views_count)',
+                        type: 'object',
+                    },
+                    target_name: {
+                        description: 'Name of the content',
+                        type: 'string',
+                    },
+                    target_type: {
+                        description: 'Type of content',
+                        enum: ['chart', 'dashboard'],
+                        type: 'string',
+                    },
+                    target_uuid: {
+                        description: 'UUID of the chart or dashboard',
+                        type: 'string',
+                    },
+                },
+                required: [
+                    'target_uuid',
+                    'target_type',
+                    'target_name',
+                    'description',
+                ],
+                type: 'object',
+            },
+            name: 'soft_delete_content',
+            type: 'custom',
+        },
+        {
+            description:
+                'Log an actionable observation about popular content. For example: a chart is very popular but not pinned, or popular content is in a private space with limited access.',
+            input_schema: {
+                properties: {
+                    description: {
+                        description:
+                            'The insight — what is noteworthy and what should the admin consider doing',
+                        type: 'string',
+                    },
+                    metadata: {
+                        description:
+                            'Supporting data (e.g., views_count, unique_viewers, space_name)',
+                        type: 'object',
+                    },
+                    target_name: {
+                        description: 'Name of the content',
+                        type: 'string',
+                    },
+                    target_type: {
+                        description: 'Type of content',
+                        enum: ['chart', 'dashboard'],
+                        type: 'string',
+                    },
+                    target_uuid: {
+                        description: 'UUID of the content',
+                        type: 'string',
+                    },
+                },
+                required: [
+                    'target_uuid',
+                    'target_type',
+                    'target_name',
+                    'description',
+                ],
+                type: 'object',
+            },
+            name: 'log_insight',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get the full details of a chart including its metricQuery, chartConfig, and tableName. Use this to understand a chart before fixing it.',
+            input_schema: {
+                properties: {
+                    chart_uuid: {
+                        description: 'UUID of the chart',
+                        type: 'string',
+                    },
+                },
+                required: ['chart_uuid'],
+                type: 'object',
+            },
+            name: 'get_chart_details',
+            type: 'custom',
+        },
+        {
+            description:
+                'Fix a broken chart by updating its metricQuery and/or chartConfig. Provide the chart UUID and the corrected metricQuery and chartConfig objects. This creates a new version of the chart (the old version is preserved in history).',
+            input_schema: {
+                properties: {
+                    chart_config: {
+                        description:
+                            'The corrected chartConfig object. Remove references to fields that no longer exist.',
+                        type: 'object',
+                    },
+                    chart_name: {
+                        description: 'Name of the chart (for logging)',
+                        type: 'string',
+                    },
+                    chart_uuid: {
+                        description: 'UUID of the chart to fix',
+                        type: 'string',
+                    },
+                    description: {
+                        description: 'What was wrong and what you fixed',
+                        type: 'string',
+                    },
+                    metric_query: {
+                        description:
+                            'The corrected metricQuery object. Remove invalid field references.',
+                        type: 'object',
+                    },
+                    table_config: {
+                        description:
+                            'The corrected tableConfig object (optional).',
+                        type: 'object',
+                    },
+                },
+                required: [
+                    'chart_uuid',
+                    'chart_name',
+                    'metric_query',
+                    'chart_config',
+                    'description',
+                ],
+                type: 'object',
+            },
+            name: 'fix_broken_chart',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get the chart-as-code JSON schema. Call this BEFORE creating any charts to understand the exact format required. The schema defines all valid field types, chart config types, and metric query structure.',
+            input_schema: {
+                properties: {},
+                required: [],
+                type: 'object',
+            },
+            name: 'get_chart_schema',
+            type: 'custom',
+        },
+        {
+            description:
+                'Create a new chart from a chart-as-code JSON definition. IMPORTANT: Call get_chart_schema first to understand the format. The chart will be placed in a "Dash Suggestions" space for admin review. Use MCP tools to explore the data model and validate with run_metric_query before creating.',
+            input_schema: {
+                properties: {
+                    chart_as_code: {
+                        description:
+                            'The full chart-as-code JSON definition. Must match the schema from get_chart_schema. Key: chartConfig.type must be "cartesian" for line/bar/area charts, "table" for tables, "big_number" for big numbers, "pie" for pie charts.',
+                        type: 'object',
+                    },
+                    description: {
+                        description:
+                            'Why this chart is useful — what gap does it fill',
+                        type: 'string',
+                    },
+                },
+                required: ['chart_as_code', 'description'],
+                type: 'object',
+            },
+            name: 'create_content_from_code',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get recent questions users have asked the AI assistant. Use this to understand what users are looking for and create charts that answer common questions. Returns the prompt text, who asked it, and when.',
+            input_schema: {
+                properties: {
+                    days: {
+                        description: 'Look back this many days (default 30)',
+                        type: 'number',
+                    },
+                    limit: {
+                        description: 'Max questions to return (default 30)',
+                        type: 'number',
+                    },
+                },
+                required: [],
+                type: 'object',
+            },
+            name: 'get_user_questions',
+            type: 'custom',
+        },
+        {
+            description:
+                'Reverse a previous action you took that was incorrect. Use this to restore content you wrongly soft-deleted, or dismiss flags you wrongly applied. For example if you deleted a chart that was created less than 30 days ago, or flagged your own agent-created content as stale, reverse it. Check get_recent_actions to find the action_uuid.',
+            input_schema: {
+                properties: {
+                    action_uuid: {
+                        description:
+                            'UUID of the action to reverse (from get_recent_actions)',
+                        type: 'string',
+                    },
+                    reason: {
+                        description:
+                            'Why this action was incorrect and should be reversed',
+                        type: 'string',
+                    },
+                },
+                required: ['action_uuid', 'reason'],
+                type: 'object',
+            },
+            name: 'reverse_own_action',
+            type: 'custom',
+        },
+        {
+            description:
+                'Get the slowest warehouse queries in the project from the last 30 days. Returns the chart or dashboard name, execution time in ms, query context, and when it ran. Use this to flag charts or dashboards with consistently slow queries so admins can optimize them.',
+            input_schema: {
+                properties: {
+                    limit: {
+                        description: 'Max results to return (default 20)',
+                        type: 'number',
+                    },
+                    threshold_ms: {
+                        description:
+                            'Minimum execution time in ms to consider slow (default 2000)',
+                        type: 'number',
+                    },
+                },
+                required: [],
+                type: 'object',
+            },
+            name: 'get_slow_queries',
+            type: 'custom',
+        },
+    ],
+} satisfies AgentCreateParams;
+
+export const agentConfigHash = createHash('md5')
+    .update(JSON.stringify(managedAgentConfig))
+    .digest('hex');


### PR DESCRIPTION
Closes:

### Description:

The Managed Agent no longer requires a manually configured `MANAGED_AGENT_AGENT_ID` environment variable. Instead, the agent is now automatically created and kept in sync with the Anthropic API on each session start.

The full agent configuration (system prompt, tools, MCP server, skills, model) is defined in a new `config/agent.ts` file. An MD5 hash of this config is computed at startup and compared against the persisted hash in the database. If the config has changed since the last run, the agent is updated in-place via the Anthropic API. If no agent exists yet, one is created. The resulting agent ID, config hash, and version are persisted to the database so subsequent runs can skip the sync when nothing has changed.

Three new columns are added to `managed_agent_settings` via a migration: `anthropic_agent_id`, `anthropic_agent_config_hash`, and `anthropic_agent_version`.

The `resourceName` used to identify the agent in Anthropic is now derived from the organization name and UUID rather than the project name, giving it a more stable and human-readable identity.