### PR TITLE
feat: load AWS extension for DuckDB credential chain when static S3 credentials are absent

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -350,6 +350,9 @@ describe('DuckdbWarehouseClient', () => {
 
         await client.runQuery('SELECT 1 AS val');
 
+        expect(runMock).toHaveBeenCalledWith('INSTALL aws;');
+        expect(runMock).toHaveBeenCalledWith('LOAD aws;');
+
         const secretSql = runMock.mock.calls
             .map(([sql]) => sql as string)
             .find((sql) =>
@@ -388,6 +391,9 @@ describe('DuckdbWarehouseClient', () => {
         });
 
         await client.runQuery('SELECT 1 AS val');
+
+        expect(runMock).not.toHaveBeenCalledWith('INSTALL aws;');
+        expect(runMock).not.toHaveBeenCalledWith('LOAD aws;');
 
         const secretSql = runMock.mock.calls
             .map(([sql]) => sql as string)

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -399,6 +399,22 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbCrede
         await db.run('SET allow_unredacted_secrets = false;');
     }
 
+    private static usesS3CredentialChain(
+        s3Config: DuckdbS3SessionConfig,
+    ): boolean {
+        return !(s3Config.accessKey && s3Config.secretKey);
+    }
+
+    private static async loadAwsExtensionForCredentialChain(
+        db: DuckdbConnection,
+        s3Config?: DuckdbS3SessionConfig,
+    ): Promise<void> {
+        if (s3Config && DuckdbWarehouseClient.usesS3CredentialChain(s3Config)) {
+            await db.run('INSTALL aws;');
+            await db.run('LOAD aws;');
+        }
+    }
+
     private static async bootstrapQuerySession(
         db: DuckdbConnection,
         client: DuckdbWarehouseClient,
@@ -407,6 +423,10 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbCrede
         const httpfsStart = performance.now();
         await db.run('INSTALL httpfs;');
         await db.run('LOAD httpfs;');
+        await DuckdbWarehouseClient.loadAwsExtensionForCredentialChain(
+            db,
+            client.s3Config,
+        );
         const httpfsMs = performance.now() - httpfsStart;
 
         await db.run('SET enable_http_metadata_cache = true;');
@@ -585,9 +605,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbCrede
     private static buildS3SecretSql(s3Config: DuckdbS3SessionConfig): string {
         const escape = (v: string) =>
             DuckdbWarehouseClient.sqlBuilder.escapeString(v);
-        const usesStaticCredentials = !!(
-            s3Config.accessKey && s3Config.secretKey
-        );
+        const usesStaticCredentials =
+            !DuckdbWarehouseClient.usesS3CredentialChain(s3Config);
         // Static keys may come from dedicated pre-aggregate env vars or fall back
         // to the base S3 config. Without them, let DuckDB resolve AWS credentials
         // through the SDK chain, including IRSA/web identity tokens.
@@ -708,6 +727,10 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbCrede
     ): Promise<void> {
         await db.run('INSTALL httpfs;');
         await db.run('LOAD httpfs;');
+        await DuckdbWarehouseClient.loadAwsExtensionForCredentialChain(
+            db,
+            this.s3Config,
+        );
 
         await DuckdbWarehouseClient.hardenInstance(db);
 


### PR DESCRIPTION
Closes:

### Description:

When using DuckDB with S3 credential chain (i.e. no static access/secret keys configured, relying on IRSA/web identity tokens or other SDK-based credential resolution), the `aws` DuckDB extension is now automatically installed and loaded before executing queries. This ensures that credential chain-based authentication works correctly in both regular query sessions and pre-aggregate sessions.

The `usesS3CredentialChain` helper was introduced to centralize the logic for determining whether static credentials are absent, replacing the inline boolean check in `buildS3SecretSql` and reusing it to conditionally load the `aws` extension. Tests were added to verify that `INSTALL aws;` and `LOAD aws;` are called when using credential chain auth, and are not called when static credentials are provided.