### PR TITLE
refactor(backend): account-aware integrations & misc controllers

### DIFF
--- a/packages/backend/src/controllers/bigquerySSOController.ts
+++ b/packages/backend/src/controllers/bigquerySSOController.ts
@@ -3,6 +3,7 @@ import {
     ApiBigqueryProjects,
     ApiErrorPayload,
     ApiSuccessEmpty,
+    assertRegisteredAccount,
 } from '@lightdash/common';
 import {
     Get,
@@ -16,6 +17,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -35,10 +37,11 @@ export class BigquerySSOController extends BaseController {
         @Query() projectId: string,
         @Request() req: express.Request,
     ): Promise<ApiBigqueryDatasets> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const databases = await this.services
             .getProjectService()
-            .getBigqueryDatasets(req.user!, projectId);
+            .getBigqueryDatasets(toSessionUser(req.account), projectId);
 
         return {
             status: 'ok',
@@ -57,10 +60,11 @@ export class BigquerySSOController extends BaseController {
     async getBigQueryProjects(
         @Request() req: express.Request,
     ): Promise<ApiBigqueryProjects> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const projects = await this.services
             .getProjectService()
-            .getBigqueryProjects(req.user!);
+            .getBigqueryProjects(toSessionUser(req.account));
 
         return {
             status: 'ok',
@@ -77,11 +81,12 @@ export class BigquerySSOController extends BaseController {
     @Get('/is-authenticated')
     @OperationId('checkBigqueryAuthentication')
     async get(@Request() req: express.Request): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         // This will throw an error if the user is not authenticated with bigquery scopes
         await this.services
             .getUserService()
-            .getAccessToken(req.user!, 'bigquery');
+            .getAccessToken(toSessionUser(req.account), 'bigquery');
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/controllers/commentsController.ts
+++ b/packages/backend/src/controllers/commentsController.ts
@@ -3,6 +3,7 @@ import {
     ApiErrorPayload,
     ApiGetComments,
     ApiResolveComment,
+    assertRegisteredAccount,
     Comment,
 } from '@lightdash/common';
 import {
@@ -21,6 +22,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -56,8 +58,9 @@ export class CommentsController extends BaseController {
         @Body()
         body: Pick<Comment, 'text' | 'replyTo' | 'mentions' | 'textHtml'>,
     ): Promise<ApiCreateComment> {
+        assertRegisteredAccount(req.account);
         const commentId = await this.services.getCommentService().createComment(
-            req.user!,
+            toSessionUser(req.account),
             dashboardUuid,
             dashboardTileUuid,
             body.text,
@@ -87,9 +90,13 @@ export class CommentsController extends BaseController {
         @Path() dashboardUuidOrSlug: string,
         @Request() req: express.Request,
     ): Promise<ApiGetComments> {
+        assertRegisteredAccount(req.account);
         const results = await this.services
             .getCommentService()
-            .findCommentsForDashboard(req.user!, dashboardUuidOrSlug);
+            .findCommentsForDashboard(
+                toSessionUser(req.account),
+                dashboardUuidOrSlug,
+            );
         this.setStatus(200);
         return {
             status: 'ok',
@@ -117,9 +124,14 @@ export class CommentsController extends BaseController {
         @Path() commentId: string,
         @Request() req: express.Request,
     ): Promise<ApiResolveComment> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getCommentService()
-            .resolveComment(req.user!, dashboardUuid, commentId);
+            .resolveComment(
+                toSessionUser(req.account),
+                dashboardUuid,
+                commentId,
+            );
         this.setStatus(200);
         return {
             status: 'ok',
@@ -146,9 +158,14 @@ export class CommentsController extends BaseController {
         @Path() commentId: string,
         @Request() req: express.Request,
     ): Promise<ApiResolveComment> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getCommentService()
-            .deleteComment(req.user!, dashboardUuid, commentId);
+            .deleteComment(
+                toSessionUser(req.account),
+                dashboardUuid,
+                commentId,
+            );
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/csvController.ts
+++ b/packages/backend/src/controllers/csvController.ts
@@ -1,6 +1,7 @@
 import {
     ApiCsvUrlResponse,
     ApiErrorPayload,
+    assertRegisteredAccount,
     UnexpectedServerError,
 } from '@lightdash/common';
 import {
@@ -15,6 +16,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -36,10 +38,11 @@ export class CsvController extends BaseController {
         @Path() jobId: string,
         @Request() req: express.Request,
     ): Promise<ApiCsvUrlResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const csvDetails = await this.services
             .getSchedulerService()
-            .getGsheetExportStatus(req.user!, jobId);
+            .getGsheetExportStatus(toSessionUser(req.account), jobId);
         return {
             status: 'ok',
             results: {

--- a/packages/backend/src/controllers/gitFilesController.ts
+++ b/packages/backend/src/controllers/gitFilesController.ts
@@ -6,6 +6,7 @@ import {
     ApiGitFileOrDirectoryResponse,
     ApiGitFileSavedResponse,
     ApiGitPullRequestCreatedResponse,
+    assertRegisteredAccount,
     CreateGitBranchRequest,
     CreateGitPullRequestRequest,
 } from '@lightdash/common';
@@ -26,6 +27,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -49,12 +51,16 @@ export class GitFilesController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGitBranchesResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
-                .listBranchesForProject(req.user!, projectUuid),
+                .listBranchesForProject(
+                    toSessionUser(req.account),
+                    projectUuid,
+                ),
         };
     }
 
@@ -72,12 +78,18 @@ export class GitFilesController extends BaseController {
         @Query() path?: string,
         @Request() req?: express.Request,
     ): Promise<ApiGitFileOrDirectoryResponse> {
+        assertRegisteredAccount(req!.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
-                .getFileOrDirectory(req!.user!, projectUuid, branch, path),
+                .getFileOrDirectory(
+                    toSessionUser(req!.account),
+                    projectUuid,
+                    branch,
+                    path,
+                ),
         };
     }
 
@@ -105,13 +117,14 @@ export class GitFilesController extends BaseController {
         },
         @Request() req: express.Request,
     ): Promise<ApiGitFileSavedResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
                 .saveFile(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     branch,
                     body.path,
@@ -145,11 +158,12 @@ export class GitFilesController extends BaseController {
         },
         @Request() req: express.Request,
     ): Promise<ApiGitFileDeletedResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getGitIntegrationService()
             .deleteFileFromRepo(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 branch,
                 body.path,
@@ -179,13 +193,14 @@ export class GitFilesController extends BaseController {
         @Body() body: CreateGitBranchRequest,
         @Request() req: express.Request,
     ): Promise<ApiGitBranchCreatedResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(201);
         return {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
                 .createBranchFromSource(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     body.name,
                     body.sourceBranch,
@@ -211,13 +226,14 @@ export class GitFilesController extends BaseController {
         @Body() body: CreateGitPullRequestRequest,
         @Request() req: express.Request,
     ): Promise<ApiGitPullRequestCreatedResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(201);
         return {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
                 .createPullRequestFromBranch(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     branch,
                     body.title,

--- a/packages/backend/src/controllers/gitIntegrationController.ts
+++ b/packages/backend/src/controllers/gitIntegrationController.ts
@@ -2,6 +2,7 @@ import {
     AdditionalMetric,
     ApiErrorPayload,
     ApiGitFileContent,
+    assertRegisteredAccount,
     CustomDimension,
     ForbiddenError,
     PullRequestCreated,
@@ -22,6 +23,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { lightdashConfig } from '../config/lightdashConfig';
 import {
     allowApiKeyAuthentication,
@@ -60,13 +62,14 @@ export class GitIntegrationController extends BaseController {
         },
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: PullRequestCreated }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
                 .createPullRequest(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     body.quoteChar || '"',
                     {
@@ -98,13 +101,14 @@ export class GitIntegrationController extends BaseController {
         },
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: PullRequestCreated }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
                 .createPullRequest(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     body.quoteChar || '"',
                     {
@@ -131,13 +135,14 @@ export class GitIntegrationController extends BaseController {
         status: 'ok';
         results: Array<string>;
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
-                .getBranches(req.user!, projectUuid),
+                .getBranches(toSessionUser(req.account), projectUuid),
         };
     }
 
@@ -158,6 +163,7 @@ export class GitIntegrationController extends BaseController {
         @Path() exploreName: string,
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ApiGitFileContent }> {
+        assertRegisteredAccount(req.account);
         if (!lightdashConfig.editYamlInUi.enabled) {
             throw new ForbiddenError('Edit YAML in UI feature is not enabled');
         }
@@ -166,7 +172,11 @@ export class GitIntegrationController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
-                .getFileForExplore(req.user!, projectUuid, exploreName),
+                .getFileForExplore(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    exploreName,
+                ),
         };
     }
 
@@ -187,6 +197,7 @@ export class GitIntegrationController extends BaseController {
         @Path() exploreName: string,
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: { filePath: string } }> {
+        assertRegisteredAccount(req.account);
         if (!lightdashConfig.editYamlInUi.enabled) {
             throw new ForbiddenError('Edit YAML in UI feature is not enabled');
         }
@@ -195,7 +206,11 @@ export class GitIntegrationController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getGitIntegrationService()
-                .getFilePathForExplore(req.user!, projectUuid, exploreName),
+                .getFilePathForExplore(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    exploreName,
+                ),
         };
     }
 
@@ -223,6 +238,7 @@ export class GitIntegrationController extends BaseController {
         },
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: PullRequestCreated }> {
+        assertRegisteredAccount(req.account);
         if (!lightdashConfig.editYamlInUi.enabled) {
             throw new ForbiddenError('Edit YAML in UI feature is not enabled');
         }
@@ -232,7 +248,7 @@ export class GitIntegrationController extends BaseController {
             results: await this.services
                 .getGitIntegrationService()
                 .createPullRequestWithFileChange(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     body.filePath,
                     body.content,

--- a/packages/backend/src/controllers/githubController.ts
+++ b/packages/backend/src/controllers/githubController.ts
@@ -1,5 +1,6 @@
 import {
     ApiSuccessEmpty,
+    assertRegisteredAccount,
     GitIntegrationConfiguration,
     GitRepo,
 } from '@lightdash/common';
@@ -16,6 +17,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { isAuthenticated, unauthorisedInDemo } from './authentication';
 import { BaseController } from './baseController';
 
@@ -45,9 +47,10 @@ export class GithubInstallController extends BaseController {
     async installGithubAppForOrganization(
         @Request() req: express.Request,
     ): Promise<void> {
+        assertRegisteredAccount(req.account);
         const context = await this.services
             .getGithubAppService()
-            .installRedirect(req.user!);
+            .installRedirect(toSessionUser(req.account));
 
         req.session.oauth = {};
         req.session.oauth.returnTo = context.returnToUrl;
@@ -72,9 +75,10 @@ export class GithubInstallController extends BaseController {
         status: 'ok';
         results: GitIntegrationConfiguration;
     }> {
+        assertRegisteredAccount(req.account);
         const config = await this.services
             .getGitIntegrationService()
-            .getConfiguration(req.user!);
+            .getConfiguration(toSessionUser(req.account));
 
         return {
             status: 'ok',
@@ -100,6 +104,7 @@ export class GithubInstallController extends BaseController {
         @Query() installation_id?: string,
         @Query() setup_action?: string,
     ): Promise<void> {
+        assertRegisteredAccount(req.account);
         if (!state || state !== req.session.oauth?.state) {
             this.setStatus(400);
             throw new Error('State does not match');
@@ -107,7 +112,7 @@ export class GithubInstallController extends BaseController {
         const redirectUrl = await this.services
             .getGithubAppService()
             .installCallback(
-                req.user!,
+                toSessionUser(req.account),
                 req.session.oauth,
                 code,
                 state,
@@ -128,9 +133,10 @@ export class GithubInstallController extends BaseController {
     async uninstallGithubAppForOrganization(
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getGithubAppService()
-            .deleteAppInstallation(req.user!);
+            .deleteAppInstallation(toSessionUser(req.account));
 
         this.setStatus(200);
         return {
@@ -151,13 +157,14 @@ export class GithubInstallController extends BaseController {
         status: 'ok';
         results: Array<GitRepo>;
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
             status: 'ok',
             results: await this.services
                 .getGithubAppService()
-                .getRepos(req.user!),
+                .getRepos(toSessionUser(req.account)),
         };
     }
 
@@ -186,10 +193,11 @@ export class GithubInstallController extends BaseController {
             defaultBranch: string;
         };
     }> {
+        assertRegisteredAccount(req.account);
         const result = await this.services
             .getGithubAppService()
             .createRepository(
-                req.user!,
+                toSessionUser(req.account),
                 body.name,
                 body.description,
                 body.isPrivate,

--- a/packages/backend/src/controllers/gitlabController.ts
+++ b/packages/backend/src/controllers/gitlabController.ts
@@ -1,4 +1,9 @@
-import { ApiSuccessEmpty, GitRepo, ParameterError } from '@lightdash/common';
+import {
+    ApiSuccessEmpty,
+    assertRegisteredAccount,
+    GitRepo,
+    ParameterError,
+} from '@lightdash/common';
 import {
     Delete,
     Get,
@@ -10,6 +15,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { isAuthenticated, unauthorisedInDemo } from './authentication';
 import { BaseController } from './baseController';
 
@@ -40,10 +46,11 @@ export class GitlabController extends BaseController {
         @Request() req: express.Request,
         @Query() gitlab_instance_url?: string,
     ): Promise<void> {
+        assertRegisteredAccount(req.account);
         const context = await this.services
             .getGitlabAppService()
             .installRedirect(
-                req.user!,
+                toSessionUser(req.account),
                 gitlab_instance_url || 'https://gitlab.com',
             );
 
@@ -72,6 +79,7 @@ export class GitlabController extends BaseController {
         @Query() state?: string,
         @Query() gitlab_instance_url?: string,
     ): Promise<void> {
+        assertRegisteredAccount(req.account);
         if (!state || state !== req.session.oauth?.state) {
             this.setStatus(400);
             throw new ParameterError('State does not match');
@@ -80,7 +88,7 @@ export class GitlabController extends BaseController {
         const redirectUrl = await this.services
             .getGitlabAppService()
             .installCallback(
-                req.user!,
+                toSessionUser(req.account),
                 req.session.oauth,
                 code,
                 state,
@@ -101,9 +109,10 @@ export class GitlabController extends BaseController {
     async uninstallGitlabIntegration(
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getGitlabAppService()
-            .deleteAppInstallation(req.user!);
+            .deleteAppInstallation(toSessionUser(req.account));
 
         this.setStatus(200);
         return {
@@ -124,13 +133,14 @@ export class GitlabController extends BaseController {
         status: 'ok';
         results: Array<GitRepo>;
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
             status: 'ok',
             results: await this.services
                 .getGitlabAppService()
-                .getProjects(req.user!),
+                .getProjects(toSessionUser(req.account)),
         };
     }
 }

--- a/packages/backend/src/controllers/googleDriveController.ts
+++ b/packages/backend/src/controllers/googleDriveController.ts
@@ -18,6 +18,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { GdriveService } from '../services/GdriveService/GdriveService';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
@@ -38,12 +39,13 @@ export class GoogleDriveController extends BaseController {
     async get(
         @Request() req: express.Request,
     ): Promise<ApiGdriveAccessTokenResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getUserService()
-                .getAccessToken(req.user!),
+                .getAccessToken(toSessionUser(req.account)),
         };
     }
 

--- a/packages/backend/src/controllers/notificationsController.ts
+++ b/packages/backend/src/controllers/notificationsController.ts
@@ -4,6 +4,7 @@ import {
     ApiNotificationResourceType,
     ApiNotificationUpdateParams,
     ApiSuccessEmpty,
+    assertRegisteredAccount,
 } from '@lightdash/common';
 import {
     Body,
@@ -20,6 +21,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -42,9 +44,10 @@ export class NotificationsController extends BaseController {
         @Request() req: express.Request,
         @Query() type: ApiNotificationResourceType,
     ): Promise<ApiGetNotifications> {
+        assertRegisteredAccount(req.account);
         const results = await this.services
             .getNotificationService()
-            .getNotifications(req.user!.userUuid, type);
+            .getNotifications(toSessionUser(req.account).userUuid, type);
 
         this.setStatus(200);
         return {

--- a/packages/backend/src/controllers/renameController.ts
+++ b/packages/backend/src/controllers/renameController.ts
@@ -8,6 +8,7 @@ import {
     ApiRenameDashboardResponse,
     ApiRenameFieldsResponse,
     ApiRenameResponse,
+    assertRegisteredAccount,
     getRequestMethod,
     LightdashRequestMethodHeader,
 } from '@lightdash/common';
@@ -26,6 +27,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -54,6 +56,7 @@ export class RenameController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ApiRenameBody,
     ): Promise<ApiJobScheduledResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const context = getRequestMethod(
             req.header(LightdashRequestMethodHeader),
@@ -62,7 +65,7 @@ export class RenameController extends BaseController {
         const scheduledJob = await this.services
             .getRenameService()
             .scheduleRenameResources({
-                user: req.user!,
+                user: toSessionUser(req.account),
                 projectUuid,
                 context,
                 ...body,
@@ -91,6 +94,7 @@ export class RenameController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ApiRenameBody,
     ): Promise<ApiRenameResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const context = getRequestMethod(
             req.header(LightdashRequestMethodHeader),
@@ -99,7 +103,7 @@ export class RenameController extends BaseController {
         const results = await this.services
             .getRenameService()
             .previewRenameResources({
-                user: req.user!,
+                user: toSessionUser(req.account),
                 projectUuid,
                 context,
                 ...body,
@@ -129,13 +133,14 @@ export class RenameController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ApiRenameChartBody,
     ): Promise<ApiRenameChartResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const context = getRequestMethod(
             req.header(LightdashRequestMethodHeader),
         );
 
         const jobId = await this.services.getRenameService().renameChart({
-            user: req.user!,
+            user: toSessionUser(req.account),
             projectUuid,
             context,
             chartUuid,
@@ -165,11 +170,12 @@ export class RenameController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiRenameFieldsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const fields = await this.services
             .getRenameService()
             .getFieldsForChart({
-                user: req.user!,
+                user: toSessionUser(req.account),
                 projectUuid,
                 chartUuid,
             });
@@ -198,6 +204,7 @@ export class RenameController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ApiRenameDashboardBody,
     ): Promise<ApiRenameDashboardResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const context = getRequestMethod(
             req.header(LightdashRequestMethodHeader),
@@ -206,7 +213,7 @@ export class RenameController extends BaseController {
         const jobId = await this.services
             .getRenameService()
             .renameDashboardFilter({
-                user: req.user!,
+                user: toSessionUser(req.account),
                 projectUuid,
                 context,
                 dashboardUuid,
@@ -237,11 +244,12 @@ export class RenameController extends BaseController {
         @Request() req: express.Request,
         @Query() table?: string,
     ): Promise<ApiRenameFieldsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const fields = await this.services
             .getRenameService()
             .getFieldsForDashboard({
-                user: req.user!,
+                user: toSessionUser(req.account),
                 projectUuid,
                 dashboardUuid,
                 tableName: table,

--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -32,6 +32,7 @@ import express from 'express';
 import fs from 'fs';
 import path from 'path';
 import { Readable } from 'stream';
+import { toSessionUser } from '../auth/account';
 import Logger from '../logging/logger';
 import {
     allowApiKeyAuthentication,
@@ -62,12 +63,13 @@ export class SlackController extends BaseController {
         @Query() forceRefresh?: boolean,
         @Query() includeChannelIds?: string,
     ): Promise<ApiSlackChannelsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSlackIntegrationService()
-                .getChannels(req.user!, {
+                .getChannels(toSessionUser(req.account), {
                     search,
                     excludeArchived,
                     excludeDms,
@@ -95,12 +97,13 @@ export class SlackController extends BaseController {
         @Request() req: express.Request,
         @Path() channelId: string,
     ): Promise<ApiSlackChannelResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getSlackIntegrationService()
-                .lookupChannelById(req.user!, channelId),
+                .lookupChannelById(toSessionUser(req.account), channelId),
         };
     }
 
@@ -121,9 +124,10 @@ export class SlackController extends BaseController {
         @Request() req: express.Request,
         @Body() body: SlackAppCustomSettings,
     ): Promise<ApiSlackCustomSettingsResponse> {
+        assertRegisteredAccount(req.account);
         await this.services
             .getSlackIntegrationService()
-            .updateAppCustomSettings(req.user!, body);
+            .updateAppCustomSettings(toSessionUser(req.account), body);
 
         this.setStatus(200);
         return {
@@ -170,11 +174,14 @@ export class SlackController extends BaseController {
     async getInstallation(
         @Request() req: express.Request,
     ): Promise<ApiSlackGetInstallationResponse> {
+        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getSlackIntegrationService()
-                .getInstallationFromOrganizationUuid(req.user!),
+                .getInstallationFromOrganizationUuid(
+                    toSessionUser(req.account),
+                ),
         };
     }
 
@@ -301,10 +308,11 @@ export class SlackController extends BaseController {
     @Get('/install')
     @OperationId('installSlack')
     async installSlack(@Request() req: express.Request): Promise<void> {
+        assertRegisteredAccount(req.account);
         try {
             const { slackOptions, metadata } = await this.services
                 .getSlackIntegrationService()
-                .getSlackInstallOptions(req.user!);
+                .getSlackInstallOptions(toSessionUser(req.account));
 
             const slackReceiver = new ExpressReceiver(slackOptions);
             await slackReceiver.installer?.handleInstallPath(
@@ -321,7 +329,7 @@ export class SlackController extends BaseController {
         } catch (error) {
             await this.services
                 .getSlackIntegrationService()
-                .trackInstallError(req.user!, error);
+                .trackInstallError(toSessionUser(req.account), error);
             throw error;
         }
     }

--- a/packages/backend/src/controllers/v2/DeployController.ts
+++ b/packages/backend/src/controllers/v2/DeployController.ts
@@ -20,6 +20,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -76,11 +77,12 @@ export class DeployController extends BaseController {
         @Path() sessionUuid: string,
         @Body() body: AnyType, // ApiAddDeployBatchRequest,
     ): Promise<ApiAddDeployBatchResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const result = await this.services
             .getDeployService()
             .addDeployBatch(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 sessionUuid,
                 (body as unknown as ApiAddDeployBatchRequest).explores,
@@ -109,10 +111,15 @@ export class DeployController extends BaseController {
         @Path() projectUuid: string,
         @Path() sessionUuid: string,
     ): Promise<ApiFinalizeDeployResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const result = await this.services
             .getDeployService()
-            .finalizeDeploy(req.user!, projectUuid, sessionUuid);
+            .finalizeDeploy(
+                toSessionUser(req.account),
+                projectUuid,
+                sessionUuid,
+            );
         return {
             status: 'ok',
             results: result,

--- a/packages/backend/src/controllers/v2/FeatureFlagController.ts
+++ b/packages/backend/src/controllers/v2/FeatureFlagController.ts
@@ -1,4 +1,4 @@
-import { ApiErrorPayload, FeatureFlag } from '@lightdash/common';
+import { ApiErrorPayload, FeatureFlag, isJwtUser } from '@lightdash/common';
 import {
     Get,
     OperationId,
@@ -10,6 +10,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import { BaseController } from '../baseController';
 
 @Route('/api/v2/feature-flag')
@@ -34,7 +35,10 @@ export class FeatureFlagController extends BaseController {
         return {
             status: 'ok',
             results: await this.services.getFeatureFlagService().get({
-                user: req.user,
+                user:
+                    req.account && !isJwtUser(req.account)
+                        ? toSessionUser(req.account)
+                        : undefined,
                 featureFlagId,
             }),
         };

--- a/packages/backend/src/controllers/v2/ProjectDefaultsController.ts
+++ b/packages/backend/src/controllers/v2/ProjectDefaultsController.ts
@@ -18,6 +18,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -69,8 +70,9 @@ export class ProjectDefaultsController extends BaseController {
         @Request() req: express.Request,
         @Body() defaults: ProjectDefaults,
     ): Promise<ApiSuccess<undefined>> {
+        assertRegisteredAccount(req.account);
         await this.services.getProjectService().replaceProjectDefaults({
-            user: req.user!,
+            user: toSessionUser(req.account),
             projectUuid,
             defaults,
         });

--- a/packages/backend/src/controllers/v2/ValidationController.ts
+++ b/packages/backend/src/controllers/v2/ValidationController.ts
@@ -2,6 +2,7 @@ import {
     ApiErrorPayload,
     ApiPaginatedValidateResponse,
     ApiSingleValidationResponse,
+    assertRegisteredAccount,
     ValidationErrorType,
     ValidationSourceType,
 } from '@lightdash/common';
@@ -18,6 +19,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -60,6 +62,7 @@ export class ValidationControllerV2 extends BaseController {
         @Query() includeChartConfigWarnings?: boolean,
         @Query() fromSettings?: boolean,
     ): Promise<ApiPaginatedValidateResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const parsedSourceTypes = sourceTypes
@@ -85,7 +88,7 @@ export class ValidationControllerV2 extends BaseController {
         return {
             status: 'ok',
             results: await this.services.getValidationService().getPaginated(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 { page, pageSize },
                 {
@@ -117,12 +120,13 @@ export class ValidationControllerV2 extends BaseController {
         @Path() validationId: number,
         @Request() req: express.Request,
     ): Promise<ApiSingleValidationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getValidationService()
-                .getById(req.user!, projectUuid, validationId),
+                .getById(toSessionUser(req.account), projectUuid, validationId),
         };
     }
 }

--- a/packages/backend/src/controllers/validationController.ts
+++ b/packages/backend/src/controllers/validationController.ts
@@ -6,6 +6,7 @@ import {
     ApiJobScheduledResponse,
     ApiValidateResponse,
     ApiValidationDismissResponse,
+    assertRegisteredAccount,
     getRequestMethod,
     LightdashRequestMethodHeader,
     ValidationTarget,
@@ -26,6 +27,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../auth/account';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
@@ -57,6 +59,7 @@ export class ValidationController extends BaseController {
             validationTargets?: ValidationTarget[];
         }, // TODO: This should be (Explore| ExploreError)[] but using this type will not process metrics/dimensions
     ): Promise<ApiJobScheduledResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const context = getRequestMethod(
             req.header(LightdashRequestMethodHeader),
@@ -68,7 +71,7 @@ export class ValidationController extends BaseController {
                 jobId: await this.services
                     .getValidationService()
                     .validate(
-                        req.user!,
+                        toSessionUser(req.account),
                         projectUuid,
                         context,
                         body.explores,
@@ -98,12 +101,18 @@ export class ValidationController extends BaseController {
         @Query() fromSettings?: boolean,
         @Query() jobId?: string,
     ): Promise<ApiValidateResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getValidationService()
-                .get(req.user!, projectUuid, fromSettings, jobId),
+                .get(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    fromSettings,
+                    jobId,
+                ),
         };
     }
 
@@ -123,10 +132,11 @@ export class ValidationController extends BaseController {
         @Path() validationId: number,
         @Request() req: express.Request,
     ): Promise<ApiValidationDismissResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getValidationService()
-            .delete(req.user!, validationId);
+            .delete(toSessionUser(req.account), validationId);
         return {
             status: 'ok',
         };
@@ -148,10 +158,15 @@ export class ValidationController extends BaseController {
         @Path() chartUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiChartValidationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const validationErrors = await this.services
             .getValidationService()
-            .validateAndUpdateChart(req.user!, projectUuid, chartUuid);
+            .validateAndUpdateChart(
+                toSessionUser(req.account),
+                projectUuid,
+                chartUuid,
+            );
         return {
             status: 'ok',
             results: {
@@ -176,10 +191,15 @@ export class ValidationController extends BaseController {
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiDashboardValidationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const validationErrors = await this.services
             .getValidationService()
-            .validateAndUpdateDashboard(req.user!, projectUuid, dashboardUuid);
+            .validateAndUpdateDashboard(
+                toSessionUser(req.account),
+                projectUuid,
+                dashboardUuid,
+            );
         return {
             status: 'ok',
             results: {


### PR DESCRIPTION
## Summary

Migrates the integrations, validation, comments, and miscellaneous controllers from `req.user!` to account-aware via `toSessionUser(req.account)`. Final PR in the controller-migration stack.

**Files touched (16):**
- `bigquerySSOController.ts` — datasets, projects, is-authenticated
- `commentsController.ts` — create, find, resolve, delete
- `csvController.ts` — gsheet export status
- `notificationsController.ts` — list notifications
- `gitFilesController.ts` — branches, file/dir read, save file, delete file, create branch, create PR
- `gitIntegrationController.ts` — create PR (chart + custom-explore), branches, get/edit explore YAML
- `githubController.ts` — install/callback/uninstall, configuration, repos, create-repo
- `gitlabController.ts` — install/callback/uninstall, projects
- `googleDriveController.ts` — `getAccessToken`
- `slackController.ts` — channels list/lookup, custom settings, installation, install flow
- `renameController.ts` — schedule rename, preview, chart fields/rename, dashboard fields/rename
- `validationController.ts` — validate (schedule), get, dismiss, validate chart, validate dashboard
- `v2/DeployController.ts` — addDeployBatch, finalizeDeploy
- `v2/FeatureFlagController.ts` — `getFeatureFlag`
- `v2/ProjectDefaultsController.ts` — `replaceProjectDefaults`
- `v2/ValidationController.ts` — paginated list, getById

**Pattern:**
1. Add `assertRegisteredAccount(req.account)` at the top of each handler
2. Replace `req.user!` with `toSessionUser(req.account)` in service calls

**Non-trivial bits:**
- `v2/FeatureFlagController.getFeatureFlag` is the only handler with no auth middleware (public endpoint). `assertRegisteredAccount` would break anonymous callers, so it uses a custom guard: `req.account && !isJwtUser(req.account) ? toSessionUser(req.account) : undefined`. Preserves the prior "pass undefined for anonymous/unauthenticated" semantics; required importing `isJwtUser`.
- `gitFilesController.getFileOrDirectory` has an optional `req?: express.Request` parameter, so the call site uses `req!.account` (assertion + `toSessionUser` both go through `req!`) instead of the usual single-bang pattern.
- `notificationsController.getNotifications` keeps the explicit `.userUuid` access — `toSessionUser(req.account).userUuid` rather than passing the whole user (could be simplified to `req.account.user.userUuid` later).

No behavior change for authenticated callers.

## Test plan

- [ ] Backend typecheck passes
- [ ] BigQuery SSO: datasets, projects, is-authenticated
- [ ] Comments: create, list for dashboard, resolve, delete
- [ ] CSV/Gsheet: export status
- [ ] Notifications: list
- [ ] Git files: branches, read file/dir, save file, delete file, create branch, create PR
- [ ] Git integration: create PR (chart + custom explore), get explore YAML, write file PR
- [ ] GitHub: install/callback/uninstall, list repos, create repo, get configuration
- [ ] GitLab: install/callback/uninstall, list projects
- [ ] Google Drive: get access token
- [ ] Slack: list channels, lookup channel, custom settings, get installation, install flow
- [ ] Rename: schedule + preview + chart rename + dashboard rename, fields lookups
- [ ] Validation v1: validate, get, dismiss, validate chart, validate dashboard
- [ ] Validation v2: paginated, getById
- [ ] Deploy v2: addDeployBatch, finalizeDeploy
- [ ] Feature flag: anonymous + authenticated requests both behave correctly
- [ ] Project defaults: replace

🤖 Generated with [Claude Code](https://claude.com/claude-code)