### PR TITLE
refactor(controllers): assert registered account on account-migrated endpoints

### DIFF
--- a/packages/backend/src/controllers/shareController.ts
+++ b/packages/backend/src/controllers/shareController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiShareResponse,
+    assertRegisteredAccount,
     CreateShareUrl,
 } from '@lightdash/common';
 import {
@@ -37,6 +38,7 @@ export class ShareController extends BaseController {
         @Path() nanoId: string,
         @Request() req: express.Request,
     ): Promise<ApiShareResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/v2/ParametersController.ts
+++ b/packages/backend/src/controllers/v2/ParametersController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiSuccess,
+    assertRegisteredAccount,
     KnexPaginateArgs,
     type ApiGetProjectParametersListResults,
     type ApiGetProjectParametersResults,
@@ -49,6 +50,7 @@ export class ParametersController extends BaseController {
         @Query() page?: number,
         @Query() pageSize?: number,
     ): Promise<ApiSuccess<ApiGetProjectParametersListResults>> {
+        assertRegisteredAccount(req.account);
         let paginateArgs: KnexPaginateArgs | undefined;
 
         if (pageSize && page) {

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -8,6 +8,7 @@ import {
     ApiExecuteAsyncDashboardChartQueryResults,
     ApiSuccessEmpty,
     assertEmbeddedAuth,
+    assertRegisteredAccount,
     assertSessionAuth,
     CacheMetadata,
     CalculateSubtotalsFromQuery,
@@ -117,6 +118,7 @@ export class EmbedController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
     ): Promise<ApiEmbedConfigResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         assertSessionAuth(req.account);
         return {
@@ -137,6 +139,7 @@ export class EmbedController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: CreateEmbedRequestBody,
     ): Promise<ApiEmbedConfigResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(201);
         assertSessionAuth(req.account);
         return {

--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -1,3 +1,4 @@
+import { assertRegisteredAccount } from '@lightdash/common';
 import express, { type Router } from 'express';
 import {
     allowApiKeyAuthentication,
@@ -162,6 +163,7 @@ dashboardRouter.post(
     isAuthenticated,
     async (req, res, next) => {
         try {
+            assertRegisteredAccount(req.account);
             const { selectedTabs } = req.body;
             const validatedSelectedTabs =
                 Array.isArray(selectedTabs) &&

--- a/packages/backend/src/routers/oauthRouter.ts
+++ b/packages/backend/src/routers/oauthRouter.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {
+    assertRegisteredAccount,
     generateOAuthAuthorizePage,
     generateOAuthRedirectPage,
     getClientName,
@@ -368,8 +369,9 @@ oauthRouter.get(
     isAuthenticated,
     async (req, res, next) => {
         try {
+            assertRegisteredAccount(req.account);
             const oauthService = getOAuthService(req);
-            const clients = await oauthService.listClients(req.account!);
+            const clients = await oauthService.listClients(req.account);
             return res.json({ status: 'ok', results: clients });
         } catch (error) {
             return next(error);
@@ -384,9 +386,10 @@ oauthRouter.post(
     unauthorisedInDemo,
     async (req, res, next) => {
         try {
+            assertRegisteredAccount(req.account);
             const { clientName, redirectUris } = req.body;
             const oauthService = getOAuthService(req);
-            const client = await oauthService.createAdminClient(req.account!, {
+            const client = await oauthService.createAdminClient(req.account, {
                 clientName,
                 redirectUris,
             });
@@ -404,11 +407,12 @@ oauthRouter.patch(
     unauthorisedInDemo,
     async (req, res, next) => {
         try {
+            assertRegisteredAccount(req.account);
             const { clientId } = req.params;
             const { clientName, redirectUris } = req.body;
             const oauthService = getOAuthService(req);
             const client = await oauthService.updateClient(
-                req.account!,
+                req.account,
                 clientId,
                 { clientName, redirectUris },
             );
@@ -426,9 +430,10 @@ oauthRouter.delete(
     unauthorisedInDemo,
     async (req, res, next) => {
         try {
+            assertRegisteredAccount(req.account);
             const { clientId } = req.params;
             const oauthService = getOAuthService(req);
-            await oauthService.deleteClient(req.account!, clientId);
+            await oauthService.deleteClient(req.account, clientId);
             return res.json({ status: 'ok', results: undefined });
         } catch (error) {
             return next(error);


### PR DESCRIPTION
## Summary

Follow-up to #22503, #22506, #22513 — those PRs migrated a batch of services from `user: SessionUser` → `account: Account` and updated their callers (controllers/routers). At migration time most call sites also gained `assertRegisteredAccount(req.account)` as the first call, which both narrows the type and rejects anonymous accounts at the controller boundary.

A handful of changed call sites didn't get the assertion. This PR closes that gap so every endpoint touched by those three PRs starts with `assertRegisteredAccount`.

## Files changed

- `packages/backend/src/ee/controllers/embedController.ts` — `getEmbedConfig`, `saveEmbedConfig`
- `packages/backend/src/controllers/shareController.ts` — `get` (getShareUrl)
- `packages/backend/src/controllers/v2/ParametersController.ts` — `getParametersList`
- `packages/backend/src/routers/dashboardRouter.ts` — `/:dashboardUuid/exportCsv` handler
- `packages/backend/src/routers/oauthRouter.ts` — `GET/POST/PATCH/DELETE /clients` admin endpoints

In `oauthRouter.ts` the `req.account!` non-null assertions were replaced with plain `req.account` because `assertRegisteredAccount` already narrows it.

For the embed endpoints, `assertRegisteredAccount` is added before the existing `assertSessionAuth` call (the two checks are complementary — registered user + session-form auth).

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [ ] CI green