### PR TITLE
feat: add configurable tool permissions for managed agent

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -306,6 +306,7 @@ export const lightdashConfigMock: LightdashConfig = {
     managedAgent: {
         enabled: false,
         anthropicApiKey: null,
+        skillIds: [],
         schedule: '*/30 * * * *',
         sessionTimeoutMs: 300000,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1163,6 +1163,7 @@ export type LightdashConfig = {
     managedAgent: {
         enabled: boolean;
         anthropicApiKey: string | null;
+        skillIds: string[];
         schedule: string;
         sessionTimeoutMs: number;
     };
@@ -2241,6 +2242,10 @@ export const parseConfig = (): LightdashConfig => {
                 process.env.MANAGED_AGENT_ANTHROPIC_API_KEY ||
                 process.env.ANTHROPIC_API_KEY ||
                 null,
+            skillIds: (process.env.MANAGED_AGENT_SKILL_IDS || '')
+                .split(',')
+                .map((skillId) => skillId.trim())
+                .filter(Boolean),
             schedule: process.env.MANAGED_AGENT_SCHEDULE || '*/30 * * * *',
             sessionTimeoutMs: parseInt(
                 process.env.MANAGED_AGENT_SESSION_TIMEOUT_MS || '300000',

--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -5,12 +5,11 @@ import type {
     BetaManagedAgentsAgent,
 } from '@anthropic-ai/sdk/resources/beta/agents';
 import { ParameterError } from '@lightdash/common/src';
-import { produce } from 'immer';
 import type { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import {
-    agentConfigHash,
-    managedAgentConfig,
+    getManagedAgentConfigHash,
+    renderManagedAgentConfig,
 } from '../services/ManagedAgentService/config/agent';
 
 type ManagedAgentClientConfig = {
@@ -20,6 +19,8 @@ type ManagedAgentClientConfig = {
 export type ManagedAgentSessionConfig = {
     serviceAccountPat: string;
     resourceName: string;
+    skillIds: string[];
+    toolSettings: Record<string, boolean>;
     persistedAgentId: string | null;
     persistedAgentConfigHash: string | null;
     persistedAgentVersion: number | null;
@@ -44,11 +45,8 @@ type CustomToolHandler = (
 export class ManagedAgentClient {
     private readonly config: ManagedAgentClientConfig;
 
-    private readonly renderedAgentConfig: AgentCreateParams;
-
     constructor(config: ManagedAgentClientConfig) {
         this.config = config;
-        this.renderedAgentConfig = this.renderAgentConfigTemplate();
     }
 
     private getAnthropicClient(): Anthropic {
@@ -62,22 +60,21 @@ export class ManagedAgentClient {
         return new Anthropic({ apiKey: anthropicApiKey });
     }
 
-    private renderAgentConfigTemplate(): AgentCreateParams {
-        return produce(managedAgentConfig, (draft) => {
-            // eslint-disable-next-line no-param-reassign
-            draft.mcp_servers[0].url = draft.mcp_servers[0].url.replace(
-                '{{LIGHTDASH_SITE_URL}}',
-                this.config.lightdashConfig.siteUrl,
-            );
+    private getRenderedAgentConfig(
+        resourceName: string,
+        skillIds: string[],
+        toolSettings: Record<string, boolean>,
+    ): AgentCreateParams {
+        const renderedAgentConfig = renderManagedAgentConfig({
+            lightdashSiteUrl: this.config.lightdashConfig.siteUrl,
+            skillIds,
+            toolSettings,
         });
-    }
-
-    private getRenderedAgentConfig(resourceName: string): AgentCreateParams {
         return {
-            ...this.renderedAgentConfig,
-            name: `${this.renderedAgentConfig.name} (${resourceName})`,
+            ...renderedAgentConfig,
+            name: `${renderedAgentConfig.name} (${resourceName})`,
             metadata: {
-                ...this.renderedAgentConfig.metadata,
+                ...renderedAgentConfig.metadata,
                 lightdash_resource: resourceName,
             },
         };
@@ -89,8 +86,10 @@ export class ManagedAgentClient {
     ): Promise<string> {
         const desiredAgent = this.getRenderedAgentConfig(
             sessionConfig.resourceName,
+            sessionConfig.skillIds,
+            sessionConfig.toolSettings,
         );
-        const desiredHash = agentConfigHash;
+        const desiredHash = getManagedAgentConfigHash(desiredAgent);
 
         if (
             sessionConfig.persistedAgentId &&
@@ -139,6 +138,11 @@ export class ManagedAgentClient {
             `[ManagedAgent] Created agent ${created.id} at version ${created.version}`,
         );
         return created.id;
+    }
+
+    async syncAgent(sessionConfig: ManagedAgentSessionConfig): Promise<string> {
+        const client = this.getAnthropicClient();
+        return this.ensureAgent(client.beta, sessionConfig);
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/backend/src/ee/database/entities/managedAgent.ts
+++ b/packages/backend/src/ee/database/entities/managedAgent.ts
@@ -15,6 +15,7 @@ export type DbManagedAgentSettings = {
     anthropic_environment_id: string | null;
     anthropic_vault_id: string | null;
     slack_channel_id: string | null;
+    tool_settings: Record<string, boolean>;
     created_at: Date;
     updated_at: Date;
 };
@@ -36,6 +37,7 @@ export type DbManagedAgentSettingsCreate = Pick<
             | 'anthropic_environment_id'
             | 'anthropic_vault_id'
             | 'slack_channel_id'
+            | 'tool_settings'
             | 'updated_at'
         >
     >;
@@ -53,6 +55,7 @@ export type DbManagedAgentSettingsUpdate = Partial<
         | 'anthropic_environment_id'
         | 'anthropic_vault_id'
         | 'slack_channel_id'
+        | 'tool_settings'
         | 'updated_at'
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260430124500_add_managed_agent_tool_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20260430124500_add_managed_agent_tool_settings.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const ManagedAgentSettingsTableName = 'managed_agent_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ManagedAgentSettingsTableName, (table) => {
+        table.jsonb('tool_settings').notNullable().defaultTo('{}');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ManagedAgentSettingsTableName, (table) => {
+        table.dropColumn('tool_settings');
+    });
+}

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -39,6 +39,7 @@ export class ManagedAgentModel {
             scheduleCron: row.schedule_cron,
             enabledByUserUuid: row.enabled_by_user_uuid,
             slackChannelId: row.slack_channel_id,
+            toolSettings: row.tool_settings ?? {},
             createdAt: row.created_at,
             updatedAt: row.updated_at,
         };
@@ -140,6 +141,7 @@ export class ManagedAgentModel {
                 schedule_cron: update.scheduleCron ?? '*/30 * * * *',
                 enabled_by_user_uuid: update.enabled ? userUuid : null,
                 slack_channel_id: update.slackChannelId ?? null,
+                tool_settings: update.toolSettings ?? {},
                 updated_at: new Date(),
             })
             .onConflict('project_uuid')
@@ -150,6 +152,9 @@ export class ManagedAgentModel {
                 }),
                 ...(update.slackChannelId !== undefined && {
                     slack_channel_id: update.slackChannelId,
+                }),
+                ...(update.toolSettings !== undefined && {
+                    tool_settings: update.toolSettings,
                 }),
                 enabled_by_user_uuid: update.enabled ? userUuid : undefined,
                 updated_at: new Date(),

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -189,10 +189,13 @@ export class ManagedAgentService extends BaseService {
         const organization = await this.organizationModel.get(
             project.organizationUuid,
         );
+        const settings = await this.managedAgentModel.getSettings(projectUuid);
 
         return {
             serviceAccountPat: serviceAccountToken,
             resourceName: `${organization.name}:${organization.organizationUuid}:${project.projectUuid}`,
+            skillIds: this.lightdashConfig.managedAgent.skillIds,
+            toolSettings: settings?.toolSettings ?? {},
             persistedAgentId: agentId,
             persistedAgentConfigHash: agentConfigHash,
             persistedAgentVersion: agentVersion,
@@ -218,6 +221,22 @@ export class ManagedAgentService extends BaseService {
                 );
             },
         };
+    }
+
+    private async syncProjectAgentConfig(projectUuid: string): Promise<void> {
+        const serviceAccountToken =
+            await this.managedAgentModel.getServiceAccountToken(projectUuid);
+
+        if (!serviceAccountToken) {
+            return;
+        }
+
+        const sessionConfig = await this.getSessionConfig(
+            projectUuid,
+            serviceAccountToken,
+        );
+
+        await this.managedAgentClient.syncAgent(sessionConfig);
     }
 
     // --- Authorization ---
@@ -318,6 +337,10 @@ export class ManagedAgentService extends BaseService {
         } else if (update.enabled === false) {
             // Cancel pending heartbeat for this specific project
             await this.schedulerClient.cancelManagedAgentHeartbeat(projectUuid);
+        }
+
+        if (update.enabled || update.toolSettings !== undefined) {
+            await this.syncProjectAgentConfig(projectUuid);
         }
 
         return settings;

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -1,7 +1,8 @@
 import type { AgentCreateParams } from '@anthropic-ai/sdk/resources/beta/agents';
 import { createHash } from 'crypto';
+import { produce } from 'immer';
 
-export const managedAgentConfig = {
+export const managedAgentConfig: AgentCreateParams = {
     name: 'Lightdash Autopilot Agent',
     description: null,
     model: {
@@ -9,26 +10,9 @@ export const managedAgentConfig = {
         speed: 'standard',
     },
     system: 'You are Autopilot, a Lightdash project health agent. You run on a schedule to keep this project clean and useful.\n\n## Skills\n\nYou have the **"Developing in Lightdash"** skill attached. Use it when creating or fixing charts:\n- It contains the full chart-as-code YAML reference, chart type guide, and field ID conventions\n- When creating charts via create_content_from_code, follow the YAML structure from the skill (sorted keys, correct chartConfig.type, contentType:        chart)\n- When fixing broken charts via fix_broken_chart, reference the skill for valid metricQuery and chartConfig shapes\n- CRITICAL: chartConfig.type must be "cartesian" for line/bar/area/scatter charts — never use "line" or "bar"\n\n## Rules\n- ALWAYS explain WHY you\'re taking an action in the description field\n- NEVER flag or soft-delete content created in the last 30 days, regardless of view count\n- NEVER flag or soft-delete content that YOU created (check get_recent_actions for created_content actions, or if the slug starts with "agent-")\n- NEVER soft-delete content if it\'s the only chart on a dashboard\n- "3+ months" means the last_viewed_at date is MORE than 90 days before today\'s date (provided in the first message). Calculate this carefully.\n- Prefer flagging over deleting when in doubt\n- For insights, only surface actionable observations\n- Check get_recent_actions first to avoid repeating yourself\n- Escalate: if you flagged something more than 24 hours ago and it hasn\'t been reversed, consider soft-deleting\n- When writing your final summary, use the "lightdash-agent-slack-messaging" skill to match Lightdash\'s Slack tone of voice\n\n## Checklist (follow in order)\n\n### 0. Context & Recovery\nCall get_recent_actions to understand what you\'ve already done.\nDon\'t re-flag content you\'ve already flagged. Escalate flagged content that\'s been ignored for 24+ hours.\n\n**Recovery check:** Review your recent soft_deleted and flagged_stale actions. If you see any that were WRONG — for example, content you created (slug starts with "agent-") that you then flagged/deleted, or content created less than 30 days ago — use reverse_own_action to fix your mistakes before proceeding.\n\n### 1. Preview Project Cleanup\nCall get_preview_projects. Flag any older than 3 months.\n\n### 2. Stale Content Detection\nCall get_stale_charts and get_stale_dashboards.\nUse today\'s date (from the first message) to calculate whether content is truly 3+ months old.\n- Content with 0 views AND created more than 30 days ago → soft_delete_content\n- Content with some views but last viewed 3+ months ago → flag_content\n- Content created in the last 30 days → SKIP regardless of views (it\'s new)\n- Content YOU created (slug starts with "agent-") → NEVER flag or delete\nInclude last_viewed_at, views_count, and created_at in the description.\n\n### 3. Broken Content\nCall get_broken_content. For each broken chart:\n- Call get_chart_details to understand the current state\n- If the fix is clear (removed field has an obvious replacement, or invalid fields can be dropped without changing the chart\'s purpose), use fix_broken_chart\n- If the fix is ambiguous or would change what the chart shows, flag it instead\n- Reference the "Developing in Lightdash" skill for valid metricQuery and chartConfig structure\n\n### 4. Content Suggestions (demand-driven)\nCreate charts when there\'s a clear signal — user demand or content gaps.\n\n**Demand-driven creation:** Call get_user_questions to see what users have been asking the AI assistant. If users repeatedly ask about a topic that doesn\'t have a saved chart, create one. This is the strongest signal for what charts to build.\n\nAlso create when you notice a gap:\n- If you soft-deleted or fixed a chart, consider whether a replacement would help\n- If get_popular_content shows heavy use of an explore with few charts, suggest one\n- If a broken chart was unfixable, create a simpler replacement\n- If the project is quite empty, create useful starter charts\n\nWhen creating, use create_content_from_code:\n1. Call get_user_questions to see what users are asking about\n2. Call get_chart_schema for the exact JSON format\n3. Use MCP tools (set_project, list_explores, find_fields) to discover the data model\n4. Use find_content (MCP) to check if a chart already exists for the topic\n5. Call run_metric_query to validate the data before creating\n6. Prefix slugs with "agent-" to identify agent-created content\n7. Place all charts in the "Agent Suggestions" space for admin review\n\nCRITICAL: chartConfig.type must be "cartesian" (for line/bar/area), "table", "big_number", or "pie". Do NOT use "line" or "bar" as the type.\n\nMax 3 charts per run. Skip if nothing warrants creation.\n\n### 5. Insights\nCall get_popular_content.\n- Surface content that is popular but not pinned\n- Surface content with high views but restricted access (private space)\n- If nothing noteworthy, skip this step\n',
-    mcp_servers: [
-        {
-            name: 'lightdash',
-            type: 'url',
-            url: '{{LIGHTDASH_SITE_URL}}/api/v1/mcp',
-        },
-    ],
+    mcp_servers: [],
     metadata: {},
-    skills: [
-        {
-            skill_id: 'skill_01BV6ecNgXFXtSFAMhK9t6Ci',
-            type: 'custom',
-            version: 'latest',
-        },
-        {
-            skill_id: 'skill_01Dj8ukzto5pSMkf99x4nZGH',
-            type: 'custom',
-            version: 'latest',
-        },
-    ],
+    skills: [],
     tools: [
         {
             configs: [
@@ -421,8 +405,87 @@ export const managedAgentConfig = {
             type: 'custom',
         },
     ],
-} satisfies AgentCreateParams;
+};
 
-export const agentConfigHash = createHash('md5')
-    .update(JSON.stringify(managedAgentConfig))
-    .digest('hex');
+type RenderManagedAgentConfigArgs = {
+    lightdashSiteUrl: string;
+    skillIds: string[];
+    toolSettings?: Record<string, boolean>;
+};
+
+const managedAgentCapabilityTools = {
+    createContent: ['create_content_from_code'],
+    modifyExistingContent: [
+        'soft_delete_content',
+        'fix_broken_chart',
+        'reverse_own_action',
+    ],
+} as const;
+
+const configurableCapabilityNames = Object.keys(managedAgentCapabilityTools);
+
+export const normalizeManagedAgentToolSettings = (
+    toolSettings: Record<string, boolean> = {},
+) =>
+    Object.fromEntries(
+        configurableCapabilityNames
+            .sort()
+            .map((capabilityName) => [
+                capabilityName,
+                toolSettings[capabilityName] ?? true,
+            ]),
+    );
+
+export const renderManagedAgentConfig = ({
+    lightdashSiteUrl,
+    skillIds,
+    toolSettings = {},
+}: RenderManagedAgentConfigArgs): AgentCreateParams => {
+    const normalizedToolSettings =
+        normalizeManagedAgentToolSettings(toolSettings);
+    const disabledCapabilities = Object.entries(normalizedToolSettings)
+        .filter(([, enabled]) => !enabled)
+        .map(([capabilityName]) => capabilityName);
+    const disabledToolNames = new Set<string>(
+        disabledCapabilities.flatMap(
+            (capabilityName) =>
+                managedAgentCapabilityTools[
+                    capabilityName as keyof typeof managedAgentCapabilityTools
+                ],
+        ),
+    );
+
+    return produce(managedAgentConfig, (draft) => {
+        // eslint-disable-next-line no-param-reassign
+        draft.mcp_servers = [
+            {
+                name: 'lightdash',
+                type: 'url',
+                url: `${lightdashSiteUrl}/api/v1/mcp`,
+            },
+        ];
+        // eslint-disable-next-line no-param-reassign
+        draft.skills = skillIds.map((skillId) => ({
+            skill_id: skillId,
+            type: 'custom',
+            version: 'latest',
+        }));
+
+        // eslint-disable-next-line no-param-reassign
+        draft.tools = draft.tools?.filter((tool) => {
+            if (tool.type !== 'custom') {
+                return true;
+            }
+
+            return !disabledToolNames.has(tool.name);
+        });
+
+        if (disabledCapabilities.length > 0) {
+            // eslint-disable-next-line no-param-reassign
+            draft.system = `${draft.system ?? ''}\n\n## Disabled capabilities\nThe following capabilities are disabled for this project and their tools are unavailable in this run: ${disabledCapabilities.join(', ')}. Skip checklist steps that require only disabled capabilities.`;
+        }
+    });
+};
+
+export const getManagedAgentConfigHash = (agentConfig: AgentCreateParams) =>
+    createHash('md5').update(JSON.stringify(agentConfig)).digest('hex');

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1146,6 +1146,16 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.boolean_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: { dataType: 'boolean' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ManagedAgentSettings: {
         dataType: 'refAlias',
         type: {
@@ -1153,6 +1163,7 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 updatedAt: { dataType: 'datetime', required: true },
                 createdAt: { dataType: 'datetime', required: true },
+                toolSettings: { ref: 'Record_string.boolean_', required: true },
                 slackChannelId: {
                     dataType: 'union',
                     subSchemas: [
@@ -1182,6 +1193,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                toolSettings: { ref: 'Record_string.boolean_' },
                 slackChannelId: {
                     dataType: 'union',
                     subSchemas: [
@@ -8970,11 +8982,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9452,11 +9464,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9471,11 +9483,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9490,11 +9502,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9509,11 +9521,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9528,11 +9540,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -21091,7 +21103,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21101,7 +21113,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21111,7 +21123,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21124,7 +21136,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21535,7 +21547,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21545,7 +21557,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21555,7 +21567,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21568,7 +21580,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1189,6 +1189,14 @@
                 "type": "object",
                 "additionalProperties": true
             },
+            "Record_string.boolean_": {
+                "properties": {},
+                "additionalProperties": {
+                    "type": "boolean"
+                },
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
             "ManagedAgentSettings": {
                 "properties": {
                     "updatedAt": {
@@ -1198,6 +1206,9 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "toolSettings": {
+                        "$ref": "#/components/schemas/Record_string.boolean_"
                     },
                     "slackChannelId": {
                         "type": "string",
@@ -1220,6 +1231,7 @@
                 "required": [
                     "updatedAt",
                     "createdAt",
+                    "toolSettings",
                     "slackChannelId",
                     "enabledByUserUuid",
                     "scheduleCron",
@@ -1230,6 +1242,9 @@
             },
             "UpdateManagedAgentSettings": {
                 "properties": {
+                    "toolSettings": {
+                        "$ref": "#/components/schemas/Record_string.boolean_"
+                    },
                     "slackChannelId": {
                         "type": "string",
                         "nullable": true
@@ -10413,6 +10428,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -22475,22 +22503,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -22845,22 +22873,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {

--- a/packages/backend/src/scripts/upload-autopilot-skill.ts
+++ b/packages/backend/src/scripts/upload-autopilot-skill.ts
@@ -1,0 +1,157 @@
+import Anthropic, { toFile } from '@anthropic-ai/sdk';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type Args = {
+    displayTitle: string;
+    skillDir: string;
+    skillId?: string;
+};
+
+const usage = `Upload the Autopilot "Developing in Lightdash" skill to Anthropic.
+
+Creates a new skill by default. To upload a new version for an existing skill,
+pass --skill-id or set SKILL_ID.
+
+Usage:
+  scripts/upload-autopilot-skill
+  scripts/upload-autopilot-skill --skill-id skill_...
+
+Options:
+  --skill-id         Existing skill ID for version upload.
+  --skill-dir        Skill directory. Default: skills/developing-in-lightdash
+  --display-title    Skill title. Default: Developing in Lightdash
+
+Env:
+  ANTHROPIC_API_KEY  Anthropic API key.
+  SKILL_ID           Existing skill ID for version upload.
+  SKILL_DIR          Skill directory.
+  DISPLAY_TITLE      Skill title.
+`;
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+
+const resolveFromRepoRoot = (inputPath: string) =>
+    path.isAbsolute(inputPath) ? inputPath : path.join(repoRoot, inputPath);
+
+const parseArgs = (): Args => {
+    const args = process.argv.slice(2);
+    const parsed: Args = {
+        displayTitle: process.env.DISPLAY_TITLE ?? 'Developing in Lightdash',
+        skillDir: process.env.SKILL_DIR ?? 'skills/developing-in-lightdash',
+        skillId: process.env.SKILL_ID,
+    };
+
+    for (let i = 0; i < args.length; i += 1) {
+        const arg = args[i];
+        switch (arg) {
+            case '--skill-id':
+                parsed.skillId = args[(i += 1)];
+                break;
+            case '--skill-dir':
+                parsed.skillDir = args[(i += 1)];
+                break;
+            case '--display-title':
+                parsed.displayTitle = args[(i += 1)];
+                break;
+            case '-h':
+            case '--help':
+                console.log(usage);
+                process.exit(0);
+                break;
+            default:
+                throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+
+    return parsed;
+};
+
+const listFiles = async (dir: string): Promise<string[]> => {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files = await Promise.all(
+        entries.map(async (entry) => {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) return listFiles(fullPath);
+            if (entry.isFile()) return [fullPath];
+            return [];
+        }),
+    );
+    return files.flat().sort();
+};
+
+const main = async () => {
+    const { displayTitle, skillDir, skillId } = parseArgs();
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) throw new Error('ANTHROPIC_API_KEY is required');
+
+    const resolvedSkillDir = resolveFromRepoRoot(skillDir);
+    const skillMd = path.join(resolvedSkillDir, 'SKILL.md');
+
+    try {
+        const skillMdStat = await stat(skillMd);
+        if (!skillMdStat.isFile()) throw new Error();
+    } catch {
+        throw new Error(`${skillMd} not found`);
+    }
+
+    const skillParent = path.dirname(resolvedSkillDir);
+    const skillTopLevel = path.basename(resolvedSkillDir);
+    const filePaths = await listFiles(resolvedSkillDir);
+    const files = await Promise.all(
+        filePaths.map(async (filePath) => {
+            const uploadName =
+                skillParent === '.'
+                    ? filePath
+                    : path.relative(skillParent, filePath);
+
+            if (
+                uploadName !== `${skillTopLevel}/SKILL.md` &&
+                !uploadName.startsWith(`${skillTopLevel}/`)
+            ) {
+                throw new Error(
+                    `Computed upload filename is outside ${skillTopLevel}/: ${uploadName}`,
+                );
+            }
+
+            return toFile(await readFile(filePath), uploadName);
+        }),
+    );
+
+    const client = new Anthropic({ apiKey });
+
+    if (skillId) {
+        console.log(`Creating new version for skill: ${skillId}`);
+        console.log(`Uploading ${files.length} files from ${resolvedSkillDir}`);
+
+        const version = await client.beta.skills.versions.create(skillId, {
+            files,
+        });
+        console.log(JSON.stringify(version, null, 2));
+        console.log('\nUpload complete');
+        console.log(`  Skill ID: ${version.skill_id}`);
+        console.log(`  Version: ${version.version}`);
+        return;
+    }
+
+    console.log(`Creating skill: ${displayTitle}`);
+    console.log(`Uploading ${files.length} files from ${resolvedSkillDir}`);
+
+    const skill = await client.beta.skills.create({
+        display_title: displayTitle,
+        files,
+    });
+    console.log(JSON.stringify(skill, null, 2));
+    console.log('\nUpload complete');
+    console.log(`  Skill ID: ${skill.id}`);
+    if (skill.latest_version) {
+        console.log(`  Version: ${skill.latest_version}`);
+    }
+};
+
+main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
+    process.exit(1);
+});

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -21,6 +21,7 @@ export type ManagedAgentSettings = {
     scheduleCron: string;
     enabledByUserUuid: string | null;
     slackChannelId: string | null;
+    toolSettings: Record<string, boolean>;
     createdAt: Date;
     updatedAt: Date;
 };
@@ -44,6 +45,7 @@ export type UpdateManagedAgentSettings = {
     enabled?: boolean;
     scheduleCron?: string;
     slackChannelId?: string | null;
+    toolSettings?: Record<string, boolean>;
 };
 
 export type CreateManagedAgentAction = {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -421,6 +421,42 @@
     padding-bottom: 0;
 }
 
+.toolTogglePanel {
+    border-radius: var(--mantine-radius-sm);
+    border: 1px solid;
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+        border-color: var(--mantine-color-ldGray-2);
+    }
+
+    @mixin dark {
+        background-color: var(--mantine-color-dark-6);
+        border-color: var(--mantine-color-dark-4);
+    }
+}
+
+.toolToggleRow {
+    min-height: 42px;
+    padding: 10px 12px;
+}
+
+.toolToggleRow + .toolToggleRow {
+    border-top: 1px solid;
+
+    @mixin light {
+        border-color: var(--mantine-color-ldGray-2);
+    }
+
+    @mixin dark {
+        border-color: var(--mantine-color-dark-4);
+    }
+}
+
+.permissionSwitch {
+    flex-shrink: 0;
+}
+
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
     .page,

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -25,6 +25,7 @@ import {
     IconLayoutDashboard,
     IconPlayerPlay,
     IconSettings,
+    IconTool,
     IconX,
 } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -57,6 +58,7 @@ const updateSettings = async (
         enabled?: boolean;
         scheduleCron?: string;
         slackChannelId?: string | null;
+        toolSettings?: Record<string, boolean>;
     },
 ) =>
     lightdashApi({
@@ -79,6 +81,30 @@ const SCHEDULE_OPTIONS = [
     { value: '0 * * * *', label: 'Hourly' },
     { value: '0 */6 * * *', label: 'Every 6 hours' },
     { value: '0 0 * * *', label: 'Daily' },
+];
+
+const CAPABILITY_GROUPS = [
+    {
+        key: 'readOnly',
+        label: 'Read content',
+        description:
+            'Reads project health signals, recent Autopilot actions, stale charts and dashboards, broken content, chart definitions, user questions, popular content, preview projects, and slow query history.',
+        locked: true,
+    },
+    {
+        key: 'createContent',
+        label: 'Create content',
+        description:
+            'Allows Autopilot to create net new suggested charts in the Agent Suggestions space from chart-as-code definitions.',
+        locked: false,
+    },
+    {
+        key: 'modifyExistingContent',
+        label: 'Modify existing content',
+        description:
+            'Allows Autopilot to soft-delete stale charts or dashboards, update broken chart definitions, and reverse its own previous content changes.',
+        locked: false,
+    },
 ];
 
 const SetupSection: FC<{
@@ -128,7 +154,8 @@ const SetupSection: FC<{
                         </Box>
                     </Group>
                     <Text fz="xs" c="dimmed" ml={46}>
-                        Your project health agent
+                        Fixes broken charts, flags stale content, suggests new
+                        ones
                     </Text>
                 </Stack>
                 <Group gap="xs">
@@ -487,6 +514,7 @@ const SettingsSidebar: FC<{
     enabled: boolean;
     schedule: string;
     slackChannelId: string | null;
+    toolSettings: Record<string, boolean>;
     isLoading: boolean;
     onClose: () => void;
 }> = ({
@@ -494,6 +522,7 @@ const SettingsSidebar: FC<{
     enabled,
     schedule,
     slackChannelId,
+    toolSettings,
     isLoading,
     onClose,
 }) => {
@@ -544,6 +573,18 @@ const SettingsSidebar: FC<{
         [mutation],
     );
 
+    const handleCapabilityToggle = useCallback(
+        (capabilityName: string, checked: boolean) => {
+            mutation.mutate({
+                toolSettings: {
+                    ...toolSettings,
+                    [capabilityName]: checked,
+                },
+            });
+        },
+        [mutation, toolSettings],
+    );
+
     return (
         <Stack gap={0} h="100%" className={classes.sidebar}>
             <Stack gap={2} className={classes.sidebarHeader}>
@@ -592,7 +633,7 @@ const SettingsSidebar: FC<{
                         }
                         disabled={isLoading || mutation.isLoading}
                         size="xs"
-                        color="dark"
+                        color="ldDark"
                     />
                 </Group>
 
@@ -638,7 +679,7 @@ const SettingsSidebar: FC<{
                                         }
                                         disabled={mutation.isLoading}
                                         size="xs"
-                                        color="dark"
+                                        color="ldDark"
                                     />
                                 )}
                             </Group>
@@ -670,6 +711,80 @@ const SettingsSidebar: FC<{
                                     </Button>
                                 </Stack>
                             )}
+                        </Stack>
+
+                        <Stack gap="md" className={classes.settingsRow}>
+                            <Stack gap={4}>
+                                <Group gap={6}>
+                                    <IconTool
+                                        size={16}
+                                        color="var(--mantine-color-dimmed)"
+                                    />
+                                    <Text fz="sm" fw={500}>
+                                        Permissions
+                                    </Text>
+                                </Group>
+                                <Text fz="xs" c="dimmed">
+                                    Choose what Autopilot can do.
+                                </Text>
+                            </Stack>
+                            <Stack gap={0} className={classes.toolTogglePanel}>
+                                {CAPABILITY_GROUPS.map((capability) => (
+                                    <Group
+                                        key={capability.key}
+                                        justify="space-between"
+                                        align="flex-start"
+                                        wrap="nowrap"
+                                        className={classes.toolToggleRow}
+                                    >
+                                        <Stack gap={3}>
+                                            <Text fz="xs" fw={500}>
+                                                {capability.label}
+                                            </Text>
+                                            <Text fz={11} c="dimmed">
+                                                {capability.description}
+                                            </Text>
+                                        </Stack>
+                                        {capability.locked ? (
+                                            <Tooltip label="Always disabled">
+                                                <Box
+                                                    component="span"
+                                                    className={
+                                                        classes.permissionSwitch
+                                                    }
+                                                >
+                                                    <Switch
+                                                        checked
+                                                        disabled
+                                                        size="xs"
+                                                        color="ldDark"
+                                                    />
+                                                </Box>
+                                            </Tooltip>
+                                        ) : (
+                                            <Switch
+                                                checked={
+                                                    toolSettings[
+                                                        capability.key
+                                                    ] ?? true
+                                                }
+                                                onChange={(e) =>
+                                                    handleCapabilityToggle(
+                                                        capability.key,
+                                                        e.currentTarget.checked,
+                                                    )
+                                                }
+                                                disabled={mutation.isLoading}
+                                                size="xs"
+                                                color="ldDark"
+                                                className={
+                                                    classes.permissionSwitch
+                                                }
+                                            />
+                                        )}
+                                    </Group>
+                                ))}
+                            </Stack>
                         </Stack>
                     </>
                 )}
@@ -867,6 +982,7 @@ export const ManagedAgentActivityPage: FC = () => {
                                     slackChannelId={
                                         settings?.slackChannelId ?? null
                                     }
+                                    toolSettings={settings?.toolSettings ?? {}}
                                     isLoading={settingsLoading}
                                     onClose={() => setSettingsOpen(false)}
                                 />

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
@@ -8,6 +8,7 @@ type ManagedAgentSettings = {
     scheduleCron: string;
     enabledByUserUuid: string | null;
     slackChannelId: string | null;
+    toolSettings: Record<string, boolean>;
     createdAt: string;
     updatedAt: string;
 };


### PR DESCRIPTION
Closes:

### Description:

Adds per-project tool permission controls for the Managed Agent (Autopilot), allowing admins to configure which capabilities the agent is allowed to use on a per-project basis.

Three capability groups are exposed in the settings sidebar:

- **Read content** — always enabled; covers reading project health signals, stale/broken content, chart definitions, etc.
- **Create content** — toggleable; allows the agent to create new suggested charts via chart-as-code in the Agent Suggestions space.
- **Modify existing content** — toggleable; allows the agent to soft-delete stale content, fix broken charts, and reverse its own previous changes.

When a capability is disabled, its associated tools are removed from the agent configuration and the system prompt is updated to inform the agent that those capabilities are unavailable. The agent config hash now incorporates the normalized tool settings, so any change to permissions triggers an automatic agent re-sync on Anthropic's side.

Tool settings are persisted in a new `tool_settings` JSONB column on `managed_agent_settings`, and the agent is re-synced whenever settings are saved with `enabled` or `toolSettings` changes.

Also adds a `upload-autopilot-skill` script for uploading or updating versioned Anthropic skill files from a local directory.