### PR TITLE
refactor(backend): account-aware sqlRunner & scheduler controllers

### DIFF
--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -11,7 +11,6 @@ import {
     ApiSchedulersResponse,
     ApiTestSchedulerResponse,
     assertRegisteredAccount,
-    AuthorizationError,
     KnexPaginateArgs,
     ReassignSchedulerOwnerRequest,
     SchedulerJobStatus,
@@ -34,6 +33,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import {
     parseEnumList,
     parseUuidList,
@@ -85,6 +85,7 @@ export class SchedulerController extends BaseController {
         @Query() createdByUserUuids?: string,
         @Query() destinations?: string,
     ): Promise<ApiSchedulerLogsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         let paginateArgs: KnexPaginateArgs | undefined;
@@ -110,7 +111,7 @@ export class SchedulerController extends BaseController {
             results: await this.services
                 .getSchedulerService()
                 .getSchedulerLogs(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     paginateArgs,
                     searchQuery,
@@ -155,6 +156,7 @@ export class SchedulerController extends BaseController {
         @Query() resourceType?: 'chart' | 'dashboard',
         @Query() resourceUuids?: string,
     ): Promise<ApiSchedulerRunsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         let paginateArgs: KnexPaginateArgs | undefined;
@@ -191,7 +193,7 @@ export class SchedulerController extends BaseController {
             results: await this.services
                 .getSchedulerService()
                 .getSchedulerRuns(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     paginateArgs,
                     searchQuery,
@@ -215,13 +217,14 @@ export class SchedulerController extends BaseController {
         @Path() runId: string,
         @Request() req: express.Request,
     ): Promise<ApiSchedulerRunLogsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
             status: 'ok',
             results: await this.services
                 .getSchedulerService()
-                .getRunLogs(req.user!, runId),
+                .getRunLogs(toSessionUser(req.account), runId),
         };
     }
 
@@ -257,6 +260,7 @@ export class SchedulerController extends BaseController {
         @Query() destinations?: string,
         @Query() includeLatestRun?: boolean,
     ): Promise<ApiSchedulersResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         let paginateArgs: KnexPaginateArgs | undefined;
 
@@ -280,7 +284,7 @@ export class SchedulerController extends BaseController {
             results: await this.services
                 .getSchedulerService()
                 .getUserSchedulers(
-                    req.user!,
+                    toSessionUser(req.account),
                     paginateArgs,
                     searchQuery,
                     sort,
@@ -334,6 +338,7 @@ export class SchedulerController extends BaseController {
         @Query() destinations?: string,
         @Query() includeLatestRun?: boolean,
     ): Promise<ApiSchedulersResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         let paginateArgs: KnexPaginateArgs | undefined;
 
@@ -367,7 +372,7 @@ export class SchedulerController extends BaseController {
             results: await this.services
                 .getSchedulerService()
                 .getSchedulers(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     paginateArgs,
                     searchQuery,
@@ -392,12 +397,13 @@ export class SchedulerController extends BaseController {
         @Path() schedulerUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSchedulerAndTargetsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSchedulerService()
-                .getScheduler(req.user!, schedulerUuid),
+                .getScheduler(toSessionUser(req.account), schedulerUuid),
         };
     }
 
@@ -421,12 +427,17 @@ export class SchedulerController extends BaseController {
         @Request() req: express.Request,
         @Body() body: AnyType, // TODO: It should be UpdateSchedulerAndTargetsWithoutId but tsoa returns an error
     ): Promise<ApiSchedulerAndTargetsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSchedulerService()
-                .updateScheduler(req.user!, schedulerUuid, body),
+                .updateScheduler(
+                    toSessionUser(req.account),
+                    schedulerUuid,
+                    body,
+                ),
         };
     }
 
@@ -450,12 +461,17 @@ export class SchedulerController extends BaseController {
         @Request() req: express.Request,
         @Body() body: { enabled: boolean },
     ): Promise<ApiSchedulerAndTargetsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSchedulerService()
-                .setSchedulerEnabled(req.user!, schedulerUuid, body.enabled),
+                .setSchedulerEnabled(
+                    toSessionUser(req.account),
+                    schedulerUuid,
+                    body.enabled,
+                ),
         };
     }
 
@@ -479,17 +495,14 @@ export class SchedulerController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ReassignSchedulerOwnerRequest,
     ): Promise<ApiReassignSchedulerOwnerResponse> {
-        if (!req.user) {
-            throw new AuthorizationError('User session not found');
-        }
-
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSchedulerService()
                 .reassignSchedulerOwner(
-                    req.user,
+                    toSessionUser(req.account),
                     projectUuid,
                     body.schedulerUuids,
                     body.newOwnerUserUuid,
@@ -518,10 +531,11 @@ export class SchedulerController extends BaseController {
         status: 'ok';
         results: undefined;
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getSchedulerService()
-            .deleteScheduler(req.user!, schedulerUuid);
+            .deleteScheduler(toSessionUser(req.account), schedulerUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -542,12 +556,13 @@ export class SchedulerController extends BaseController {
         @Path() schedulerUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiScheduledJobsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSchedulerService()
-                .getScheduledJobs(req.user!, schedulerUuid),
+                .getScheduledJobs(toSessionUser(req.account), schedulerUuid),
         };
     }
 
@@ -598,6 +613,7 @@ export class SchedulerController extends BaseController {
         @Request() req: express.Request,
         @Body() body: AnyType, // TODO: It should be CreateSchedulerAndTargets but tsoa returns an error
     ): Promise<ApiTestSchedulerResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
@@ -606,7 +622,7 @@ export class SchedulerController extends BaseController {
                 jobId: (
                     await this.services
                         .getSchedulerService()
-                        .sendScheduler(req.user!, body)
+                        .sendScheduler(toSessionUser(req.account), body)
                 ).jobId,
             },
         };
@@ -630,6 +646,7 @@ export class SchedulerController extends BaseController {
         @Path() schedulerUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiTestSchedulerResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -637,7 +654,10 @@ export class SchedulerController extends BaseController {
                 jobId: (
                     await this.services
                         .getSchedulerService()
-                        .sendSchedulerByUuid(req.user!, schedulerUuid)
+                        .sendSchedulerByUuid(
+                            toSessionUser(req.account),
+                            schedulerUuid,
+                        )
                 ).jobId,
             },
         };

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -43,6 +43,7 @@ import {
 } from '@tsoa/runtime';
 import express from 'express';
 import { getContextFromQueryOrHeader } from '../analytics/LightdashAnalytics';
+import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -66,12 +67,13 @@ export class SqlRunnerController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiWarehouseTablesCatalog> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getWarehouseTables(req.user!, projectUuid),
+                .getWarehouseTables(toSessionUser(req.account), projectUuid),
         };
     }
 
@@ -94,6 +96,7 @@ export class SqlRunnerController extends BaseController {
         @Query() schemaName?: string,
         @Query() databaseName?: string,
     ): Promise<ApiWarehouseTableFields> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
@@ -101,7 +104,7 @@ export class SqlRunnerController extends BaseController {
             results: await this.services
                 .getProjectService()
                 .getWarehouseFields(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     QueryExecutionContext.SQL_RUNNER,
                     tableName,
@@ -128,6 +131,7 @@ export class SqlRunnerController extends BaseController {
         @Body() body: SqlRunnerBody,
         @Request() req: express.Request,
     ): Promise<ApiJobScheduledResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
@@ -135,7 +139,7 @@ export class SqlRunnerController extends BaseController {
             results: await this.services
                 .getSavedSqlService()
                 .getResultJobFromSql(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     body.sql,
                     body.limit,
@@ -160,6 +164,7 @@ export class SqlRunnerController extends BaseController {
         @Body() body: SqlRunnerPivotQueryBody,
         @Request() req: express.Request,
     ): Promise<ApiJobScheduledResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
@@ -167,7 +172,7 @@ export class SqlRunnerController extends BaseController {
             results: await this.services
                 .getSavedSqlService()
                 .getResultJobFromSqlPivotQuery(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     body,
                     getContextFromQueryOrHeader(req),
@@ -191,12 +196,13 @@ export class SqlRunnerController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<AnyType> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         this.setHeader('Content-Type', 'application/json');
 
         const readStream = await this.services
             .getProjectService()
-            .getFileStream(req.user!, projectUuid, fileId);
+            .getFileStream(toSessionUser(req.account), projectUuid, fileId);
 
         const { res } = req;
         if (res) {
@@ -226,12 +232,13 @@ export class SqlRunnerController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSqlChart> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
-                .getSqlChart(req.user!, projectUuid, uuid),
+                .getSqlChart(toSessionUser(req.account), projectUuid, uuid),
         };
     }
 
@@ -251,12 +258,18 @@ export class SqlRunnerController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSqlChart> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
-                .getSqlChart(req.user!, projectUuid, undefined, slug),
+                .getSqlChart(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    undefined,
+                    slug,
+                ),
         };
     }
 
@@ -276,13 +289,14 @@ export class SqlRunnerController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiJobScheduledResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
                 .getSqlChartResultJob(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     slug,
                     undefined,
@@ -307,13 +321,14 @@ export class SqlRunnerController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiJobScheduledResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
                 .getSqlChartResultJob(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     undefined,
                     uuid,
@@ -342,12 +357,13 @@ export class SqlRunnerController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateSqlChart,
     ): Promise<ApiCreateSqlChart> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
-                .createSqlChart(req.user!, projectUuid, body),
+                .createSqlChart(toSessionUser(req.account), projectUuid, body),
         };
     }
 
@@ -373,12 +389,18 @@ export class SqlRunnerController extends BaseController {
         @Request() req: express.Request,
         @Body() body: UpdateSqlChart,
     ): Promise<ApiUpdateSqlChart> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
-                .updateSqlChart(req.user!, projectUuid, uuid, body),
+                .updateSqlChart(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    uuid,
+                    body,
+                ),
         };
     }
 
@@ -402,8 +424,11 @@ export class SqlRunnerController extends BaseController {
         @Path() uuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
-        await this.services.getSavedSqlService().delete(req.user!, uuid);
+        await this.services
+            .getSavedSqlService()
+            .delete(toSessionUser(req.account), uuid);
         return {
             status: 'ok',
             results: undefined,
@@ -430,17 +455,18 @@ export class SqlRunnerController extends BaseController {
         @Path() uuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSqlChart> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const promotedSqlChart = await this.services
             .getPromoteService()
-            .promoteSqlChart(req.user!, projectUuid, uuid);
+            .promoteSqlChart(toSessionUser(req.account), projectUuid, uuid);
 
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
                 .getSqlChart(
-                    req.user!,
+                    toSessionUser(req.account),
                     promotedSqlChart.projectUuid,
                     promotedSqlChart.savedSqlUuid,
                 ),
@@ -463,12 +489,17 @@ export class SqlRunnerController extends BaseController {
         @Path() uuid: string,
         @Request() req: express.Request,
     ): Promise<ApiPromotionChangesResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getPromoteService()
-                .getPromoteSqlChartDiff(req.user!, projectUuid, uuid),
+                .getPromoteSqlChartDiff(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    uuid,
+                ),
         };
     }
 
@@ -490,10 +521,14 @@ export class SqlRunnerController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getProjectService()
-            .populateWarehouseTablesCache(req.user!, projectUuid);
+            .populateWarehouseTablesCache(
+                toSessionUser(req.account),
+                projectUuid,
+            );
         return {
             status: 'ok',
             results: undefined,
@@ -583,10 +618,11 @@ export class SqlRunnerController extends BaseController {
         @Path() name: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getProjectService()
-            .deleteVirtualView(req.user!, projectUuid, name);
+            .deleteVirtualView(toSessionUser(req.account), projectUuid, name);
         return {
             status: 'ok',
             results: undefined,
@@ -610,6 +646,7 @@ export class SqlRunnerController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateVirtualViewPayload,
     ): Promise<ApiGithubDbtWritePreview> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const { name } = body;
 
@@ -617,7 +654,11 @@ export class SqlRunnerController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
-                .writeBackPreview(req.user!, projectUuid, name),
+                .writeBackPreview(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    name,
+                ),
         };
     }
 
@@ -638,6 +679,7 @@ export class SqlRunnerController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateVirtualViewPayload,
     ): Promise<ApiGithubDbtWriteBack> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const { name, sql, columns } = body;
 
@@ -646,7 +688,7 @@ export class SqlRunnerController extends BaseController {
             results: await this.services
                 .getGitIntegrationService()
                 .createPullRequestFromSql(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     name,
                     sql,
@@ -668,12 +710,17 @@ export class SqlRunnerController extends BaseController {
         @Path() savedSqlUuid: string,
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: SchedulerAndTargets[] }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
-                .getSchedulers(req.user!, projectUuid, savedSqlUuid),
+                .getSchedulers(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    savedSqlUuid,
+                ),
         };
     }
 
@@ -695,12 +742,18 @@ export class SqlRunnerController extends BaseController {
         @Body() body: CreateSchedulerAndTargetsWithoutIds,
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: SchedulerAndTargets }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(201);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedSqlService()
-                .createScheduler(req.user!, projectUuid, savedSqlUuid, body),
+                .createScheduler(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    savedSqlUuid,
+                    body,
+                ),
         };
     }
 }


