### PR TITLE
refactor(backend): migrate ProjectController from user to account

### DIFF
--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -16,6 +16,7 @@ import {
     OauthAccount,
     Organization,
     OssEmbed,
+    RegisteredAccount,
     ServiceAcctAccount,
     SessionAccount,
     SessionUser,
@@ -170,6 +171,21 @@ export const fromApiKey = (
         },
     });
 };
+
+/**
+ * Reconstruct a SessionUser from a RegisteredAccount without re-fetching from
+ * the database. Reuses the ability already built at request authentication
+ * time, so downstream code authorizes against the same set of rules the
+ * controller checked. Carries `requestContext` from the account so audit log
+ * entries written by downstream services keep IP/userAgent/requestId.
+ */
+export const toSessionUser = (account: RegisteredAccount): SessionUser => ({
+    ...account.user,
+    organizationUuid: account.organization.organizationUuid,
+    organizationName: account.organization.name,
+    organizationCreatedAt: account.organization.createdAt,
+    requestContext: account.requestContext,
+});
 
 export const fromSession = (
     sessionUser: SessionUser,

--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -172,19 +172,21 @@ export const fromApiKey = (
     });
 };
 
-/**
- * Reconstruct a SessionUser from a RegisteredAccount without re-fetching from
- * the database. Reuses the ability already built at request authentication
- * time, so downstream code authorizes against the same set of rules the
- * controller checked. Carries `requestContext` from the account so audit log
- * entries written by downstream services keep IP/userAgent/requestId.
- */
 export const toSessionUser = (account: RegisteredAccount): SessionUser => ({
     ...account.user,
     organizationUuid: account.organization.organizationUuid,
     organizationName: account.organization.name,
     organizationCreatedAt: account.organization.createdAt,
     requestContext: account.requestContext,
+    serviceAccount:
+        account.authentication.type === 'service-account'
+            ? {
+                  uuid: account.authentication.serviceAccountUuid,
+                  description: account.authentication.serviceAccountDescription,
+                  attributedUserEmail:
+                      account.authentication.attributedUserEmail,
+              }
+            : undefined,
 });
 
 export const fromSession = (

--- a/packages/backend/src/auth/account/index.ts
+++ b/packages/backend/src/auth/account/index.ts
@@ -1,2 +1,2 @@
-export { fromJwt, fromSession } from './account';
+export { fromJwt, fromSession, toSessionUser } from './account';
 export { requestContextFromExpress } from './requestContext';

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -18,7 +18,7 @@ import {
     ApiSqlChartAsCodeUpsertResponse,
     ApiSqlQueryResults,
     ApiSuccessEmpty,
-    AuthorizationError,
+    assertRegisteredAccount,
     CalculateTotalFromQuery,
     ChartAsCode,
     CreateProjectMember,
@@ -74,6 +74,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import type { DbTagUpdate } from '../database/entities/tags';
 import {
     allowApiKeyAuthentication,
@@ -99,11 +100,12 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiProjectResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getProject(projectUuid, req.account!),
+                .getProject(projectUuid, req.account),
         };
     }
 
@@ -122,11 +124,12 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiChartListResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getCharts(req.user!, projectUuid),
+                .getCharts(toSessionUser(req.account), projectUuid),
         };
     }
 
@@ -148,12 +151,13 @@ export class ProjectController extends BaseController {
         @Query() excludeChartsSavedInDashboard?: boolean,
     ): Promise<ApiChartSummaryListResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
                 .getChartSummaries(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     excludeChartsSavedInDashboard,
                 ),
@@ -174,15 +178,13 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSpaceSummaryListResponse> {
-        if (!req.user) {
-            throw new AuthorizationError('User session not found');
-        }
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getSpaces(req.user, projectUuid),
+                .getSpaces(toSessionUser(req.account), projectUuid),
         };
     }
 
@@ -201,9 +203,10 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiProjectAccessListResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const results = await this.services
             .getProjectService()
