### PR TITLE
chore: enable `Embedding` flag in preview envs for e2e tests

### DIFF
--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -75,6 +75,12 @@ services:
             CUSTOM_ROLES_ENABLED: true
             LIGHTDASH_ENABLE_TIMEZONE_SUPPORT: true
 
+            # Force-enable embedding flag in preview envs so e2e tests don't
+            # depend on PostHog targeting reaching the ephemeral test org.
+            # Picked up via LEGACY_ENABLE_ENV_VARS in parseConfig.ts → unified
+            # enabledFeatureFlags allowlist (step 1a).
+            EMBEDDING_ENABLED: true
+
             PERSISTENT_DOWNLOAD_URLS_ENABLED: true
 
             # these were set in https://dashboard.render.com/env-group/evg-cfn4dlhmbjst4ho7s160 but can be public


### PR DESCRIPTION
test-all

### Description:

Adds `EMBEDDING_ENABLED: true` to the preview environment Docker Compose configuration so that the embedding feature flag is force-enabled in preview environments. This ensures E2E tests that rely on embedding functionality are not dependent on PostHog feature flag targeting reaching the ephemeral test organisation.