### PR TITLE
fix: move "open target" link to title action icon in managed agent activity sidebar

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -300,6 +300,10 @@
     );
 }
 
+.titleAction {
+    flex-shrink: 0;
+}
+
 .fieldPill {
     padding: 2px 8px;
     border-radius: 4px;

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -7,6 +7,7 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
+    Anchor,
     Box,
     Button,
     Group,
@@ -410,6 +411,8 @@ const SlowDetails: FC<{ metadata: Record<string, unknown> }> = ({
 
 type ContentContext = {
     description: string | null;
+    projectUuid: string;
+    spaceUuid: string | null;
     spaceName: string | null;
     updatedAt: Date | string | null;
     updatedByUser: UpdatedByUser | undefined;
@@ -420,6 +423,8 @@ type ContentContext = {
 
 const toContentContext = (content: SavedChart | Dashboard): ContentContext => ({
     description: content.description?.trim() || null,
+    projectUuid: content.projectUuid,
+    spaceUuid: content.spaceUuid ?? null,
     spaceName: content.spaceName ?? null,
     updatedAt: content.updatedAt ?? null,
     updatedByUser: content.updatedByUser,
@@ -438,6 +443,9 @@ const ContentContextDetails: FC<{
     const verifiedBy = context.verification?.verifiedBy
         ? `${context.verification.verifiedBy.firstName} ${context.verification.verifiedBy.lastName}`.trim()
         : null;
+    const spaceUrl = context.spaceUuid
+        ? `/projects/${context.projectUuid}/spaces/${context.spaceUuid}`
+        : null;
 
     return (
         <Stack gap="sm">
@@ -445,7 +453,13 @@ const ContentContextDetails: FC<{
             <Stack gap={10}>
                 {context.spaceName && (
                     <InfoRow icon={IconFolder} label="Space">
-                        {context.spaceName}
+                        {spaceUrl ? (
+                            <Anchor href={spaceUrl} fz="xs" fw={500}>
+                                {context.spaceName}
+                            </Anchor>
+                        ) : (
+                            context.spaceName
+                        )}
                     </InfoRow>
                 )}
                 {context.updatedAt && (
@@ -505,7 +519,7 @@ const DetailSidebar: FC<{
         },
     });
 
-    const chartLink =
+    const targetLink =
         action.targetType === 'chart'
             ? `/projects/${action.projectUuid}/saved/${action.targetUuid}`
             : action.targetType === 'dashboard'
@@ -524,6 +538,9 @@ const DetailSidebar: FC<{
         uuidOrSlug:
             action.targetType === 'dashboard' ? action.targetUuid : undefined,
         projectUuid: action.projectUuid,
+        useQueryOptions: {
+            onError: () => undefined,
+        },
     });
     const { data: chartViewStats } = useChartViewStats(
         action.targetType === 'chart' ? action.targetUuid : undefined,
@@ -581,17 +598,6 @@ const DetailSidebar: FC<{
                                 </UnstyledButton>
                             </Menu.Target>
                             <Menu.Dropdown>
-                                {chartLink && (
-                                    <Menu.Item
-                                        component="a"
-                                        href={chartLink}
-                                        leftSection={
-                                            <IconExternalLink size={14} />
-                                        }
-                                    >
-                                        Open {action.targetType}
-                                    </Menu.Item>
-                                )}
                                 <Menu.Item
                                     leftSection={<IconArrowBackUp size={14} />}
                                     disabled={
@@ -626,6 +632,25 @@ const DetailSidebar: FC<{
                     <TruncatedText maxWidth={260} fz="sm" fw={600}>
                         {action.targetName}
                     </TruncatedText>
+                    {targetLink && (
+                        <Tooltip label={`Open ${action.targetType}`}>
+                            <ActionIcon
+                                component="a"
+                                href={targetLink}
+                                aria-label={`Open ${action.targetType}`}
+                                variant="subtle"
+                                color="gray"
+                                size="sm"
+                                radius="md"
+                                className={classes.titleAction}
+                            >
+                                <MantineIcon
+                                    icon={IconExternalLink}
+                                    size="sm"
+                                />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
                 </Group>
             </Stack>
 

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -15,6 +15,7 @@ import {
 } from '@tabler/icons-react';
 import { type FC, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
+import { BetaBadge } from '../../../components/common/BetaBadge';
 import useHealth from '../../../hooks/health/useHealth';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
@@ -164,17 +165,23 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                                 <Text fz="lg" fw={700}>
                                     Autopilot
                                 </Text>
+                                <BetaBadge />
                                 <Box className={classes.activePill}>
                                     <Box className={classes.activeDotSmall} />
                                     Active &middot; {formatSchedule(schedule)}
                                 </Box>
                             </Group>
                             <Text fz="sm" c="dimmed" fw={500}>
-                                {actionCount > 0
-                                    ? `${actionCount} actions — ${actionSummary}`
-                                    : 'Monitoring your project'}
+                                {actionCount > 0 ? (
+                                    <>
+                                        {actionCount} actions
+                                        {actionSummary && ` - ${actionSummary}`}
+                                    </>
+                                ) : (
+                                    'Monitoring your project'
+                                )}
                                 {lastActionAt &&
-                                    ` · last run ${formatRelative(lastActionAt)}`}
+                                    ` · last action ${formatRelative(lastActionAt)}`}
                             </Text>
                         </Stack>
                     </Group>
@@ -206,9 +213,12 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                             <IconBolt size={18} />
                         </Box>
                         <Stack gap={4}>
-                            <Text fz="lg" fw={700}>
-                                Autopilot
-                            </Text>
+                            <Group gap={8} align="center">
+                                <Text fz="lg" fw={700}>
+                                    Autopilot
+                                </Text>
+                                <BetaBadge />
+                            </Group>
                             <Group
                                 gap={6}
                                 wrap="nowrap"


### PR DESCRIPTION
Closes:

### Description:

Moves the "Open chart/dashboard" link out of the dropdown menu and into an inline icon button next to the target name in the detail sidebar. The link now appears as a subtle external link icon (`IconExternalLink`) with a tooltip, positioned directly beside the title. A `flex-shrink: 0` style is added to prevent the icon from being squeezed when the title text is long.

Additionally, suppresses errors from the dashboard/chart data fetch when the target is not found, preventing unnecessary error states in the UI.