### PR TITLE
feat(data-apps): click-to-edit element inspector

### DIFF
--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -1,9 +1,28 @@
-import { useRef, type FC } from 'react';
-import { useAppSdkBridge, type QueryEvent } from './hooks/useAppSdkBridge';
+import { useCallback, useEffect, useRef, type FC } from 'react';
+import {
+    useAppSdkBridge,
+    type ElementSelectedEvent,
+    type QueryEvent,
+} from './hooks/useAppSdkBridge';
 
 type Props = {
     src: string;
     onQueryEvent?: (event: QueryEvent) => void;
+    onElementSelected?: (event: ElementSelectedEvent) => void;
+    /** When true, the iframe-side inspector overlay is active and clicks
+     *  are intercepted to produce element-selected events. */
+    inspectorEnabled?: boolean;
+    /** Called whenever the iframe SDK announces (or fails to announce) the
+     *  inspector capability. Stays `false` until the SDK posts
+     *  `lightdash:inspect:available`, so older sandboxes (resumed with a
+     *  pre-inspector SDK) keep this `false` and let the parent hide the
+     *  Inspect button. Resets to `false` on every iframe `src` change. */
+    onInspectorAvailabilityChange?: (available: boolean) => void;
+    /** Called when the user presses Esc to leave inspect mode. The handler
+     *  lives on the parent's window because that's where focus actually
+     *  sits during inspect mode (the toolbar button before any click; the
+     *  prompt editor after each click — TipTap yanks focus back on insert). */
+    onInspectorCancelled?: () => void;
 };
 
 /**
@@ -17,9 +36,64 @@ type Props = {
  * API calls through postMessage, and this component's bridge executes them
  * using the current user's session.
  */
-const AppIframePreview: FC<Props> = ({ src, onQueryEvent }) => {
+const AppIframePreview: FC<Props> = ({
+    src,
+    onQueryEvent,
+    onElementSelected,
+    inspectorEnabled,
+    onInspectorAvailabilityChange,
+    onInspectorCancelled,
+}) => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
-    const { handleIframeLoad } = useAppSdkBridge(iframeRef, onQueryEvent);
+    // Memoized so the bridge's message listener doesn't re-attach on every
+    // parent render — AppGenerate re-renders on every keystroke (editor's
+    // `onUpdate` → `setIsPromptEmpty`) and we don't want to thrash listeners.
+    const handleAnnounce = useCallback(() => {
+        onInspectorAvailabilityChange?.(true);
+    }, [onInspectorAvailabilityChange]);
+    const { handleIframeLoad, enableInspector, disableInspector } =
+        useAppSdkBridge(
+            iframeRef,
+            onQueryEvent,
+            onElementSelected,
+            handleAnnounce,
+        );
+
+    // Reset availability to false on every iframe URL change. This fires
+    // before the browser starts loading the new content, so the new SDK's
+    // `available` announce will flip it back to true if it's wired up. Old
+    // SDKs in resumed sandboxes never announce, so it stays false.
+    useEffect(() => {
+        onInspectorAvailabilityChange?.(false);
+    }, [src, onInspectorAvailabilityChange]);
+
+    // Toggling the prop while the iframe is alive — push the change through.
+    useEffect(() => {
+        if (inspectorEnabled) enableInspector();
+        else disableInspector();
+    }, [inspectorEnabled, enableInspector, disableInspector]);
+
+    // Esc-to-cancel. Lives on the parent's window because focus is on the
+    // parent (the toolbar button before any click; the editor afterwards) —
+    // the iframe never holds focus during inspect mode, so an iframe-side
+    // keydown listener would never fire.
+    useEffect(() => {
+        if (!inspectorEnabled) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onInspectorCancelled?.();
+            }
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [inspectorEnabled, onInspectorCancelled]);
+
+    // The iframe reloads on every new app version. The useEffect above won't
+    // re-fire if `inspectorEnabled` was already true, so re-sync on load.
+    const handleLoad = () => {
+        handleIframeLoad();
+        if (inspectorEnabled) enableInspector();
+    };
 
     return (
         <iframe
@@ -29,7 +103,7 @@ const AppIframePreview: FC<Props> = ({ src, onQueryEvent }) => {
             title="App preview"
             sandbox="allow-scripts allow-modals"
             allow=""
-            onLoad={handleIframeLoad}
+            onLoad={handleLoad}
         />
     );
 };

--- a/packages/frontend/src/features/apps/AppPromptEditor.module.css
+++ b/packages/frontend/src/features/apps/AppPromptEditor.module.css
@@ -1,0 +1,68 @@
+/* AppPromptEditor — TipTap-based replacement for the data-app prompt
+ * textarea. Mention nodes (element refs from the iframe inspector) render
+ * as inline pills; everything else is plain text. */
+
+.editorContent {
+    min-height: 24px;
+    max-height: 144px;
+    overflow-y: auto;
+    font-size: var(--mantine-font-size-sm);
+    padding: 0;
+
+    /* TipTap wraps content in <p> — strip its default margins so the editor
+     * matches the old textarea's vertical rhythm. */
+    & :global(.ProseMirror) {
+        outline: none;
+        min-height: 24px;
+    }
+    & :global(.ProseMirror p) {
+        margin: 0;
+        padding: 0;
+        line-height: 1.4;
+    }
+
+    /* Placeholder shown when the editor is empty. */
+    & :global(p.is-empty.is-editor-empty:first-child::before) {
+        content: attr(data-placeholder);
+        float: left;
+        height: 0;
+        pointer-events: none;
+        @mixin light {
+            color: var(--mantine-color-ldGray-6);
+        }
+        @mixin dark {
+            color: var(--mantine-color-ldDark-2);
+        }
+    }
+}
+
+/* Pill shown both inside the editor (mention node) and inside the chat
+ * bubble (parsed reference). Same class in both contexts so input and
+ * post-submit display look identical. Styled as a neutral gray "chip" —
+ * visible but quiet, won't compete with the user's prose. */
+.elementPill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 1px 6px;
+    margin: 0 1px;
+    border-radius: var(--mantine-radius-sm);
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    line-height: 1.4;
+    vertical-align: baseline;
+    white-space: nowrap;
+    max-width: 280px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--mantine-color-foreground-0);
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+        border: 1px solid var(--mantine-color-ldGray-3);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-4);
+        border: 1px solid var(--mantine-color-ldDark-5);
+    }
+}