-            .getProjectAccess(req.user!, projectUuid);
+            .getProjectAccess(toSessionUser(req.account), projectUuid);
         return {
             status: 'ok',
             results,
@@ -229,9 +232,14 @@ export class ProjectController extends BaseController {
         @Path() userUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetProjectMemberResponse> {
+        assertRegisteredAccount(req.account);
         const results = await this.services
             .getProjectService()
-            .getProjectMemberAccess(req.user!, projectUuid, userUuid);
+            .getProjectMemberAccess(
+                toSessionUser(req.account),
+                projectUuid,
+                userUuid,
+            );
         this.setStatus(200);
         return {
             status: 'ok',
@@ -258,9 +266,10 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         await this.services
             .getProjectService()
-            .createProjectAccess(req.user!, projectUuid, body);
+            .createProjectAccess(toSessionUser(req.account), projectUuid, body);
         return {
             status: 'ok',
             results: undefined,
@@ -288,9 +297,15 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         await this.services
             .getProjectService()
-            .updateProjectAccess(req.user!, projectUuid, userUuid, body);
+            .updateProjectAccess(
+                toSessionUser(req.account),
+                projectUuid,
+                userUuid,
+                body,
+            );
         return {
             status: 'ok',
             results: undefined,
@@ -317,9 +332,14 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         await this.services
             .getProjectService()
-            .deleteProjectAccess(req.user!, projectUuid, userUuid);
+            .deleteProjectAccess(
+                toSessionUser(req.account),
+                projectUuid,
+                userUuid,
+            );
         return {
             status: 'ok',
             results: undefined,
@@ -339,9 +359,10 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiGetProjectGroupAccesses> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const results = await this.services
             .getProjectService()
-            .getProjectGroupAccesses(req.user!, projectUuid);
+            .getProjectGroupAccesses(toSessionUser(req.account), projectUuid);
         return {
             status: 'ok',
             results,
@@ -372,11 +393,12 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ApiSqlQueryResults }> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .runSqlQuery(req.user!, projectUuid, body.sql),
+                .runSqlQuery(toSessionUser(req.account), projectUuid, body.sql),
         };
     }
 
@@ -397,9 +419,10 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiCalculateTotalResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const totalResult = await this.services
             .getAsyncQueryService()
-            .calculateTotalFromQuery(req.account!, projectUuid, body);
+            .calculateTotalFromQuery(req.account, projectUuid, body);
         return {
             status: 'ok',
             results: totalResult,
@@ -420,9 +443,10 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiCalculateSubtotalsResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const subtotalsResult = await this.services
             .getAsyncQueryService()
-            .calculateSubtotalsFromQuery(req.account!, projectUuid, body);
+            .calculateSubtotalsFromQuery(req.account, projectUuid, body);
         return {
             status: 'ok',
             results: subtotalsResult,
@@ -443,9 +467,10 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: Record<string, DbtExposure> }> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const exposures = await this.services
             .getProjectService()
-            .getDbtExposures(req.user!, projectUuid);
+            .getDbtExposures(toSessionUser(req.account), projectUuid);
         return {
             status: 'ok',
             results: exposures,
@@ -468,11 +493,15 @@ export class ProjectController extends BaseController {
         results: UserWarehouseCredentials | undefined;
     }> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getProjectCredentialsPreference(req.user!, projectUuid),
+                .getProjectCredentialsPreference(
+                    toSessionUser(req.account),
+                    projectUuid,
+                ),
         };
     }
 
@@ -492,11 +521,15 @@ export class ProjectController extends BaseController {
         results: UserWarehouseCredentials[];
     }> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getProjectUserWarehouseCredentials(req.user!, projectUuid),
+                .getProjectUserWarehouseCredentials(
+                    toSessionUser(req.account),
+                    projectUuid,
+                ),
         };
     }
 
@@ -514,10 +547,11 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         await this.services
             .getProjectService()
             .upsertProjectCredentialsPreference(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 userWarehouseCredentialsUuid,
             );
@@ -550,11 +584,12 @@ export class ProjectController extends BaseController {
         }[];
     }> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getCustomMetrics(req.user!, projectUuid),
+                .getCustomMetrics(toSessionUser(req.account), projectUuid),
         };
     }
 
@@ -577,9 +612,10 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         await this.services
             .getProjectService()
