### PR TITLE
feat: project-level color palette picker

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -615,6 +615,34 @@ export class ProjectController extends BaseController {
     }
 
     /**
+     * Set the project's color palette to one of its organization's palettes,
+     * or null to inherit from the organization's active palette.
+     * @summary Update project color palette
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('{projectUuid}/colorPalette')
+    @OperationId('updateProjectColorPalette')
+    async updateProjectColorPalette(
+        @Path() projectUuid: string,
+        @Body() body: { colorPaletteUuid: string | null },
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+        await this.services
+            .getProjectService()
+            .updateColorPalette(req.user!, projectUuid, body.colorPaletteUuid);
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
      * Get all dashboards in a project
      * @summary List dashboards
      */

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -31,6 +31,7 @@ export type DbProject = {
     created_by_user_uuid: string | null;
     has_default_user_spaces: boolean;
     project_defaults: ProjectDefaults | null;
+    color_palette_uuid: string | null;
 };
 
 type CreateDbProject = Pick<
@@ -63,6 +64,7 @@ type UpdateDbProject = Partial<
         | 'query_timezone'
         | 'has_default_user_spaces'
         | 'project_defaults'
+        | 'color_palette_uuid'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260430151206_add_color_palette_uuid_to_projects.ts
+++ b/packages/backend/src/database/migrations/20260430151206_add_color_palette_uuid_to_projects.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+const ProjectsTable = 'projects';
+const OrganizationColorPalettesTable = 'organization_color_palettes';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ProjectsTable, (table) => {
+        table
+            .uuid('color_palette_uuid')
+            .nullable()
+            .references('color_palette_uuid')
+            .inTable(OrganizationColorPalettesTable)
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ProjectsTable, (table) => {
+        table.dropColumn('color_palette_uuid');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -257,6 +257,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectParametersModel: models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:
                         models.getOrganizationWarehouseCredentialsModel(),
+                    organizationModel: models.getOrganizationModel(),
                     projectCompileLogModel: models.getProjectCompileLogModel(),
                     adminNotificationService:
                         repository.getAdminNotificationService(),
@@ -334,6 +335,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectParametersModel: models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:
                         models.getOrganizationWarehouseCredentialsModel(),
+                    organizationModel: models.getOrganizationModel(),
                     pivotTableService: repository.getPivotTableService(),
                     prometheusMetrics,
                     permissionsService: repository.getPermissionsService(),

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -519,12 +519,37 @@ export class EmbedService extends BaseService {
             canExportPagePdf,
             canDateZoom,
         } = decodedToken.content;
-        const selectedPalette = paletteUuid
-            ? await this.organizationModel.findColorPalette(
-                  dashboard.organizationUuid,
-                  paletteUuid,
-              )
-            : null;
+        // Embed paletteUuid query param overrides everything; otherwise fall back
+        // through chart → dashboard → space → project → org via the resolver.
+        let selectedPalette: {
+            colors: string[];
+            darkColors: string[] | null;
+        } | null = null;
+        if (paletteUuid) {
+            const override = await this.organizationModel.findColorPalette(
+                dashboard.organizationUuid,
+                paletteUuid,
+            );
+            if (override) {
+                selectedPalette = {
+                    colors: override.colors,
+                    darkColors: override.darkColors,
+                };
+            }
+        } else {
+            const resolved = await this.savedChartModel.resolveColorPalette({
+                dashboardUuid: dashboard.uuid,
+                spaceUuid: dashboard.spaceUuid,
+                projectUuid: dashboard.projectUuid,
+                organizationUuid: dashboard.organizationUuid,
+            });
+            if (resolved) {
+                selectedPalette = {
+                    colors: resolved.colors,
+                    darkColors: resolved.darkColors,
+                };
+            }
+        }
 
         this.analytics.trackAccount<EmbedDashboardViewed>(account, {
             event: 'embed_dashboard.viewed',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2213,6 +2213,10 @@ const models: TsoaRoute.Models = {
                         ],
                     },
                 },
+                parameterOrder: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
                 pinnedParameters: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -8982,11 +8986,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9126,17 +9130,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9165,7 +9169,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9173,11 +9177,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9192,7 +9192,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9200,7 +9200,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9384,17 +9388,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9464,11 +9468,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9483,11 +9487,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9502,11 +9506,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9521,11 +9525,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9540,11 +9544,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -19833,6 +19837,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                colorPaletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 projectDefaults: { ref: 'ProjectDefaults' },
                 hasDefaultUserSpaces: { dataType: 'boolean', required: true },
                 organizationWarehouseCredentialsUuid: { dataType: 'string' },
@@ -21103,7 +21115,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21113,7 +21125,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21123,7 +21135,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21136,7 +21148,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -46921,6 +46933,81 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateDefaultUserSpaces',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_updateProjectColorPalette: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                colorPaletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/colorPalette',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.updateProjectColorPalette,
+        ),
+
+        async function ProjectController_updateProjectColorPalette(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_updateProjectColorPalette,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateProjectColorPalette',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2375,6 +2375,12 @@
                         },
                         "type": "array"
                     },