--- a/packages/frontend/src/features/apps/AppPromptEditor.tsx
+++ b/packages/frontend/src/features/apps/AppPromptEditor.tsx
@@ -1,0 +1,288 @@
+/**
+ * AppPromptEditor — TipTap-based replacement for the data-app prompt
+ * textarea. Element references from the iframe inspector are inserted as
+ * mention nodes that render as inline pills (visually clean) but serialize
+ * back to the bracketed wire format on submit so Claude receives the same
+ * `[h1 "FORMULA 1" @src/App.jsx:14]: …` text as before.
+ *
+ * Modeled on `AiPromptEditor.tsx` from the AI table calculation feature —
+ * same Mention.extend() pattern with split renderText/renderHTML.
+ */
+
+import Mention from '@tiptap/extension-mention';
+import Placeholder from '@tiptap/extension-placeholder';
+import {
+    EditorContent,
+    useEditor,
+    type Editor,
+    type JSONContent,
+} from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import {
+    forwardRef,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+    type ClipboardEvent as ReactClipboardEvent,
+} from 'react';
+import classes from './AppPromptEditor.module.css';
+
+export type ElementRef = {
+    /** Rendered HTML tag (e.g. `h1`, `div`, `button`). */
+    tag: string;
+    /** Visible text content of the clicked element, possibly truncated. */
+    text: string;
+    /** Build-time source location `path:line`. Empty when unavailable. */
+    loc: string;
+};
+
+export type AppPromptEditorHandle = {
+    insertElementRef: (ref: ElementRef) => void;
+    clear: () => void;
+    focus: () => void;
+    getText: () => string;
+};
+
+type Props = {
+    placeholder?: string;
+    autoFocus?: boolean;
+    disabled?: boolean;
+    /** Called after every content change with whether the editor is empty —
+     *  the parent uses this to enable/disable the submit button. */
+    onEmptyChange?: (isEmpty: boolean) => void;
+    /** Submit triggered by Enter (without Shift). The text is the wire-
+     *  format string that mention nodes serialize to. */
+    onSubmit?: (text: string) => void;
+    /** Forwarded paste events — used by the parent to detect image paste. */
+    onPaste?: (e: ReactClipboardEvent) => void;
+};
+
+/** Wire-format string a mention node serializes to. Mirrors the bracket
+ *  format the iframe inspector and skill.md already use. */
+function refToWireString({ tag, text, loc }: ElementRef): string {
+    const head = text ? `${tag} "${text}"` : tag;
+    return loc ? `[${head} @${loc}]` : `[${head}]`;
+}
+
+function pillInner(tag: string, text: string): string {
+    return text ? `<${tag}> ${text}` : `<${tag}>`;
+}
+
+const ElementMention = Mention.extend({
+    name: 'elementRef',
+    // Pills behave as a single character — backspace deletes the whole pill.
+    atom: true,
+    addAttributes() {
+        return {
+            tag: {
+                default: '',
+                parseHTML: (el) => el.getAttribute('data-tag') ?? '',
+                renderHTML: (attrs) =>
+                    attrs.tag ? { 'data-tag': attrs.tag } : {},
+            },
+            text: {
+                default: '',
+                parseHTML: (el) => el.getAttribute('data-text') ?? '',
+                renderHTML: (attrs) =>
+                    attrs.text ? { 'data-text': attrs.text } : {},
+            },
+            loc: {
+                default: '',
+                parseHTML: (el) => el.getAttribute('data-loc') ?? '',
+                renderHTML: (attrs) =>
+                    attrs.loc ? { 'data-loc': attrs.loc } : {},
+            },
+        };
+    },
+    // The base Mention extension's Backspace handler replaces the pill
+    // with its suggestion char (`@`) — useful for re-triggering an
+    // autocomplete, but we don't have one. Override to fully delete the
+    // pill in one keystroke.
+    addKeyboardShortcuts() {
+        return {
+            Backspace: () =>
+                this.editor.commands.command(({ tr, state }) => {
+                    const { selection } = state;
+                    const { empty, anchor } = selection;
+                    if (!empty || anchor <= 0) return false;
+                    let deleted = false;
+                    state.doc.nodesBetween(
+                        Math.max(0, anchor - 1),
+                        anchor,
+                        (node, pos) => {
+                            if (node.type.name === this.name) {
+                                tr.delete(pos, pos + node.nodeSize);
+                                deleted = true;
+                                return false;
+                            }
+                        },
+                    );
+                    return deleted;
+                }),
+        };
+    },
+    // Explicit NodeView so the contenteditable surface gets the pill DOM
+    // we actually want. The CSS-module class wasn't reliably landing through
+    // renderHTML — building the element ourselves removes the indirection.
+    addNodeView() {
+        return ({ node }) => {
+            const dom = document.createElement('span');
+            dom.className = classes.elementPill;
+            dom.contentEditable = 'false';
+            dom.textContent = pillInner(
+                (node.attrs.tag as string) || '',
+                (node.attrs.text as string) || '',
+            );
+            if (node.attrs.tag) {
+                dom.setAttribute('data-tag', node.attrs.tag as string);
+            }
+            if (node.attrs.text) {
+                dom.setAttribute('data-text', node.attrs.text as string);
+            }
+            if (node.attrs.loc) {
+                dom.setAttribute('data-loc', node.attrs.loc as string);
+                dom.setAttribute('title', `Source: ${node.attrs.loc}`);
+            }
+            return { dom };
+        };
+    },
+}).configure({
+    // What `editor.getText()` returns for this node — the wire format Claude
+    // sees in the iteration prompt.
+    renderText: ({ node }) =>
+        refToWireString({
+            tag: node.attrs.tag ?? '',
+            text: node.attrs.text ?? '',
+            loc: node.attrs.loc ?? '',
+        }),
+    // Used for getHTML()/copy/paste — match the NodeView output so a copy
+    // out of the editor produces the same span structure.
+    renderHTML: ({ node }) => [
+        'span',
+        { class: classes.elementPill, contenteditable: 'false' },
+        pillInner(
+            (node.attrs.tag as string) || '',
+            (node.attrs.text as string) || '',
+        ),
+    ],
+});
+
+const AppPromptEditor = forwardRef<AppPromptEditorHandle, Props>(
+    function AppPromptEditor(
+        { placeholder, autoFocus, disabled, onEmptyChange, onSubmit, onPaste },
+        ref,
+    ) {
+        // Refs so the editor's stable handlers (configured once at editor
+        // mount) always reach the latest callback closures.
+        const onSubmitRef = useRef(onSubmit);
+        onSubmitRef.current = onSubmit;
+        const onPasteRef = useRef(onPaste);
+        onPasteRef.current = onPaste;
+        const editorRef = useRef<Editor | null>(null);
+
+        const editor = useEditor({
+            extensions: [
+                StarterKit.configure({
+                    // Single-paragraph behaviour like a textarea — disable
+                    // every block-level node we don't need.
+                    heading: false,
+                    bulletList: false,
+                    orderedList: false,
+                    blockquote: false,
+                    codeBlock: false,
+                    horizontalRule: false,
+                    code: false,
+                }),
+                ElementMention,
+                Placeholder.configure({ placeholder: placeholder ?? '' }),
+            ],
+            editable: !disabled,
+            autofocus: autoFocus ?? false,
+            onUpdate: ({ editor: e }) => {
+                onEmptyChange?.(e.isEmpty);
+            },
+            editorProps: {
+                handleKeyDown: (_, event) => {
+                    if (event.key === 'Enter' && !event.shiftKey) {
+                        const text = editorRef.current?.getText() ?? '';
+                        const submit = onSubmitRef.current;
+                        if (text.trim() && submit) {
+                            event.preventDefault();
+                            submit(text);
+                            return true;
+                        }
+                    }
+                    return false;
+                },
+                handleDOMEvents: {
+                    paste(_view, event) {
+                        onPasteRef.current?.(
+                            event as unknown as ReactClipboardEvent,
+                        );
+                        // Don't claim the event — TipTap should still handle
+                        // text paste normally.
+                        return false;
+                    },
+                },
+            },
+        });
+
+        editorRef.current = editor;
+
+        useEffect(() => {
+            editor?.setEditable(!disabled);
+        }, [editor, disabled]);
+
+        useImperativeHandle(
+            ref,
+            () => ({
+                insertElementRef: (elementRef) => {
+                    if (!editor) return;
+                    // Each clicked element starts on its own line so multiple
+                    // refs stack into a list — same UX as the textarea
+                    // implementation. Skip the leading break when the
+                    // cursor is at the start of the document or right after
+                    // a line break.
+                    const { from } = editor.state.selection;
+                    const before = editor.state.doc.textBetween(
+                        0,
+                        from,
+                        '\n',
+                        '\n',
+                    );
+                    const needsBreak =
+                        before.length > 0 && !before.endsWith('\n');
+                    const inserts: JSONContent[] = [];
+                    if (needsBreak) inserts.push({ type: 'hardBreak' });
+                    inserts.push({
+                        type: 'elementRef',
+                        attrs: {
+                            tag: elementRef.tag,
+                            text: elementRef.text,
+                            loc: elementRef.loc,
+                        },
+                    });
+                    // Single space after the pill so typed text doesn't slam
+                    // against it. The pill itself is the visual delimiter
+                    // between "what" and "what to do" — no colon needed.
+                    inserts.push({ type: 'text', text: ' ' });
+                    editor.chain().focus().insertContent(inserts).run();
+                },
+                clear: () => {
+                    editor?.commands.clearContent();
+                },
+                focus: () => {
+                    editor?.commands.focus('end');
+                },
+                getText: () => editor?.getText({ blockSeparator: '\n' }) ?? '',
+            }),
+            [editor],
+        );
+
+        return (
+            <EditorContent editor={editor} className={classes.editorContent} />
+        );
+    },
+);
+
+export default AppPromptEditor;

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
+    IconClick,
     IconDatabase,
     IconDatabaseOff,
     IconLayoutDashboard,
