### PR TITLE
fix: use package name instead of direct path for `ParameterError` import

### DIFF
--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -4,7 +4,7 @@ import type {
     AgentUpdateParams,
     BetaManagedAgentsAgent,
 } from '@anthropic-ai/sdk/resources/beta/agents';
-import { ParameterError } from '@lightdash/common/src';
+import { ParameterError } from '@lightdash/common';
 import type { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import {


### PR DESCRIPTION
Closes:

### Description:
Fixes the import path for `ParameterError` in `ManagedAgentClient.ts`, replacing the deep import `@lightdash/common/src` with the correct package root import `@lightdash/common`.