### PR TITLE
chore: remove ShowHideRows and ShowHideColumns feature flags

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -828,14 +828,12 @@ describe('getMultiProjectSetupConfig', () => {
 });
 
 describe('legacy feature-flag env vars (compat repair for trivial-batch)', () => {
-    // The change-chart-explore / show-hide-rows / show-hide-columns env-var
-    // parsers were removed when those flags were migrated to DB-backed
-    // resolution. Re-translating them via the legacy enable list preserves
-    // backward compat for self-hosted deployments that set these vars.
+    // The change-chart-explore env-var parser was removed when that flag was
+    // migrated to DB-backed resolution. Re-translating it via the legacy
+    // enable list preserves backward compat for self-hosted deployments that
+    // set the var.
     test.each([
         ['CHANGE_CHART_EXPLORE_ENABLED', 'change-chart-explore'],
-        ['SHOW_HIDE_ROWS_ENABLED', 'show-hide-rows'],
-        ['SHOW_HIDE_COLUMNS_ENABLED', 'show-hide-columns'],
         ['GOOGLE_CHAT_ENABLED', 'google-chat-enabled'],
         ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
         ['USER_IMPERSONATION_ENABLED', 'user-impersonation'],

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1538,8 +1538,6 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
 > = [
     // Add per migration; truthy env value enables the flag.
     ['CHANGE_CHART_EXPLORE_ENABLED', 'change-chart-explore'],
-    ['SHOW_HIDE_ROWS_ENABLED', 'show-hide-rows'],
-    ['SHOW_HIDE_COLUMNS_ENABLED', 'show-hide-columns'],
     ['GOOGLE_CHAT_ENABLED', 'google-chat-enabled'],
     // helm defaults set USE_SQL_PIVOT_RESULTS=true for all cloud deployments;
     // translating to enabledFeatureFlags ensures both existing and new cloud

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -79,11 +79,6 @@ export enum FeatureFlags {
     ChangeChartExplore = 'change-chart-explore',
 
     /**
-     * Enable show/hide N rows from start/end of chart data
-     */
-    ShowHideRows = 'show-hide-rows',
-
-    /**
      * Keep visited dashboard tabs mounted in the DOM (hidden) for instant
      * re-switching. Enabled by default; disabled per-org for orgs where
      * large dashboards spiked browser memory to 3 GB+ from accumulated
@@ -97,11 +92,6 @@ export enum FeatureFlags {
      * Existing metric filters are always displayed regardless of this flag.
      */
     MetricDashboardFilters = 'metric-dashboard-filters',
-
-    /**
-     * Enable user-configurable column limit for pivoted queries
-     */
-    ShowHideColumns = 'show-hide-columns',
 
     /**
      * Enable data apps feature. Works alongside the APPS_RUNTIME_ENABLED

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -4,7 +4,6 @@ import {
     ChartType,
     createDashboardFilterRuleFromField,
     DashboardTileTypes,
-    FeatureFlags,
     getChartKind,
     getCustomLabelsFromTableConfig,
     getDimensions,
@@ -120,7 +119,6 @@ import {
 } from '../../hooks/useQueryResults';
 import { useAccount } from '../../hooks/user/useAccount';
 import { useDuplicateChartMutation } from '../../hooks/useSavedQuery';
-import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { useCreateShareMutation } from '../../hooks/useShare';
 import { Can } from '../../providers/Ability';
 import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
@@ -200,7 +198,6 @@ const computeDashboardChartSeries = (
     validPivotDimensions: string[] | undefined,
     resultData: InfiniteQueryResults | undefined,
     itemsMap: ItemsMap,
-    isShowHideColumnsEnabled: boolean,
 ) => {
     if (!chart.chartConfig || !resultData || resultData.rows.length === 0) {
         return [];
@@ -225,9 +222,7 @@ const computeDashboardChartSeries = (
             yFields: chart.chartConfig.config.layout.yField,
             defaultLabel: firstSerie?.label,
             itemsMap,
-            columnLimit: isShowHideColumnsEnabled
-                ? chart.chartConfig.config.columnLimit
-                : undefined,
+            columnLimit: chart.chartConfig.config.columnLimit,
         });
         const sortedByPivot =
             !!validPivotDimensions?.length &&
@@ -240,9 +235,7 @@ const computeDashboardChartSeries = (
             existingSeries: chart.chartConfig.config.eChartsConfig.series || [],
             sortedByPivot,
         });
-        return isShowHideColumnsEnabled
-            ? newSeries.filter((s) => !s.isFilteredOut)
-            : newSeries;
+        return newSeries.filter((s) => !s.isFilteredOut);
     }
     return [];
 };
@@ -310,26 +303,14 @@ const ValidDashboardChartTile: FC<{
             metricQuery,
         );
 
-        const { data: showHideColumnsFlag } = useServerFeatureFlag(
-            FeatureFlags.ShowHideColumns,
-        );
-        const isShowHideColumnsEnabled = showHideColumnsFlag?.enabled ?? false;
-
         const computedSeries: Series[] = useMemo(() => {
             return computeDashboardChartSeries(
                 chart,
                 validPivotDimensions,
                 resultsData,
                 fields,
-                isShowHideColumnsEnabled,
             );
-        }, [
-            resultsData,
-            chart,
-            validPivotDimensions,
-            fields,
-            isShowHideColumnsEnabled,
-        ]);
+        }, [resultsData, chart, validPivotDimensions, fields]);
 
         const resultsDataWithQueryData = useMemo(
             () => ({
@@ -459,25 +440,18 @@ const ValidDashboardChartTileMinimal: FC<{
         dashboardChartReadyQuery.executeQueryResponse.metricQuery,
     );
 
-    const { data: showHideColumnsFlag } = useServerFeatureFlag(
-        FeatureFlags.ShowHideColumns,
-    );
-    const isShowHideColumnsEnabled = showHideColumnsFlag?.enabled ?? false;
-
     const computedSeries: Series[] = useMemo(() => {
         return computeDashboardChartSeries(
             chart,
             validPivotDimensions,
             resultsData,
             dashboardChartReadyQuery.executeQueryResponse?.fields,
-            isShowHideColumnsEnabled,
         );
     }, [
         resultsData,
         chart,
         validPivotDimensions,
         dashboardChartReadyQuery.executeQueryResponse?.fields,
-        isShowHideColumnsEnabled,
     ]);
 
     const resultsDataWithQueryData = useMemo(

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -1,9 +1,4 @@
-import {
-    FeatureFlags,
-    getItemLabel,
-    getItemMap,
-    isField,
-} from '@lightdash/common';
+import { getItemLabel, getItemMap, isField } from '@lightdash/common';
 import { Box, Loader, Text } from '@mantine-8/core';
 import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import {
@@ -25,7 +20,6 @@ import type {
     useGetReadyQueryResults,
     useInfiniteQueryResults,
 } from '../../../hooks/useQueryResults';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import PivotTable from '../../common/PivotTable';
@@ -99,14 +93,8 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
     const dimensions = query.data?.metricQuery?.dimensions ?? [];
     const metrics = query.data?.metricQuery?.metrics ?? [];
     const explorerColumnOrder = useExplorerSelector(selectColumnOrder);
-    const { data: showHideColumnsFlag } = useServerFeatureFlag(
-        FeatureFlags.ShowHideColumns,
-    );
-    const isShowHideColumnsEnabled = showHideColumnsFlag?.enabled ?? false;
     const columnLimit =
-        isShowHideColumnsEnabled &&
-        chartConfig.type === 'cartesian' &&
-        chartConfig.config
+        chartConfig.type === 'cartesian' && chartConfig.config
             ? chartConfig.config.columnLimit
             : undefined;
 

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlags } from '@lightdash/common';
 import { Box, Button, Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
@@ -7,7 +6,6 @@ import {
     isChunkLoadError,
     triggerChunkErrorReload,
 } from '../../features/chunkErrorHandler';
-import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { computeLimitedRowCount, sliceRows } from '../../utils/sliceRows';
 import LoadingChart from '../common/LoadingChart';
 import PivotTable from '../common/PivotTable';
@@ -55,17 +53,12 @@ const SimpleTable: FC<SimpleTableProps> = ({
     } = useVisualizationContext();
 
     const hasSignaledScreenshotReady = useRef(false);
-    const { data: showHideRowsFlag } = useServerFeatureFlag(
-        FeatureFlags.ShowHideRows,
-    );
-    const isShowHideRowsEnabled = showHideRowsFlag?.enabled ?? false;
 
     const rowLimit = isTableVisualizationConfig(visualizationConfig)
         ? visualizationConfig.chartConfig.rowLimit
         : undefined;
 
     const needsAllRows =
-        isShowHideRowsEnabled &&
         rowLimit != null &&
         rowLimit.count > 0 &&
         (rowLimit.direction === 'last' || rowLimit.mode === 'hide');
@@ -209,19 +202,13 @@ const SimpleTable: FC<SimpleTableProps> = ({
     }, [visualizationConfig]);
 
     const slicedRows = useMemo(
-        () =>
-            sliceRows(resultsData?.rows || [], isShowHideRowsEnabled, rowLimit),
-        [resultsData?.rows, isShowHideRowsEnabled, rowLimit],
+        () => sliceRows(resultsData?.rows || [], rowLimit),
+        [resultsData?.rows, rowLimit],
     );
 
     const totalRowsCount = useMemo(
-        () =>
-            computeLimitedRowCount(
-                resultsData?.totalResults || 0,
-                isShowHideRowsEnabled,
-                rowLimit,
-            ),
-        [resultsData?.totalResults, isShowHideRowsEnabled, rowLimit],
+        () => computeLimitedRowCount(resultsData?.totalResults || 0, rowLimit),
+        [resultsData?.totalResults, rowLimit],
     );
 
     if (!isTableVisualizationConfig(visualizationConfig)) return null;

--- a/packages/frontend/src/components/SimpleTable/sliceRows.test.ts
+++ b/packages/frontend/src/components/SimpleTable/sliceRows.test.ts
@@ -9,7 +9,7 @@ describe('sliceRows', () => {
     describe('show first N rows', () => {
         it('returns first 5 rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'show',
                     direction: 'first',
                     count: 5,
@@ -19,7 +19,7 @@ describe('sliceRows', () => {
 
         it('returns first 3 rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'show',
                     direction: 'first',
                     count: 3,
@@ -29,7 +29,7 @@ describe('sliceRows', () => {
 
         it('returns all rows when count exceeds length', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'show',
                     direction: 'first',
                     count: 100,
@@ -39,7 +39,7 @@ describe('sliceRows', () => {
 
         it('returns empty array when count is 0', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'show',
                     direction: 'first',
                     count: 0,
@@ -49,7 +49,7 @@ describe('sliceRows', () => {
 
         it('clamps negative count to 0', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'show',
                     direction: 'first',
                     count: -5,
@@ -61,7 +61,7 @@ describe('sliceRows', () => {
     describe('show last N rows', () => {
         it('returns last 5 rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'show',
                     direction: 'last',
                     count: 5,
@@ -71,7 +71,7 @@ describe('sliceRows', () => {
 
         it('returns last 3 rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'show',
                     direction: 'last',
                     count: 3,
@@ -81,7 +81,7 @@ describe('sliceRows', () => {
 
         it('returns all rows when count exceeds length', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'show',
                     direction: 'last',
                     count: 100,
@@ -91,7 +91,7 @@ describe('sliceRows', () => {
 
         it('returns empty array when count is 0', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'show',
                     direction: 'last',
                     count: 0,
@@ -103,7 +103,7 @@ describe('sliceRows', () => {
     describe('hide first N rows', () => {
         it('hides first 3 rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'hide',
                     direction: 'first',
                     count: 3,
@@ -113,7 +113,7 @@ describe('sliceRows', () => {
 
         it('hides first 5 rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'hide',
                     direction: 'first',
                     count: 5,
@@ -123,7 +123,7 @@ describe('sliceRows', () => {
 
         it('returns empty array when hiding all rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'hide',
                     direction: 'first',
                     count: 10,
@@ -133,7 +133,7 @@ describe('sliceRows', () => {
 
         it('returns empty array when hiding more than all rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'hide',
                     direction: 'first',
                     count: 100,
@@ -143,7 +143,7 @@ describe('sliceRows', () => {
 
         it('returns all rows when hiding 0', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'hide',
                     direction: 'first',
                     count: 0,
@@ -155,7 +155,7 @@ describe('sliceRows', () => {
     describe('hide last N rows', () => {
         it('hides last 3 rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'hide',
                     direction: 'last',
                     count: 3,
@@ -165,7 +165,7 @@ describe('sliceRows', () => {
 
         it('hides last 5 rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'hide',
                     direction: 'last',
                     count: 5,
@@ -175,7 +175,7 @@ describe('sliceRows', () => {
 
         it('returns empty array when hiding all rows', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'hide',
                     direction: 'last',
                     count: 10,
@@ -185,7 +185,7 @@ describe('sliceRows', () => {
 
         it('returns all rows when hiding 0', () => {
             expect(
-                sliceRows(rows, true, {
+                sliceRows(rows, {
                     mode: 'hide',
                     direction: 'last',
                     count: 0,
@@ -194,25 +194,9 @@ describe('sliceRows', () => {
         });
     });
 
-    describe('when flag is disabled', () => {
-        it('returns all rows regardless of rowLimit', () => {
-            expect(
-                sliceRows(rows, false, {
-                    mode: 'show',
-                    direction: 'first',
-                    count: 3,
-                }),
-            ).toBe(rows);
-        });
-
-        it('returns all rows when rowLimit is undefined', () => {
-            expect(sliceRows(rows, false, undefined)).toBe(rows);
-        });
-    });
-
     describe('when rowLimit is undefined', () => {
-        it('returns all rows even if flag is enabled', () => {
-            expect(sliceRows(rows, true, undefined)).toBe(rows);
+        it('returns all rows', () => {
+            expect(sliceRows(rows, undefined)).toBe(rows);
         });
     });
 });
@@ -220,23 +204,13 @@ describe('sliceRows', () => {
 describe('computeLimitedRowCount', () => {
     const serverTotal = 5000;
 
-    it('returns server total when flag is off', () => {
-        expect(
-            computeLimitedRowCount(serverTotal, false, {
-                mode: 'show',
-                direction: 'first',
-                count: 10,
-            }),
-        ).toBe(5000);
-    });
-
     it('returns server total when rowLimit is undefined', () => {
-        expect(computeLimitedRowCount(serverTotal, true, undefined)).toBe(5000);
+        expect(computeLimitedRowCount(serverTotal, undefined)).toBe(5000);
     });
 
     it('returns count when showing within server total', () => {
         expect(
-            computeLimitedRowCount(serverTotal, true, {
+            computeLimitedRowCount(serverTotal, {
                 mode: 'show',
                 direction: 'first',
                 count: 10,
@@ -246,7 +220,7 @@ describe('computeLimitedRowCount', () => {
 
     it('clamps to server total when count exceeds it', () => {
         expect(
-            computeLimitedRowCount(serverTotal, true, {
+            computeLimitedRowCount(serverTotal, {
                 mode: 'show',
                 direction: 'first',
                 count: 10000,
@@ -256,7 +230,7 @@ describe('computeLimitedRowCount', () => {
 
     it('works the same for last direction in show mode', () => {
         expect(
-            computeLimitedRowCount(serverTotal, true, {
+            computeLimitedRowCount(serverTotal, {
                 mode: 'show',
                 direction: 'last',
                 count: 10,
@@ -266,7 +240,7 @@ describe('computeLimitedRowCount', () => {
 
     it('returns remaining rows when hiding', () => {
         expect(
-            computeLimitedRowCount(serverTotal, true, {
+            computeLimitedRowCount(serverTotal, {
                 mode: 'hide',
                 direction: 'first',
                 count: 10,
@@ -276,7 +250,7 @@ describe('computeLimitedRowCount', () => {
 
     it('returns 0 when hiding all rows', () => {
         expect(
-            computeLimitedRowCount(serverTotal, true, {
+            computeLimitedRowCount(serverTotal, {
                 mode: 'hide',
                 direction: 'first',
                 count: 5000,
@@ -286,7 +260,7 @@ describe('computeLimitedRowCount', () => {
 
     it('handles zero count', () => {
         expect(
-            computeLimitedRowCount(serverTotal, true, {
+            computeLimitedRowCount(serverTotal, {
                 mode: 'show',
                 direction: 'first',
                 count: 0,
@@ -296,7 +270,7 @@ describe('computeLimitedRowCount', () => {
 
     it('returns server total when hiding 0 rows', () => {
         expect(
-            computeLimitedRowCount(serverTotal, true, {
+            computeLimitedRowCount(serverTotal, {
                 mode: 'hide',
                 direction: 'first',
                 count: 0,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -1,6 +1,5 @@
 import {
     CartesianSeriesType,
-    FeatureFlags,
     getItemId,
     isCustomDimension,
     isDimension,
@@ -24,7 +23,6 @@ import {
 import { IconRotate360 } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { EMPTY_X_AXIS } from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
-import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import FieldSelect from '../../../common/FieldSelect';
 import MantineIcon from '../../../common/MantineIcon';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
@@ -41,14 +39,6 @@ type Props = {
 export const Layout: FC<Props> = ({ items }) => {
     const { visualizationConfig, pivotDimensions, setPivotDimensions } =
         useVisualizationContext();
-    const { data: showHideRowsFlag } = useServerFeatureFlag(
-        FeatureFlags.ShowHideRows,
-    );
-    const isShowHideRowsEnabled = showHideRowsFlag?.enabled ?? false;
-    const { data: showHideColumnsFlag } = useServerFeatureFlag(
-        FeatureFlags.ShowHideColumns,
-    );
-    const isShowHideColumnsEnabled = showHideColumnsFlag?.enabled ?? false;
 
     const isCartesianChart =
         isCartesianVisualizationConfig(visualizationConfig);
@@ -490,37 +480,33 @@ export const Layout: FC<Props> = ({ items }) => {
                 </Config.Section>
             </Config>
 
-            {isShowHideRowsEnabled && (
+            <Config>
+                <Config.Section>
+                    <Config.Heading>Data</Config.Heading>
+                    <RowLimitControls
+                        rowLimit={rowLimit}
+                        onRowLimitChange={setRowLimit}
+                    />
+                </Config.Section>
+            </Config>
+            {pivotDimensions && pivotDimensions.length > 0 && (
                 <Config>
                     <Config.Section>
-                        <Config.Heading>Data</Config.Heading>
-                        <RowLimitControls
-                            rowLimit={rowLimit}
-                            onRowLimitChange={setRowLimit}
+                        <Config.Heading>Column limit</Config.Heading>
+                        <NumberInput
+                            size="xs"
+                            min={1}
+                            max={200}
+                            step={1}
+                            allowDecimal={false}
+                            clampBehavior="strict"
+                            placeholder="No limit"
+                            value={columnLimit ?? ''}
+                            onChange={handleColumnLimitChange}
                         />
                     </Config.Section>
                 </Config>
             )}
-            {isShowHideColumnsEnabled &&
-                pivotDimensions &&
-                pivotDimensions.length > 0 && (
-                    <Config>
-                        <Config.Section>
-                            <Config.Heading>Column limit</Config.Heading>
-                            <NumberInput
-                                size="xs"
-                                min={1}
-                                max={200}
-                                step={1}
-                                allowDecimal={false}
-                                clampBehavior="strict"
-                                placeholder="No limit"
-                                value={columnLimit ?? ''}
-                                onChange={handleColumnLimitChange}
-                            />
-                        </Config.Section>
-                    </Config>
-                )}
         </Stack>
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -1,9 +1,7 @@
 import { DragDropContext, type DropResult } from '@hello-pangea/dnd';
-import { FeatureFlags } from '@lightdash/common';
 import { Box, Checkbox, Stack, Switch, Tooltip } from '@mantine-8/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
@@ -27,10 +25,6 @@ const GeneralSettings: FC = () => {
     } = useVisualizationContext();
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const { showToastError } = useToaster();
-    const { data: showHideRowsFlag } = useServerFeatureFlag(
-        FeatureFlags.ShowHideRows,
-    );
-    const isShowHideRowsEnabled = showHideRowsFlag?.enabled ?? false;
     const { dimensions } = resultsData?.metricQuery || {
         dimensions: [] as string[],
     };
@@ -256,7 +250,7 @@ const GeneralSettings: FC = () => {
                 />
             </Config.Section>
 
-            {isShowHideRowsEnabled && !isPivotTableEnabled && (
+            {!isPivotTableEnabled && (
                 <Config.Section>
                     <Config.Heading>Data</Config.Heading>
                     <RowLimitControls

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -198,7 +198,7 @@ describe('getExpectedSeriesMap', () => {
             expect(Object.keys(result)).toStrictEqual(Object.keys(allResult));
         });
 
-        test('should return identical result when columnLimit is undefined (flag-off path)', () => {
+        test('should return identical result when columnLimit is undefined', () => {
             const withoutLimit = getExpectedSeriesMap(pivotSeriesMapArgs);
             const withUndefinedLimit = getExpectedSeriesMap({
                 ...pivotSeriesMapArgs,
@@ -788,7 +788,7 @@ describe('useCartesianChartConfig', () => {
         expect(result.current.columnLimit).toBeUndefined();
     });
 
-    test('should preserve saved columnLimit in validConfig when feature flag is off', () => {
+    test('should preserve saved columnLimit in validConfig', () => {
         const { result } = renderHook(() =>
             // @ts-expect-error partially mock params for hook
             useCartesianChartConfig({

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -192,18 +192,9 @@ const useCartesianChartConfig = ({
     cartesianType,
     tableCalculationsMetadata,
 }: Args) => {
-    const { data: showHideColumnsFlag } = useServerFeatureFlag(
-        FeatureFlags.ShowHideColumns,
-    );
-    const isShowHideColumnsEnabled = showHideColumnsFlag?.enabled ?? false;
-
     const [columnLimit, setColumnLimit] = useState<number | undefined>(
         initialChartConfig?.columnLimit,
     );
-
-    const effectiveColumnLimit = isShowHideColumnsEnabled
-        ? columnLimit
-        : undefined;
 
     const [dirtyLayout, setDirtyLayout] = useState<
         Partial<CartesianChart['layout']> | undefined
@@ -1118,7 +1109,7 @@ const useCartesianChartConfig = ({
                     yFields: dirtyLayout.yField,
                     defaultLabel,
                     itemsMap,
-                    columnLimit: effectiveColumnLimit,
+                    columnLimit,
                 });
                 const sortedByPivot = isSortedByPivot({
                     pivotDimensions: pivotKeys,
@@ -1159,7 +1150,7 @@ const useCartesianChartConfig = ({
         referenceLines,
         itemsMap,
         seriesHiddenStatesKey, // Re-run when series hidden states change
-        effectiveColumnLimit,
+        columnLimit,
     ]);
 
     const { dirtyChartType } = useMemo(() => {
@@ -1266,9 +1257,7 @@ const useCartesianChartConfig = ({
             conditionalFormattings,
             metadata: dirtyMetadata,
             rowLimit,
-            columnLimit: isShowHideColumnsEnabled
-                ? columnLimit
-                : initialChartConfig?.columnLimit,
+            columnLimit,
         };
     }, [
         dirtyLayout,
@@ -1278,9 +1267,7 @@ const useCartesianChartConfig = ({
         tooltip,
         tooltipSort,
         rowLimit,
-        isShowHideColumnsEnabled,
         columnLimit,
-        initialChartConfig?.columnLimit,
     ]);
 
     const updateMetadata = useCallback(
@@ -1345,7 +1332,7 @@ const useCartesianChartConfig = ({
         updateMetadata,
         rowLimit,
         setRowLimit,
-        columnLimit: effectiveColumnLimit,
+        columnLimit,
         setColumnLimit,
     };
 };

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -438,12 +438,7 @@ describe('filterSeriesWithNoData', () => {
             { metric_a: 20, metric_b: null },
         ];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            rowLimit,
-        );
+        const filtered = filterSeriesWithNoData(series, results, rowLimit);
         expect(filtered).toHaveLength(1);
         expect(filtered[0].encode?.tooltip?.[0]).toBe('metric_a');
     });
@@ -455,12 +450,7 @@ describe('filterSeriesWithNoData', () => {
             { metric_a: 20 },
         ];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            rowLimit,
-        );
+        const filtered = filterSeriesWithNoData(series, results, rowLimit);
         expect(filtered).toHaveLength(1);
         expect(filtered[0].encode?.tooltip?.[0]).toBe('metric_a');
     });
@@ -472,12 +462,7 @@ describe('filterSeriesWithNoData', () => {
             { metric_a: 20, metric_b: 0 },
         ];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            rowLimit,
-        );
+        const filtered = filterSeriesWithNoData(series, results, rowLimit);
         expect(filtered).toHaveLength(2);
     });
 
@@ -488,12 +473,7 @@ describe('filterSeriesWithNoData', () => {
             { metric_a: 20, metric_b: '' },
         ];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            rowLimit,
-        );
+        const filtered = filterSeriesWithNoData(series, results, rowLimit);
         expect(filtered).toHaveLength(2);
     });
 
@@ -501,12 +481,7 @@ describe('filterSeriesWithNoData', () => {
         const series = [makeSeries('metric_a'), makeSeries(undefined)];
         const results = [{ metric_a: 10 }];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            rowLimit,
-        );
+        const filtered = filterSeriesWithNoData(series, results, rowLimit);
         expect(filtered).toHaveLength(2);
     });
 
@@ -514,25 +489,7 @@ describe('filterSeriesWithNoData', () => {
         const series = [makeSeries('metric_a'), makeSeries('metric_b')];
         const results: Record<string, unknown>[] = [];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            rowLimit,
-        );
-        expect(filtered).toBe(series);
-    });
-
-    test('returns unfilteredSeries when isShowHideRowsEnabled is false', () => {
-        const series = [makeSeries('metric_a'), makeSeries('metric_b')];
-        const results = [{ metric_a: 10, metric_b: null }];
-
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            false,
-            rowLimit,
-        );
+        const filtered = filterSeriesWithNoData(series, results, rowLimit);
         expect(filtered).toBe(series);
     });
 
@@ -540,12 +497,7 @@ describe('filterSeriesWithNoData', () => {
         const series = [makeSeries('metric_a'), makeSeries('metric_b')];
         const results = [{ metric_a: 10, metric_b: null }];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            undefined,
-        );
+        const filtered = filterSeriesWithNoData(series, results, undefined);
         expect(filtered).toBe(series);
     });
 
@@ -556,12 +508,7 @@ describe('filterSeriesWithNoData', () => {
             { metric_a: 20, metric_b: 5 },
         ];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            rowLimit,
-        );
+        const filtered = filterSeriesWithNoData(series, results, rowLimit);
         expect(filtered).toHaveLength(2);
     });
 
@@ -576,12 +523,7 @@ describe('filterSeriesWithNoData', () => {
             { metric_a: 20, metric_b: '∅' },
         ];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            rowLimit,
-        );
+        const filtered = filterSeriesWithNoData(series, results, rowLimit);
         // '∅' is a truthy string — series is kept. This is a known limitation:
         // getResultValueArray falls back from null raw to formatted string.
         expect(filtered).toHaveLength(2);
@@ -603,12 +545,7 @@ describe('filterSeriesWithNoData', () => {
             { metric_a: 20, label_col: null, metric_b: null },
         ];
 
-        const filtered = filterSeriesWithNoData(
-            series,
-            results,
-            true,
-            rowLimit,
-        );
+        const filtered = filterSeriesWithNoData(series, results, rowLimit);
         expect(filtered).toHaveLength(2);
     });
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -8,7 +8,6 @@ import {
     CustomFormatType,
     DimensionType,
     evaluateConditionalFormatExpression,
-    FeatureFlags,
     formatItemValue,
     formatNumberValue,
     formatValueWithExpression,
@@ -100,7 +99,6 @@ import {
     type RowKeyMap,
 } from '../plottedData/getPlottedData';
 import { type InfiniteQueryResults } from '../useQueryResults';
-import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import { getCartesianConditionalFormattingColor } from './cartesianConditionalFormatting';
 import {
     applyTimezoneShiftToEchartsOptions,
@@ -1405,10 +1403,9 @@ const getLongestLabel = ({
 export const filterSeriesWithNoData = (
     unfilteredSeries: EChartsSeries[],
     results: Record<string, unknown>[],
-    isShowHideRowsEnabled: boolean,
     rowLimit: RowLimit | undefined,
 ): EChartsSeries[] => {
-    if (!isShowHideRowsEnabled || !rowLimit) {
+    if (!rowLimit) {
         return unfilteredSeries;
     }
     if (results.length === 0) return unfilteredSeries;
@@ -2405,10 +2402,6 @@ const useEchartsCartesianConfig = (
     } = useVisualizationContext();
 
     const theme = useMantineTheme();
-    const { data: showHideRowsFlag } = useServerFeatureFlag(
-        FeatureFlags.ShowHideRows,
-    );
-    const isShowHideRowsEnabled = showHideRowsFlag?.enabled ?? false;
 
     const validCartesianConfig = useMemo(() => {
         if (!isCartesianVisualizationConfig(visualizationConfig)) return;
@@ -2483,13 +2476,8 @@ const useEchartsCartesianConfig = (
     }, [resultsData, pivotDimensions, pivotedKeys, nonPivotedKeys]);
 
     const rows = useMemo(
-        () =>
-            sliceRows(
-                allRows,
-                isShowHideRowsEnabled,
-                validCartesianConfig?.rowLimit,
-            ),
-        [allRows, isShowHideRowsEnabled, validCartesianConfig?.rowLimit],
+        () => sliceRows(allRows, validCartesianConfig?.rowLimit),
+        [allRows, validCartesianConfig?.rowLimit],
     );
 
     // Pivot references from hidden series, used for resolving custom tooltip references
@@ -2540,7 +2528,6 @@ const useEchartsCartesianConfig = (
         return filterSeriesWithNoData(
             unfilteredSeries,
             resultsAndMinsAndMaxes.results,
-            isShowHideRowsEnabled,
             validCartesianConfig?.rowLimit,
         );
     }, [
@@ -2552,7 +2539,6 @@ const useEchartsCartesianConfig = (
         pivotValuesColumnsMap,
         parameters,
         resultsAndMinsAndMaxes.results,
-        isShowHideRowsEnabled,
         resolvedTimezone,
     ]);
 
@@ -2570,10 +2556,7 @@ const useEchartsCartesianConfig = (
             series,
             validCartesianConfig,
             resultsData,
-            displayedRows:
-                isShowHideRowsEnabled && validCartesianConfig?.rowLimit
-                    ? rows
-                    : undefined,
+            displayedRows: validCartesianConfig?.rowLimit ? rows : undefined,
             minsAndMaxes: resultsAndMinsAndMaxes.minsAndMaxes,
             parameters,
             resolvedTimezone: axisTimezone,
@@ -2585,7 +2568,6 @@ const useEchartsCartesianConfig = (
         series,
         resultsData,
         rows,
-        isShowHideRowsEnabled,
         resultsAndMinsAndMaxes.minsAndMaxes,
         parameters,
         axisTimezone,
@@ -3095,11 +3077,7 @@ const useEchartsCartesianConfig = (
     // mapping (row index → category index) stays correct.
     const paddedDataToRender = useMemo(() => {
         const continuousRange = axes.continuousDateRange;
-        if (
-            !continuousRange ||
-            !isShowHideRowsEnabled ||
-            !validCartesianConfig?.rowLimit
-        )
+        if (!continuousRange || !validCartesianConfig?.rowLimit)
             return dataToRender;
         const xFieldId = validCartesianConfig?.layout?.flipAxes
             ? validCartesianConfig?.layout?.yField?.[0]
@@ -3113,7 +3091,6 @@ const useEchartsCartesianConfig = (
     }, [
         dataToRender,
         axes.continuousDateRange,
-        isShowHideRowsEnabled,
         validCartesianConfig?.rowLimit,
         validCartesianConfig?.layout?.flipAxes,
         validCartesianConfig?.layout?.yField,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -78,10 +78,7 @@ import { CustomRoles } from '../ee/pages/customRoles/CustomRoles';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
 import { useProject } from '../hooks/useProject';
-import {
-    useClientFeatureFlag,
-    useServerFeatureFlag,
-} from '../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';

--- a/packages/frontend/src/utils/sliceRows.ts
+++ b/packages/frontend/src/utils/sliceRows.ts
@@ -2,10 +2,9 @@ import type { RowLimit } from '@lightdash/common';
 
 export function sliceRows<T>(
     allRows: T[],
-    isEnabled: boolean,
     rowLimit: RowLimit | undefined,
 ): T[] {
-    if (!isEnabled || !rowLimit) return allRows;
+    if (!rowLimit) return allRows;
     const count = Math.max(0, rowLimit.count);
     if (rowLimit.mode === 'show') {
         if (rowLimit.direction === 'first') return allRows.slice(0, count);
@@ -19,10 +18,9 @@ export function sliceRows<T>(
 
 export function computeLimitedRowCount(
     serverTotal: number,
-    isEnabled: boolean,
     rowLimit: RowLimit | undefined,
 ): number {
-    if (!isEnabled || !rowLimit) return serverTotal;
+    if (!rowLimit) return serverTotal;
     const count = Math.min(Math.max(0, rowLimit.count), serverTotal);
     if (rowLimit.mode === 'show') return count;
     return serverTotal - count;


### PR DESCRIPTION
## Summary

Graduates the **show/hide rows** and **column limit** chart-config controls from experimental to default-on by deleting the feature flag gates. Both flags hit 100% PostHog rollout in early April after the rollout discussion in #feat-internal-tools, but the code-side cleanup was never completed at the time. This PR finishes that work.

## Why this approach (not a DB migration)

The first iteration of this PR added a migration to seed `feature_flags.default_enabled = true`. That's not the established pattern in this codebase — there's no precedent for seeding flag defaults via migration, and it conflicts with the agreed plan to remove these flags entirely (chat in `#feat-internal-tools`, 9 Apr 2026). Replaced with the standard graduation pattern used in #17741 (AgentV2) and #20179 (metrics catalog tree mode): just delete the gate.

## Changes

**Common**
- Remove `FeatureFlags.ShowHideRows` and `FeatureFlags.ShowHideColumns` enum entries

**Backend**
- Drop `SHOW_HIDE_ROWS_ENABLED` and `SHOW_HIDE_COLUMNS_ENABLED` from `LEGACY_ENABLE_ENV_VARS` in `parseConfig.ts`
- Update the matching parity test in `parseConfig.test.ts`

**Frontend** — strip the `useServerFeatureFlag(...)` check at every call site:
- `components/SimpleTable/index.tsx`
- `components/Explorer/ResultsCard/ExplorerResults.tsx`
- `components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx`
- `components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx`
- `components/DashboardTiles/DashboardChartTile.tsx`
- `hooks/cartesianChartConfig/useCartesianChartConfig.ts`
- `hooks/echarts/useEchartsCartesianConfig.ts`

**Utility simplification**
- `utils/sliceRows.ts` — drop the `isEnabled` boolean parameter from `sliceRows()` and `computeLimitedRowCount()`. The flag was the only reason this parameter existed.
- Updated the `sliceRows.test.ts` and `useEchartsCartesianConfig.test.ts` to match; deleted the now-obsolete "isShowHideRowsEnabled is false" test case.

Net: **−298 / +86 lines** across 14 files.

## Behavior change

- Cloud instances already at 100% PostHog rollout: **no observable change**.
- Self-hosted instances that set `SHOW_HIDE_ROWS_ENABLED=true` / `SHOW_HIDE_COLUMNS_ENABLED=true` env vars: **no observable change** (controls were already on for them).
- Self-hosted instances that did **not** set those env vars: row-limit Switch and column-limit input now appear in chart config out-of-the-box. This matches what was announced to Wise on 30 March 2026 and is the expected target state.

The legacy env vars (`SHOW_HIDE_ROWS_ENABLED`, `SHOW_HIDE_COLUMNS_ENABLED`) become no-ops after this PR. They're safe to leave in operator configs — `parseConfig` will silently ignore unknown legacy flag IDs.

## Docs

Companion docs PR: lightdash/mintlify-docs#587 — already documents both controls without mentioning a flag, so it's coherent with the graduated state.

## Test plan

- [x] `pnpm -F common build` — clean
- [x] `pnpm -F frontend typecheck` — clean
- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend exec jest packages/backend/src/config/parseConfig.test.ts` — 86 passed
- [x] `pnpm -F frontend exec vitest run` on the affected suites — 104 passed
- [ ] Manual smoke: confirm the row-limit Switch and column-limit input render in chart config without any flag override
- [ ] Manual smoke: confirm a saved chart with `rowLimit` / `columnLimit` set still loads and behaves correctly post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)