### PR TITLE
feat(data-apps): My apps name links to builder instead of preview

### DIFF
--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -169,27 +169,18 @@ const MyAppsPanel: FC = () => {
                     const displayName =
                         app.name || `Untitled app ${app.appUuid.slice(0, 8)}`;
 
-                    if (hasReadyVersion(app)) {
-                        return (
-                            <Anchor
-                                component={Link}
-                                to={`/projects/${app.projectUuid}/apps/${app.appUuid}/preview`}
-                                target="_blank"
-                                fz="sm"
-                                fw={500}
-                                c="inherit"
-                                underline="hover"
-                                truncate="end"
-                            >
-                                {displayName}
-                            </Anchor>
-                        );
-                    }
-
                     return (
-                        <Text fz="sm" fw={500} truncate="end">
+                        <Anchor
+                            component={Link}
+                            to={`/projects/${app.projectUuid}/apps/${app.appUuid}`}
+                            fz="sm"
+                            fw={500}
+                            c="inherit"
+                            underline="hover"
+                            truncate="end"
+                        >
                             {displayName}
-                        </Text>
+                        </Anchor>
                     );
                 },
             },


### PR DESCRIPTION
### Description:
In the settings page it makes more sense to go to the builder page which also contains the preview anyways.
