### PR TITLE
fix(explorer): clarify SqlCard permission copy

### DIFF
--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -181,9 +181,8 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
             {cannotViewSqlAuthoredFields ? (
                 <Box p="sm">
                     <Callout variant="info" title="SQL preview unavailable">
-                        This chart contains custom SQL fields. You need the{' '}
-                        <strong>Manage custom fields</strong> permission to view
-                        the compiled SQL.
+                        This chart contains custom SQL fields that you don't
+                        have permission to view.
                     </Callout>
                 </Box>
             ) : (


### PR DESCRIPTION
## Summary

- Replaces the prescriptive permission instruction in the SQL preview callout with a user-facing summary.
- Before: "This chart contains custom SQL fields. You need the **Manage custom fields** permission to view the compiled SQL."
- After: "This chart contains custom SQL fields that you don't have permission to view."

## Why

The previous copy told users which permission they were missing, which is implementation detail they can't act on directly (they'd need an admin anyway). The new copy explains the situation in plain language.

## Test plan

- [ ] As a user without the "Manage custom fields" permission, open a chart that uses a custom SQL dimension and confirm the SQL card shows the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)