### PR TITLE
refactor(backend): account-aware org/users/groups controllers

### DIFF
--- a/packages/backend/src/controllers/groupsController.ts
+++ b/packages/backend/src/controllers/groupsController.ts
@@ -5,6 +5,7 @@ import {
     ApiGroupResponse,
     ApiSuccessEmpty,
     ApiUpdateProjectGroupAccess,
+    assertRegisteredAccount,
     CreateProjectGroupAccess,
     UpdateGroupWithMembers,
 } from '@lightdash/common';
@@ -25,6 +26,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import {
     CreateDBProjectGroupAccess,
     UpdateDBProjectGroupAccess,
@@ -56,12 +58,18 @@ export class GroupsController extends BaseController {
         @Query() includeMembers?: number,
         @Query() offset?: number,
     ): Promise<ApiGroupResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getGroupService()
-                .get(req.user!, groupUuid, includeMembers, offset),
+                .get(
+                    toSessionUser(req.account),
+                    groupUuid,
+                    includeMembers,
+                    offset,
+                ),
         };
     }
 
@@ -81,8 +89,11 @@ export class GroupsController extends BaseController {
         @Path() groupUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
-        await this.services.getGroupService().delete(req.user!, groupUuid);
+        await this.services
+            .getGroupService()
+            .delete(toSessionUser(req.account), groupUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -107,9 +118,10 @@ export class GroupsController extends BaseController {
         @Path() userUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         const createdMember = await this.services
             .getGroupService()
-            .addGroupMember(req.user!, {
+            .addGroupMember(toSessionUser(req.account), {
                 groupUuid,
                 userUuid,
             });
@@ -138,9 +150,10 @@ export class GroupsController extends BaseController {
         @Path() userUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         const deleted = await this.services
             .getGroupService()
-            .removeGroupMember(req.user!, {
+            .removeGroupMember(toSessionUser(req.account), {
                 userUuid,
                 groupUuid,
             });
@@ -163,12 +176,13 @@ export class GroupsController extends BaseController {
         @Path() groupUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGroupMembersResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getGroupService()
-                .getGroupMembers(req.user!, groupUuid),
+                .getGroupMembers(toSessionUser(req.account), groupUuid),
         };
     }
 
@@ -188,9 +202,10 @@ export class GroupsController extends BaseController {
         @Request() req: express.Request,
         @Body() body: UpdateGroupWithMembers,
     ): Promise<ApiGroupResponse> {
+        assertRegisteredAccount(req.account);
         const group = await this.services
             .getGroupService()
-            .update(req.user!, groupUuid, body);
+            .update(toSessionUser(req.account), groupUuid, body);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -217,9 +232,10 @@ export class GroupsController extends BaseController {
         @Body() projectGroupAccess: Pick<CreateProjectGroupAccess, 'role'>,
         @Request() req: express.Request,
     ): Promise<ApiCreateProjectGroupAccess> {
+        assertRegisteredAccount(req.account);
         const results = await this.services
             .getGroupService()
-            .addProjectAccess(req.user!, {
+            .addProjectAccess(toSessionUser(req.account), {
                 groupUuid,
                 projectUuid,
                 role: projectGroupAccess.role,
@@ -251,10 +267,11 @@ export class GroupsController extends BaseController {
         projectGroupAccess: UpdateDBProjectGroupAccess,
         @Request() req: express.Request,
     ): Promise<ApiUpdateProjectGroupAccess> {
+        assertRegisteredAccount(req.account);
         const results = await this.services
             .getGroupService()
             .updateProjectAccess(
-                req.user!,
+                toSessionUser(req.account),
                 { groupUuid, projectUuid },
                 projectGroupAccess,
             );
@@ -283,9 +300,10 @@ export class GroupsController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         const removed = await this.services
             .getGroupService()
-            .removeProjectAccess(req.user!, {
+            .removeProjectAccess(toSessionUser(req.account), {
                 groupUuid,
                 projectUuid,
             });

--- a/packages/backend/src/controllers/impersonationController.ts
+++ b/packages/backend/src/controllers/impersonationController.ts
@@ -3,6 +3,7 @@ import {
     ApiStartImpersonationRequest,
     ApiStartImpersonationResponse,
     ApiStopImpersonationResponse,
+    assertRegisteredAccount,
 } from '@lightdash/common';
 import {
     Body,
@@ -15,6 +16,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -35,19 +37,25 @@ export class ImpersonationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ApiStartImpersonationRequest,
     ): Promise<ApiStartImpersonationResponse> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getUserService()
-            .startImpersonation(req.user!, body.targetUserUuid, {
-                isSessionAuth: req.account?.authentication.type === 'session',
-                getImpersonation: () => req.session.impersonation,
-                setImpersonation: (data) => {
-                    req.session.impersonation = data;
+            .startImpersonation(
+                toSessionUser(req.account),
+                body.targetUserUuid,
+                {
+                    isSessionAuth:
+                        req.account.authentication.type === 'session',
+                    getImpersonation: () => req.session.impersonation,
+                    setImpersonation: (data) => {
+                        req.session.impersonation = data;
+                    },
+                    context: {
+                        ip: req.ip,
+                        userAgent: req.get('user-agent'),
+                    },
                 },
-                context: {
-                    ip: req.ip,
-                    userAgent: req.get('user-agent'),
-                },
-            });
+            );
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -15,7 +15,6 @@ import {
     ApiSuccessEmpty,
     ApiUserSchedulersSummaryResponse,
     assertRegisteredAccount,
-    AuthorizationError,
     CreateColorPalette,
     CreateGroup,
     CreateOrganization,
@@ -50,6 +49,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -96,12 +96,13 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateOrganization,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getOrganizationService()
-            .createAndJoinOrg(req.user!, body);
+            .createAndJoinOrg(toSessionUser(req.account), body);
         const sessionUser = await req.services
             .getUserService()
-            .getSessionByUserUuid(req.user!.userUuid);
+            .getSessionByUserUuid(req.account.user.userUuid);
         await new Promise<void>((resolve, reject) => {
             req.login(sessionUser, (err) => {
                 if (err) {
@@ -130,7 +131,10 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: UpdateOrganization,
     ): Promise<ApiSuccessEmpty> {
-        await this.services.getOrganizationService().updateOrg(req.user!, body);
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getOrganizationService()
+            .updateOrg(toSessionUser(req.account), body);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -151,9 +155,10 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Path() organizationUuid: string,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getOrganizationService()
-            .delete(organizationUuid, req.user!);
+            .delete(organizationUuid, toSessionUser(req.account));
         await new Promise<void>((resolve, reject) => {
             req.session.destroy((err) => {
                 if (err) {
@@ -208,6 +213,7 @@ export class OrganizationController extends BaseController {
         @Query() projectUuid?: string,
         @Query() googleOidcOnly?: boolean,
     ): Promise<ApiOrganizationMemberProfiles> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         let paginateArgs: KnexPaginateArgs | undefined;
 
@@ -223,7 +229,7 @@ export class OrganizationController extends BaseController {
             results: await this.services
                 .getOrganizationService()
                 .getUsers(
-                    req.user!,
+                    toSessionUser(req.account),
                     includeGroups,
                     paginateArgs,
                     searchQuery,
@@ -246,12 +252,13 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Path() userUuid: UUID,
     ): Promise<ApiOrganizationMemberProfile> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .getMemberByUuid(req.user!, userUuid),
+                .getMemberByUuid(toSessionUser(req.account), userUuid),
         };
     }
 
@@ -268,12 +275,13 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Path() email: string,
     ): Promise<ApiOrganizationMemberProfile> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .getMemberByEmail(req.user!, email),
+                .getMemberByEmail(toSessionUser(req.account), email),
         };
     }
 
@@ -299,12 +307,13 @@ export class OrganizationController extends BaseController {
         @Path() userUuid: string,
         @Body() body: OrganizationMemberProfileUpdate,
     ): Promise<ApiOrganizationMemberProfile> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .updateMember(req.user!, userUuid, body),
+                .updateMember(toSessionUser(req.account), userUuid, body),
         };
     }
 
@@ -325,7 +334,10 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Path() userUuid: string,
     ): Promise<ApiSuccessEmpty> {
-        await this.services.getUserService().delete(req.user!, userUuid);
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getUserService()
+            .delete(toSessionUser(req.account), userUuid);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -346,16 +358,13 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Path() userUuid: string,
     ): Promise<ApiUserSchedulersSummaryResponse> {
-        if (!req.user) {
-            throw new AuthorizationError('User session not found');
-        }
-
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSchedulerService()
-                .getUserSchedulersSummary(req.user, userUuid),
+                .getUserSchedulersSummary(toSessionUser(req.account), userUuid),
         };
     }
 
@@ -378,17 +387,14 @@ export class OrganizationController extends BaseController {
         @Path() userUuid: string,
         @Body() body: ReassignUserSchedulersRequest,
     ): Promise<ApiReassignUserSchedulersResponse> {
-        if (!req.user) {
-            throw new AuthorizationError('User session not found');
-        }
-
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSchedulerService()
                 .reassignUserSchedulers(
-                    req.user,
+                    toSessionUser(req.account),
                     userUuid,
                     body.newOwnerUserUuid,
                 ),
@@ -406,12 +412,13 @@ export class OrganizationController extends BaseController {
     async getOrganizationAllowedEmailDomains(
         @Request() req: express.Request,
     ): Promise<ApiOrganizationAllowedEmailDomains> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .getAllowedEmailDomains(req.user!),
+                .getAllowedEmailDomains(toSessionUser(req.account)),
         };
     }
 
@@ -428,12 +435,13 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: UpdateAllowedEmailDomains,
     ): Promise<ApiOrganizationAllowedEmailDomains> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .updateAllowedEmailDomains(req.user!, body),
+                .updateAllowedEmailDomains(toSessionUser(req.account), body),
         };
     }
 
@@ -454,9 +462,10 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateGroup,
     ): Promise<ApiCreateGroupResponse> {
+        assertRegisteredAccount(req.account);
         const group = await this.services
             .getOrganizationService()
-            .addGroupToOrganization(req.user!, body);
+            .addGroupToOrganization(toSessionUser(req.account), body);
         this.setStatus(201);
         return {
             status: 'ok',
@@ -480,6 +489,7 @@ export class OrganizationController extends BaseController {
         @Query() includeMembers?: number,
         @Query() searchQuery?: string,
     ): Promise<ApiGroupListResponse> {
+        assertRegisteredAccount(req.account);
         let paginateArgs: KnexPaginateArgs | undefined;
 
         if (pageSize && page) {
@@ -492,7 +502,7 @@ export class OrganizationController extends BaseController {
         const groups = await this.services
             .getOrganizationService()
             .listGroupsInOrganization(
-                req.user!,
+                toSessionUser(req.account),
                 includeMembers,
                 paginateArgs,
                 searchQuery,
@@ -517,12 +527,13 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateColorPalette,
     ): Promise<ApiCreatedColorPaletteResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(201);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .createColorPalette(req.user!, body),
+                .createColorPalette(toSessionUser(req.account), body),
         };
     }
 
@@ -558,12 +569,17 @@ export class OrganizationController extends BaseController {
         @Path() colorPaletteUuid: string,
         @Body() body: UpdateColorPalette,
     ): Promise<ApiColorPaletteResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .updateColorPalette(req.user!, colorPaletteUuid, body),
+                .updateColorPalette(
+                    toSessionUser(req.account),
+                    colorPaletteUuid,
+                    body,
+                ),
         };
     }
 
@@ -578,9 +594,10 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Path() colorPaletteUuid: string,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getOrganizationService()
-            .deleteColorPalette(req.user!, colorPaletteUuid);
+            .deleteColorPalette(toSessionUser(req.account), colorPaletteUuid);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -599,12 +616,16 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Path() colorPaletteUuid: string,
     ): Promise<ApiColorPaletteResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .setActiveColorPalette(req.user!, colorPaletteUuid),
+                .setActiveColorPalette(
+                    toSessionUser(req.account),
+                    colorPaletteUuid,
+                ),
         };
     }
 
@@ -623,10 +644,11 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateProjectOptionalCredentials,
     ): Promise<ApiSuccess<ApiCreateProjectResults>> {
+        assertRegisteredAccount(req.account);
         const results = await this.services
             .getProjectService()
             .createWithoutCompile(
-                req.user!,
+                toSessionUser(req.account),
                 body,
                 getRequestMethod(req.header(LightdashRequestMethodHeader)),
             );
@@ -648,15 +670,15 @@ export class OrganizationController extends BaseController {
     async getImpersonationSettings(
         @Request() req: express.Request,
     ): Promise<ApiImpersonationOrganizationSettingsResponse> {
-        const user = req.user!;
+        assertRegisteredAccount(req.account);
         const enabled = await this.services
             .getOrganizationService()
-            .getImpersonationEnabled(user);
+            .getImpersonationEnabled(toSessionUser(req.account));
 
         return {
             status: 'ok',
             results: {
-                organizationUuid: user.organizationUuid!,
+                organizationUuid: req.account.organization.organizationUuid!,
                 impersonationEnabled: enabled,
             },
         };
@@ -679,15 +701,18 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: UpdateImpersonationOrganizationSettings,
     ): Promise<ApiImpersonationOrganizationSettingsResponse> {
-        const user = req.user!;
+        assertRegisteredAccount(req.account);
         await this.services
             .getOrganizationService()
-            .updateImpersonationEnabled(user, body.impersonationEnabled);
+            .updateImpersonationEnabled(
+                toSessionUser(req.account),
+                body.impersonationEnabled,
+            );
 
         return {
             status: 'ok',
             results: {
-                organizationUuid: user.organizationUuid!,
+                organizationUuid: req.account.organization.organizationUuid!,
                 impersonationEnabled: body.impersonationEnabled,
             },
         };

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -8,7 +8,6 @@ import {
     ApiSuccessEmpty,
     ApiUserAllowedOrganizationsResponse,
     assertRegisteredAccount,
-    AuthorizationError,
     CreatePersonalAccessToken,
     getRequestMethod,
     LightdashRequestMethodHeader,
@@ -39,6 +38,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { UserModel } from '../models/UserModel';
 import {
     allowApiKeyAuthentication,
@@ -63,9 +63,7 @@ export class UserController extends BaseController {
     async getAuthenticatedUser(
         @Request() req: express.Request,
     ): Promise<ApiGetAuthenticatedUserResponse> {
-        if (!req.user) {
-            throw new AuthorizationError('User session not found');
-        }
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const impersonationSession = req.session?.impersonation;
@@ -80,7 +78,9 @@ export class UserController extends BaseController {
         return {
             status: 'ok',
             results: {
-                ...UserModel.lightdashUserFromSession(req.user),
+                ...UserModel.lightdashUserFromSession(
+                    toSessionUser(req.account),
+                ),
                 impersonation,
             },
         };
@@ -134,9 +134,10 @@ export class UserController extends BaseController {
     async createEmailOneTimePasscode(
         @Request() req: express.Request,
     ): Promise<ApiEmailStatusResponse> {
+        assertRegisteredAccount(req.account);
         const status = await this.services
             .getUserService()
-            .sendOneTimePasscodeToPrimaryEmail(req.user!);
+            .sendOneTimePasscodeToPrimaryEmail(toSessionUser(req.account));
         this.setStatus(200);
         return {
             status: 'ok',
@@ -157,10 +158,11 @@ export class UserController extends BaseController {
         @Request() req: express.Request,
         @Query() passcode?: string,
     ): Promise<ApiEmailStatusResponse> {
+        assertRegisteredAccount(req.account);
         // Throws 404 error if not found
         const status = await this.services
             .getUserService()
-            .getPrimaryEmailStatus(req.user!, passcode);
+            .getPrimaryEmailStatus(toSessionUser(req.account), passcode);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -180,9 +182,10 @@ export class UserController extends BaseController {
     async getOrganizationsUserCanJoin(
         @Request() req: express.Request,
     ): Promise<ApiUserAllowedOrganizationsResponse> {
+        assertRegisteredAccount(req.account);
         const status = await this.services
             .getUserService()
-            .getAllowedOrganizations(req.user!);
+            .getAllowedOrganizations(toSessionUser(req.account));
         this.setStatus(200);
         return {
             status: 'ok',
@@ -208,12 +211,13 @@ export class UserController extends BaseController {
         @Request() req: express.Request,
         @Path() organizationUuid: string,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getUserService()
-            .joinOrg(req.user!, organizationUuid);
+            .joinOrg(toSessionUser(req.account), organizationUuid);
         const sessionUser = await req.services
             .getUserService()
-            .getSessionByUserUuid(req.user!.userUuid);
+            .getSessionByUserUuid(req.account.user.userUuid);
         await new Promise<void>((resolve, reject) => {
             req.login(sessionUser, (err) => {
                 if (err) {
@@ -240,9 +244,10 @@ export class UserController extends BaseController {
     async deleteUser(
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getUserService()
-            .delete(req.user!, req.user!.userUuid);
+            .delete(toSessionUser(req.account), req.account.user.userUuid);
 
         await new Promise<void>((resolve, reject) => {
             req.session.destroy((err) => {
@@ -270,12 +275,13 @@ export class UserController extends BaseController {
         status: 'ok';
         results: UserWarehouseCredentials[];
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getUserService()
-                .getWarehouseCredentials(req.user!),
+                .getWarehouseCredentials(toSessionUser(req.account)),
         };
     }
 
@@ -293,12 +299,13 @@ export class UserController extends BaseController {
         status: 'ok';
         results: UserWarehouseCredentials;
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getUserService()
-                .createWarehouseCredentials(req.user!, body),
+                .createWarehouseCredentials(toSessionUser(req.account), body),
         };
     }
 
@@ -317,12 +324,17 @@ export class UserController extends BaseController {
         status: 'ok';
         results: UserWarehouseCredentials;
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getUserService()
-                .updateWarehouseCredentials(req.user!, uuid, body),
+                .updateWarehouseCredentials(
+                    toSessionUser(req.account),
+                    uuid,
+                    body,
+                ),
         };
     }
 
@@ -337,9 +349,10 @@ export class UserController extends BaseController {
         @Request() req: express.Request,
         @Path() uuid: string,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getUserService()
-            .deleteWarehouseCredentials(req.user!, uuid);
+            .deleteWarehouseCredentials(toSessionUser(req.account), uuid);
         this.setStatus(200);
         return {
             status: 'ok',


### PR DESCRIPTION
## Summary

Migrates the org / user / groups controllers from `req.user!` to account-aware via `toSessionUser(req.account)`.

**Files touched (4):**
- `organizationController.ts` — all org/member/group/color-palette/impersonation-settings endpoints
- `userController.ts` — `getAuthenticatedUser`, OTP, allowed orgs, joinOrg, deleteUser, warehouse credentials
- `groupsController.ts` — full group CRUD + project access
- `impersonationController.ts` — `startImpersonation`

**Non-trivial bits (not pure find-replace):**
- `organizationController.getImpersonationSettings` / `updateImpersonationSettings` now read `req.account.organization.organizationUuid!` instead of `req.user!.organizationUuid!` (different source object, same nullability — `AccountOrganization` is `Partial<…>`)
- `organizationController.createAndJoinOrg` and `userController.joinOrganization` / `deleteUser` use `req.account.user.userUuid` directly (skipping the `toSessionUser` round-trip) for the follow-up `getSessionByUserUuid` call
- `userController.getAuthenticatedUser` replaces an `if (!req.user) throw AuthorizationError` guard with `assertRegisteredAccount` — error type changes from `AuthorizationError` to `ForbiddenError` on the unreachable failure path (`isAuthenticated` middleware prevents it in practice)
- `impersonationController.startImpersonation` drops optional chaining on `req.account?.authentication.type` after the assertion, with the options object reflowed
- Drops now-unused `AuthorizationError` imports from `userController.ts` and `organizationController.ts`

## Test plan

- [ ] Backend typecheck passes
- [ ] `GET /api/v1/user` returns the current user (incl. impersonation block when active)
- [ ] Org CRUD, member listing/search/pagination, member role updates, member delete
- [ ] User OTP send/verify, join allowed org, delete self
- [ ] User warehouse credential CRUD
- [ ] Groups: create, get, update, delete, member add/remove, project access add/update/remove
- [ ] Color palette: create, update, set-active, delete
- [ ] Start/stop impersonation (session auth path) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)