### PR TITLE
feat: pass `chartUuid` and `dashboardUuid` to async query warehouse metadata

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4866,6 +4866,8 @@ export class AsyncQueryService extends ProjectService {
         limit,
         tileUuid,
         parameters,
+        chartUuid,
+        dashboardUuid,
     }: {
         account: Account;
         projectUuid: string;
@@ -4878,6 +4880,8 @@ export class AsyncQueryService extends ProjectService {
         limit?: number;
         tileUuid?: string;
         parameters?: ParametersValuesMap;
+        chartUuid?: string;
+        dashboardUuid?: string;
     }) {
         const startTime = performance.now();
 
@@ -4898,6 +4902,8 @@ export class AsyncQueryService extends ProjectService {
             organization_uuid: organizationUuid,
             project_uuid: projectUuid,
             query_context: context,
+            ...(chartUuid ? { chart_uuid: chartUuid } : {}),
+            ...(dashboardUuid ? { dashboard_uuid: dashboardUuid } : {}),
         };
         const durationWarehouse = performance.now() - sectionStartWarehouse;
 
@@ -5168,6 +5174,7 @@ export class AsyncQueryService extends ProjectService {
             config: sqlChart.config,
             limit: limit ?? sqlChart.limit,
             parameters: combinedParameters,
+            chartUuid: sqlChart.savedSqlUuid,
         });
 
         // Disconnect the ssh tunnel to avoid leaking connections, another client is created in the scheduler task
@@ -5267,6 +5274,8 @@ export class AsyncQueryService extends ProjectService {
             dashboardSorts,
             limit: limit ?? savedChart.limit,
             parameters: combinedParameters,
+            chartUuid: savedChart.savedSqlUuid,
+            dashboardUuid,
         });
 
         // Disconnect the ssh tunnel to avoid leaking connections, another client is created in the scheduler task


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7377/sql-runner-saved-chart-queries-dont-include-chart-uuid-in-warehouse

BUG FIX REPORT
  ════════════════════════════════════════
  Issue:           PROD-7377 — SQL runner saved chart queries don't include chart_uuid in warehouse query tags
  Symptom:         Warehouse query tags for saved SQL runner charts only contained {user_uuid, organization_uuid, project_uuid, explore_name,
  query_context, query_uuid} with no chart identifier, breaking warehouse-log → chart attribution.
  Root cause:      `prepareSqlChartAsyncQueryArgs` (AsyncQueryService.ts:4857) didn't accept or propagate the saved-SQL chart UUID into queryTags.
  Both callers had the chart object but never passed its UUID down. Explore-based charts already set `chart_uuid` (line 4008/4327); SQL chart path
  missed it.
  Fix:             Added optional `chartUuid` and `dashboardUuid` parameters to `prepareSqlChartAsyncQueryArgs`; included them in queryTags when
  present. Wired `sqlChart.savedSqlUuid` from `executeAsyncSqlChartQuery` (line 5174) and `savedChart.savedSqlUuid` + `dashboardUuid` from
  `executeAsyncDashboardSqlChartQuery` (line 5277). `RunQueryTags` already supported both fields.
  Test:            Created a SQL chart in the Jaffle shop project (uuid 31028a9f-…), executed it via POST /api/v2/projects/{uuid}/query/sql-chart and
  /dashboard-sql-chart, captured queryTags via temporary log to /tmp. Confirmed:
                   - sql-chart: chart_uuid present
                   - dashboard-sql-chart: chart_uuid AND dashboard_uuid present
                   Backend typecheck + lint pass. Test data deleted.
  Regression risk: LOW. Only adds tag fields. Both new params are optional, spread is conditional, and sql_runner ad-hoc (non-saved) queries don't go
  through these callers so they're unaffected. RunQueryTags already typed `chart_uuid?` / `dashboard_uuid?`.
  Status:          DONE
  ════════════════════════════════════════

### Description:
Passes `chartUuid` and `dashboardUuid` through to the SQL query execution context, so that these identifiers are included in the query metadata when running SQL chart queries. This allows queries to be traced back to their originating chart and dashboard.