### PR TITLE
feat(cli): add Snowflake Cortex support to install-skills command

### DIFF
--- a/packages/cli/src/handlers/installSkills.ts
+++ b/packages/cli/src/handlers/installSkills.ts
@@ -19,7 +19,7 @@ function getGitHubRawBase(repo: string): string {
     return `https://raw.githubusercontent.com/${repo}/${CLI_VERSION}`;
 }
 
-type AgentType = 'claude' | 'cursor' | 'codex';
+type AgentType = 'claude' | 'cursor' | 'codex' | 'cortex';
 
 type InstallSkillsOptions = {
     verbose: boolean;
@@ -44,7 +44,7 @@ type GitHubContentItem = {
     size: number;
 };
 
-function getAgentSkillsDir(agent: AgentType): string {
+function getAgentProjectSkillsDir(agent: AgentType): string {
     switch (agent) {
         case 'claude':
             return '.claude/skills';
@@ -52,6 +52,23 @@ function getAgentSkillsDir(agent: AgentType): string {
             return '.cursor/skills';
         case 'codex':
             return '.codex/skills';
+        case 'cortex':
+            return '.cortex/skills';
+        default:
+            throw new Error(`Unknown agent type: ${agent}`);
+    }
+}
+
+function getAgentGlobalSkillsDir(agent: AgentType): string {
+    switch (agent) {
+        case 'claude':
+            return '.claude/skills';
+        case 'cursor':
+            return '.cursor/skills';
+        case 'codex':
+            return '.codex/skills';
+        case 'cortex':
+            return '.snowflake/cortex/skills';
         default:
             throw new Error(`Unknown agent type: ${agent}`);
     }
@@ -73,19 +90,20 @@ function findGitRoot(startDir: string): string | null {
 }
 
 function getInstallPath(options: InstallSkillsOptions): string {
-    const skillsDir = getAgentSkillsDir(options.agent);
-
-    // If explicit path provided, use it
+    // If explicit path provided, use it with project-level directory structure
     if (options.path) {
+        const skillsDir = getAgentProjectSkillsDir(options.agent);
         return path.join(options.path, skillsDir);
     }
 
-    // If global, use home directory
+    // If global, use home directory with global directory structure
     if (options.global) {
+        const skillsDir = getAgentGlobalSkillsDir(options.agent);
         return path.join(os.homedir(), skillsDir);
     }
 
     // Project install: find git root
+    const skillsDir = getAgentProjectSkillsDir(options.agent);
     const cwd = process.cwd();
     const gitRoot = findGitRoot(cwd);
 
@@ -284,51 +302,74 @@ type InstalledSkillInfo = {
 };
 
 function findInstalledSkills(): InstalledSkillInfo[] {
-    const agents: AgentType[] = ['claude', 'cursor', 'codex'];
+    const agents: AgentType[] = ['claude', 'cursor', 'codex', 'cortex'];
     const results: InstalledSkillInfo[] = [];
-
-    const roots: Array<{ path: string; scope: 'global' | 'project' }> = [
-        { path: os.homedir(), scope: 'global' },
-    ];
 
     const cwd = process.cwd();
     const gitRoot = findGitRoot(cwd);
-    roots.push({ path: gitRoot || cwd, scope: 'project' });
+    const projectRoot = gitRoot || cwd;
 
-    for (const root of roots) {
-        for (const agent of agents) {
-            const skillsDir = path.join(root.path, getAgentSkillsDir(agent));
-            if (!fs.existsSync(skillsDir)) {
-                // eslint-disable-next-line no-continue
-                continue;
-            }
-
-            let entries: string[];
+    for (const agent of agents) {
+        // Check global path
+        const globalSkillsDir = path.join(
+            os.homedir(),
+            getAgentGlobalSkillsDir(agent),
+        );
+        if (fs.existsSync(globalSkillsDir)) {
             try {
-                entries = fs.readdirSync(skillsDir);
+                const entries = fs.readdirSync(globalSkillsDir);
+                entries
+                    .filter((e) =>
+                        fs.statSync(path.join(globalSkillsDir, e)).isDirectory(),
+                    )
+                    .forEach((entry) => {
+                        const manifest = readSkillManifest(
+                            path.join(globalSkillsDir, entry),
+                        );
+                        if (manifest) {
+                            results.push({
+                                name: entry,
+                                version: manifest.version,
+                                agent,
+                                scope: 'global',
+                                isOutdated: manifest.version !== CLI_VERSION,
+                            });
+                        }
+                    });
             } catch {
-                // eslint-disable-next-line no-continue
-                continue;
+                // Ignore read errors
             }
+        }
 
-            entries
-                .filter((e) =>
-                    fs.statSync(path.join(skillsDir, e)).isDirectory(),
-                )
-                .forEach((entry) => {
-                    const manifest = readSkillManifest(
-                        path.join(skillsDir, entry),
-                    );
-                    if (manifest) {
-                        results.push({
-                            name: entry,
-                            version: manifest.version,
-                            agent,
-                            scope: root.scope,
-                            isOutdated: manifest.version !== CLI_VERSION,
-                        });
-                    }
-                });
+        // Check project path
+        const projectSkillsDir = path.join(
+            projectRoot,
+            getAgentProjectSkillsDir(agent),
+        );
+        if (fs.existsSync(projectSkillsDir)) {
+            try {
+                const entries = fs.readdirSync(projectSkillsDir);
+                entries
+                    .filter((e) =>
+                        fs.statSync(path.join(projectSkillsDir, e)).isDirectory(),
+                    )
+                    .forEach((entry) => {
+                        const manifest = readSkillManifest(
+                            path.join(projectSkillsDir, entry),
+                        );
+                        if (manifest) {
+                            results.push({
+                                name: entry,
+                                version: manifest.version,
+                                agent,
+                                scope: 'project',
+                                isOutdated: manifest.version !== CLI_VERSION,
+                            });
+                        }
+                    });
+            } catch {
+                // Ignore read errors
+            }
         }
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1333,7 +1333,7 @@ program
 program
     .command('install-skills')
     .description(
-        'Installs Lightdash skills for AI coding assistants (Claude, Cursor, Codex)',
+        'Installs Lightdash skills for AI coding assistants (Claude, Cursor, Codex, Snowflake Cortex)',
     )
     .addHelpText(
         'after',
@@ -1365,23 +1365,35 @@ ${styles.bold('Examples:')}
   )} --source my-org/lightdash-fork ${styles.secondary(
       '-- installs skills from a custom GitHub repo',
   )}
+  ${styles.title('⚡')}️lightdash ${styles.bold(
+      'install-skills',
+  )} --agent cortex ${styles.secondary(
+      '-- installs skills for Snowflake Cortex',
+  )}
+  ${styles.title('⚡')}️lightdash ${styles.bold(
+      'install-skills',
+  )} --agent cortex --global ${styles.secondary(
+      '-- installs skills globally for Cortex (~/.snowflake/cortex/skills/)',
+  )}
 
 ${styles.bold('Installation paths:')}
   ${styles.secondary('Project-level (default):')}
     .claude/skills/    (Claude)
     .cursor/skills/    (Cursor)
     .codex/skills/     (Codex)
+    .cortex/skills/    (Cortex)
 
   ${styles.secondary('Global (--global):')}
-    ~/.claude/skills/  (Claude)
-    ~/.cursor/skills/  (Cursor)
-    ~/.codex/skills/   (Codex)
+    ~/.claude/skills/            (Claude)
+    ~/.cursor/skills/            (Cursor)
+    ~/.codex/skills/             (Codex)
+    ~/.snowflake/cortex/skills/  (Cortex)
 `,
     )
     .option('--verbose', 'Show detailed output', false)
     .addOption(
         new Option('--agent <agent>', 'Target agent for skill installation')
-            .choices(['claude', 'cursor', 'codex'])
+            .choices(['claude', 'cursor', 'codex', 'cortex'])
             .default('claude'),
     )
     .option(


### PR DESCRIPTION
Add cortex as a new agent type with custom path conventions:
- Project: .cortex/skills/
- Global: ~/.snowflake/cortex/skills/

https://claude.ai/code/session_012tJtwW4V8QJmARSu2JWzd8

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
