### PR TITLE
chore: restrict backend imports from `@lightdash/common/src` deep paths

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -37,6 +37,21 @@ module.exports = {
         '@typescript-eslint/no-throw-literal': 'off',
         // no-throw-literal replaced with only-throw-error
         '@typescript-eslint/only-throw-error': 'off',
+        'no-restricted-imports': [
+            'error',
+            {
+                patterns: [
+                    {
+                        group: [
+                            '@lightdash/common/src',
+                            '@lightdash/common/src/*',
+                        ],
+                        message:
+                            'Backend runtime code must import from @lightdash/common, not @lightdash/common/src. Deep source imports are not available in the production image.',
+                    },
+                ],
+            },
+        ],
     },
     overrides: [
         {
@@ -77,6 +92,15 @@ module.exports = {
             files: [
                 'src/database/migrations/*.ts',
                 'src/routers/*.ts',
+            ],
+            rules: {
+                '@typescript-eslint/no-unsafe-member-access': 'off',
+                '@typescript-eslint/no-unsafe-assignment': 'off',
+                '@typescript-eslint/no-unsafe-call': 'off',
+            },
+        },
+        {
+            files: [
                 '*.mock.ts',
                 '*.test.ts',
                 '*.spec.ts',
@@ -85,6 +109,7 @@ module.exports = {
                 '@typescript-eslint/no-unsafe-member-access': 'off',
                 '@typescript-eslint/no-unsafe-assignment': 'off',
                 '@typescript-eslint/no-unsafe-call': 'off',
+                'no-restricted-imports': 'off',
             },
         },
         {


### PR DESCRIPTION
Closes:

### Description:
Adds an ESLint rule to the backend package that prevents importing directly from `@lightdash/common/src` or `@lightdash/common/src/*`. These deep source imports are not available in the production image, so backend runtime code must import from `@lightdash/common` instead. The restriction is disabled for test files, where such imports may be acceptable.