### PR TITLE
feat: match underlying dbt names in table and field search

### DIFF
--- a/packages/backend/src/models/SearchModel/utils/search.ts
+++ b/packages/backend/src/models/SearchModel/utils/search.ts
@@ -162,8 +162,10 @@ export function getTableOrFieldMatchCount(
     tableOrField: CompiledTable | CompiledField,
 ) {
     const labelMatches = tableOrField.label.match(regex) ?? [];
+    const nameMatches = tableOrField.name.match(regex) ?? [];
     const descriptionMatches = tableOrField.description?.match(regex) ?? [];
 
     // remove duplicate matches
-    return new Set([...labelMatches, ...descriptionMatches]).size;
+    return new Set([...labelMatches, ...nameMatches, ...descriptionMatches])
+        .size;
 }

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -47,6 +47,7 @@ const BasePanel = () => {
                 explores = new Fuse(Object.values(exploresResult.data), {
                     keys: [
                         'label',
+                        'name',
                         'preAggregateSource.preAggregateName',
                         'preAggregateSource.sourceExploreName',
                     ],

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -11,6 +11,7 @@ import {
     HoverCard,
     NavLink,
     Paper,
+    Stack,
     Text,
 } from '@mantine-8/core';
 import { useToggle } from '@mantine/hooks';
@@ -62,6 +63,13 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
             ? `Pre-aggregate for ${preAggregateSource.sourceExploreName}`
             : explore.description;
 
+    const normalizedQuery = query?.trim().toLowerCase() ?? '';
+    const showUnderlyingName =
+        normalizedQuery !== '' &&
+        explore.name !== displayLabel &&
+        explore.name.toLowerCase().includes(normalizedQuery) &&
+        !displayLabel.toLowerCase().includes(normalizedQuery);
+
     // Determine rightSection
     let rightSection;
     if (isError) {
@@ -108,14 +116,27 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
             onMouseLeave={needsHoverCard ? undefined : () => toggleHover(false)}
             label={
                 isError ? (
-                    <Highlight
-                        component={Text}
-                        highlight={query ?? ''}
-                        truncate
-                        fz="inherit"
-                    >
-                        {displayLabel}
-                    </Highlight>
+                    <Stack gap={2}>
+                        <Highlight
+                            component={Text}
+                            highlight={query ?? ''}
+                            truncate
+                            fz="inherit"
+                        >
+                            {displayLabel}
+                        </Highlight>
+                        {showUnderlyingName && (
+                            <Highlight
+                                component={Text}
+                                highlight={query ?? ''}
+                                truncate
+                                fz="xs"
+                                c="ldGray.7"
+                            >
+                                {explore.name}
+                            </Highlight>
+                        )}
+                    </Stack>
                 ) : (
                     <TableItemDetailPreview
                         label={displayLabel}
@@ -124,16 +145,29 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
                         closePreview={() => toggleHover(false)}
                         offset={0}
                     >
-                        <Highlight
-                            component={Text}
-                            highlight={query ?? ''}
-                            truncate
-                            fz="sm"
-                            fw={500}
-                            c="ldDark.8"
-                        >
-                            {displayLabel}
-                        </Highlight>
+                        <Stack gap={2}>
+                            <Highlight
+                                component={Text}
+                                highlight={query ?? ''}
+                                truncate
+                                fz="sm"
+                                fw={500}
+                                c="ldDark.8"
+                            >
+                                {displayLabel}
+                            </Highlight>
+                            {showUnderlyingName && (
+                                <Highlight
+                                    component={Text}
+                                    highlight={query ?? ''}
+                                    truncate
+                                    fz="xs"
+                                    c="ldGray.7"
+                                >
+                                    {explore.name}
+                                </Highlight>
+                            )}
+                        </Stack>
                     </TableItemDetailPreview>
                 )
             }

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
@@ -81,7 +81,6 @@ export const getSearchItemMap = (
             };
         }
 
-        const underlyingName = item.name !== item.label ? item.name : undefined;
         return {
             type: SearchItemType.TABLE,
             typeLabel: item.name === item.explore ? 'Table' : 'Joined table',
@@ -90,9 +89,7 @@ export const getSearchItemMap = (
                     ? undefined
                     : `${item.exploreLabel} - `,
             title: item.label,
-            description: [underlyingName, item.description]
-                .filter(Boolean)
-                .join(' · '),
+            description: item.description,
             item: item,
             location: {
                 pathname: `/projects/${projectUuid}/tables/${item.explore}`,
@@ -132,7 +129,6 @@ export const getSearchItemMap = (
                 },
             },
         );
-        const underlyingName = item.name !== item.label ? item.name : undefined;
         return {
             type: SearchItemType.FIELD,
             typeLabel:
@@ -142,9 +138,7 @@ export const getSearchItemMap = (
                     ? `${item.tableLabel} - `
                     : `${item.exploreLabel} - ${item.tableLabel} - `,
             title: item.label,
-            description: [underlyingName, item.description]
-                .filter(Boolean)
-                .join(' · '),
+            description: item.description,
             meta: item,
             location: explorePath,
         };

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
@@ -81,6 +81,7 @@ export const getSearchItemMap = (
             };
         }
 
+        const underlyingName = item.name !== item.label ? item.name : undefined;
         return {
             type: SearchItemType.TABLE,
             typeLabel: item.name === item.explore ? 'Table' : 'Joined table',
@@ -89,7 +90,9 @@ export const getSearchItemMap = (
                     ? undefined
                     : `${item.exploreLabel} - `,
             title: item.label,
-            description: item.description,
+            description: [underlyingName, item.description]
+                .filter(Boolean)
+                .join(' · '),
             item: item,
             location: {
                 pathname: `/projects/${projectUuid}/tables/${item.explore}`,
@@ -129,6 +132,7 @@ export const getSearchItemMap = (
                 },
             },
         );
+        const underlyingName = item.name !== item.label ? item.name : undefined;
         return {
             type: SearchItemType.FIELD,
             typeLabel:
@@ -138,7 +142,9 @@ export const getSearchItemMap = (
                     ? `${item.tableLabel} - `
                     : `${item.exploreLabel} - ${item.tableLabel} - `,
             title: item.label,
-            description: item.description,
+            description: [underlyingName, item.description]
+                .filter(Boolean)
+                .join(' · '),
             meta: item,
             location: explorePath,
         };


### PR DESCRIPTION
## Summary

Closes #7493
Closes: PROD-4608

When a customer renames a dbt model with a friendly Lightdash label (e.g. `customer_order_payments` → "Customer order payments"), the dbt name was no longer searchable. Searching by the underlying dbt name returned no results.

This change makes both the **Explore sidebar** search and the **global omnibar** search match against the underlying `name` (dbt model / field name) in addition to the friendly `label`.

### Changes

- **Sidebar search** (`packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx`) — added `name` to Fuse.js search keys.
- **Sidebar result** (`ExploreNavLink.tsx`) — when the query matches the dbt `name` but not the displayed `label`, the dbt name appears as a small highlighted subtitle under the friendly label so the user understands why the row matched.
- **Global search backend** (`packages/backend/src/models/SearchModel/utils/search.ts`) — `getTableOrFieldMatchCount` now counts matches against `name` for tables and fields, in addition to `label` and `description`. (Tables/fields are filtered in-memory from `cached_explores`, so no DB query change is needed.)

## Screenshots

<img width="2400" height="1516" alt="CleanShot 2026-05-01 at 10 13 24@2x" src="https://github.com/user-attachments/assets/8b78f35a-d3ca-476c-9ff7-bba543f2322b" />

<img width="2402" height="870" alt="CleanShot 2026-05-01 at 10 16 30@2x" src="https://github.com/user-attachments/assets/9c56ed6a-9ee0-40af-9486-e09a81a170e8" />

## Test plan

- [x] `pnpm -F frontend typecheck`, `pnpm -F backend typecheck`
- [x] `pnpm -F frontend lint`, `pnpm -F backend lint`
- [x] `pnpm -F backend test:dev:nowatch` (22 suites / 381 tests pass)
- [x] Manual: searching dbt name in Explore sidebar surfaces the renamed table with subtle dbt-name subtitle
- [x] Manual: searching dbt name in Cmd+K global omnibar returns the renamed table with dbt name in description
- [ ] Manual: searching by friendly label still works (sidebar shows clean label only, no subtitle)
- [ ] Manual: dbt field name search returns matching field in the omnibar

🤖 Generated with [Claude Code](https://claude.com/claude-code)