### PR TITLE
chore: migrate `MetricDashboardFilters` to legacy feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -347,9 +347,6 @@ export const lightdashConfigMock: LightdashConfig = {
             region: 'mock_region',
         },
     },
-    metricDashboardFilters: {
-        enabled: undefined,
-    },
     appRuntime: {
         enabled: false,
         lightdashOrigin: 'https://test.lightdash.cloud',

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -848,6 +848,7 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
             'ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED',
             'organization-warehouse-credentials',
         ],
+        ['METRIC_DASHBOARD_FILTERS_ENABLED', 'metric-dashboard-filters'],
     ])('legacy %s=true translates to enabledFeatureFlags', (envVar, flagId) => {
         process.env[envVar] = 'true';
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1254,9 +1254,6 @@ export type LightdashConfig = {
         duckdbQueryMemoryLimit: string | null;
         s3?: Omit<S3Config, 'expirationTime'>;
     };
-    metricDashboardFilters: {
-        enabled: boolean | undefined;
-    };
     appRuntime: AppRuntimeConfig;
     enabledFeatureFlags: Set<string>;
     disabledFeatureFlags: Set<string>;
@@ -1571,6 +1568,7 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
         'ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED',
         'organization-warehouse-credentials',
     ],
+    ['METRIC_DASHBOARD_FILTERS_ENABLED', 'metric-dashboard-filters'],
 ];
 
 const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
@@ -2298,11 +2296,6 @@ export const parseConfig = (): LightdashConfig => {
             duckdbQueryMemoryLimit:
                 process.env.PRE_AGGREGATE_DUCKDB_QUERY_MEMORY_LIMIT ?? null,
             s3: preAggregatesS3,
-        },
-        metricDashboardFilters: {
-            enabled: process.env.METRIC_DASHBOARD_FILTERS_ENABLED
-                ? process.env.METRIC_DASHBOARD_FILTERS_ENABLED === 'true'
-                : undefined,
         },
         appRuntime: parseAppRuntimeConfig(siteUrl),
         enabledFeatureFlags: new Set([

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -37,8 +37,6 @@ export class FeatureFlagModel {
         // Initialize the handlers for feature flag logic
         this.featureFlagHandlers = {
             [FeatureFlags.EditYamlInUi]: this.getEditYamlInUiEnabled.bind(this),
-            [FeatureFlags.MetricDashboardFilters]:
-                this.getMetricDashboardFiltersEnabled.bind(this),
             [FeatureFlags.EnableTimezoneSupport]:
                 this.getEnableTimezoneSupportEnabled.bind(this),
             [FeatureFlags.EnableDataApps]:
@@ -105,31 +103,6 @@ export class FeatureFlagModel {
         return {
             id: featureFlagId,
             enabled: this.lightdashConfig.editYamlInUi.enabled,
-        };
-    }
-
-    private async getMetricDashboardFiltersEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.metricDashboardFilters.enabled ??
-            (user
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.MetricDashboardFilters,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
         };
     }
 


### PR DESCRIPTION
Closes:

### Description:

Migrates the `MetricDashboardFilters` feature flag from a custom config-based handler to the unified legacy environment variable translation system (`LEGACY_ENABLE_ENV_VARS`). 

Previously, `METRIC_DASHBOARD_FILTERS_ENABLED` was parsed into a dedicated `metricDashboardFilters` config field, which was then used in a custom `FeatureFlagModel` handler that fell back to PostHog if the env var was not set. This has been replaced by adding `METRIC_DASHBOARD_FILTERS_ENABLED` → `metric-dashboard-filters` to the legacy env var translation list, aligning it with how other flags like `EMBEDDING_ENABLED` are handled. The dedicated config field and custom handler have been removed.