### PR TITLE
feat(analytics): track sql/template table calculation saves

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -496,6 +496,30 @@ type FormulaTableCalculationSavedEvent = BaseTrack & {
     };
 };
 
+type SqlTableCalculationSavedEvent = BaseTrack & {
+    event: 'sql_table_calculation.saved';
+    properties: {
+        organizationId: string;
+        projectId: string;
+        savedChartUuid: string;
+        action: 'created' | 'updated';
+        sqlCount: number;
+        totalTableCalculationCount: number;
+    };
+};
+
+type TemplateTableCalculationSavedEvent = BaseTrack & {
+    event: 'template_table_calculation.saved';
+    properties: {
+        organizationId: string;
+        projectId: string;
+        savedChartUuid: string;
+        action: 'created' | 'updated';
+        templateCount: number;
+        totalTableCalculationCount: number;
+    };
+};
+
 type ChartHistoryEvent = BaseTrack & {
     event: 'saved_chart_history.view';
     properties: {
@@ -1819,6 +1843,8 @@ type TypedEvent =
     | DeleteSavedChartEvent
     | RestoredSavedChartEvent
     | FormulaTableCalculationSavedEvent
+    | SqlTableCalculationSavedEvent
+    | TemplateTableCalculationSavedEvent
     | CreateSavedChartEvent
     | ChartHistoryEvent
     | ViewChartVersionEvent

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -29,6 +29,8 @@ import {
     isFormulaTableCalculation,
     isJwtUser,
     isSchedulerGsheetsOptions,
+    isSqlTableCalculation,
+    isTemplateTableCalculation,
     isUserWithOrg,
     isValidFrequency,
     isValidTimezone,
@@ -451,6 +453,64 @@ export class SavedChartService
         };
     }
 
+    static getSqlTableCalculationEventProperties(
+        savedChart: SavedChartDAO,
+        action: 'created' | 'updated',
+    ):
+        | {
+              organizationId: string;
+              projectId: string;
+              savedChartUuid: string;
+              action: 'created' | 'updated';
+              sqlCount: number;
+              totalTableCalculationCount: number;
+          }
+        | undefined {
+        const { tableCalculations } = savedChart.metricQuery;
+        const sqlCount = tableCalculations.filter(isSqlTableCalculation).length;
+        if (sqlCount === 0) {
+            return undefined;
+        }
+        return {
+            organizationId: savedChart.organizationUuid,
+            projectId: savedChart.projectUuid,
+            savedChartUuid: savedChart.uuid,
+            action,
+            sqlCount,
+            totalTableCalculationCount: tableCalculations.length,
+        };
+    }
+
+    static getTemplateTableCalculationEventProperties(
+        savedChart: SavedChartDAO,
+        action: 'created' | 'updated',
+    ):
+        | {
+              organizationId: string;
+              projectId: string;
+              savedChartUuid: string;
+              action: 'created' | 'updated';
+              templateCount: number;
+              totalTableCalculationCount: number;
+          }
+        | undefined {
+        const { tableCalculations } = savedChart.metricQuery;
+        const templateCount = tableCalculations.filter(
+            isTemplateTableCalculation,
+        ).length;
+        if (templateCount === 0) {
+            return undefined;
+        }
+        return {
+            organizationId: savedChart.organizationUuid,
+            projectId: savedChart.projectUuid,
+            savedChartUuid: savedChart.uuid,
+            action,
+            templateCount,
+            totalTableCalculationCount: tableCalculations.length,
+        };
+    }
+
     private async updateChartFieldUsage(
         projectUuid: string,
         chartExplore: Explore | ExploreError,
@@ -567,6 +627,32 @@ export class SavedChartService
                 event: 'formula_table_calculation.saved',
                 userId: user.userUuid,
                 properties: formulaProperties,
+            });
+        }
+
+        const sqlProperties =
+            SavedChartService.getSqlTableCalculationEventProperties(
+                savedChart,
+                'updated',
+            );
+        if (sqlProperties) {
+            this.analytics.track({
+                event: 'sql_table_calculation.saved',
+                userId: user.userUuid,
+                properties: sqlProperties,
+            });
+        }
+
+        const templateProperties =
+            SavedChartService.getTemplateTableCalculationEventProperties(
+                savedChart,
+                'updated',
+            );
+        if (templateProperties) {
+            this.analytics.track({
+                event: 'template_table_calculation.saved',
+                userId: user.userUuid,
+                properties: templateProperties,
             });
         }
 