+                    "parameterOrder": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "pinnedParameters": {
                         "items": {
                             "type": "string"
@@ -10438,19 +10444,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -10479,10 +10472,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -10491,8 +10484,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10502,16 +10495,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -10599,10 +10592,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -10611,8 +10604,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -21214,6 +21207,10 @@
             },
             "Project": {
                 "properties": {
+                    "colorPaletteUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "projectDefaults": {
                         "$ref": "#/components/schemas/ProjectDefaults"
                     },
@@ -21263,6 +21260,7 @@
                     }
                 },
                 "required": [
+                    "colorPaletteUuid",
                     "hasDefaultUserSpaces",
                     "createdByUserUuid",
                     "queryTimezone",
@@ -22503,22 +22501,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -31369,7 +31367,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2849.2",
+        "version": "0.2853.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -40493,6 +40491,64 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/UpdateDefaultUserSpaces"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/colorPalette": {
+            "patch": {
+                "operationId": "updateProjectColorPalette",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Set the project's color palette to one of its organization's palettes,\nor null to inherit from the organization's active palette.",
+                "summary": "Update project color palette",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "colorPaletteUuid": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "required": ["colorPaletteUuid"],
+                                "type": "object"
                             }
                         }
                     }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -109,6 +109,7 @@ export const expectedProject: Project = {
     queryTimezone: null,
     createdByUserUuid: null,
     hasDefaultUserSpaces: false,
+    colorPaletteUuid: null,
 };
 
 const metricFilter: MetricFilterRule = {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -585,6 +585,17 @@ export class ProjectModel {
             .where('project_uuid', projectUuid);
     }
 
+    async updateColorPalette(
+        projectUuid: string,
+        colorPaletteUuid: string | null,
+    ): Promise<void> {
+        await this.database('projects')
+            .update({
+                color_palette_uuid: colorPaletteUuid,
+            })
+            .where('project_uuid', projectUuid);
+    }
+
     async update(projectUuid: string, data: UpdateProject): Promise<void> {
         // Invalidate warehouse credentials cache
         warehouseCredentialsCache?.del(projectUuid);
@@ -682,6 +693,7 @@ export class ProjectModel {
                   organization_warehouse_credentials_uuid: string | null;
                   has_default_user_spaces: boolean;
                   project_defaults: ProjectDefaults | null;
+                  color_palette_uuid: string | null;
               }
             | {
                   name: string;
@@ -699,6 +711,7 @@ export class ProjectModel {
                   organization_warehouse_credentials_uuid: string | null;
                   has_default_user_spaces: boolean;
                   project_defaults: ProjectDefaults | null;
+                  color_palette_uuid: string | null;
               }
         )[];
         return wrapSentryTransaction(
@@ -765,6 +778,9 @@ export class ProjectModel {
                         this.database
                             .ref('project_defaults')
                             .withSchema(ProjectTableName),
+                        this.database
+                            .ref('color_palette_uuid')
+                            .withSchema(ProjectTableName),
                     ])
                     .select<QueryResult>()
                     .where('projects.project_uuid', projectUuid);
@@ -807,6 +823,7 @@ export class ProjectModel {
                         undefined,
                     hasDefaultUserSpaces: project.has_default_user_spaces,
                     projectDefaults: project.project_defaults ?? undefined,
+                    colorPaletteUuid: project.color_palette_uuid ?? null,
                 };
 
                 // If project uses organization warehouse credentials, load them
@@ -1008,6 +1025,7 @@ export class ProjectModel {
             organizationWarehouseCredentialsUuid:
                 project.organizationWarehouseCredentialsUuid,
             hasDefaultUserSpaces: project.hasDefaultUserSpaces,
+            colorPaletteUuid: project.colorPaletteUuid ?? null,
         };
     }
 

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -511,62 +511,48 @@ export class SavedChartModel {
             return { paletteUuid: null, colors: override, darkColors: null };
         }
 
-        const projectPalette = await this.database(ProjectTableName)
+        // Single query: LEFT JOIN the palettes table twice (project's palette
+        // and org's palette) and COALESCE so the project palette wins when set
+        // and falls back to the org's active palette otherwise.
+        const result = await this.database(ProjectTableName)
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
             .leftJoin(
-                OrganizationColorPaletteTableName,
+                `${OrganizationColorPaletteTableName} as project_palette`,
+                'project_palette.color_palette_uuid',
                 `${ProjectTableName}.color_palette_uuid`,
-                `${OrganizationColorPaletteTableName}.color_palette_uuid`,
+            )
+            .leftJoin(
+                `${OrganizationColorPaletteTableName} as org_palette`,
+                'org_palette.color_palette_uuid',
+                `${OrganizationTableName}.color_palette_uuid`,
             )
             .where(`${ProjectTableName}.project_uuid`, args.projectUuid)
-            .select<
-                {
-                    color_palette_uuid: string | null;
-                    colors: string[] | null;
-                    dark_colors: string[] | null;
-                }[]
-            >([
-                `${OrganizationColorPaletteTableName}.color_palette_uuid`,
-                `${OrganizationColorPaletteTableName}.colors`,
-                `${OrganizationColorPaletteTableName}.dark_colors`,
+            .select<{
+                color_palette_uuid: string | null;
+                colors: string[] | null;
+                dark_colors: string[] | null;
+            }>([
+                this.database.raw(
+                    'COALESCE(project_palette.color_palette_uuid, org_palette.color_palette_uuid) as color_palette_uuid',
+                ),
+                this.database.raw(
+                    'COALESCE(project_palette.colors, org_palette.colors) as colors',
+                ),
+                this.database.raw(
+                    'COALESCE(project_palette.dark_colors, org_palette.dark_colors) as dark_colors',
+                ),
             ])
             .first();
 
-        if (projectPalette?.color_palette_uuid && projectPalette.colors) {
+        if (result?.color_palette_uuid && result.colors) {
             return {
-                paletteUuid: projectPalette.color_palette_uuid,
-                colors: projectPalette.colors,
-                darkColors: projectPalette.dark_colors,
-            };
-        }
-
-        const orgPalette = await this.database(OrganizationTableName)
-            .leftJoin(
-                OrganizationColorPaletteTableName,
-                `${OrganizationTableName}.color_palette_uuid`,
-                `${OrganizationColorPaletteTableName}.color_palette_uuid`,
-            )
-            .where(
-                `${OrganizationTableName}.organization_uuid`,
-                args.organizationUuid,
-            )
-            .select<
-                {
-                    color_palette_uuid: string | null;
-                    colors: string[] | null;
-                    dark_colors: string[] | null;
-                }[]
-            >([
-                `${OrganizationColorPaletteTableName}.color_palette_uuid`,
-                `${OrganizationColorPaletteTableName}.colors`,
-                `${OrganizationColorPaletteTableName}.dark_colors`,
-            ])
-            .first();
-
-        if (orgPalette?.color_palette_uuid && orgPalette.colors) {
-            return {
-                paletteUuid: orgPalette.color_palette_uuid,
-                colors: orgPalette.colors,
-                darkColors: orgPalette.dark_colors,
+                paletteUuid: result.color_palette_uuid,
+                colors: result.colors,
+                darkColors: result.dark_colors,
             };
         }
 

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -488,6 +488,91 @@ export class SavedChartModel {
         this.contentVerificationModel = args.contentVerificationModel;
     }
 
+    /**
+     * Resolves the color palette for a chart by walking up the
+     * chart → dashboard → space → project → organization hierarchy.
+     *
+     * The lightdashConfig.appearance.overrideColorPalette wins over everything,
+     * matching OrganizationModel.get() behaviour.
+     */
+    async resolveColorPalette(args: {
+        chartUuid?: string;
+        dashboardUuid?: string;
+        spaceUuid?: string;
+        projectUuid: string;
+        organizationUuid: string;
+    }): Promise<{
+        paletteUuid: string | null;
+        colors: string[];
+        darkColors: string[] | null;
+    } | null> {
+        const override = this.lightdashConfig.appearance.overrideColorPalette;
+        if (override && override.length > 0) {
+            return { paletteUuid: null, colors: override, darkColors: null };
+        }
+
+        const projectPalette = await this.database(ProjectTableName)
+            .leftJoin(
+                OrganizationColorPaletteTableName,
+                `${ProjectTableName}.color_palette_uuid`,
+                `${OrganizationColorPaletteTableName}.color_palette_uuid`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, args.projectUuid)
+            .select<
+                {
+                    color_palette_uuid: string | null;
+                    colors: string[] | null;
+                    dark_colors: string[] | null;
+                }[]
+            >([
+                `${OrganizationColorPaletteTableName}.color_palette_uuid`,
+                `${OrganizationColorPaletteTableName}.colors`,
+                `${OrganizationColorPaletteTableName}.dark_colors`,
+            ])
+            .first();
+
+        if (projectPalette?.color_palette_uuid && projectPalette.colors) {
+            return {
+                paletteUuid: projectPalette.color_palette_uuid,
+                colors: projectPalette.colors,
+                darkColors: projectPalette.dark_colors,
+            };
+        }
+
+        const orgPalette = await this.database(OrganizationTableName)
+            .leftJoin(
+                OrganizationColorPaletteTableName,
+                `${OrganizationTableName}.color_palette_uuid`,
+                `${OrganizationColorPaletteTableName}.color_palette_uuid`,
+            )
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                args.organizationUuid,
+            )
+            .select<
+                {
+                    color_palette_uuid: string | null;
+                    colors: string[] | null;
+                    dark_colors: string[] | null;
+                }[]
+            >([
+                `${OrganizationColorPaletteTableName}.color_palette_uuid`,
+                `${OrganizationColorPaletteTableName}.colors`,
+                `${OrganizationColorPaletteTableName}.dark_colors`,
+            ])
+            .first();
+
+        if (orgPalette?.color_palette_uuid && orgPalette.colors) {
+            return {
+                paletteUuid: orgPalette.color_palette_uuid,
+                colors: orgPalette.colors,
+                darkColors: orgPalette.dark_colors,
+            };
+        }
+
+        return null;
+    }
+
     static convertVersionSummary(row: VersionSummaryRow): ChartVersionSummary {
         return {
             chartUuid: row.saved_query_uuid,
@@ -937,11 +1022,6 @@ export class SavedChartModel {
                         `${OrganizationTableName}.organization_id`,
                         `${ProjectTableName}.organization_id`,
                     )
-                    .leftJoin(
-                        OrganizationColorPaletteTableName,
-                        `${OrganizationTableName}.color_palette_uuid`,
-                        `${OrganizationColorPaletteTableName}.color_palette_uuid`,
-                    )
                     .innerJoin(
                         'saved_queries_versions',
                         `${SavedChartsTableName}.saved_query_id`,
@@ -973,7 +1053,6 @@ export class SavedChartModel {
                             space_uuid: string;
                             spaceName: string;
                             dashboardName: string | null;
-                            color_palette: string[] | null;
                             slug: string;
                             deleted_at: Date | null;
                             deleted_by_user_uuid: string | null;
@@ -1002,7 +1081,6 @@ export class SavedChartModel {
                         'saved_queries_versions.timezone',
                         'saved_queries_versions.parameters',
                         `${OrganizationTableName}.organization_uuid`,
-                        `${OrganizationColorPaletteTableName}.colors as color_palette`,
                         `${UserTableName}.user_uuid`,
                         `${UserTableName}.first_name`,
                         `${UserTableName}.last_name`,
@@ -1140,6 +1218,7 @@ export class SavedChartModel {
                     additionalMetricsRows,
                     customBinDimensionsRows,
                     customSqlDimensionsRows,
+                    resolvedPalette,
                 ] = await Promise.all([
                     fieldsQuery,
                     sortsQuery,
@@ -1147,6 +1226,13 @@ export class SavedChartModel {
                     additionalMetricsQuery,
                     customBinDimensionsQuery,
                     customSqlDimensionsQuery,
+                    this.resolveColorPalette({
+                        chartUuid: savedQuery.saved_query_uuid,
+                        dashboardUuid: savedQuery.dashboard_uuid ?? undefined,
+                        spaceUuid: savedQuery.space_uuid,
+                        projectUuid: savedQuery.project_uuid,
+                        organizationUuid: savedQuery.organization_uuid,
+                    }),
                 ]);
 
                 // Filters out "null" fields
@@ -1190,21 +1276,6 @@ export class SavedChartModel {
                     type: savedQuery.chart_type,
                     config: savedQuery.chart_config,
                 } as ChartConfig;
-
-                const getColorPalette = () => {
-                    if (
-                        this.lightdashConfig.appearance.overrideColorPalette &&
-                        this.lightdashConfig.appearance.overrideColorPalette
-                            .length > 0
-                    ) {
-                        return this.lightdashConfig.appearance
-                            .overrideColorPalette;
-                    }
-                    if (savedQuery.color_palette) {
-                        return savedQuery.color_palette;
-                    }
-                    return ECHARTS_DEFAULT_COLORS;
-                };
 
                 const verification =
                     (await this.contentVerificationModel?.getByContent(
@@ -1332,7 +1403,8 @@ export class SavedChartModel {
                     pinnedListOrder: null,
                     dashboardUuid: savedQuery.dashboard_uuid,
                     dashboardName: savedQuery.dashboardName,
-                    colorPalette: getColorPalette(),
+                    colorPalette:
+                        resolvedPalette?.colors ?? ECHARTS_DEFAULT_COLORS,
                     slug: savedQuery.slug,
                     verification,
                     // Soft delete fields (only populated when deleted: true)

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -40,6 +40,7 @@ import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel
 import type { GroupsModel } from '../../models/GroupsModel';
 import type { JobModel } from '../../models/JobModel/JobModel';
 import type { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
+import type { OrganizationModel } from '../../models/OrganizationModel';
 import type { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
 import type { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -259,6 +260,7 @@ const getMockedAsyncQueryService = (
         } as unknown as ProjectParametersModel,
         organizationWarehouseCredentialsModel:
             {} as OrganizationWarehouseCredentialsModel,
+        organizationModel: {} as OrganizationModel,
         pivotTableService: new PivotTableService({
             lightdashConfig,
             fileStorageClient: {} as FileStorageClient,

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -23,6 +23,7 @@ import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel
 import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
+import { OrganizationModel } from '../../models/OrganizationModel';
 import { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
 import { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -86,6 +87,7 @@ describe('Csv service', () => {
             projectParametersModel: {} as ProjectParametersModel,
             organizationWarehouseCredentialsModel:
                 {} as OrganizationWarehouseCredentialsModel,
+            organizationModel: {} as OrganizationModel,
             projectCompileLogModel: {} as ProjectCompileLogModel,
             adminNotificationService: {} as AdminNotificationService,
             spacePermissionService: {} as SpacePermissionService,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -338,6 +338,7 @@ export const projectWithSensitiveFields: Project = {
     queryTimezone: null,
     createdByUserUuid: sessionAccount.user.id,
     hasDefaultUserSpaces: false,
+    colorPaletteUuid: null,
 };
 
 export const projectSummary: ProjectSummary = {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -32,6 +32,7 @@ import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel
 import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
+import { OrganizationModel } from '../../models/OrganizationModel';
 import { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
 import { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -255,6 +256,7 @@ const getMockedProjectService = (
         } as unknown as ProjectParametersModel,
         organizationWarehouseCredentialsModel:
             {} as unknown as OrganizationWarehouseCredentialsModel,
+        organizationModel: {} as unknown as OrganizationModel,
         projectCompileLogModel:
             projectCompileLogModel as unknown as ProjectCompileLogModel,
         adminNotificationService: {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -222,6 +222,7 @@ import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel
 import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
+import { OrganizationModel } from '../../models/OrganizationModel';
 import { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
 import { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -297,6 +298,7 @@ export type ProjectServiceArguments = {
     featureFlagModel: FeatureFlagModel;
     projectParametersModel: ProjectParametersModel;
     organizationWarehouseCredentialsModel: OrganizationWarehouseCredentialsModel;
+    organizationModel: OrganizationModel;
     projectCompileLogModel: ProjectCompileLogModel;
     adminNotificationService: AdminNotificationService;
     spacePermissionService: SpacePermissionService;
@@ -367,6 +369,8 @@ export class ProjectService extends BaseService {
 
     organizationWarehouseCredentialsModel: OrganizationWarehouseCredentialsModel;
 
+    organizationModel: OrganizationModel;
+
     adminNotificationService: AdminNotificationService;
 
     spacePermissionService: SpacePermissionService;
@@ -404,6 +408,7 @@ export class ProjectService extends BaseService {
         projectParametersModel,
         projectCompileLogModel,
         organizationWarehouseCredentialsModel,
+        organizationModel,
         adminNotificationService,
         spacePermissionService,
         contentVerificationModel,
@@ -441,6 +446,7 @@ export class ProjectService extends BaseService {
         this.projectCompileLogModel = projectCompileLogModel;
         this.organizationWarehouseCredentialsModel =
             organizationWarehouseCredentialsModel;
+        this.organizationModel = organizationModel;
         this.adminNotificationService = adminNotificationService;
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
@@ -6468,6 +6474,41 @@ export class ProjectService extends BaseService {
         await this.projectModel.updateDefaultUserSpaces(
             projectUuid,
             data.hasDefaultUserSpaces,
+        );
+    }
+
+    async updateColorPalette(
+        user: SessionUser,
+        projectUuid: string,
+        colorPaletteUuid: string | null,
+    ): Promise<void> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'update',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (colorPaletteUuid !== null) {
+            const palette = await this.organizationModel.findColorPalette(
+                organizationUuid,
+                colorPaletteUuid,
+            );
+            if (!palette) {
+                throw new ParameterError(
+                    'Color palette does not belong to this organization',
+                );
+            }
+        }
+
+        await this.projectModel.updateColorPalette(
+            projectUuid,
+            colorPaletteUuid,
         );
     }
 

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -648,6 +648,7 @@ export class ServiceRepository
                         this.models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:
                         this.models.getOrganizationWarehouseCredentialsModel(),
+                    organizationModel: this.models.getOrganizationModel(),
                     projectCompileLogModel:
                         this.models.getProjectCompileLogModel(),
                     adminNotificationService:
@@ -703,6 +704,7 @@ export class ServiceRepository
                         this.models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:
                         this.models.getOrganizationWarehouseCredentialsModel(),
+                    organizationModel: this.models.getOrganizationModel(),
                     pivotTableService: this.getPivotTableService(),
                     prometheusMetrics: this.prometheusMetrics,
                     permissionsService: this.getPermissionsService(),

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -605,6 +605,7 @@ export type CreateProject = Omit<
     | 'queryTimezone'
     | 'createdByUserUuid'
     | 'hasDefaultUserSpaces'
+    | 'colorPaletteUuid'
 > & {
     warehouseConnection: CreateWarehouseCredentials;
     copyWarehouseConnectionFromUpstreamProject?: boolean;
@@ -636,6 +637,7 @@ export type UpdateProject = Omit<
     | 'queryTimezone'
     | 'createdByUserUuid'
     | 'hasDefaultUserSpaces'
+    | 'colorPaletteUuid'
 > & {
     warehouseConnection: CreateWarehouseCredentials;
 };

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -590,6 +590,7 @@ export type Project = {
     organizationWarehouseCredentialsUuid?: string;
     hasDefaultUserSpaces: boolean;
     projectDefaults?: ProjectDefaults;
+    colorPaletteUuid: string | null;
 };
 
 export type ProjectSummary = Pick<

--- a/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
+++ b/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
@@ -1,28 +1,30 @@
 import {
-    Box,
-    Group,
-    Skeleton,
+    Anchor,
+    Button,
+    LoadingOverlay,
     Stack,
     Text,
     Title,
-    Tooltip,
 } from '@mantine-8/core';
-import { IconInfoCircle } from '@tabler/icons-react';
+import { IconExternalLink } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { Link } from 'react-router';
 import { useColorPalettes } from '../../hooks/appearance/useOrganizationAppearance';
 import useHealth from '../../hooks/health/useHealth';
 import {
     useProject,
     useUpdateProjectColorPalette,
 } from '../../hooks/useProject';
+import useApp from '../../providers/App/useApp';
 import Callout from '../common/Callout';
 import MantineIcon from '../common/MantineIcon';
 import { PalettePicker } from '../common/PalettePicker/PalettePicker';
-import { SettingsCard } from '../common/Settings/SettingsCard';
+import { SettingsGridCard } from '../common/Settings/SettingsCard';
 
 type Props = { projectUuid: string };
 
 const ProjectAppearance: FC<Props> = ({ projectUuid }) => {
+    const { user } = useApp();
     const { data: project, isInitialLoading: isProjectLoading } =
         useProject(projectUuid);
     const { data: palettes = [], isInitialLoading: isPalettesLoading } =
@@ -35,29 +37,33 @@ const ProjectAppearance: FC<Props> = ({ projectUuid }) => {
         health.appearance.overrideColorPalette.length > 0;
 
     const isLoading = isProjectLoading || isPalettesLoading || isHealthLoading;
+    const canManageOrgPalettes =
+        user.data?.ability?.can('update', 'Organization') ?? false;
 
     return (
-        <Stack gap="sm">
-            <Group gap="xxs">
-                <Title order={5}>Appearance</Title>
-                <Tooltip
-                    label="Pick a color palette for charts in this project. Palettes are managed at the organization level."
-                    position="bottom"
-                >
-                    <Box>
-                        <MantineIcon icon={IconInfoCircle} color="gray" />
-                    </Box>
-                </Tooltip>
-            </Group>
-
-            <SettingsCard mb="lg">
-                <Stack gap="md">
-                    <Text size="sm" c="ldGray.6">
+        <Stack gap="sm" pos="relative">
+            <LoadingOverlay visible={isLoading} />
+            <SettingsGridCard>
+                <Stack gap="xs">
+                    <Title order={4}>Appearance</Title>
+                    <Text c="ldGray.6" fz="sm">
                         Choose which organization color palette charts in this
                         project should use, or inherit the organization's active
                         palette.
                     </Text>
-
+                    <Text c="ldGray.6" fz="xs">
+                        Palettes are managed at the{' '}
+                        <Anchor
+                            component={Link}
+                            to="/generalSettings/appearance"
+                            fz="xs"
+                        >
+                            organization level
+                        </Anchor>
+                        .
+                    </Text>
+                </Stack>
+                <Stack gap="md">
                     {overrideActive && (
                         <Callout variant="info">
                             A color palette override is set in your instance
@@ -66,22 +72,33 @@ const ProjectAppearance: FC<Props> = ({ projectUuid }) => {
                         </Callout>
                     )}
 
-                    {isLoading ? (
-                        <Skeleton height={36} />
-                    ) : (
-                        <PalettePicker
-                            label="Color palette"
-                            value={project?.colorPaletteUuid ?? null}
-                            onChange={(next) => updateColorPalette.mutate(next)}
-                            palettes={palettes}
-                            parentLabel="organization"
-                            disabled={
-                                overrideActive || updateColorPalette.isLoading
+                    <PalettePicker
+                        label="Color palette"
+                        value={project?.colorPaletteUuid ?? null}
+                        onChange={(next) => updateColorPalette.mutate(next)}
+                        palettes={palettes}
+                        parentLabel="organization"
+                        disabled={
+                            overrideActive || updateColorPalette.isLoading
+                        }
+                    />
+
+                    {canManageOrgPalettes && (
+                        <Button
+                            component={Link}
+                            to="/generalSettings/appearance"
+                            variant="default"
+                            size="xs"
+                            leftSection={
+                                <MantineIcon icon={IconExternalLink} />
                             }
-                        />
+                            style={{ alignSelf: 'flex-end' }}
+                        >
+                            Manage organization palettes
+                        </Button>
                     )}
                 </Stack>
-            </SettingsCard>
+            </SettingsGridCard>
         </Stack>
     );
 };

--- a/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
+++ b/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
@@ -1,5 +1,5 @@
 import {
-    ActionIcon,
+    Box,
     Group,
     Skeleton,
     Stack,
@@ -44,14 +44,9 @@ const ProjectAppearance: FC<Props> = ({ projectUuid }) => {
                     label="Pick a color palette for charts in this project. Palettes are managed at the organization level."
                     position="bottom"
                 >
-                    <ActionIcon
-                        size="xs"
-                        color="gray"
-                        variant="subtle"
-                        aria-label="Appearance info"
-                    >
-                        <MantineIcon icon={IconInfoCircle} />
-                    </ActionIcon>
+                    <Box>
+                        <MantineIcon icon={IconInfoCircle} color="gray" />
+                    </Box>
                 </Tooltip>
             </Group>
 

--- a/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
+++ b/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
@@ -1,0 +1,94 @@
+import {
+    ActionIcon,
+    Group,
+    Skeleton,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useColorPalettes } from '../../hooks/appearance/useOrganizationAppearance';
+import useHealth from '../../hooks/health/useHealth';
+import {
+    useProject,
+    useUpdateProjectColorPalette,
+} from '../../hooks/useProject';
+import Callout from '../common/Callout';
+import MantineIcon from '../common/MantineIcon';
+import { PalettePicker } from '../common/PalettePicker/PalettePicker';
+import { SettingsCard } from '../common/Settings/SettingsCard';
+
+type Props = { projectUuid: string };
+
+const ProjectAppearance: FC<Props> = ({ projectUuid }) => {
+    const { data: project, isInitialLoading: isProjectLoading } =
+        useProject(projectUuid);
+    const { data: palettes = [], isInitialLoading: isPalettesLoading } =
+        useColorPalettes();
+    const { data: health, isInitialLoading: isHealthLoading } = useHealth();
+    const updateColorPalette = useUpdateProjectColorPalette(projectUuid);
+
+    const overrideActive =
+        !!health?.appearance.overrideColorPalette &&
+        health.appearance.overrideColorPalette.length > 0;
+
+    const isLoading = isProjectLoading || isPalettesLoading || isHealthLoading;
+
+    return (
+        <Stack gap="sm">
+            <Group gap="xxs">
+                <Title order={5}>Appearance</Title>
+                <Tooltip
+                    label="Pick a color palette for charts in this project. Palettes are managed at the organization level."
+                    position="bottom"
+                >
+                    <ActionIcon
+                        size="xs"
+                        color="gray"
+                        variant="subtle"
+                        aria-label="Appearance info"
+                    >
+                        <MantineIcon icon={IconInfoCircle} />
+                    </ActionIcon>
+                </Tooltip>
+            </Group>
+
+            <SettingsCard mb="lg">
+                <Stack gap="md">
+                    <Text size="sm" c="ldGray.6">
+                        Choose which organization color palette charts in this
+                        project should use, or inherit the organization's active
+                        palette.
+                    </Text>
+
+                    {overrideActive && (
+                        <Callout variant="info">
+                            A color palette override is set in your instance
+                            configuration. Project-level selection is disabled
+                            while the override is active.
+                        </Callout>
+                    )}
+
+                    {isLoading ? (
+                        <Skeleton height={36} />
+                    ) : (
+                        <PalettePicker
+                            label="Color palette"
+                            value={project?.colorPaletteUuid ?? null}
+                            onChange={(next) => updateColorPalette.mutate(next)}
+                            palettes={palettes}
+                            parentLabel="organization"
+                            disabled={
+                                overrideActive || updateColorPalette.isLoading
+                            }
+                        />
+                    )}
+                </Stack>
+            </SettingsCard>
+        </Stack>
+    );
+};
+
+export default ProjectAppearance;

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
@@ -14,9 +14,24 @@
     flex-shrink: 0;
 }
 
-.preview {
-    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+.miniChartCardLight,
+.miniChartCardDark {
+    padding: var(--mantine-spacing-xs);
     border: 1px solid var(--mantine-color-gray-2);
     border-radius: var(--mantine-radius-sm);
-    background: var(--mantine-color-gray-0);
+    flex: 1;
+}
+
+.miniChartCardLight {
+    background: var(--mantine-color-white);
+}
+
+.miniChartCardDark {
+    background: var(--mantine-color-dark-7);
+    border-color: var(--mantine-color-dark-5);
+}
+
+.miniChartLight,
+.miniChartDark {
+    width: 100%;
 }

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
@@ -1,0 +1,15 @@
+.row {
+    width: 100%;
+    justify-content: space-between;
+}
+
+.name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.swatches {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
@@ -13,3 +13,14 @@
 .swatches {
     flex-shrink: 0;
 }
+
+.preview {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    border: 1px solid var(--mantine-color-gray-2);
+    border-radius: var(--mantine-radius-sm);
+    background: var(--mantine-color-gray-0);
+}
+
+.previewRow > svg {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
@@ -20,7 +20,3 @@
     border-radius: var(--mantine-radius-sm);
     background: var(--mantine-color-gray-0);
 }
-
-.previewRow > svg {
-    flex-shrink: 0;
-}

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -13,7 +13,7 @@ import MantineIcon from '../MantineIcon';
 import classes from './PalettePicker.module.css';
 
 const INHERIT_VALUE = '__inherit__';
-const DROPDOWN_SWATCH_LIMIT = 5;
+const SWATCH_LIMIT = 5;
 
 type Props = {
     value: string | null;
@@ -35,31 +35,23 @@ const SwatchInline: FC<{
     icon: typeof IconSun;
     label: string;
     colors: string[];
-    limit?: number;
+    limit: number;
     swatchSize?: number;
-    wrap?: boolean;
-}> = ({ icon, label, colors, limit, swatchSize = 12, wrap = false }) => {
-    const visible = limit ? colors.slice(0, limit) : colors;
-    return (
-        <Tooltip label={label} position="top" withinPortal>
-            <Group
-                gap={4}
-                wrap={wrap ? 'wrap' : 'nowrap'}
-                className={wrap ? classes.previewRow : undefined}
-            >
-                <MantineIcon icon={icon} size={14} color="gray" />
-                {visible.map((color, index) => (
-                    <ColorSwatch
-                        key={`${color}-${index}`}
-                        size={swatchSize}
-                        color={color}
-                        withShadow={false}
-                    />
-                ))}
-            </Group>
-        </Tooltip>
-    );
-};
+}> = ({ icon, label, colors, limit, swatchSize = 12 }) => (
+    <Tooltip label={label} position="top" withinPortal>
+        <Group gap={4} wrap="nowrap">
+            <MantineIcon icon={icon} size={14} color="gray" />
+            {colors.slice(0, limit).map((color, index) => (
+                <ColorSwatch
+                    key={`${color}-${index}`}
+                    size={swatchSize}
+                    color={color}
+                    withShadow={false}
+                />
+            ))}
+        </Group>
+    </Tooltip>
+);
 
 const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
     name,
@@ -73,7 +65,7 @@ const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
                     icon={IconSun}
                     label="Light mode"
                     colors={swatches.colors}
-                    limit={DROPDOWN_SWATCH_LIMIT}
+                    limit={SWATCH_LIMIT}
                 />
                 {swatches.darkColors && swatches.darkColors.length > 0 && (
                     <>
@@ -82,7 +74,7 @@ const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
                             icon={IconMoon}
                             label="Dark mode"
                             colors={swatches.darkColors}
-                            limit={DROPDOWN_SWATCH_LIMIT}
+                            limit={SWATCH_LIMIT}
                         />
                     </>
                 )}
@@ -97,16 +89,16 @@ const SelectedPalettePreview: FC<{ swatches: SwatchSet }> = ({ swatches }) => (
             icon={IconSun}
             label="Light mode"
             colors={swatches.colors}
+            limit={SWATCH_LIMIT}
             swatchSize={16}
-            wrap
         />
         {swatches.darkColors && swatches.darkColors.length > 0 && (
             <SwatchInline
                 icon={IconMoon}
                 label="Dark mode"
                 colors={swatches.darkColors}
+                limit={SWATCH_LIMIT}
                 swatchSize={16}
-                wrap
             />
         )}
     </Stack>

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -8,12 +8,14 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { IconMoon, IconSun } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useMemo, type FC } from 'react';
+import EChartsReact, { type EChartsOption } from '../../EChartsReactWrapper';
 import MantineIcon from '../MantineIcon';
 import classes from './PalettePicker.module.css';
 
 const INHERIT_VALUE = '__inherit__';
 const SWATCH_LIMIT = 5;
+const PREVIEW_BAR_HEIGHTS = [4, 7, 5, 9, 6];
 
 type Props = {
     value: string | null;
@@ -36,15 +38,14 @@ const SwatchInline: FC<{
     label: string;
     colors: string[];
     limit: number;
-    swatchSize?: number;
-}> = ({ icon, label, colors, limit, swatchSize = 12 }) => (
+}> = ({ icon, label, colors, limit }) => (
     <Tooltip label={label} position="top" withinPortal>
         <Group gap={4} wrap="nowrap">
             <MantineIcon icon={icon} size={14} color="gray" />
             {colors.slice(0, limit).map((color, index) => (
                 <ColorSwatch
                     key={`${color}-${index}`}
-                    size={swatchSize}
+                    size={12}
                     color={color}
                     withShadow={false}
                 />
@@ -87,25 +88,64 @@ const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
     </Group>
 );
 
-const SelectedPalettePreview: FC<{ swatches: SwatchSet }> = ({ swatches }) => (
-    <Stack gap="xs" className={classes.preview}>
-        <SwatchInline
-            icon={IconSun}
-            label="Light mode"
-            colors={swatches.colors}
-            limit={SWATCH_LIMIT}
-            swatchSize={16}
-        />
-        {swatches.darkColors && swatches.darkColors.length > 0 && (
-            <SwatchInline
-                icon={IconMoon}
-                label="Dark mode"
-                colors={swatches.darkColors}
-                limit={SWATCH_LIMIT}
-                swatchSize={16}
+const MiniBarChart: FC<{ colors: string[]; theme: 'light' | 'dark' }> = ({
+    colors,
+    theme,
+}) => {
+    const option = useMemo<EChartsOption>(() => {
+        const visible = colors.slice(0, SWATCH_LIMIT);
+        return {
+            animation: false,
+            grid: { left: 4, right: 4, top: 4, bottom: 4, containLabel: false },
+            xAxis: { type: 'category', data: [''], show: false },
+            yAxis: { type: 'value', show: false, max: 10 },
+            series: visible.map((color, i) => ({
+                type: 'bar',
+                data: [PREVIEW_BAR_HEIGHTS[i] ?? 5],
+                itemStyle: { color, borderRadius: [2, 2, 0, 0] },
+                barWidth: 10,
+            })),
+        };
+    }, [colors]);
+
+    return (
+        <div
+            className={
+                theme === 'dark'
+                    ? classes.miniChartDark
+                    : classes.miniChartLight
+            }
+        >
+            <EChartsReact
+                option={option}
+                style={{ height: 60, width: '100%' }}
+                opts={{ renderer: 'svg' }}
             />
+        </div>
+    );
+};
+
+const SelectedPalettePreview: FC<{ swatches: SwatchSet }> = ({ swatches }) => (
+    <Group gap="xs" grow align="stretch" wrap="nowrap">
+        <Tooltip label="Light mode" position="top" withinPortal>
+            <Stack gap={4} className={classes.miniChartCardLight}>
+                <Group gap={4} justify="center">
+                    <MantineIcon icon={IconSun} size={12} color="gray" />
+                </Group>
+                <MiniBarChart colors={swatches.colors} theme="light" />
+            </Stack>
+        </Tooltip>
+        {swatches.darkColors && swatches.darkColors.length > 0 && (
+            <Tooltip label="Dark mode" position="top" withinPortal>
+                <Stack gap={4} className={classes.miniChartCardDark}>
+                    <Group gap={4} justify="center">
+                        <MantineIcon icon={IconMoon} size={12} color="dimmed" />
+                    </Group>
+                    <MiniBarChart colors={swatches.darkColors} theme="dark" />
+                </Stack>
+            </Tooltip>
         )}
-    </Stack>
+    </Group>
 );
 
 export const PalettePicker: FC<Props> = ({

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -1,12 +1,19 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { ColorSwatch, Group, Select, Text, Tooltip } from '@mantine-8/core';
+import {
+    ColorSwatch,
+    Group,
+    Select,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
 import { IconMoon, IconSun } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../MantineIcon';
 import classes from './PalettePicker.module.css';
 
 const INHERIT_VALUE = '__inherit__';
-const SWATCH_LIMIT = 5;
+const DROPDOWN_SWATCH_LIMIT = 5;
 
 type Props = {
     value: string | null;
@@ -24,25 +31,35 @@ type SwatchSet = {
     darkColors: string[] | null;
 };
 
-const SwatchRow: FC<{
+const SwatchInline: FC<{
     icon: typeof IconSun;
     label: string;
     colors: string[];
-}> = ({ icon, label, colors }) => (
-    <Tooltip label={label} position="top" withinPortal>
-        <Group gap={4} wrap="nowrap">
-            <MantineIcon icon={icon} size="sm" color="gray" />
-            {colors.slice(0, SWATCH_LIMIT).map((color, index) => (
-                <ColorSwatch
-                    key={`${color}-${index}`}
-                    size={12}
-                    color={color}
-                    withShadow={false}
-                />
-            ))}
-        </Group>
-    </Tooltip>
-);
+    limit?: number;
+    swatchSize?: number;
+    wrap?: boolean;
+}> = ({ icon, label, colors, limit, swatchSize = 12, wrap = false }) => {
+    const visible = limit ? colors.slice(0, limit) : colors;
+    return (
+        <Tooltip label={label} position="top" withinPortal>
+            <Group
+                gap={4}
+                wrap={wrap ? 'wrap' : 'nowrap'}
+                className={wrap ? classes.previewRow : undefined}
+            >
+                <MantineIcon icon={icon} size={14} color="gray" />
+                {visible.map((color, index) => (
+                    <ColorSwatch
+                        key={`${color}-${index}`}
+                        size={swatchSize}
+                        color={color}
+                        withShadow={false}
+                    />
+                ))}
+            </Group>
+        </Tooltip>
+    );
+};
 
 const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
     name,
@@ -52,24 +69,47 @@ const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
         <Text className={classes.name}>{name}</Text>
         {swatches && (
             <Group gap="xs" wrap="nowrap" className={classes.swatches}>
-                <SwatchRow
+                <SwatchInline
                     icon={IconSun}
                     label="Light mode"
                     colors={swatches.colors}
+                    limit={DROPDOWN_SWATCH_LIMIT}
                 />
                 {swatches.darkColors && swatches.darkColors.length > 0 && (
                     <>
                         <Text c="ldGray.3">/</Text>
-                        <SwatchRow
+                        <SwatchInline
                             icon={IconMoon}
                             label="Dark mode"
                             colors={swatches.darkColors}
+                            limit={DROPDOWN_SWATCH_LIMIT}
                         />
                     </>
                 )}
             </Group>
         )}
     </Group>
+);
+
+const SelectedPalettePreview: FC<{ swatches: SwatchSet }> = ({ swatches }) => (
+    <Stack gap="xs" className={classes.preview}>
+        <SwatchInline
+            icon={IconSun}
+            label="Light mode"
+            colors={swatches.colors}
+            swatchSize={16}
+            wrap
+        />
+        {swatches.darkColors && swatches.darkColors.length > 0 && (
+            <SwatchInline
+                icon={IconMoon}
+                label="Dark mode"
+                colors={swatches.darkColors}
+                swatchSize={16}
+                wrap
+            />
+        )}
+    </Stack>
 );
 
 export const PalettePicker: FC<Props> = ({
@@ -97,24 +137,33 @@ export const PalettePicker: FC<Props> = ({
         ]),
     );
 
+    const selectedSwatches = value
+        ? (swatchesByValue.get(value) ?? null)
+        : null;
+
     return (
-        <Select
-            label={label}
-            description={description}
-            placeholder={placeholder}
-            data={data}
-            value={value ?? INHERIT_VALUE}
-            onChange={(next) =>
-                onChange(next && next !== INHERIT_VALUE ? next : null)
-            }
-            disabled={disabled}
-            allowDeselect={false}
-            renderOption={({ option }) => (
-                <PaletteOptionRow
-                    name={option.label}
-                    swatches={swatchesByValue.get(option.value) ?? null}
-                />
+        <Stack gap="sm">
+            <Select
+                label={label}
+                description={description}
+                placeholder={placeholder}
+                data={data}
+                value={value ?? INHERIT_VALUE}
+                onChange={(next) =>
+                    onChange(next && next !== INHERIT_VALUE ? next : null)
+                }
+                disabled={disabled}
+                allowDeselect={false}
+                renderOption={({ option }) => (
+                    <PaletteOptionRow
+                        name={option.label}
+                        swatches={swatchesByValue.get(option.value) ?? null}
+                    />
+                )}
+            />
+            {selectedSwatches && (
+                <SelectedPalettePreview swatches={selectedSwatches} />
             )}
-        />
+        </Stack>
     );
 };

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -144,6 +144,7 @@ export const PalettePicker: FC<Props> = ({
     return (
         <Stack gap="sm">
             <Select
+                size="xs"
                 label={label}
                 description={description}
                 placeholder={placeholder}

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -58,7 +58,9 @@ const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
     swatches,
 }) => (
     <Group gap="sm" wrap="nowrap" className={classes.row}>
-        <Text className={classes.name}>{name}</Text>
+        <Text size="xs" className={classes.name}>
+            {name}
+        </Text>
         {swatches && (
             <Group gap="xs" wrap="nowrap" className={classes.swatches}>
                 <SwatchInline
@@ -69,7 +71,9 @@ const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
                 />
                 {swatches.darkColors && swatches.darkColors.length > 0 && (
                     <>
-                        <Text c="ldGray.3">/</Text>
+                        <Text size="xs" c="ldGray.3">
+                            /
+                        </Text>
                         <SwatchInline
                             icon={IconMoon}
                             label="Dark mode"

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -1,9 +1,12 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
-import { ColorSwatch, Group, Select, Text } from '@mantine-8/core';
+import { ColorSwatch, Group, Select, Text, Tooltip } from '@mantine-8/core';
+import { IconMoon, IconSun } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineIcon from '../MantineIcon';
 import classes from './PalettePicker.module.css';
 
 const INHERIT_VALUE = '__inherit__';
+const SWATCH_LIMIT = 5;
 
 type Props = {
     value: string | null;
@@ -16,22 +19,54 @@ type Props = {
     placeholder?: string;
 };
 
-const PaletteOptionRow: FC<{ name: string; colors: string[] | null }> = ({
+type SwatchSet = {
+    colors: string[];
+    darkColors: string[] | null;
+};
+
+const SwatchRow: FC<{
+    icon: typeof IconSun;
+    label: string;
+    colors: string[];
+}> = ({ icon, label, colors }) => (
+    <Tooltip label={label} position="top" withinPortal>
+        <Group gap={4} wrap="nowrap">
+            <MantineIcon icon={icon} size="sm" color="gray" />
+            {colors.slice(0, SWATCH_LIMIT).map((color, index) => (
+                <ColorSwatch
+                    key={`${color}-${index}`}
+                    size={12}
+                    color={color}
+                    withShadow={false}
+                />
+            ))}
+        </Group>
+    </Tooltip>
+);
+
+const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
     name,
-    colors,
+    swatches,
 }) => (
-    <Group gap="xs" wrap="nowrap" className={classes.row}>
+    <Group gap="sm" wrap="nowrap" className={classes.row}>
         <Text className={classes.name}>{name}</Text>
-        {colors && colors.length > 0 && (
-            <Group gap={2} wrap="nowrap" className={classes.swatches}>
-                {colors.slice(0, 8).map((color, index) => (
-                    <ColorSwatch
-                        key={`${color}-${index}`}
-                        size={14}
-                        color={color}
-                        withShadow={false}
-                    />
-                ))}
+        {swatches && (
+            <Group gap="xs" wrap="nowrap" className={classes.swatches}>
+                <SwatchRow
+                    icon={IconSun}
+                    label="Light mode"
+                    colors={swatches.colors}
+                />
+                {swatches.darkColors && swatches.darkColors.length > 0 && (
+                    <>
+                        <Text c="ldGray.3">/</Text>
+                        <SwatchRow
+                            icon={IconMoon}
+                            label="Dark mode"
+                            colors={swatches.darkColors}
+                        />
+                    </>
+                )}
             </Group>
         )}
     </Group>
@@ -55,8 +90,11 @@ export const PalettePicker: FC<Props> = ({
         })),
     ];
 
-    const swatchesByValue = new Map<string, string[]>(
-        palettes.map((palette) => [palette.colorPaletteUuid, palette.colors]),
+    const swatchesByValue = new Map<string, SwatchSet>(
+        palettes.map((palette) => [
+            palette.colorPaletteUuid,
+            { colors: palette.colors, darkColors: palette.darkColors },
+        ]),
     );
 
     return (
@@ -74,7 +112,7 @@ export const PalettePicker: FC<Props> = ({
             renderOption={({ option }) => (
                 <PaletteOptionRow
                     name={option.label}
-                    colors={swatchesByValue.get(option.value) ?? null}
+                    swatches={swatchesByValue.get(option.value) ?? null}
                 />
             )}
         />

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -1,0 +1,82 @@
+import { type OrganizationColorPalette } from '@lightdash/common';
+import { ColorSwatch, Group, Select, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import classes from './PalettePicker.module.css';
+
+const INHERIT_VALUE = '__inherit__';
+
+type Props = {
+    value: string | null;
+    onChange: (value: string | null) => void;
+    palettes: OrganizationColorPalette[];
+    parentLabel: string;
+    disabled?: boolean;
+    label?: string;
+    description?: string;
+    placeholder?: string;
+};
+
+const PaletteOptionRow: FC<{ name: string; colors: string[] | null }> = ({
+    name,
+    colors,
+}) => (
+    <Group gap="xs" wrap="nowrap" className={classes.row}>
+        <Text className={classes.name}>{name}</Text>
+        {colors && colors.length > 0 && (
+            <Group gap={2} wrap="nowrap" className={classes.swatches}>
+                {colors.slice(0, 8).map((color, index) => (
+                    <ColorSwatch
+                        key={`${color}-${index}`}
+                        size={14}
+                        color={color}
+                        withShadow={false}
+                    />
+                ))}
+            </Group>
+        )}
+    </Group>
+);
+
+export const PalettePicker: FC<Props> = ({
+    value,
+    onChange,
+    palettes,
+    parentLabel,
+    disabled,
+    label,
+    description,
+    placeholder,
+}) => {
+    const data = [
+        { value: INHERIT_VALUE, label: `Inherit from ${parentLabel}` },
+        ...palettes.map((palette) => ({
+            value: palette.colorPaletteUuid,
+            label: palette.name,
+        })),
+    ];
+
+    const swatchesByValue = new Map<string, string[]>(
+        palettes.map((palette) => [palette.colorPaletteUuid, palette.colors]),
+    );
+
+    return (
+        <Select
+            label={label}
+            description={description}
+            placeholder={placeholder}
+            data={data}
+            value={value ?? INHERIT_VALUE}
+            onChange={(next) =>
+                onChange(next && next !== INHERIT_VALUE ? next : null)
+            }
+            disabled={disabled}
+            allowDeselect={false}
+            renderOption={({ option }) => (
+                <PaletteOptionRow
+                    name={option.label}
+                    colors={swatchesByValue.get(option.value) ?? null}
+                />
+            )}
+        />
+    );
+};

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -104,6 +104,8 @@ const MiniBarChart: FC<{ colors: string[]; theme: 'light' | 'dark' }> = ({
                 data: [PREVIEW_BAR_HEIGHTS[i] ?? 5],
                 itemStyle: { color, borderRadius: [2, 2, 0, 0] },
                 barWidth: 10,
+                cursor: 'default',
+                silent: true,
             })),
         };
     }, [colors]);

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -216,6 +216,39 @@ const updateDefaultUserSpaces = async (
         body: JSON.stringify(data),
     });
 
+const updateProjectColorPalette = async (
+    uuid: string,
+    colorPaletteUuid: string | null,
+) =>
+    lightdashApi<undefined>({
+        url: `/projects/${uuid}/colorPalette`,
+        method: 'PATCH',
+        body: JSON.stringify({ colorPaletteUuid }),
+    });
+
+export const useUpdateProjectColorPalette = (uuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<undefined, ApiError, string | null>(
+        (colorPaletteUuid) => updateProjectColorPalette(uuid, colorPaletteUuid),
+        {
+            mutationKey: ['project_color_palette_update', uuid],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries(['project', uuid]);
+                showToastSuccess({
+                    title: 'Project color palette updated',
+                });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to update project color palette',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
 export const useUpdateDefaultUserSpaces = (uuid: string) => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -11,6 +11,7 @@ import { DefaultUserSpaces } from '../components/DefaultUserSpaces';
 import PreAggregateAudit from '../components/PreAggregateAudit';
 import PreAggregateMaterializations from '../components/PreAggregateMaterializations';
 import ProjectUserAccess from '../components/ProjectAccess';
+import ProjectAppearance from '../components/ProjectAppearance/ProjectAppearance';
 import { UpdateProjectConnection } from '../components/ProjectConnection';
 import ProjectParameters from '../components/ProjectParameters';
 import ProjectTablesConfiguration from '../components/ProjectTablesConfiguration/ProjectTablesConfiguration';
@@ -57,6 +58,10 @@ const ProjectSettings: FC = () => {
             {
                 path: `/projectAccess`,
                 element: <ProjectUserAccess projectUuid={projectUuid} />,
+            },
+            {
+                path: `/appearance`,
+                element: <ProjectAppearance projectUuid={projectUuid} />,
             },
             {
                 path: `/usageAnalytics`,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -991,6 +991,26 @@ const Settings: FC = () => {
                                     </Can>
 
                                     <Can
+                                        I="update"
+                                        this={subject('Project', {
+                                            organizationUuid:
+                                                organization.organizationUuid,
+                                            projectUuid: project.projectUuid,
+                                        })}
+                                    >
+                                        <RouterNavLink
+                                            label="Appearance"
+                                            exact
+                                            to={`/generalSettings/projectManagement/${project.projectUuid}/appearance`}
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconPalette}
+                                                />
+                                            }
+                                        />
+                                    </Can>
+
+                                    <Can
                                         I="manage"
                                         this={subject('Project', {
                                             organizationUuid:


### PR DESCRIPTION
Closes: [PROD-7160](https://linear.app/lightdash/issue/PROD-7160)

### Description:

Lets each project pick one of its organization's color palettes (or inherit the org's active palette) via a new Project Settings → Appearance page. Palettes themselves are still managed at the org level — the project UI is a read-only picker, with a link/button back to org-level palette management for users with the right permission. Selecting a palette renders side-by-side mini bar charts (one for light mode, one for dark mode) so you can preview how the colors will look against each background before saving.

Backend adds `projects.color_palette_uuid` (FK with `ON DELETE SET NULL`), a dedicated `PATCH /projects/{uuid}/colorPalette` endpoint with same-org validation (no new CASL scope), and a shared `SavedChartModel.resolveColorPalette` resolver (single COALESCE query) that walks chart → dashboard → space → project → org. Chart fetch, embed dashboard fetch, and AI viz all route through it; the embed `paletteUuid` query param still overrides everything.

Frontend ships a generic `PalettePicker` (Mantine v8, `parentLabel` prop) and a `ProjectAppearance` panel using the standard `SettingsGridCard` left/right layout; the resolver and picker are intentionally generic so PR2–4 (chart/dashboard/space-level palette) can drop in without changing call sites.

### Screenshots

**Project Settings → Appearance — light/dark mini bar chart preview of the selected palette:**

![Appearance with bar-chart preview](https://raw.githubusercontent.com/lightdash/lightdash/assets/pr-22590/palette-final-appearance.png)

**Picker open — each option shows a compact light (☀) and dark (🌙) swatch summary:**

![Picker dropdown](https://raw.githubusercontent.com/lightdash/lightdash/assets/pr-22590/palette-final-dropdown.png)

**Dashboard chart picks up the project palette via the resolver (deep navy from "Customer Segments Aurora"):**

![Dashboard with new palette](https://raw.githubusercontent.com/lightdash/lightdash/assets/pr-22590/palette-5-dashboard.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)