### PR TITLE
refactor(backend): account-aware charts/dashboards/spaces/content controllers

### DIFF
--- a/packages/backend/src/controllers/dashboardController.ts
+++ b/packages/backend/src/controllers/dashboardController.ts
@@ -5,7 +5,7 @@ import {
     ApiPromoteDashboardResponse,
     ApiPromotionChangesResponse,
     ApiSuccessEmpty,
-    AuthorizationError,
+    assertRegisteredAccount,
     type ApiCreateDashboardSchedulerResponse,
     type ApiDashboardSchedulersResponse,
     type ApiGetDashboardHistoryResponse,
@@ -26,6 +26,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -55,12 +56,13 @@ export class DashboardController extends BaseController {
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiPromoteDashboardResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getPromoteService()
-                .promoteDashboard(req.user!, dashboardUuid),
+                .promoteDashboard(toSessionUser(req.account), dashboardUuid),
         };
     }
 
@@ -78,12 +80,16 @@ export class DashboardController extends BaseController {
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiPromotionChangesResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getPromoteService()
-                .getPromoteDashboardDiff(req.user!, dashboardUuid),
+                .getPromoteDashboardDiff(
+                    toSessionUser(req.account),
+                    dashboardUuid,
+                ),
         };
     }
 
@@ -101,12 +107,13 @@ export class DashboardController extends BaseController {
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetDashboardHistoryResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .getHistory(req.user!, dashboardUuid),
+                .getHistory(toSessionUser(req.account), dashboardUuid),
         };
     }
 
@@ -126,12 +133,17 @@ export class DashboardController extends BaseController {
         @Path() versionUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetDashboardVersionResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .getVersion(req.user!, dashboardUuid, versionUuid),
+                .getVersion(
+                    toSessionUser(req.account),
+                    dashboardUuid,
+                    versionUuid,
+                ),
         };
     }
 