@@ -71,6 +72,32 @@ export const ImageButton: FC<{
         className={classes.resourceButton}
     >
         Images
+    </Button>
+);
+
+/**
+ * Toggle button that activates the iframe-side element inspector.
+ * While enabled, clicks inside the preview iframe are intercepted and
+ * inserted as bracketed references at the textarea cursor (e.g.
+ * `[button "Total Revenue"]: `), so the user can compose targeted edits.
+ *
+ * The caller is expected to render this only when an inspector-capable
+ * preview is mounted (i.e. gate on `inspectorAvailable`), so no `disabled`
+ * prop is needed.
+ */
+export const InspectButton: FC<{
+    enabled: boolean;
+    onToggle: () => void;
+}> = ({ enabled, onToggle }) => (
+    <Button
+        variant={enabled ? 'filled' : 'default'}
+        color={enabled ? 'violet' : undefined}
+        size="xs"
+        leftSection={<MantineIcon icon={IconClick} size={14} />}
+        onClick={onToggle}
+        className={classes.resourceButton}
+    >
+        Inspect
     </Button>
 );
 

--- a/packages/frontend/src/features/apps/ChatMessageContent.tsx
+++ b/packages/frontend/src/features/apps/ChatMessageContent.tsx
@@ -1,0 +1,90 @@
+/**
+ * Renders a user chat message, parsing bracketed element references
+ * (`[h1 "FORMULA 1" @src/App.jsx:14]`) and showing them as inline pills
+ * with the same styling as the input editor's mention pills. Anything
+ * outside a reference renders as plain text, with newlines preserved.
+ *
+ * Used in the data-app chat history so post-submit messages match the
+ * pre-submit input editor visually.
+ */
+import { Fragment, type FC } from 'react';
+import classes from './AppPromptEditor.module.css';
+
+// Capture: tag, optional "text", optional @loc.
+// Loc allows any char except `]` (which terminates the reference) so paths
+// with spaces (e.g. `My Component/App.tsx:42`) round-trip cleanly.
+const REF_PATTERN =
+    /\[([A-Za-z][A-Za-z0-9-]*)(?:\s+"([^"]*)")?(?:\s+@([^\]]+))?\]/g;
+
+type Segment =
+    | { kind: 'text'; value: string }
+    | { kind: 'ref'; tag: string; text: string; loc: string };
+
+function parse(content: string): Segment[] {
+    const segments: Segment[] = [];
+    let cursor = 0;
+    REF_PATTERN.lastIndex = 0;
+    let match: RegExpExecArray | null = REF_PATTERN.exec(content);
+    while (match !== null) {
+        if (match.index > cursor) {
+            segments.push({
+                kind: 'text',
+                value: content.slice(cursor, match.index),
+            });
+        }
+        segments.push({
+            kind: 'ref',
+            tag: match[1] ?? '',
+            text: match[2] ?? '',
+            loc: match[3] ?? '',
+        });
+        cursor = match.index + match[0].length;
+        match = REF_PATTERN.exec(content);
+    }
+    if (cursor < content.length) {
+        segments.push({ kind: 'text', value: content.slice(cursor) });
+    }
+    return segments;
+}
+
+const TextWithBreaks: FC<{ value: string }> = ({ value }) => {
+    const lines = value.split('\n');
+    return (
+        <>
+            {lines.map((line, i) => (
+                <Fragment key={i}>
+                    {i > 0 && <br />}
+                    {line}
+                </Fragment>
+            ))}
+        </>
+    );
+};
+
+const ChatMessageContent: FC<{ content: string }> = ({ content }) => {
+    const segments = parse(content);
+    if (segments.length === 0) return null;
+    return (
+        <>
+            {segments.map((seg, i) => {
+                if (seg.kind === 'text') {
+                    return <TextWithBreaks key={i} value={seg.value} />;
+                }
+                const inner = seg.text
+                    ? `<${seg.tag}> ${seg.text}`
+                    : `<${seg.tag}>`;
+                return (
+                    <span
+                        key={i}
+                        className={classes.elementPill}
+                        title={seg.loc ? `Source: ${seg.loc}` : undefined}
+                    >
+                        {inner}
+                    </span>
+                );
+            })}
+        </>
+    );
+};
+
+export default ChatMessageContent;

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -68,6 +68,11 @@ const isQueryResultGet = (method: string, path: string): boolean =>
     method.toUpperCase() === 'GET' &&
     /^\/api\/v2\/projects\/[^/]+\/query\/[^/]+$/.test(path);
 