-            .updateMetadata(req.user!, projectUuid, body);
+            .updateMetadata(toSessionUser(req.account), projectUuid, body);
         return {
             status: 'ok',
             results: undefined,
@@ -605,9 +641,14 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         await this.services
             .getProjectService()
-            .updateDefaultUserSpaces(req.user!, projectUuid, body);
+            .updateDefaultUserSpaces(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
+            );
         return {
             status: 'ok',
             results: undefined,
@@ -627,6 +668,7 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiGetDashboardsResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
 
         const chartUuid: string | undefined =
             typeof req.query.chartUuid === 'string'
@@ -637,7 +679,12 @@ export class ProjectController extends BaseController {
 
         const results = await this.services
             .getDashboardService()
-            .getAllByProject(req.user!, projectUuid, chartUuid, includePrivate);
+            .getAllByProject(
+                toSessionUser(req.account),
+                projectUuid,
+                chartUuid,
+                includePrivate,
+            );
 
         return {
             status: 'ok',
@@ -665,6 +712,7 @@ export class ProjectController extends BaseController {
     ): Promise<ApiCreateDashboardResponse> {
         const dashboardService = this.services.getDashboardService();
         this.setStatus(201);
+        assertRegisteredAccount(req.account);
 
         let results: ApiCreateDashboardResponse['results'];
 
@@ -676,7 +724,7 @@ export class ProjectController extends BaseController {
             }
 
             results = await dashboardService.duplicate(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 duplicateFrom.toString(),
                 body,
@@ -689,7 +737,7 @@ export class ProjectController extends BaseController {
             }
 
             results = await dashboardService.create(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 body,
             );
@@ -720,9 +768,10 @@ export class ProjectController extends BaseController {
     ): Promise<ApiCreateDashboardWithChartsResponse> {
         const dashboardService = this.services.getDashboardService();
         this.setStatus(201);
+        assertRegisteredAccount(req.account);
 
         const results = await dashboardService.createDashboardWithCharts(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             body,
         );
@@ -751,10 +800,11 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiUpdateDashboardsResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
 
         const results = await this.services
             .getDashboardService()
-            .updateMultiple(req.user!, projectUuid, body);
+            .updateMultiple(toSessionUser(req.account), projectUuid, body);
 
         return {
             status: 'ok',
@@ -790,10 +840,16 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ApiCreatePreviewResults }> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
 
         const results = await this.services
             .getProjectService()
-            .createPreview(req.user!, projectUuid, body, RequestMethod.WEB_APP);
+            .createPreview(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
+                RequestMethod.WEB_APP,
+            );
 
         return {
             status: 'ok',
@@ -819,16 +875,17 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
 
         const { schedulerTimezone: oldDefaultProjectTimezone } =
             await this.services
                 .getProjectService()
-                .getProject(projectUuid, req.account!);
+                .getProject(projectUuid, req.account);
 
         await this.services
             .getProjectService()
             .updateDefaultSchedulerTimezone(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 body.schedulerTimezone,
             );
@@ -836,16 +893,20 @@ export class ProjectController extends BaseController {
         try {
             await this.services
                 .getSchedulerService()
-                .updateSchedulersWithDefaultTimezone(req.user!, projectUuid, {
-                    oldDefaultProjectTimezone,
-                    newDefaultProjectTimezone: body.schedulerTimezone,
-                });
+                .updateSchedulersWithDefaultTimezone(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    {
+                        oldDefaultProjectTimezone,
+                        newDefaultProjectTimezone: body.schedulerTimezone,
+                    },
+                );
         } catch (e) {
             // reset the old timezone when it fails to set the hours
             await this.services
                 .getProjectService()
                 .updateDefaultSchedulerTimezone(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     oldDefaultProjectTimezone,
                 );
@@ -877,10 +938,15 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
 
         await this.services
             .getProjectService()
-            .updateQueryTimezone(req.user!, projectUuid, body.queryTimezone);
+            .updateQueryTimezone(
+                toSessionUser(req.account),
+                projectUuid,
+                body.queryTimezone,
+            );
 
         return {
             status: 'ok',
@@ -905,9 +971,10 @@ export class ProjectController extends BaseController {
         @Body() body: Pick<Tag, 'name' | 'color'>,
         @Request() req: express.Request,
     ): Promise<ApiCreateTagResponse> {
+        assertRegisteredAccount(req.account);
         const { tagUuid } = await this.services
             .getProjectService()
-            .createTag(req.user!, {
+            .createTag(toSessionUser(req.account), {
                 ...body,
                 projectUuid,
             });
@@ -936,7 +1003,10 @@ export class ProjectController extends BaseController {
         @Path() tagUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        await this.services.getProjectService().deleteTag(req.user!, tagUuid);
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getProjectService()
+            .deleteTag(toSessionUser(req.account), tagUuid);
 
         this.setStatus(200);
 
@@ -963,9 +1033,10 @@ export class ProjectController extends BaseController {
         @Body() body: DbTagUpdate,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getProjectService()
-            .updateTag(req.user!, tagUuid, body);
+            .updateTag(toSessionUser(req.account), tagUuid, body);
 
         this.setStatus(200);
 
@@ -991,9 +1062,10 @@ export class ProjectController extends BaseController {
         })[],
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getProjectService()
-            .replaceYamlTags(req.user!, projectUuid, body);
+            .replaceYamlTags(toSessionUser(req.account), projectUuid, body);
 
         return {
             status: 'ok',
@@ -1018,10 +1090,11 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiGetTagsResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
 
         const results = await this.services
             .getProjectService()
-            .getTags(req.user!, projectUuid);
+            .getTags(toSessionUser(req.account), projectUuid);
 
         return {
             status: 'ok',
@@ -1045,11 +1118,18 @@ export class ProjectController extends BaseController {
         @Query() languageMap?: boolean,
     ): Promise<ApiChartAsCodeListResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getCoderService()
-                .getCharts(req.user!, projectUuid, ids, offset, languageMap),
+                .getCharts(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    ids,
+                    offset,
+                    languageMap,
+                ),
         };
     }
 
@@ -1069,12 +1149,13 @@ export class ProjectController extends BaseController {
         @Query() languageMap?: boolean,
     ): Promise<ApiDashboardAsCodeListResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getCoderService()
                 .getDashboards(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     ids,
                     offset,
@@ -1106,10 +1187,11 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiChartAsCodeUpsertResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services.getCoderService().upsertChart(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 slug,
                 {
@@ -1139,11 +1221,17 @@ export class ProjectController extends BaseController {
         @Query() offset?: number,
     ): Promise<ApiSqlChartAsCodeListResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getCoderService()
-                .getSqlCharts(req.user!, projectUuid, ids, offset),
+                .getSqlCharts(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    ids,
+                    offset,
+                ),
         };
     }
 
@@ -1170,10 +1258,11 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSqlChartAsCodeUpsertResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services.getCoderService().upsertSqlChart(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 slug,
                 {
@@ -1211,10 +1300,11 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiDashboardAsCodeUpsertResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services.getCoderService().upsertDashboard(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 slug,
                 {
@@ -1276,12 +1366,17 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccess<ApiRefreshResults>> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         const context = getRequestMethod(
             req.header(LightdashRequestMethodHeader),
         );
         const results = await this.services
             .getProjectService()
-            .scheduleCompileProject(req.user!, projectUuid, context);
+            .scheduleCompileProject(
+                toSessionUser(req.account),
+                projectUuid,
+                context,
+            );
         return {
             status: 'ok',
             results,
@@ -1305,11 +1400,12 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccess<{ jobIds: string[] }>> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .refreshPreAggregates(req.user!, projectUuid),
+                .refreshPreAggregates(toSessionUser(req.account), projectUuid),
         };
     }
 
@@ -1333,12 +1429,13 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccess<{ jobIds: string[] }>> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
                 .refreshPreAggregateByDefinitionName(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     preAggregateDefinitionName,
                 ),
@@ -1358,11 +1455,12 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiVerifiedContentListResponse> {
         this.setStatus(200);
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getContentVerificationService()
-                .listVerifiedContent(req.user!, projectUuid),
+                .listVerifiedContent(toSessionUser(req.account), projectUuid),
         };
     }
 }

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -707,8 +707,8 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
         @Query() duplicateFrom?: string,
     ): Promise<ApiCreateDashboardResponse> {
-        const dashboardService = this.services.getDashboardService();
         assertRegisteredAccount(req.account);
+        const dashboardService = this.services.getDashboardService();
         this.setStatus(201);
 
         let results: ApiCreateDashboardResponse['results'];
@@ -763,8 +763,8 @@ export class ProjectController extends BaseController {
         @Body() body: CreateDashboardWithCharts,
         @Request() req: express.Request,
     ): Promise<ApiCreateDashboardWithChartsResponse> {
-        const dashboardService = this.services.getDashboardService();
         assertRegisteredAccount(req.account);
+        const dashboardService = this.services.getDashboardService();
         this.setStatus(201);
 
         const results = await dashboardService.createDashboardWithCharts(

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -100,12 +100,11 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiProjectResponse> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getProject(projectUuid, req.account),
+                .getProject(projectUuid, req.account!),
         };
     }
 
@@ -123,8 +122,8 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiChartListResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -150,8 +149,8 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
         @Query() excludeChartsSavedInDashboard?: boolean,
     ): Promise<ApiChartSummaryListResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -202,8 +201,8 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiProjectAccessListResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         const results = await this.services
             .getProjectService()
             .getProjectAccess(toSessionUser(req.account), projectUuid);
@@ -265,8 +264,8 @@ export class ProjectController extends BaseController {
         @Body() body: CreateProjectMember,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         await this.services
             .getProjectService()
             .createProjectAccess(toSessionUser(req.account), projectUuid, body);
@@ -296,8 +295,8 @@ export class ProjectController extends BaseController {
         @Body() body: UpdateProjectMember,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         await this.services
             .getProjectService()
             .updateProjectAccess(
@@ -331,8 +330,8 @@ export class ProjectController extends BaseController {
         @Path() userUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         await this.services
             .getProjectService()
             .deleteProjectAccess(
@@ -358,8 +357,8 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetProjectGroupAccesses> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         const results = await this.services
             .getProjectService()
             .getProjectGroupAccesses(toSessionUser(req.account), projectUuid);
@@ -392,8 +391,8 @@ export class ProjectController extends BaseController {
         @Body() body: { sql: string },
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ApiSqlQueryResults }> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -419,10 +418,9 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiCalculateTotalResponse> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         const totalResult = await this.services
             .getAsyncQueryService()
-            .calculateTotalFromQuery(req.account, projectUuid, body);
+            .calculateTotalFromQuery(req.account!, projectUuid, body);
         return {
             status: 'ok',
             results: totalResult,
@@ -443,10 +441,9 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiCalculateSubtotalsResponse> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         const subtotalsResult = await this.services
             .getAsyncQueryService()
-            .calculateSubtotalsFromQuery(req.account, projectUuid, body);
+            .calculateSubtotalsFromQuery(req.account!, projectUuid, body);
         return {
             status: 'ok',
             results: subtotalsResult,
@@ -466,8 +463,8 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: Record<string, DbtExposure> }> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         const exposures = await this.services
             .getProjectService()
             .getDbtExposures(toSessionUser(req.account), projectUuid);
@@ -492,8 +489,8 @@ export class ProjectController extends BaseController {
         status: 'ok';
         results: UserWarehouseCredentials | undefined;
     }> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -520,8 +517,8 @@ export class ProjectController extends BaseController {
         status: 'ok';
         results: UserWarehouseCredentials[];
     }> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -546,8 +543,8 @@ export class ProjectController extends BaseController {
         @Path() userWarehouseCredentialsUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         await this.services
             .getProjectService()
             .upsertProjectCredentialsPreference(
@@ -583,8 +580,8 @@ export class ProjectController extends BaseController {
             chartUrl: string;
         }[];
     }> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -611,8 +608,8 @@ export class ProjectController extends BaseController {
         @Body() body: UpdateMetadata,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         await this.services
             .getProjectService()
             .updateMetadata(toSessionUser(req.account), projectUuid, body);
@@ -640,8 +637,8 @@ export class ProjectController extends BaseController {
         @Body() body: UpdateDefaultUserSpaces,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         await this.services
             .getProjectService()
             .updateDefaultUserSpaces(
@@ -667,8 +664,8 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetDashboardsResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
 
         const chartUuid: string | undefined =
             typeof req.query.chartUuid === 'string'
@@ -711,8 +708,8 @@ export class ProjectController extends BaseController {
         @Query() duplicateFrom?: string,
     ): Promise<ApiCreateDashboardResponse> {
         const dashboardService = this.services.getDashboardService();
-        this.setStatus(201);
         assertRegisteredAccount(req.account);
+        this.setStatus(201);
 
         let results: ApiCreateDashboardResponse['results'];
 
@@ -767,8 +764,8 @@ export class ProjectController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiCreateDashboardWithChartsResponse> {
         const dashboardService = this.services.getDashboardService();
-        this.setStatus(201);
         assertRegisteredAccount(req.account);
+        this.setStatus(201);
 
         const results = await dashboardService.createDashboardWithCharts(
             toSessionUser(req.account),
@@ -799,8 +796,8 @@ export class ProjectController extends BaseController {
         @Body() body: UpdateMultipleDashboards[],
         @Request() req: express.Request,
     ): Promise<ApiUpdateDashboardsResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
 
         const results = await this.services
             .getDashboardService()
@@ -839,8 +836,8 @@ export class ProjectController extends BaseController {
         },
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ApiCreatePreviewResults }> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
 
         const results = await this.services
             .getProjectService()
@@ -874,8 +871,8 @@ export class ProjectController extends BaseController {
         @Body() body: UpdateSchedulerSettings,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
 
         const { schedulerTimezone: oldDefaultProjectTimezone } =
             await this.services
@@ -937,8 +934,8 @@ export class ProjectController extends BaseController {
         @Body() body: UpdateQueryTimezoneSettings,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
 
         await this.services
             .getProjectService()
@@ -1089,8 +1086,8 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetTagsResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
 
         const results = await this.services
             .getProjectService()
@@ -1117,8 +1114,8 @@ export class ProjectController extends BaseController {
         @Query() offset?: number,
         @Query() languageMap?: boolean,
     ): Promise<ApiChartAsCodeListResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -1148,8 +1145,8 @@ export class ProjectController extends BaseController {
         @Query() offset?: number,
         @Query() languageMap?: boolean,
     ): Promise<ApiDashboardAsCodeListResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -1186,8 +1183,8 @@ export class ProjectController extends BaseController {
         },
         @Request() req: express.Request,
     ): Promise<ApiChartAsCodeUpsertResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services.getCoderService().upsertChart(
@@ -1220,8 +1217,8 @@ export class ProjectController extends BaseController {
         @Query() ids?: string[],
         @Query() offset?: number,
     ): Promise<ApiSqlChartAsCodeListResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -1257,8 +1254,8 @@ export class ProjectController extends BaseController {
         },
         @Request() req: express.Request,
     ): Promise<ApiSqlChartAsCodeUpsertResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services.getCoderService().upsertSqlChart(
@@ -1299,8 +1296,8 @@ export class ProjectController extends BaseController {
         }, // Simplify filter type for tsoa
         @Request() req: express.Request,
     ): Promise<ApiDashboardAsCodeUpsertResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services.getCoderService().upsertDashboard(
@@ -1365,8 +1362,8 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccess<ApiRefreshResults>> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         const context = getRequestMethod(
             req.header(LightdashRequestMethodHeader),
         );
@@ -1399,8 +1396,8 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccess<{ jobIds: string[] }>> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -1428,8 +1425,8 @@ export class ProjectController extends BaseController {
         @Path() preAggregateDefinitionName: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccess<{ jobIds: string[] }>> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
@@ -1454,8 +1451,8 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiVerifiedContentListResponse> {
-        this.setStatus(200);
         assertRegisteredAccount(req.account);
+        this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services


### PR DESCRIPTION
## Summary

- Adds `toSessionUser(account)` helper in `auth/account` so service code can derive a `SessionUser` from a `RegisteredAccount` without re-fetching from the database.
- Replaces six `userModel.findSessionUserByUUID(account.user.userUuid)` calls with the helper in `CoderService` (`upsertChart` / `upsertSqlChart` / `upsertDashboard`), `DashboardService` (`duplicate` / `createDashboardWithCharts`), and `ProjectService.createPreview`. Removes the now-unused `userModel` injection on `CoderService` and `DashboardService`.
- Fixes the inconsistency in `createPreview` where `createWithoutCompile` was called with a rehydrated `SessionUser` while `scheduleCompileProject` was called with `account` — both now derive from the single `account` argument.

## Why

The previous SPK-424 pattern rebuilt the user — and therefore the CASL `ability` — from the database mid-request, after the controller had already authorized using `account.user.ability`. That introduces a TOCTOU between the two ability sets and adds an extra DB roundtrip per write, which multiplies on bulk content-as-code uploads. `account.user` is a `LightdashSessionUser` and already carries `userUuid`, `firstName`, `lastName`, and the `ability` built at authentication time — reattaching the org fields produces a `SessionUser`-shaped value for downstream consumers without another DB hit.

## Test plan

- [x] \`pnpm -F backend typecheck\`
- [x] \`pnpm -F backend test\` for the touched services (115 tests pass)
- [ ] Smoke \`lightdash upload\` against a project with multiple charts and dashboards
- [ ] Smoke project preview creation