### PR TITLE
fix: improve partial compilation error messages with field names and model-prefix hints

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -368,7 +368,12 @@ export const compile = async (options: CompileHandlerOptions) => {
             e.warnings.length > 0
         ) {
             status = styles.warning('PARTIAL_SUCCESS');
-            messages = `: ${styles.warning(e.warnings.map((warning) => warning.message).join(', '))}`;
+            messages = `\n${e.warnings
+                .map(
+                    (warning) =>
+                        `    ${styles.warning(`⚠ ${warning.message}`)}`,
+                )
+                .join('\n')}`;
             partialSuccess += 1;
         } else {
             status = styles.success('SUCCESS');

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -632,6 +632,87 @@ describe('Explore compilation with model-level parameters', () => {
                 compiler.compileExplore(exploreWithInvalidParameterReference),
             ).toThrow('Missing parameters: b.nonexistent_param');
         });
+
+        test('should hint the model name prefix when a short-form parameter reference matches a model-level parameter', () => {
+            // Reproduces PROD-6943: a short-form reference like
+            // `${lightdash.parameters.active_status}` doesn't match the
+            // model-prefixed available parameter `b.active_status`.
+            const exploreWithShortFormParameterReference = {
+                ...exploreWithParameters,
+                joinedTables: [
+                    {
+                        table: 'b',
+                        sqlOn: "${a.dim1} = ${b.dim1} AND ${ld.parameters.active_status} = 'active'",
+                    },
+                ],
+            };
+
+            expect(() =>
+                compiler.compileExplore(exploreWithShortFormParameterReference),
+            ).toThrow(
+                /Missing parameters: active_status\..*Hint:.*"active_status" is a model-level parameter.*\${lightdash\.parameters\.b\.active_status}/,
+            );
+        });
+    });
+
+    describe('Partial compilation surfaces field-level errors clearly', () => {
+        const partialCompiler = new ExploreCompiler(warehouseClientMock, {
+            allowPartialCompilation: true,
+        });
+
+        test('should produce a warning that names the failing dimension and hints the model prefix', () => {
+            // Reproduces PROD-6943: a dimension referencing a model-level
+            // parameter via the short form silently compiles to NULL. The
+            // warning surfaced to the user must name the dimension and
+            // explain how to fix the reference.
+            const exploreWithBadDimension: UncompiledExplore = {
+                ...exploreWithParameters,
+                joinedTables: [],
+                tables: {
+                    ...exploreWithParameters.tables,
+                    a: {
+                        ...exploreWithParameters.tables.a,
+                        dimensions: {
+                            ...exploreWithParameters.tables.a.dimensions,
+                            selected_team: {
+                                ...exploreWithParameters.tables.a.dimensions
+                                    .dim1,
+                                name: 'selected_team',
+                                label: 'selected_team',
+                                sql: "CASE WHEN ${lightdash.parameters.region} = 'US' THEN 1 ELSE 0 END",
+                            },
+                        },
+                    },
+                },
+            };
+
+            const result = partialCompiler.compileExplore(
+                exploreWithBadDimension,
+            );
+
+            expect(result.warnings).toBeDefined();
+            const warningMessages = (result.warnings ?? []).map(
+                (w) => w.message,
+            );
+            const dimWarning = warningMessages.find((m) =>
+                m.includes('selected_team'),
+            );
+            expect(dimWarning).toBeDefined();
+            expect(dimWarning).toContain(
+                'Dimension "selected_team" failed to compile',
+            );
+            expect(dimWarning).toContain('Missing parameters: region');
+            expect(dimWarning).toContain('${lightdash.parameters.a.region}');
+            // Confirm the placeholder NULL compiledSql is still present so
+            // the rest of the explore still ships.
+            expect(result.tables.a.dimensions.selected_team.compiledSql).toBe(
+                'NULL',
+            );
+            expect(
+                result.tables.a.dimensions.selected_team.compilationError
+                    ?.message,
+            ).toContain('selected_team');
+        });
     });
 
     describe('Parameter resolution in join conditions', () => {

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -714,10 +714,11 @@ export class ExploreCompiler {
                         ),
                     };
                 } catch (e) {
-                    const errorMessage =
+                    const baseMessage =
                         e instanceof Error
                             ? e.message
-                            : `Failed to compile dimension "${dimensionKey}"`;
+                            : 'unknown compile error';
+                    const errorMessage = `Dimension "${dimensionKey}" failed to compile: ${baseMessage}`;
                     return {
                         ...prev,
                         [dimensionKey]:
@@ -753,10 +754,11 @@ export class ExploreCompiler {
                         ),
                     };
                 } catch (e) {
-                    const errorMessage =
+                    const baseMessage =
                         e instanceof Error
                             ? e.message
-                            : `Failed to compile metric "${metricKey}"`;
+                            : 'unknown compile error';
+                    const errorMessage = `Metric "${metricKey}" failed to compile: ${baseMessage}`;
                     return {
                         ...prev,
                         [metricKey]: ExploreCompiler.createMetricWithError(

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -89,10 +89,30 @@ export const validateParameterReferences = (
     );
 
     if (missingParameters.length > 0) {
+        // When a short-form reference (e.g. `attribution_source`) doesn't match
+        // but a model-prefixed parameter does (e.g. `model.attribution_source`),
+        // surface the correct full reference so the user knows what to write.
+        const hints = missingParameters.reduce<string[]>((acc, missing) => {
+            if (missing.includes('.')) return acc;
+            const matches = availableParameters.filter((p) =>
+                p.endsWith(`.${missing}`),
+            );
+            if (matches.length === 0) return acc;
+            const suggestions = matches
+                .map((m) => `\${lightdash.parameters.${m}}`)
+                .join(' or ');
+            acc.push(
+                `"${missing}" is a model-level parameter — use the model name prefix: ${suggestions}`,
+            );
+            return acc;
+        }, []);
+
+        const hintMsg = hints.length > 0 ? ` Hint: ${hints.join('; ')}` : '';
+
         throw new CompileError(
             `Failed to compile explore "${tableName}". Missing parameters: ${missingParameters.join(
                 ', ',
-            )}`,
+            )}.${hintMsg}`,
             {},
         );
     }


### PR DESCRIPTION
Closes: PROD-6943

### Description:

When a parameter is referenced using the short form (e.g. `${lightdash.parameters.region}`) but only exists as a model-prefixed parameter (e.g. `a.region`), the compiler now detects this mismatch and surfaces a hint pointing to the correct full reference (e.g. `${lightdash.parameters.a.region}`) instead of silently compiling to `NULL` or throwing a generic missing parameter error.

Partial compilation warnings for dimensions and metrics now include the field name in the error message (e.g. `Dimension "selected_team" failed to compile: ...`) so it's immediately clear which field is broken and why.

The CLI compile output for partial successes now displays each warning on its own indented line with a `⚠` prefix, making it easier to read when multiple warnings are present.