+export type ElementSelectedEvent = {
+    /** Bracketed reference produced by the iframe inspector, e.g. `[button "Save"]`. */
+    label: string;
+};
+
 /**
  * Parent-side fetch proxy for sandboxed iframe SDK communication.
  *
@@ -78,16 +83,41 @@ const isQueryResultGet = (method: string, path: string): boolean =>
  *
  * When onQueryEvent is provided, metric query requests and their results
  * are intercepted and reported for the query inspector overlay.
+ *
+ * When onElementSelected is provided, click-to-edit selections from the
+ * iframe inspector are forwarded to the caller. Use the returned
+ * enableInspector / disableInspector helpers to toggle the iframe-side
+ * overlay.
+ *
+ * `onInspectorAvailable` fires when the iframe SDK announces capability on
+ * mount. The bridge doesn't track availability state itself — the parent
+ * owns it and is responsible for resetting on iframe `src` change.
  */
 export function useAppSdkBridge(
     iframeRef: RefObject<HTMLIFrameElement | null>,
     onQueryEvent?: (event: QueryEvent) => void,
+    onElementSelected?: (event: ElementSelectedEvent) => void,
+    onInspectorAvailable?: () => void,
 ) {
     const handleMessage = useCallback(
         async (event: MessageEvent) => {
             if (event.source !== iframeRef.current?.contentWindow) return;
 
             const { data } = event;
+
+            if (data?.type === 'lightdash:inspect:available') {
+                onInspectorAvailable?.();
+                return;
+            }
+
+            if (data?.type === 'lightdash:inspect:selected') {
+                const label = typeof data.label === 'string' ? data.label : '';
+                if (label && onElementSelected) {
+                    onElementSelected({ label });
+                }
+                return;
+            }
+
             if (data?.type !== 'lightdash:sdk:fetch') return;
 
             const { id, method, path, body, metadata } = data;
@@ -252,7 +282,7 @@ export function useAppSdkBridge(
                 });
             }
         },
-        [iframeRef, onQueryEvent],
+        [iframeRef, onQueryEvent, onElementSelected, onInspectorAvailable],
     );
 
     useEffect(() => {
@@ -267,5 +297,23 @@ export function useAppSdkBridge(
         );
     }, [iframeRef]);
 
-    return { handleIframeLoad };
+    const enableInspector = useCallback(() => {
+        iframeRef.current?.contentWindow?.postMessage(
+            { type: 'lightdash:inspect:enable' },
+            '*',
+        );
+    }, [iframeRef]);
+
+    const disableInspector = useCallback(() => {
+        iframeRef.current?.contentWindow?.postMessage(
+            { type: 'lightdash:inspect:disable' },
+            '*',
+        );
+    }, [iframeRef]);
+
+    return {
+        handleIframeLoad,
+        enableInspector,
+        disableInspector,
+    };
 }

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -66,9 +66,14 @@ import { ChartIcon, IconBox } from '../components/common/ResourceIcon';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import TransferItemsModal from '../components/common/TransferItemsModal/TransferItemsModal';
 import AppIframePreview from '../features/apps/AppIframePreview';
