### PR TITLE
fix: update locked capability tooltip label to "Always on"

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -752,7 +752,7 @@ const SettingsSidebar: FC<{
                                             </Text>
                                         </Stack>
                                         {capability.locked ? (
-                                            <Tooltip label="Always disabled">
+                                            <Tooltip label="Always on">
                                                 <Box
                                                     component="span"
                                                     className={


### PR DESCRIPTION
Closes:

### Description:
Fixes an incorrect tooltip label on locked agent capabilities. The tooltip previously read "Always disabled" but has been corrected to "Always on", which accurately reflects that a locked capability is permanently enabled rather than disabled.