### PR TITLE
chore: migrate `AiDashboardSummary` feature flag to server flag

### DIFF
--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -27,7 +27,6 @@ import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
 import { LightdashConfig } from '../../../config/parseConfig';
 import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
-import { isFeatureFlagEnabled } from '../../../postHog';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
 import {
@@ -149,16 +148,13 @@ export class AiService {
         });
     }
 
-    private static async throwOnFeatureDisabled(user: SessionUser) {
-        const isAIDashboardSummaryEnabled = await isFeatureFlagEnabled(
-            'ai-dashboard-summary' as FeatureFlags,
+    private async throwOnFeatureDisabled(user: SessionUser) {
+        const { enabled } = await this.featureFlagService.get({
             user,
-            {
-                throwOnTimeout: true,
-            },
-        );
+            featureFlagId: FeatureFlags.AiDashboardSummary,
+        });
 
-        if (!isAIDashboardSummaryEnabled) {
+        if (!enabled) {
             throw new Error('AI Dashboard summary feature not enabled!');
         }
     }
@@ -315,7 +311,7 @@ export class AiService {
         dashboardUuid: string,
         opts: Pick<DashboardSummary, 'context' | 'tone' | 'audiences'>,
     ) {
-        await AiService.throwOnFeatureDisabled(user);
+        await this.throwOnFeatureDisabled(user);
         const startTime = new Date().getTime();
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
@@ -424,7 +420,7 @@ export class AiService {
         projectUuid: string,
         dashboardUuidOrSlug: string,
     ) {
-        await AiService.throwOnFeatureDisabled(user);
+        await this.throwOnFeatureDisabled(user);
 
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -109,6 +109,12 @@ export enum FeatureFlags {
      * is true. Disabled by default.
      */
     EnableDataApps = 'enable-data-apps',
+
+    /**
+     * Enable AI Dashboard Summary feature (generates summaries of dashboard
+     * contents using the AI Copilot).
+     */
+    AiDashboardSummary = 'ai-dashboard-summary',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -1,9 +1,9 @@
 import { subject } from '@casl/ability';
 import {
     ContentType,
+    FeatureFlags,
     ResourceViewItemType,
     type Dashboard,
-    type FeatureFlags,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -65,7 +65,7 @@ import {
     useVerifyDashboardMutation,
 } from '../../../hooks/useContentVerification';
 import { useProject } from '../../../hooks/useProject';
-import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -150,9 +150,11 @@ const DashboardHeader = memo(
             dashboardTiles,
             dashboardTabs,
         );
-        const isDashboardSummariesEnabled = useClientFeatureFlag(
-            'ai-dashboard-summary' as FeatureFlags,
+        const { data: aiDashboardSummaryFlag } = useServerFeatureFlag(
+            FeatureFlags.AiDashboardSummary,
         );
+        const isDashboardSummariesEnabled =
+            aiDashboardSummaryFlag?.enabled ?? false;
 
         const { search, pathname } = useLocation();
         const navigate = useNavigate();


### PR DESCRIPTION
Closes:

### Description:

Migrates the AI Dashboard Summary feature flag check from using the client-side `isFeatureFlagEnabled` / `useClientFeatureFlag` approach to the server-side `FeatureFlagService`. This ensures the feature flag is evaluated consistently through the standard service layer.

- Adds `AiDashboardSummary` as a named entry in the `FeatureFlags` enum, replacing the previously hardcoded `'ai-dashboard-summary'` string.
- Converts `throwOnFeatureDisabled` from a static method to an instance method so it can access `this.featureFlagService`.
- Updates the frontend `DashboardHeader` to use `useServerFeatureFlag` instead of `useClientFeatureFlag` when checking whether the AI Dashboard Summary feature is enabled.