@@ -1293,6 +1379,32 @@ export class SavedChartService
             });
         }
 
+        const createSqlProperties =
+            SavedChartService.getSqlTableCalculationEventProperties(
+                newSavedChart,
+                'created',
+            );
+        if (createSqlProperties) {
+            this.analytics.track({
+                event: 'sql_table_calculation.saved',
+                userId: user.userUuid,
+                properties: createSqlProperties,
+            });
+        }
+
+        const createTemplateProperties =
+            SavedChartService.getTemplateTableCalculationEventProperties(
+                newSavedChart,
+                'created',
+            );
+        if (createTemplateProperties) {
+            this.analytics.track({
+                event: 'template_table_calculation.saved',
+                userId: user.userUuid,
+                properties: createTemplateProperties,
+            });
+        }
+
         SavedChartService.getConditionalFormattingEventProperties(
             newSavedChart,
         )?.forEach((properties) => {
@@ -1431,6 +1543,32 @@ export class SavedChartService
                 event: 'formula_table_calculation.saved',
                 userId: user.userUuid,
                 properties: duplicateFormulaProperties,
+            });
+        }
+
+        const duplicateSqlProperties =
+            SavedChartService.getSqlTableCalculationEventProperties(
+                newSavedChart,
+                'created',
+            );
+        if (duplicateSqlProperties) {
+            this.analytics.track({
+                event: 'sql_table_calculation.saved',
+                userId: user.userUuid,
+                properties: duplicateSqlProperties,
+            });
+        }
+
+        const duplicateTemplateProperties =
+            SavedChartService.getTemplateTableCalculationEventProperties(
+                newSavedChart,
+                'created',
+            );
+        if (duplicateTemplateProperties) {
+            this.analytics.track({
+                event: 'template_table_calculation.saved',
+                userId: user.userUuid,
+                properties: duplicateTemplateProperties,
             });
         }
 


### PR DESCRIPTION
## Summary

- Adds `sql_table_calculation.saved` and `template_table_calculation.saved` events as siblings to the existing `formula_table_calculation.saved`, so we can segment table-calc creation/edit usage by type in our internal analytics instance.
- Fires on the same chart-save paths the formula event already covers: `createSavedChart`, `saveVersion`, and duplicate.
- Mirrors the formula event shape: `{ organizationId, projectId, savedChartUuid, action: 'created' | 'updated', <typed>Count, totalTableCalculationCount }`.

## Why

Today only formula table calcs have a typed save event, so SQL and template TCs are invisible in analytics outside of the umbrella `saved_chart_version.created` event (which only carries the total count, not a per-type breakdown). With this change we can answer "how many SQL/template/formula table calcs are being created/edited?" via three sibling events.

## Behaviour

| Chart contains | Events fired on save |
|---|---|
| Only SQL TCs | `sql_table_calculation.saved` |
| Only template TCs | `template_table_calculation.saved` |
| Only formula TCs | `formula_table_calculation.saved` (unchanged) |
| Mixed | One event per type present |
| No TCs | None (each helper short-circuits when its count is 0) |

`saved_chart_version.created` continues to fire on every save with `tableCalculationsCount` (total).

## Granularity caveat

These events are per-chart-save, not per-individual-TC. A re-save of an existing chart still emits `action: 'updated'` events for whichever types are present — we cannot distinguish "added a new SQL TC" from "edited an unrelated field on a chart that happens to have SQL TCs". This matches the existing formula event's semantics.

## Test plan

- [ ] Save a chart containing only a SQL table calculation → `sql_table_calculation.saved` fires with `action: 'created'`, `sqlCount: 1`, `totalTableCalculationCount: 1`
- [ ] Save a chart containing only a template table calculation → `template_table_calculation.saved` fires with `templateCount: 1`
- [ ] Save a chart with a mix of SQL + formula TCs → both `sql_table_calculation.saved` and `formula_table_calculation.saved` fire
- [ ] Save a chart with no table calculations → no `*_table_calculation.saved` events fire
- [ ] Edit a chart that has SQL TCs and re-save → `sql_table_calculation.saved` fires with `action: 'updated'`
- [ ] Duplicate a chart that has template TCs → `template_table_calculation.saved` fires with `action: 'created'` on the new chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)