### PR TITLE
feat: gate managed agent heartbeat and UI on `AiAutopilot` feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -301,7 +301,6 @@ export const lightdashConfigMock: LightdashConfig = {
         projectId: 'test-project-id',
     },
     managedAgent: {
-        enabled: false,
         anthropicApiKey: null,
         skillIds: [],
         schedule: '*/30 * * * *',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1158,7 +1158,6 @@ export type LightdashConfig = {
         projectId?: string;
     };
     managedAgent: {
-        enabled: boolean;
         anthropicApiKey: string | null;
         skillIds: string[];
         schedule: string;
@@ -2239,7 +2238,6 @@ export const parseConfig = (): LightdashConfig => {
             projectId: process.env.GOOGLE_CLOUD_PROJECT_ID,
         },
         managedAgent: {
-            enabled: process.env.MANAGED_AGENT_ENABLED === 'true',
             anthropicApiKey:
                 process.env.MANAGED_AGENT_ANTHROPIC_API_KEY ||
                 process.env.ANTHROPIC_API_KEY ||

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -419,6 +419,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     dashboardModel: models.getDashboardModel(),
                     spaceModel: models.getSpaceModel(),
                     userModel: models.getUserModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
                     serviceAccountModel: models.getServiceAccountModel(),
                     schedulerClient: clients.getSchedulerClient(),
                     slackClient: clients.getSlackClient(),

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -132,41 +132,25 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 );
             },
             [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: async (payload) => {
-                if (!this.lightdashConfig.managedAgent.enabled) {
-                    return;
-                }
-
-                // Backwards compat: legacy in-flight jobs (from before this
-                // change) have an empty payload. Re-enqueue per-project jobs
-                // with the new payload shape and exit — the new jobs will
-                // then follow the single-project path below.
-                if (!payload?.projectUuid) {
-                    Logger.info(
-                        'Migrating managed agent heartbeat jobs to per-project payloads',
-                    );
-                    const enabledProjects =
-                        await this.managedAgentService.getEnabledProjects();
-                    for (const project of enabledProjects) {
-                        const schedule =
-                            project.scheduleCron ??
-                            this.lightdashConfig.managedAgent.schedule;
-                        // eslint-disable-next-line no-await-in-loop
-                        await this.schedulerClient.scheduleManagedAgentHeartbeat(
-                            schedule,
-                            project.projectUuid,
-                        );
-                    }
-                    return;
-                }
-
                 const { projectUuid } = payload;
                 const settings = (
                     await this.managedAgentService.getEnabledProjects()
-                ).find((p) => p.projectUuid === projectUuid);
+                ).find((project) => project.projectUuid === projectUuid);
 
                 if (!settings) {
                     Logger.info(
                         `Managed agent disabled for project ${projectUuid}, stopping heartbeat loop`,
+                    );
+                    return;
+                }
+
+                const aiAutopilotEnabled =
+                    await this.managedAgentService.isAiAutopilotEnabledForProject(
+                        settings,
+                    );
+                if (!aiAutopilotEnabled) {
+                    Logger.info(
+                        `AI autopilot feature flag disabled for project ${projectUuid}, skipping managed agent heartbeat`,
                     );
                     return;
                 }

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    FeatureFlags,
     ForbiddenError,
     ManagedAgentActionType,
     ManagedAgentTargetType,
@@ -21,6 +22,7 @@ import type { SlackClient } from '../../../clients/Slack/SlackClient';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import type { AnalyticsModel } from '../../../models/AnalyticsModel';
 import type { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
+import type { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import type { OrganizationModel } from '../../../models/OrganizationModel';
 import type { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import type { SavedChartModel } from '../../../models/SavedChartModel';
@@ -47,6 +49,7 @@ type ManagedAgentServiceDependencies = {
     dashboardModel: DashboardModel;
     spaceModel: SpaceModel;
     userModel: UserModel;
+    featureFlagModel: FeatureFlagModel;
     serviceAccountModel: ServiceAccountModel;
     schedulerClient: SchedulerClient;
     slackClient: SlackClient;
@@ -74,6 +77,8 @@ export class ManagedAgentService extends BaseService {
 
     private readonly userModel: UserModel;
 
+    private readonly featureFlagModel: FeatureFlagModel;
+
     private readonly serviceAccountModel: ServiceAccountModel;
 
     private readonly schedulerClient: SchedulerClient;
@@ -94,6 +99,7 @@ export class ManagedAgentService extends BaseService {
         this.dashboardModel = deps.dashboardModel;
         this.spaceModel = deps.spaceModel;
         this.userModel = deps.userModel;
+        this.featureFlagModel = deps.featureFlagModel;
         this.serviceAccountModel = deps.serviceAccountModel;
         this.schedulerClient = deps.schedulerClient;
         this.slackClient = deps.slackClient;
@@ -348,6 +354,26 @@ export class ManagedAgentService extends BaseService {
 
     async getEnabledProjects(): Promise<ManagedAgentSettings[]> {
         return this.managedAgentModel.getEnabledProjects();
+    }
+
+    async isAiAutopilotEnabledForProject(
+        settings: ManagedAgentSettings,
+    ): Promise<boolean> {
+        const project = await this.projectModel.getSummary(
+            settings.projectUuid,
+        );
+        const user = settings.enabledByUserUuid
+            ? await this.userModel.findSessionUserAndOrgByUuid(
+                  settings.enabledByUserUuid,
+                  project.organizationUuid,
+              )
+            : undefined;
+        const featureFlag = await this.featureFlagModel.get({
+            user,
+            featureFlagId: FeatureFlags.AiAutopilot,
+        });
+
+        return featureFlag.enabled;
     }
 
     // --- Actions API ---

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -137,9 +137,6 @@ export const BaseResponse: HealthState = {
     dataApps: {
         enabled: false,
     },
-    managedAgent: {
-        enabled: false,
-    },
 };
 
 export const userMock = {

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -238,9 +238,6 @@ export class HealthService extends BaseService {
             dataApps: {
                 enabled: this.lightdashConfig.appRuntime.enabled,
             },
-            managedAgent: {
-                enabled: this.lightdashConfig.managedAgent.enabled,
-            },
         };
     }
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -511,9 +511,6 @@ export type HealthState = {
     dataApps: {
         enabled: boolean;
     };
-    managedAgent: {
-        enabled: boolean;
-    };
 };
 
 // Deploy Session Types

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -105,6 +105,11 @@ export enum FeatureFlags {
      * contents using the AI Copilot).
      */
     AiDashboardSummary = 'ai-dashboard-summary',
+
+    /**
+     * Enable Autopilot project health agent.
+     */
+    AiAutopilot = 'ai-autopilot',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -16,7 +17,7 @@ import {
 import { type FC, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { BetaBadge } from '../../../components/common/BetaBadge';
-import useHealth from '../../../hooks/health/useHealth';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
 import classes from './ManagedAgentHomeCard.module.css';
@@ -101,8 +102,10 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
     projectUuid,
 }) => {
     const navigate = useNavigate();
-    const { data: health } = useHealth();
-    const managedAgentEnabled = !!health?.managedAgent?.enabled;
+    const { data: aiAutopilotFlag } = useServerFeatureFlag(
+        FeatureFlags.AiAutopilot,
+    );
+    const managedAgentEnabled = !!aiAutopilotFlag?.enabled;
     const { data: settings } = useManagedAgentSettings({
         enabled: managedAgentEnabled,
     });
@@ -141,7 +144,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
 
     const [setupOpen, setSetupOpen] = useState(false);
 
-    if (!health?.managedAgent?.enabled) return null;
+    if (!managedAgentEnabled) return null;
 
     const handleClick = () => {
         if (isEnabled) {

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -137,9 +137,6 @@ export default function mockHealthResponse(
         dataApps: {
             enabled: false,
         },
-        managedAgent: {
-            enabled: false,
-        },
         ...overrides,
     };
 }


### PR DESCRIPTION
Closes:

### Description:

Replaces the `MANAGED_AGENT_ENABLED` environment variable / `managedAgent.enabled` config flag with a proper `AiAutopilot` feature flag for controlling access to the Autopilot project health agent.

The `managedAgent.enabled` field has been removed from `LightdashConfig`, `HealthState`, and the health API response. Instead, the `ManagedAgentService` now checks the `AiAutopilot` feature flag (via `FeatureFlagModel`) on a per-project basis before running the managed agent heartbeat. The frontend `ManagedAgentHomeCard` has been updated to use `useServerFeatureFlag(FeatureFlags.AiAutopilot)` rather than reading from the health response.

The legacy backwards-compatibility path in the scheduler worker that handled empty-payload heartbeat jobs (migrating them to per-project payloads) has also been removed, as that migration is no longer needed.