@@ -155,10 +167,11 @@ export class DashboardController extends BaseController {
         @Path() versionUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getDashboardService()
-            .rollback(req.user!, dashboardUuid, versionUuid);
+            .rollback(toSessionUser(req.account), dashboardUuid, versionUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -178,13 +191,11 @@ export class DashboardController extends BaseController {
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiDashboardSchedulersResponse> {
-        if (!req.user) {
-            throw new AuthorizationError('User session not found');
-        }
+        assertRegisteredAccount(req.account);
 
         const schedulers = await this.services
             .getDashboardService()
-            .getSchedulers(req.user, dashboardUuid);
+            .getSchedulers(toSessionUser(req.account), dashboardUuid);
 
         this.setStatus(200);
 
@@ -210,12 +221,17 @@ export class DashboardController extends BaseController {
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiCreateDashboardSchedulerResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .createScheduler(req.user!, dashboardUuid, req.body),
+                .createScheduler(
+                    toSessionUser(req.account),
+                    dashboardUuid,
+                    req.body,
+                ),
         };
     }
 
@@ -237,12 +253,13 @@ export class DashboardController extends BaseController {
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiContentVerificationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .verifyDashboard(req.user!, dashboardUuid),
+                .verifyDashboard(toSessionUser(req.account), dashboardUuid),
         };
     }
 
@@ -264,10 +281,11 @@ export class DashboardController extends BaseController {
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiContentVerificationDeleteResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getDashboardService()
-            .unverifyDashboard(req.user!, dashboardUuid);
+            .unverifyDashboard(toSessionUser(req.account), dashboardUuid);
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/controllers/favoritesController.ts
+++ b/packages/backend/src/controllers/favoritesController.ts
@@ -1,4 +1,5 @@
 import {
+    assertRegisteredAccount,
     type ApiErrorPayload,
     type ApiFavoriteItems,
     type ApiToggleFavorite,
@@ -18,6 +19,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -39,9 +41,10 @@ export class FavoritesController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiFavoriteItems> {
+        assertRegisteredAccount(req.account);
         const items = await this.services
             .getFavoritesService()
-            .getFavorites(req.user!, projectUuid);
+            .getFavorites(toSessionUser(req.account), projectUuid);
         this.setStatus(200);
         return {
             status: 'ok',
@@ -65,10 +68,11 @@ export class FavoritesController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ToggleFavoriteRequest,
     ): Promise<ApiToggleFavorite> {
+        assertRegisteredAccount(req.account);
         const result = await this.services
             .getFavoritesService()
             .toggleFavorite(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 body.contentType,
                 body.contentUuid,

--- a/packages/backend/src/controllers/pinningController.ts
+++ b/packages/backend/src/controllers/pinningController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiPinnedItems,
+    assertRegisteredAccount,
     UpdatePinnedItemOrder,
 } from '@lightdash/common';
 import {
@@ -17,6 +18,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -44,9 +46,14 @@ export class PinningController extends BaseController {
         @Path() pinnedListUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiPinnedItems> {
+        assertRegisteredAccount(req.account);
         const pinnedItems = await this.services
             .getPinningService()
-            .getPinnedItems(req.user!, projectUuid, pinnedListUuid);
+            .getPinnedItems(
+                toSessionUser(req.account),
+                projectUuid,
+                pinnedListUuid,
+            );
         this.setStatus(200);
         return {
             status: 'ok',
@@ -77,10 +84,11 @@ export class PinningController extends BaseController {
         @Body()
         body: Array<UpdatePinnedItemOrder>,
     ): Promise<ApiPinnedItems> {
+        assertRegisteredAccount(req.account);
         const pinnedItems = await this.services
             .getPinningService()
             .updatePinnedItemsOrder(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 pinnedListUuid,
                 body,

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -10,7 +10,7 @@ import {
     ApiPromoteChartResponse,
     ApiPromotionChangesResponse,
     ApiSuccessEmpty,
-    AuthorizationError,
+    assertRegisteredAccount,
     DateZoom,
     QueryExecutionContext,
     SortField,
@@ -39,6 +39,7 @@ import {
     getContextFromHeader,
     getContextFromQueryOrHeader,
 } from '../analytics/LightdashAnalytics';
+import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     deprecatedResultsRoute,
@@ -78,6 +79,7 @@ export class SavedChartController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiRunQueryResponse> {
+        assertRegisteredAccount(req.account);
         const context = getContextFromQueryOrHeader(req);
 
         await this.services
@@ -85,7 +87,7 @@ export class SavedChartController extends BaseController {
             .trackDeprecatedRouteCalled(
                 {
                     event: 'deprecated_route.called',
-                    userId: req.user!.userUuid,
+                    userId: toSessionUser(req.account).userUuid,
                     properties: {
                         route: req.path,
                         context: context ?? QueryExecutionContext.API,
@@ -100,7 +102,7 @@ export class SavedChartController extends BaseController {
         return {
             status: 'ok',
             results: await this.services.getProjectService().runViewChartQuery({
-                account: req.account!,
+                account: req.account,
                 chartUuid,
                 versionUuid: undefined,
                 invalidateCache: body.invalidateCache,
@@ -164,12 +166,13 @@ export class SavedChartController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetChartHistoryResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedChartService()
-                .getHistory(req.user!, chartUuid),
+                .getHistory(toSessionUser(req.account), chartUuid),
         };
     }
 
@@ -189,12 +192,13 @@ export class SavedChartController extends BaseController {
         @Path() versionUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetChartVersionResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedChartService()
-                .getVersion(req.user!, chartUuid, versionUuid),
+                .getVersion(toSessionUser(req.account), chartUuid, versionUuid),
         };
     }
 
@@ -219,13 +223,14 @@ export class SavedChartController extends BaseController {
         @Path() versionUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiRunQueryResponse> {
+        assertRegisteredAccount(req.account);
         const context = getContextFromHeader(req);
         await this.services
             .getLightdashAnalyticsService()
             .trackDeprecatedRouteCalled(
                 {
                     event: 'deprecated_route.called',
-                    userId: req.user!.userUuid,
+                    userId: toSessionUser(req.account).userUuid,
                     properties: {
                         route: req.path,
                         context: context ?? QueryExecutionContext.API,
@@ -241,7 +246,7 @@ export class SavedChartController extends BaseController {
         return {
             status: 'ok',
             results: await this.services.getProjectService().runViewChartQuery({
-                account: req.account!,
+                account: req.account,
                 chartUuid,
                 versionUuid,
                 context,
@@ -269,10 +274,11 @@ export class SavedChartController extends BaseController {
         @Path() versionUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getSavedChartService()
-            .rollback(req.user!, chartUuid, versionUuid);
+            .rollback(toSessionUser(req.account), chartUuid, versionUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -333,12 +339,13 @@ export class SavedChartController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiPromoteChartResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getPromoteService()
-                .promoteChart(req.user!, chartUuid),
+                .promoteChart(toSessionUser(req.account), chartUuid),
         };
     }
 
@@ -356,12 +363,13 @@ export class SavedChartController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiPromotionChangesResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getPromoteService()
-                .getPromoteChartDiff(req.user!, chartUuid),
+                .getPromoteChartDiff(toSessionUser(req.account), chartUuid),
         };
     }
 
@@ -378,13 +386,11 @@ export class SavedChartController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSavedChartSchedulersResponse> {
-        if (!req.user) {
-            throw new AuthorizationError('User session not found');
-        }
+        assertRegisteredAccount(req.account);
 
         const schedulers = await this.services
             .getSavedChartService()
-            .getSchedulers(req.user, chartUuid);
+            .getSchedulers(toSessionUser(req.account), chartUuid);
 
         this.setStatus(200);
 
@@ -410,12 +416,17 @@ export class SavedChartController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiCreateSavedChartSchedulerResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedChartService()
-                .createScheduler(req.user!, chartUuid, req.body),
+                .createScheduler(
+                    toSessionUser(req.account),
+                    chartUuid,
+                    req.body,
+                ),
         };
     }
 
@@ -433,12 +444,13 @@ export class SavedChartController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiExportChartImageResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getUnfurlService()
-                .exportChart(chartUuid, req.user!),
+                .exportChart(chartUuid, toSessionUser(req.account)),
         };
     }
 
@@ -460,12 +472,13 @@ export class SavedChartController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiContentVerificationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSavedChartService()
-                .verifyChart(req.user!, chartUuid),
+                .verifyChart(toSessionUser(req.account), chartUuid),
         };
     }
 
@@ -487,10 +500,11 @@ export class SavedChartController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiContentVerificationDeleteResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getSavedChartService()
-            .unverifyChart(req.user!, chartUuid);
+            .unverifyChart(toSessionUser(req.account), chartUuid);
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/controllers/shareController.ts
+++ b/packages/backend/src/controllers/shareController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiShareResponse,
+    assertRegisteredAccount,
     CreateShareUrl,
 } from '@lightdash/common';
 import {
@@ -17,6 +18,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -60,9 +62,10 @@ export class ShareController extends BaseController {
         @Body() body: CreateShareUrl,
         @Request() req: express.Request,
     ): Promise<ApiShareResponse> {
+        assertRegisteredAccount(req.account);
         const shareUrl = await this.services
             .getShareService()
-            .createShareUrl(req.user!, body.path, body.params);
+            .createShareUrl(toSessionUser(req.account), body.path, body.params);
         this.setStatus(201);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/spaceController.ts
+++ b/packages/backend/src/controllers/spaceController.ts
@@ -5,6 +5,7 @@ import {
     ApiSpaceDeleteImpactResponse,
     ApiSpaceResponse,
     ApiSuccessEmpty,
+    assertRegisteredAccount,
     CreateSpace,
     UpdateSpace,
 } from '@lightdash/common';
@@ -24,6 +25,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -51,10 +53,11 @@ export class SpaceController extends BaseController {
         @Path() spaceUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSpaceResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const results = await this.services
             .getSpaceService()
-            .getSpace(projectUuid, req.user!, spaceUuid);
+            .getSpace(projectUuid, toSessionUser(req.account), spaceUuid);
         return {
             status: 'ok',
             results,
@@ -77,12 +80,13 @@ export class SpaceController extends BaseController {
         @Path() spaceUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSpaceDeleteImpactResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSpaceService()
-                .getDeleteImpact(req.user!, spaceUuid),
+                .getDeleteImpact(toSessionUser(req.account), spaceUuid),
         };
     }
 
@@ -107,10 +111,11 @@ export class SpaceController extends BaseController {
         @Body() body: CreateSpace,
         @Request() req: express.Request,
     ): Promise<ApiSpaceResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const results = await this.services
             .getSpaceService()
-            .createSpace(projectUuid, req.user!, body);
+            .createSpace(projectUuid, toSessionUser(req.account), body);
         return {
             status: 'ok',
             results,
@@ -137,8 +142,11 @@ export class SpaceController extends BaseController {
         @Path() spaceUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
-        await this.services.getSpaceService().delete(req.user!, spaceUuid);
+        await this.services
+            .getSpaceService()
+            .delete(toSessionUser(req.account), spaceUuid);
         return {
             status: 'ok',
             results: undefined,
@@ -168,10 +176,11 @@ export class SpaceController extends BaseController {
         @Body() body: UpdateSpace,
         @Request() req: express.Request,
     ): Promise<ApiSpaceResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const results = await this.services
             .getSpaceService()
-            .updateSpace(req.user!, spaceUuid, body);
+            .updateSpace(toSessionUser(req.account), spaceUuid, body);
         return {
             status: 'ok',
             results,
@@ -201,11 +210,12 @@ export class SpaceController extends BaseController {
         @Body() body: AddSpaceUserAccess,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getSpaceService()
             .addSpaceUserAccess(
-                req.user!,
+                toSessionUser(req.account),
                 spaceUuid,
                 body.userUuid,
                 body.spaceRole,
@@ -239,10 +249,15 @@ export class SpaceController extends BaseController {
         @Path() userUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getSpaceService()
-            .removeSpaceUserAccess(req.user!, spaceUuid, userUuid);
+            .removeSpaceUserAccess(
+                toSessionUser(req.account),
+                spaceUuid,
+                userUuid,
+            );
         return {
             status: 'ok',
             results: undefined,
@@ -273,11 +288,12 @@ export class SpaceController extends BaseController {
         @Body() body: AddSpaceGroupAccess,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getSpaceService()
             .addSpaceGroupAccess(
-                req.user!,
+                toSessionUser(req.account),
                 spaceUuid,
                 body.groupUuid,
                 body.spaceRole,
@@ -311,10 +327,15 @@ export class SpaceController extends BaseController {
         @Path() groupUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getSpaceService()
-            .removeSpaceGroupAccess(req.user!, spaceUuid, groupUuid);
+            .removeSpaceGroupAccess(
+                toSessionUser(req.account),
+                spaceUuid,
+                groupUuid,
+            );
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/controllers/v2/ContentController.ts
+++ b/packages/backend/src/controllers/v2/ContentController.ts
@@ -7,6 +7,7 @@ import {
     ApiPermanentlyDeleteContentBody,
     ApiRestoreContentBody,
     ApiSuccessEmpty,
+    assertRegisteredAccount,
     ContentActionMove,
     ContentType,
     ParameterError,
@@ -28,6 +29,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import { ContentArgs } from '../../models/ContentModel/ContentModelTypes';
 import { allowApiKeyAuthentication, isAuthenticated } from '../authentication';
 import { BaseController } from '../baseController';
@@ -56,11 +58,12 @@ export class ContentController extends BaseController {
         @Query() sortBy?: ContentArgs['sortBy'],
         @Query() sortDirection?: ContentArgs['sortDirection'],
     ): Promise<ApiContentResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services.getContentService().find(
-                req.user!,
+                toSessionUser(req.account),
                 {
                     projectUuids,
                     spaceUuids,
@@ -93,6 +96,7 @@ export class ContentController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: ApiContentActionBody<ContentActionMove>,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         if (body.action.type !== 'move') {
@@ -102,7 +106,7 @@ export class ContentController extends BaseController {
         await this.services
             .getContentService()
             .move(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 body.item,
                 body.action.targetSpaceUuid,
@@ -125,6 +129,7 @@ export class ContentController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: ApiContentBulkActionBody<ContentActionMove>,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         if (body.action.type !== 'move') {
@@ -134,7 +139,7 @@ export class ContentController extends BaseController {
         await this.services
             .getContentService()
             .bulkMove(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 body.content,
                 body.action.targetSpaceUuid,
@@ -160,11 +165,12 @@ export class ContentController extends BaseController {
         @Query() contentTypes?: ContentType[],
         @Query() deletedByUserUuids?: string[],
     ): Promise<ApiDeletedContentResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services.getContentService().findDeleted(
-                req.user!,
+                toSessionUser(req.account),
                 {
                     projectUuids,
                     search,
@@ -192,10 +198,11 @@ export class ContentController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: ApiRestoreContentBody,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getContentService()
-            .restoreContent(req.user!, projectUuid, body.item);
+            .restoreContent(toSessionUser(req.account), projectUuid, body.item);
         return { status: 'ok', results: undefined };
     }
 
@@ -212,10 +219,15 @@ export class ContentController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: ApiPermanentlyDeleteContentBody,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getContentService()
-            .permanentlyDeleteContent(req.user!, projectUuid, body.item);
+            .permanentlyDeleteContent(
+                toSessionUser(req.account),
+                projectUuid,
+                body.item,
+            );
         return { status: 'ok', results: undefined };
     }
 }

--- a/packages/backend/src/controllers/v2/DashboardController.ts
+++ b/packages/backend/src/controllers/v2/DashboardController.ts
@@ -1,5 +1,5 @@
 import {
-    AuthorizationError,
+    assertRegisteredAccount,
     type ApiDashboardPaginatedSchedulersResponse,
     type ApiErrorPayload,
     type KnexPaginateArgs,
@@ -17,6 +17,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -46,10 +47,7 @@ export class DashboardControllerV2 extends BaseController {
         @Query() page?: number,
         @Query() searchQuery?: string,
     ): Promise<ApiDashboardPaginatedSchedulersResponse> {
-        if (!req.user) {
-            throw new AuthorizationError('User session not found');
-        }
-
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         let paginateArgs: KnexPaginateArgs | undefined;
@@ -65,7 +63,7 @@ export class DashboardControllerV2 extends BaseController {
             results: await this.services
                 .getDashboardService()
                 .getSchedulers(
-                    req.user,
+                    toSessionUser(req.account),
                     dashboardUuid,
                     searchQuery,
                     paginateArgs,

--- a/packages/backend/src/controllers/v2/ProjectDashboardController.ts
+++ b/packages/backend/src/controllers/v2/ProjectDashboardController.ts
@@ -1,4 +1,5 @@
 import {
+    assertRegisteredAccount,
     type ApiDashboardResponse,
     type ApiErrorPayload,
     type ApiGetComments,
@@ -20,6 +21,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -44,14 +46,19 @@ export class ProjectDashboardControllerV2 extends BaseController {
         @Path() dashboardUuidOrSlug: string,
         @Request() req: express.Request,
     ): Promise<ApiDashboardResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .getByIdOrSlug(req.user!, dashboardUuidOrSlug, {
-                    projectUuid,
-                }),
+                .getByIdOrSlug(
+                    toSessionUser(req.account),
+                    dashboardUuidOrSlug,
+                    {
+                        projectUuid,
+                    },
+                ),
         };
     }
 
@@ -73,12 +80,13 @@ export class ProjectDashboardControllerV2 extends BaseController {
         @Body() body: UpdateDashboard,
         @Request() req: express.Request,
     ): Promise<ApiDashboardResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .update(req.user!, dashboardUuidOrSlug, body, {
+                .update(toSessionUser(req.account), dashboardUuidOrSlug, body, {
                     projectUuid,
                 }),
         };
@@ -101,9 +109,12 @@ export class ProjectDashboardControllerV2 extends BaseController {
         @Path() dashboardUuidOrSlug: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getDashboardService()
-            .delete(req.user!, dashboardUuidOrSlug, { projectUuid });
+            .delete(toSessionUser(req.account), dashboardUuidOrSlug, {
+                projectUuid,
+            });
         this.setStatus(200);
         return {
             status: 'ok',
@@ -124,14 +135,19 @@ export class ProjectDashboardControllerV2 extends BaseController {
         @Path() dashboardUuidOrSlug: string,
         @Request() req: express.Request,
     ): Promise<ApiGetComments> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getCommentService()
-                .findCommentsForDashboard(req.user!, dashboardUuidOrSlug, {
-                    projectUuid,
-                }),
+                .findCommentsForDashboard(
+                    toSessionUser(req.account),
+                    dashboardUuidOrSlug,
+                    {
+                        projectUuid,
+                    },
+                ),
         };
     }
 }

--- a/packages/backend/src/controllers/v2/ProjectSavedChartController.ts
+++ b/packages/backend/src/controllers/v2/ProjectSavedChartController.ts
@@ -1,4 +1,5 @@
 import {
+    assertRegisteredAccount,
     type ApiErrorPayload,
     type ApiSavedChartResponse,
     type ApiSuccessEmpty,
@@ -16,6 +17,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -66,9 +68,12 @@ export class ProjectSavedChartControllerV2 extends BaseController {
         @Path() chartUuidOrSlug: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getSavedChartService()
-            .delete(req.user!, chartUuidOrSlug, { projectUuid });
+            .delete(toSessionUser(req.account), chartUuidOrSlug, {
+                projectUuid,
+            });
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/v2/SavedChartController.ts
+++ b/packages/backend/src/controllers/v2/SavedChartController.ts
@@ -1,5 +1,5 @@
 import {
-    AuthorizationError,
+    assertRegisteredAccount,
     type ApiErrorPayload,
     type ApiSavedChartPaginatedSchedulersResponse,
     type KnexPaginateArgs,
@@ -17,6 +17,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -47,10 +48,7 @@ export class SavedChartControllerV2 extends BaseController {
         @Query() searchQuery?: string,
         @Query() formats?: string,
     ): Promise<ApiSavedChartPaginatedSchedulersResponse> {
-        if (!req.user) {
-            throw new AuthorizationError('User session not found');
-        }
-
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         let paginateArgs: KnexPaginateArgs | undefined;
@@ -70,7 +68,7 @@ export class SavedChartControllerV2 extends BaseController {
             results: await this.services
                 .getSavedChartService()
                 .getSchedulers(
-                    req.user,
+                    toSessionUser(req.account),
                     chartUuid,
                     searchQuery,
                     paginateArgs,


### PR DESCRIPTION
## Summary

Migrates the charts, dashboards, spaces, and content controllers from `req.user!` to account-aware via `toSessionUser(req.account)`.

**Files touched (11):**
- `dashboardController.ts` — promote, history/version, rollback, schedulers, verify/unverify
- `savedChartController.ts` — chart history/version, rollback, promote, schedulers, export, verify/unverify, deprecated chart/version run routes (also drops `!` from `req.account` in `runViewChartQuery` calls)
- `spaceController.ts` — space CRUD, delete-impact, user/group access add/remove
- `favoritesController.ts` — list and toggle
- `pinningController.ts` — list and reorder
- `shareController.ts` — `createShareUrl`
- `v2/ContentController.ts` — find, move, bulkMove, deleted listing, restore, permanent delete
- `v2/DashboardController.ts` — paginated schedulers
- `v2/ProjectDashboardController.ts` — getByIdOrSlug, update, delete, comments
- `v2/ProjectSavedChartController.ts` — delete
- `v2/SavedChartController.ts` — paginated schedulers

**Pattern:**
1. Add `assertRegisteredAccount(req.account)` at the top of each handler
2. Replace `req.user!` with `toSessionUser(req.account)` in service calls
3. Drop `!` on `req.account` where the assertion already narrows the type (e.g. `runViewChartQuery({ account: req.account, ... })`)

**Non-trivial bits:**
- `dashboardController.getDashboardSchedulers`, `savedChartController.getChartSchedulers`, `v2/DashboardController` and `v2/SavedChartController` paginated schedulers all replace `if (!req.user) throw AuthorizationError` guards with `assertRegisteredAccount`
- Drops now-unused `AuthorizationError` imports from the four controllers above

Sibling endpoints in `savedChartController.ts` (lines 142, 312) are intentionally left using `req.account!` directly — those service signatures already accept `Account` and don't need the `toSessionUser` bridge.

## Test plan

- [ ] Backend typecheck passes
- [ ] Dashboard: promote + diff, history + version + rollback, schedulers list/create, verify/unverify
- [ ] Dashboard v2: get/update/delete by uuid or slug, comments, paginated schedulers
- [ ] Charts: history + version + rollback, promote + diff, schedulers list/create, export image, verify/unverify, deprecated run routes
- [ ] Charts v2: paginated schedulers, delete by uuid or slug
- [ ] Spaces: get, create, update, delete, delete-impact, user access add/remove, group access add/remove
- [ ] Content v2: find (active + deleted), move (single + bulk), restore, permanent delete
- [ ] Favorites list + toggle
- [ ] Pinning list + reorder
- [ ] Share: create share URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)