+import AppPromptEditor, {
+    type AppPromptEditorHandle,
+    type ElementRef,
+} from '../features/apps/AppPromptEditor';
 import {
     DashboardButton,
     ImageButton,
+    InspectButton,
     QueryButton,
     SelectedDashboardSection,
     SelectedImageSection,
@@ -77,6 +82,7 @@ import {
     type SelectedDashboard,
 } from '../features/apps/AppResourcePicker';
 import AppTemplatePicker from '../features/apps/AppTemplatePicker';
+import ChatMessageContent from '../features/apps/ChatMessageContent';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -97,6 +103,24 @@ import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
 import useApp from '../providers/App/useApp';
 import classes from './AppGenerate.module.css';
+
+/**
+ * Parse `[tag "text" @loc]` (or `[tag @loc]`, `[tag "text"]`, `[tag]`) from
+ * the iframe inspector's `lightdash:inspect:selected` payload into the
+ * structured attrs the editor's mention node expects. Returns null if the
+ * label doesn't match the expected shape — defensive against future SDK
+ * versions that might emit a different format.
+ */
+function parseElementRefLabel(label: string): ElementRef | null {
+    // Loc allows any char except `]` (which terminates the reference) so
+    // paths with spaces (e.g. `My Component/App.tsx:42`) round-trip cleanly.
+    const m =
+        /^\[([A-Za-z][A-Za-z0-9-]*)(?:\s+"([^"]*)")?(?:\s+@([^\]]+))?\]$/.exec(
+            label,
+        );
+    if (!m) return null;
+    return { tag: m[1] ?? '', text: m[2] ?? '', loc: m[3] ?? '' };
+}
 
 type ChatChart = {
     name: string;
@@ -132,7 +156,20 @@ const AppPreview: FC<{
     appUuid: string;
     version: number;
     onQueryEvent?: (event: QueryEvent) => void;
-}> = ({ projectUuid, appUuid, version, onQueryEvent }) => {
+    inspectorEnabled?: boolean;
+    onElementSelected?: (event: { label: string }) => void;
+    onInspectorAvailabilityChange?: (available: boolean) => void;
+    onInspectorCancelled?: () => void;
+}> = ({
+    projectUuid,
+    appUuid,
+    version,
+    onQueryEvent,
+    inspectorEnabled,
+    onElementSelected,
+    onInspectorAvailabilityChange,
+    onInspectorCancelled,
+}) => {
     const {
         data: token,
         isLoading,
@@ -166,7 +203,16 @@ const AppPreview: FC<{
 
     if (!previewUrl) return null;
 
-    return <AppIframePreview src={previewUrl} onQueryEvent={onQueryEvent} />;
+    return (
+        <AppIframePreview
+            src={previewUrl}
+            onQueryEvent={onQueryEvent}
+            inspectorEnabled={inspectorEnabled}
+            onElementSelected={onElementSelected}
+            onInspectorAvailabilityChange={onInspectorAvailabilityChange}
+            onInspectorCancelled={onInspectorCancelled}
+        />
+    );
 };
 
 const LoadingDots: FC = () => (
@@ -201,7 +247,12 @@ const AppGenerate: FC = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const queryClient = useQueryClient();
-    const [prompt, setPrompt] = useState('');
+    // Editor handle (TipTap-based) — replaces the previous controlled
+    // textarea + `prompt` state. The editor owns its content; the parent
+    // reads on submit via `getText()` and tracks emptiness via the
+    // `onEmptyChange` callback for the submit button's disabled state.
+    const promptEditorRef = useRef<AppPromptEditorHandle | null>(null);
+    const [isPromptEmpty, setIsPromptEmpty] = useState(true);
     // Starter-template wizard state (only meaningful for v1 of a new app).
     // 'pick'    → show the 4 template cards (replaces the empty state)
     // 'confirm' → wizard collapses; the textarea takes over. Picking any
@@ -222,7 +273,32 @@ const AppGenerate: FC = () => {
     const [selectedCharts, setSelectedCharts] = useState<SelectedChart[]>([]);
     const [selectedDashboard, setSelectedDashboard] =
         useState<SelectedDashboard | null>(null);
+    // Click-to-edit ("Inspect") mode. While on, the iframe overlays a hover
+    // outline and intercepts clicks; each click inserts an element-reference
+    // pill at the editor cursor so the user can compose targeted edits.
+    // Stays on across multiple clicks; the user toggles off when done.
+    const [inspectorEnabled, setInspectorEnabled] = useState(false);
+    // Capability flag — flipped to true when the iframe SDK announces the
+    // inspector. Existing apps in resumed sandboxes may have an older SDK
+    // that never announces, in which case the toggle stays hidden.
+    const [inspectorAvailable, setInspectorAvailable] = useState(false);
     const [trackedQueries, setTrackedQueries] = useState<QueryEvent[]>([]);
+    const handleElementSelected = useCallback((event: { label: string }) => {
+        const ref = parseElementRefLabel(event.label);
+        if (!ref) {
+            console.warn(
+                '[apps] Ignoring unrecognized inspector label:',
+                event.label,
+            );
+            return;
+        }
+        promptEditorRef.current?.insertElementRef(ref);
+    }, []);
+    // Stable so AppIframePreview's keydown listener doesn't re-attach on
+    // every render of this page.
+    const handleInspectorCancelled = useCallback(() => {
+        setInspectorEnabled(false);
+    }, []);
     const handleQueryEvent = useCallback((event: QueryEvent) => {
         setTrackedQueries((prev) => {
             // If this event has a queryUuid, merge it with an existing entry
@@ -300,13 +376,16 @@ const AppGenerate: FC = () => {
     // vs. the post-submit URL update (undefined → newUuid).
     const prevUrlAppUuid = useRef(urlAppUuid);
     const resetSessionState = useCallback(() => {
-        setPrompt('');
+        promptEditorRef.current?.clear();
+        setIsPromptEmpty(true);
         setSelectedCharts([]);
         setSelectedDashboard(null);
         setImageAttachments([]);
         setLocalMessages([]);
         setPreviewApp(null);
         setTrackedQueries([]);
+        setInspectorEnabled(false);
+        setInspectorAvailable(false);
         setSelectedTemplate(null);
         setWizardStage('pick');
         setPendingClarification(null);
@@ -349,7 +428,6 @@ const AppGenerate: FC = () => {
     const { user } = useApp();
     const ability = useAbilityContext();
     const messagesEndRef = useRef<HTMLDivElement>(null);
-    const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     // Fetch version history (polling is handled by the Web Worker below)
     const {
@@ -756,7 +834,7 @@ const AppGenerate: FC = () => {
     });
 
     const handleSubmit = async () => {
-        const trimmed = prompt.trim();
+        const trimmed = (promptEditorRef.current?.getText() ?? '').trim();
         if (!trimmed || isLoading) return;
 
         // Send structured chart refs (uuid + per-chart sample-data opt-in).
@@ -849,7 +927,8 @@ const AppGenerate: FC = () => {
                 version: null,
             },
         ]);
-        setPrompt('');
+        promptEditorRef.current?.clear();
+        setIsPromptEmpty(true);
         setImageAttachments([]);
         setSelectedCharts([]);
         setSelectedDashboard(null);
@@ -996,16 +1075,11 @@ const AppGenerate: FC = () => {
         // clarifier produces those dynamically on submit.
         setSelectedTemplate(template);
         setWizardStage('confirm');
-        setPrompt('');
-        // Focus the textarea so the user can immediately type.
-        setTimeout(() => textareaRef.current?.focus(), 0);
-    };
-
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
-            e.preventDefault();
-            void handleSubmit();
-        }
+        promptEditorRef.current?.clear();
+        setIsPromptEmpty(true);
+        // Focus the editor so the user can immediately type. The setTimeout
+        // gives the editor a tick to mount when the input area first appears.
+        setTimeout(() => promptEditorRef.current?.focus(), 0);
     };
 
     const handleCancel = () => {
@@ -1108,7 +1182,11 @@ const AppGenerate: FC = () => {
                                                             classes.userBubble
                                                         }
                                                     >
-                                                        {msg.content}
+                                                        <ChatMessageContent
+                                                            content={
+                                                                msg.content
+                                                            }
+                                                        />
                                                         {msg.charts.length >
                                                             0 && (
                                                             <Box
@@ -1453,26 +1531,14 @@ const AppGenerate: FC = () => {
                                 )}
                                 <Box className={classes.inputWrapper}>
                                     <Box className={classes.textareaColumn}>
-                                        <Textarea
-                                            ref={textareaRef}
+                                        <AppPromptEditor
+                                            ref={promptEditorRef}
                                             placeholder="Describe the app you want to build..."
-                                            autosize
                                             autoFocus
-                                            minRows={1}
-                                            maxRows={6}
-                                            value={prompt}
-                                            onChange={(e) =>
-                                                setPrompt(e.currentTarget.value)
-                                            }
-                                            onKeyDown={handleKeyDown}
-                                            onPaste={handlePaste}
                                             disabled={isLoading}
-                                            classNames={{
-                                                root: classes.textareaRoot,
-                                                input: classes.textarea,
-                                                wrapper:
-                                                    classes.textareaWrapper,
-                                            }}
+                                            onEmptyChange={setIsPromptEmpty}
+                                            onSubmit={() => void handleSubmit()}
+                                            onPaste={handlePaste}
                                         />
                                     </Box>
                                     {isBuilding ? (
@@ -1495,7 +1561,7 @@ const AppGenerate: FC = () => {
                                             color="violet"
                                             onClick={() => void handleSubmit()}
                                             disabled={
-                                                !prompt.trim() || isLoading
+                                                isPromptEmpty || isLoading
                                             }
                                             loading={
                                                 isGenerating || isIterating
@@ -1532,6 +1598,14 @@ const AppGenerate: FC = () => {
                                                 MAX_IMAGES_PER_VERSION
                                         }
                                     />
+                                    {inspectorAvailable && (
+                                        <InspectButton
+                                            enabled={inspectorEnabled}
+                                            onToggle={() =>
+                                                setInspectorEnabled((v) => !v)
+                                            }
+                                        />
+                                    )}
                                 </Group>
                                 <Box
                                     className={classes.resourceSections}
@@ -1809,6 +1883,14 @@ const AppGenerate: FC = () => {
                                     appUuid={previewApp.appUuid}
                                     version={previewApp.version}
                                     onQueryEvent={handleQueryEvent}
+                                    inspectorEnabled={inspectorEnabled}
+                                    onElementSelected={handleElementSelected}
+                                    onInspectorAvailabilityChange={
+                                        setInspectorAvailable
+                                    }
+                                    onInspectorCancelled={
+                                        handleInspectorCancelled
+                                    }
                                 />
                             ) : (
                                 <Box className={classes.previewEmpty}>

--- a/packages/query-sdk/src/client.ts
+++ b/packages/query-sdk/src/client.ts
@@ -6,6 +6,7 @@
  */
 
 import { createApiTransport } from './apiTransport';
+import { mountInspector } from './inspector';
 import { createPostMessageTransport } from './postMessageTransport';
 import { QueryBuilder } from './query';
 import type { LightdashClientConfig, LightdashUser, Transport } from './types';
@@ -78,6 +79,7 @@ export function createClient(): LightdashClient {
         const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
         if (params.get('transport') === 'postMessage') {
             const projectUuid = params.get('projectUuid') ?? '';
+            mountInspector(window.parent);
             return new LightdashClient(
                 { apiKey: '', baseUrl: '', projectUuid },
                 createPostMessageTransport({ targetWindow: window.parent, projectUuid }),

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -43,3 +43,9 @@ export type {
     SdkFetchResponse,
     SdkReadyMessage,
 } from './postMessageTransport';
+
+// Element inspector (click-to-edit) — protocol types for parent bridge.
+export type {
+    InspectAvailableMessage,
+    InspectSelectedMessage,
+} from './inspector';

--- a/packages/query-sdk/src/inspector.ts
+++ b/packages/query-sdk/src/inspector.ts
@@ -1,0 +1,255 @@
+/**
+ * Element inspector ("click-to-edit") runtime that lives inside the sandboxed
+ * iframe. The Lightdash parent window enables it via postMessage; on click,
+ * this module captures a human-readable label for the clicked element and
+ * posts it back. The parent inserts that label as a pill at the prompt
+ * editor cursor so the user can compose targeted edits like:
+ *
+ *     [button "Total Revenue" @src/Toolbar.tsx:42] make this blue
+ *     [div "$2.4M" @src/Dashboard.tsx:88] rename to Net Revenue
+ *
+ * Claude opens the file at `<path>:<line>` directly. When the loc is missing
+ * (DOM node injected outside JSX, or pre-transform build), it falls back to
+ * grepping `/app/src/` for the quoted text.
+ */
+
+type EnableMessage = { type: 'lightdash:inspect:enable' };
+type DisableMessage = { type: 'lightdash:inspect:disable' };
+
+export type InspectSelectedMessage = {
+    type: 'lightdash:inspect:selected';
+    label: string;
+};
+
+/**
+ * Announced by the iframe SDK on mount so the parent can detect that the
+ * inspector is wired up. Older SDKs (loaded by resumed sandboxes) never
+ * send this, so the parent leaves the Inspect button hidden for them.
+ */
+export type InspectAvailableMessage = {
+    type: 'lightdash:inspect:available';
+};
+
+const OVERLAY_ID = 'lightdash-inspector-overlay';
+const LABEL_ID = 'lightdash-inspector-label';
+const HIGHLIGHT_COLOR = '#7c3aed';
+const MAX_TEXT_LEN = 40;
+const ANCESTOR_TEXT_LOOKBACK = 3;
+
+function isOurOwnElement(el: Element | null): boolean {
+    if (!el) return false;
+    return el.id === OVERLAY_ID || el.id === LABEL_ID;
+}
+
+/**
+ * Builds a label like `[tag "text" @src/path:line]` for a clicked element.
+ *
+ * The `@<path>:<line>` suffix is the primary key — it comes from a build-
+ * time JSX transform (see sandbox `vite.config.js`) that stamps every
+ * element with `data-loc="<rel-path>:<line>"`. With prop spreading, the
+ * caller's call site wins over any nested component's own loc, so the
+ * value reflects the user-facing source. The visible text and tag stay in
+ * the label so the user can confirm they clicked what they meant to click.
+ *
+ * Falls back to tag-only for elements without text — class names from
+ * shadcn/Tailwind are utility-heavy and not grep-useful, so we don't
+ * bother emitting them.
+ */
+function buildLabel(el: Element): string {
+    const tag = el.tagName.toLowerCase();
+
+    let text = '';
+    let cur: Element | null = el;
+    for (let i = 0; i < ANCESTOR_TEXT_LOOKBACK && cur; i += 1) {
+        const raw = (cur.textContent ?? '').replace(/\s+/g, ' ').trim();
+        if (raw) {
+            text = raw.length > MAX_TEXT_LEN
+                ? `${raw.slice(0, MAX_TEXT_LEN)}…`
+                : raw;
+            break;
+        }
+        cur = cur.parentElement;
+    }
+
+    // Walk up to the closest ancestor that carries a build-time source loc.
+    // For elements whose call site lives in user code, this is set on the
+    // element itself; for icon SVGs and other library-rendered children it
+    // lives on a wrapping ancestor.
+    const locEl = el.closest('[data-loc]');
+    const loc = locEl?.getAttribute('data-loc') ?? '';
+
+    // Inner double quotes would break the bracketed format — replace with
+    // single quotes so the label is always well-formed and grep-friendly.
+    const safe = text ? text.replace(/"/g, "'") : '';
+    const head = safe ? `${tag} "${safe}"` : tag;
+
+    return loc ? `[${head} @${loc}]` : `[${head}]`;
+}
+
+let overlayBox: HTMLDivElement | null = null;
+let overlayLabel: HTMLDivElement | null = null;
+
+function ensureOverlay(): { box: HTMLDivElement; label: HTMLDivElement } {
+    if (overlayBox && overlayLabel) {
+        return { box: overlayBox, label: overlayLabel };
+    }
+    const box = document.createElement('div');
+    box.id = OVERLAY_ID;
+    Object.assign(box.style, {
+        position: 'fixed',
+        pointerEvents: 'none',
+        zIndex: '2147483647',
+        border: `2px solid ${HIGHLIGHT_COLOR}`,
+        borderRadius: '4px',
+        background: 'rgba(124, 58, 237, 0.12)',
+        boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0)',
+        display: 'none',
+    } satisfies Partial<CSSStyleDeclaration>);
+
+    const label = document.createElement('div');
+    label.id = LABEL_ID;
+    Object.assign(label.style, {
+        position: 'fixed',
+        pointerEvents: 'none',
+        zIndex: '2147483647',
+        background: HIGHLIGHT_COLOR,
+        color: 'white',
+        font: '11px ui-sans-serif, system-ui, sans-serif',
+        padding: '2px 6px',
+        borderRadius: '3px',
+        whiteSpace: 'nowrap',
+        maxWidth: '320px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        display: 'none',
+    } satisfies Partial<CSSStyleDeclaration>);
+
+    document.body.appendChild(box);
+    document.body.appendChild(label);
+    overlayBox = box;
+    overlayLabel = label;
+    return { box, label };
+}
+
+function hideOverlay() {
+    if (overlayBox) overlayBox.style.display = 'none';
+    if (overlayLabel) overlayLabel.style.display = 'none';
+}
+
+function positionOverlay(el: Element, labelText: string) {
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+        hideOverlay();
+        return;
+    }
+    const { box, label } = ensureOverlay();
+    box.style.display = 'block';
+    box.style.top = `${rect.top}px`;
+    box.style.left = `${rect.left}px`;
+    box.style.width = `${rect.width}px`;
+    box.style.height = `${rect.height}px`;
+    label.textContent = labelText;
+    label.style.display = 'block';
+    label.style.top = `${Math.max(0, rect.top - 22)}px`;
+    label.style.left = `${rect.left}px`;
+}
+
+let enabled = false;
+let currentTarget: Element | null = null;
+let parentWindow: Window | null = null;
+let listenersAttached = false;
+let messageListenerAttached = false;
+
+function onPointerMove(e: PointerEvent) {
+    if (!enabled) return;
+    const target = e.target as Element | null;
+    if (!target || isOurOwnElement(target)) return;
+    if (target === currentTarget) return;
+    currentTarget = target;
+    positionOverlay(target, buildLabel(target));
+}
+
+function onClick(e: MouseEvent) {
+    if (!enabled) return;
+    const target = e.target as Element | null;
+    if (!target || isOurOwnElement(target)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (typeof e.stopImmediatePropagation === 'function') {
+        e.stopImmediatePropagation();
+    }
+    const label = buildLabel(target);
+    parentWindow?.postMessage(
+        {
+            type: 'lightdash:inspect:selected',
+            label,
+        } satisfies InspectSelectedMessage,
+        '*',
+    );
+}
+
+function onScrollOrResize() {
+    if (enabled && currentTarget) {
+        positionOverlay(currentTarget, buildLabel(currentTarget));
+    }
+}
+
+function setEnabled(next: boolean) {
+    if (enabled === next) return;
+    enabled = next;
+    if (enabled) {
+        document.documentElement.style.cursor = 'crosshair';
+    } else {
+        document.documentElement.style.cursor = '';
+        currentTarget = null;
+        hideOverlay();
+    }
+}
+
+function attachListeners() {
+    if (listenersAttached) return;
+    listenersAttached = true;
+    // Capture phase — we need to see events before the app's own handlers.
+    window.addEventListener('pointermove', onPointerMove, true);
+    window.addEventListener('click', onClick, true);
+    window.addEventListener('scroll', onScrollOrResize, true);
+    window.addEventListener('resize', onScrollOrResize, true);
+}
+
+/**
+ * Mounts the inspector. Listens for `lightdash:inspect:enable` /
+ * `lightdash:inspect:disable` from the parent window and posts back a
+ * `lightdash:inspect:selected` event when the user clicks an element while
+ * inspect mode is active. Idempotent — safe to call multiple times.
+ */
+export function mountInspector(parent: Window): void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return;
+    }
+    parentWindow = parent;
+    attachListeners();
+
+    // Announce capability so the parent can show the Inspect button. Older
+    // SDKs running in resumed sandboxes don't send this, leaving the button
+    // hidden — they keep working as before.
+    parent.postMessage(
+        { type: 'lightdash:inspect:available' } satisfies InspectAvailableMessage,
+        '*',
+    );
+
+    if (messageListenerAttached) return;
+    messageListenerAttached = true;
+    window.addEventListener('message', (event: MessageEvent) => {
+        const data = event.data as
+            | EnableMessage
+            | DisableMessage
+            | { type?: unknown }
+            | undefined;
+        if (!data || typeof data.type !== 'string') return;
+        if (data.type === 'lightdash:inspect:enable') {
+            setEnabled(true);
+        } else if (data.type === 'lightdash:inspect:disable') {
+            setEnabled(false);
+        }
+    });
+}

--- a/sandboxes/data-apps/template/package.json
+++ b/sandboxes/data-apps/template/package.json
@@ -44,6 +44,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.1",
         "autoprefixer": "10.4.20",
+        "oxc-parser": "0.128.0",
         "postcss": "8.5.1",
         "tailwindcss": "3.4.17",
         "typescript": "5.7.3",

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -142,6 +142,62 @@ Each file contains:
   **Only strip the prefix if it matches the explore name.** If it doesn't match, it's a joined table.
 - **Table calculation names:** Do NOT strip — pass them through as-is.
 
+## Element references in iteration prompts
+
+The Lightdash preview pane has an "Inspect" toggle. When the user clicks an
+element in the live preview, the chat editor inserts a bracketed reference at
+the textarea cursor. Users can stack multiple references in a single prompt
+to compose several targeted edits at once:
+
+```
+[button "Save" @src/components/Toolbar.tsx:42] make this blue
+[div "$2.4M" @src/Dashboard.tsx:88] rename to Net Revenue
+[h3 "Q1 Dashboard" @src/Dashboard.tsx:14] tighter spacing
+```
+
+Each line targets one element. Resolve each reference, edit only that
+component, and move on. The instruction immediately follows the reference
+on the same line (a colon between them is optional — users may include
+one).
+
+### Format
+
+A reference always starts with the rendered tag, optionally followed by a
+visible-text hint, optionally followed by `@<path>:<line>`:
+
+| Form | Example | Meaning |
+|---|---|---|
+| `[<tag> "<text>" @<path>:<line>]` | `[button "Save" @src/components/Toolbar.tsx:42]` | Build-time loc available — primary case. |
+| `[<tag> @<path>:<line>]` | `[svg @src/Dashboard.tsx:88]` | Element had no text (icon button, empty container) but a loc is available — open the file at that line. |
+| `[<tag> "<text>"]` *(no `@…`)* | `[button "Save"]` | Loc unavailable (DOM node injected outside JSX, or pre-transform build). Fall back to grepping the text. |
+
+The `<tag>` is the **rendered** HTML tag (`button`, `h3`, `div`, `span`,
+`svg`), not the React component name. shadcn `<Button>` renders as `<button>`,
+`<CardTitle>` as `<h3>`, `<Card>` as `<div>`. Keep that in mind when reading
+references — the source uses the React component name.
+
+### Resolution strategy
+
+1. **`@<path>:<line>` is authoritative.** It's stamped at build time on the
+   user-facing call site (props spread through shadcn primitives, so the
+   caller's loc wins over the primitive's own loc). Open that file at that
+   line — that is the component to edit. No grep needed.
+2. **No `@…` segment** — fall back to text:
+   - Grep `/app/src/` for the quoted text. It's almost always hardcoded JSX.
+     Inner double quotes are normalized to single quotes in the label, so
+     grep both forms if needed.
+   - Narrow by tag if multiple matches.
+3. **Scope edits to the matched component.** Don't refactor neighbors unless
+   the requested change requires it.
+
+### When you can't resolve a reference
+
+If grep returns no hits, the file at the given loc doesn't have anything
+matching the text/tag, or the matches are too ambiguous to choose between,
+say so and ask the user to clarify or re-select. Don't guess and edit the
+wrong component — the user will see the wrong thing change and lose trust
+in the tool.
+
 ## SDK Reference
 
 The client and provider are already set up in `main.jsx`. Import `query` and `useLightdash` — that's it.

--- a/sandboxes/data-apps/template/vite.config.js
+++ b/sandboxes/data-apps/template/vite.config.js
@@ -1,12 +1,151 @@
 import react from '@vitejs/plugin-react';
+import fs from 'node:fs/promises';
+import { parseSync } from 'oxc-parser';
 import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
+
+/**
+ * Build a binary-searchable index of newline offsets so we can map JSX
+ * element start offsets to 1-indexed line numbers without scanning the
+ * whole file once per element.
+ */
+function buildLineIndex(code) {
+    const idx = [0];
+    for (let i = 0; i < code.length; i += 1) {
+        if (code.charCodeAt(i) === 10) idx.push(i + 1);
+    }
+    return idx;
+}
+
+function offsetToLine(lineIdx, offset) {
+    let lo = 0;
+    let hi = lineIdx.length - 1;
+    while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        if (lineIdx[mid] <= offset) lo = mid;
+        else hi = mid - 1;
+    }
+    return lo + 1;
+}
+
+function walkAst(node, fn) {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+        for (const child of node) walkAst(child, fn);
+        return;
+    }
+    if (typeof node.type === 'string') fn(node);
+    for (const key of Object.keys(node)) {
+        if (key === 'parent') continue;
+        walkAst(node[key], fn);
+    }
+}
+
+function alreadyHasDataLoc(opening) {
+    return opening.attributes?.some(
+        (attr) =>
+            attr.type === 'JSXAttribute' &&
+            attr.name?.type === 'JSXIdentifier' &&
+            attr.name?.name === 'data-loc',
+    );
+}
+
+/**
+ * Annotate every JSX opening element with `data-loc="<rel-path>:<line>"`
+ * by parsing with oxc and splicing attributes into the source string.
+ *
+ * Why both lowercase tags AND capitalized React components get annotated:
+ * shadcn primitives spread `{...props}` onto their root element, so when
+ * Dashboard.tsx renders <Button>, the data-loc from the call site is
+ * passed as a prop and spread last — overriding the data-loc the visitor
+ * injected inside button.tsx. The DOM ends up with the caller's loc, which
+ * is what Claude needs to edit. Components that don't spread props
+ * silently drop the attribute, and the inspector falls back to the closest
+ * ancestor that does carry one.
+ *
+ * Returns null on parse error so Vite re-loads the file and OXC produces
+ * its own (better) diagnostic.
+ */
+function annotateJsx(code, filename, relPath) {
+    const lang = filename.endsWith('.tsx') ? 'tsx' : 'jsx';
+    const result = parseSync(filename, code, { sourceType: 'module', lang });
+    if (result.errors?.length) return null;
+
+    const targets = [];
+    walkAst(result.program, (node) => {
+        if (node.type !== 'JSXOpeningElement') return;
+        if (!node.name) return;
+        if (alreadyHasDataLoc(node)) return;
+        targets.push(node);
+    });
+    if (targets.length === 0) return null;
+
+    const lineIdx = buildLineIndex(code);
+    // Splice in reverse so each insertion's offset stays valid against the
+    // original positions reported by the parser.
+    targets.sort((a, b) => b.name.end - a.name.end);
+    let out = code;
+    for (const node of targets) {
+        const line = offsetToLine(lineIdx, node.start);
+        const insertion = ` data-loc="${relPath}:${line}"`;
+        out = out.slice(0, node.name.end) + insertion + out.slice(node.name.end);
+    }
+    return out;
+}
+
+/**
+ * Vite plugin that stamps `data-loc` on every JSX opening element BEFORE
+ * @vitejs/plugin-react v6's OXC-based JSX transform sees the file. The
+ * Lightdash element inspector reads `data-loc` via `closest('[data-loc]')`
+ * to map a clicked DOM node back to its source line, so iteration prompts
+ * can target the exact component the user pointed at.
+ *
+ * Why `load` and not `transform`: Vite 8 + Rolldown processes user JSX/TSX
+ * files through the native OXC pipeline and skips the `transform` hook for
+ * them. `load` still fires (so Vite knows the source), so we read +
+ * annotate + return the modified source for OXC to pick up.
+ *
+ * Why oxc-parser instead of @babel/core: oxc-parser is the same engine
+ * already in the stack (via Rolldown), no JS-side codegen is needed
+ * because we splice text by character offset, and the Babel dep weight
+ * isn't worth carrying for one transform.
+ */
+function jsxSourceLocVitePlugin() {
+    let cwd = process.cwd();
+    return {
+        name: 'lightdash-jsx-source-loc',
+        configResolved(config) {
+            cwd = config.root;
+        },
+        async load(id) {
+            // Strip query strings vite sometimes appends (e.g. ?v=123).
+            const filename = id.split('?')[0];
+            if (!/\.(jsx|tsx)$/.test(filename)) return null;
+
+            const srcDir = path.join(cwd, 'src') + path.sep;
+            if (!filename.startsWith(srcDir)) return null;
+
+            const code = await fs.readFile(filename, 'utf-8');
+
+            // Cheap out: nothing JSX-ish to annotate. Return null so Vite
+            // re-reads via its own loader rather than us shadowing it with
+            // an opinion-free `code`.
+            if (!/<[A-Za-z]/.test(code)) return null;
+
+            const relPath = path
+                .relative(cwd, filename)
+                .replace(/\\/g, '/');
+            const annotated = annotateJsx(code, filename, relPath);
+            return annotated ?? code;
+        },
+    };
+}
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), 'VITE_');
 
     return {
-        plugins: [react()],
+        plugins: [jsxSourceLocVitePlugin(), react()],
         base: './',
         resolve: {
             alias: {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-374/add-click-to-edit-for-selected-app-elements

### Description:
Adds an "Inspect" toggle on the data-app preview iframe. While active, hovering highlights elements and clicking inserts a bracketed reference (e.g. `[h1 "Driver Championship" @src/Dashboard.tsx:42]: `) at the prompt textarea cursor, so users can compose targeted edits without describing elements manually. Multiple references stack into a single iteration prompt.

The iframe SDK announces capability on mount; sandboxes resumed on an older SDK never announce, so the parent hides the toggle for them.

A Vite load-hook plugin runs each user JSX/TSX file through @babel/core before OXC's transform, stamping every JSX element with `data-loc`. Prop spreading in shadcn primitives means the caller's loc wins on the DOM, so references point at the user's source, not library internals. skill.md teaches Claude to open the file at that line directly.



https://github.com/user-attachments/assets/4925ff08-0d1d-4b5d-a1c0-559aeb238abd