### PR DESCRIPTION
## Summary

Migrates the SQL Runner and Scheduler controllers from `req.user!` to account-aware via `toSessionUser(req.account)`.

**Files touched (2):**
- `schedulerController.ts` — logs, runs, run-logs, user/project schedulers, scheduler CRUD, enable/disable, reassign-owner, scheduled jobs, send/test
- `sqlRunnerController.ts` — warehouse tables/fields, result jobs, file streams, SQL chart CRUD + slug lookup, promote, virtual views, write-back to git, schedulers

**Pattern:**
1. Add `assertRegisteredAccount(req.account)` at the top of each handler
2. Replace `req.user!` with `toSessionUser(req.account)` in service calls

**Non-trivial bits:**
- `schedulerController.reassignSchedulerOwner` replaces an `if (!req.user) throw AuthorizationError` guard with `assertRegisteredAccount` (error type changes on the unreachable failure path)
- Drops now-unused `AuthorizationError` import from `schedulerController.ts`

No behavior change for authenticated callers.

## Test plan

- [ ] Backend typecheck passes
- [ ] Scheduler: list logs/runs/jobs, get scheduler, update, enable/disable, delete, reassign owner
- [ ] Scheduler: send-now and test endpoints still queue jobs
- [ ] SQL Runner: list warehouse tables/fields, run SQL + pivot SQL, file stream, get/update/delete SQL chart by uuid + slug
- [ ] SQL Runner: promote chart, get promote diff
- [ ] SQL Runner: create/update virtual view, delete virtual view, write-back preview + PR
- [ ] SQL chart schedulers: list + create

🤖 Generated with [Claude Code](https://claude.com/claude-code)