### PR TITLE
feat: support DuckDB credential chain for S3 when static credentials are absent

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -328,6 +328,80 @@ describe('DuckdbWarehouseClient', () => {
         expect(streamMock).toHaveBeenCalledTimes(2);
     });
 
+    it('should use DuckDB credential chain for S3 config without static credentials', async () => {
+        const runMock = jest.fn();
+        const streamMock = jest.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(streamMock, runMock),
+        );
+
+        const client = DuckdbWarehouseClient.createForPreAggregate({
+            type: 'duckdb_s3',
+            s3Config: {
+                endpoint: 's3.eu-west-1.amazonaws.com',
+                region: 'eu-west-1',
+                forcePathStyle: false,
+                useSsl: true,
+            },
+        });
+
+        await client.runQuery('SELECT 1 AS val');
+
+        const secretSql = runMock.mock.calls
+            .map(([sql]) => sql as string)
+            .find((sql) =>
+                sql.includes('CREATE OR REPLACE SECRET __lightdash_s3'),
+            );
+
+        expect(secretSql).toContain('PROVIDER credential_chain');
+        expect(secretSql).toContain('REFRESH auto');
+        expect(secretSql).toContain("VALIDATION 'none'");
+        expect(secretSql).toContain("REGION 'eu-west-1'");
+        expect(secretSql).toContain("ENDPOINT 's3.eu-west-1.amazonaws.com'");
+        expect(secretSql).not.toContain('KEY_ID');
+        expect(secretSql).not.toContain("SECRET '");
+    });
+
+    it('should use static DuckDB S3 credentials when configured', async () => {
+        const runMock = jest.fn();
+        const streamMock = jest.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(streamMock, runMock),
+        );
+
+        const client = DuckdbWarehouseClient.createForPreAggregate({
+            type: 'duckdb_s3',
+            s3Config: {
+                endpoint: 'localhost:9000',
+                region: 'us-east-1',
+                accessKey: 'key',
+                secretKey: 'secret',
+                forcePathStyle: true,
+                useSsl: false,
+            },
+        });
+
+        await client.runQuery('SELECT 1 AS val');
+
+        const secretSql = runMock.mock.calls
+            .map(([sql]) => sql as string)
+            .find((sql) =>
+                sql.includes('CREATE OR REPLACE SECRET __lightdash_s3'),
+            );
+
+        expect(secretSql).not.toContain('PROVIDER credential_chain');
+        expect(secretSql).toContain("KEY_ID 'key'");
+        expect(secretSql).toContain("SECRET 'secret'");
+        expect(secretSql).toContain("URL_STYLE 'path'");
+        expect(secretSql).toContain('USE_SSL false');
+    });
+
     it('should treat instanceCacheKey as the shared instance identity', async () => {
         const runMock = jest.fn();
         const streamMock = jest.fn(async () =>

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -585,6 +585,19 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbCrede
     private static buildS3SecretSql(s3Config: DuckdbS3SessionConfig): string {
         const escape = (v: string) =>
             DuckdbWarehouseClient.sqlBuilder.escapeString(v);
+        const usesStaticCredentials = !!(
+            s3Config.accessKey && s3Config.secretKey
+        );
+        // Static keys may come from dedicated pre-aggregate env vars or fall back
+        // to the base S3 config. Without them, let DuckDB resolve AWS credentials
+        // through the SDK chain, including IRSA/web identity tokens.
+        const providerClause = usesStaticCredentials
+            ? ''
+            : `PROVIDER credential_chain,
+            REFRESH auto,
+            -- Defer credential validation to S3 operations so local bootstrap
+            -- does not require AWS credentials when using runtime-provided roles.
+            VALIDATION 'none',`;
         const regionClause = s3Config.region
             ? `REGION '${escape(s3Config.region)}',`
             : '';
@@ -597,6 +610,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbCrede
 
         return `CREATE OR REPLACE SECRET __lightdash_s3 (
             TYPE s3,
+            ${providerClause}
             ${keyIdClause}
             ${secretClause}
             ENDPOINT '${escape(s3Config.endpoint)}',


### PR DESCRIPTION
Closes: #22594

### Description:

Adds support for IAM-based (credential chain) authentication when configuring DuckDB with S3 for pre-aggregates. Previously, S3 secrets were always created with static credentials. Now, if no `accessKey`/`secretKey` are provided, DuckDB will use the AWS credential chain provider (e.g. IRSA/web identity tokens) instead.

When using the credential chain:

- `PROVIDER credential_chain` is set to allow runtime-resolved roles
- `REFRESH auto` ensures credentials are refreshed automatically
- `VALIDATION 'none'` defers credential validation to actual S3 operations, so bootstrapping does not fail in environments where credentials are only available at runtime

Static credentials continue to work as before when both `accessKey` and `secretKey` are explicitly configured.