### PR TITLE
feat: space-level color palette picker (PR2/4)

### DIFF
--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -17,6 +17,7 @@ export type DbSpace = {
     deleted_at: Date | null;
     deleted_by_user_uuid: string | null;
     is_default_user_space: boolean;
+    color_palette_uuid: string | null;
 };
 
 export type CreateDbSpace = Pick<
@@ -34,7 +35,10 @@ export type CreateDbSpace = Pick<
 export type UpdateDbSpace = Partial<
     Pick<
         DbSpace,
-        'name' | 'inherit_parent_permissions' | 'project_member_access_role'
+        | 'name'
+        | 'inherit_parent_permissions'
+        | 'project_member_access_role'
+        | 'color_palette_uuid'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260501142105_add_color_palette_uuid_to_spaces.ts
+++ b/packages/backend/src/database/migrations/20260501142105_add_color_palette_uuid_to_spaces.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+const SpacesTable = 'spaces';
+const OrganizationColorPalettesTable = 'organization_color_palettes';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SpacesTable, (table) => {
+        table
+            .uuid('color_palette_uuid')
+            .nullable()
+            .references('color_palette_uuid')
+            .inTable(OrganizationColorPalettesTable)
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SpacesTable, (table) => {
+        table.dropColumn('color_palette_uuid');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8986,11 +8986,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9468,11 +9468,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9487,11 +9487,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9506,11 +9506,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9525,11 +9525,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9544,11 +9544,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -18005,6 +18005,14 @@ const models: TsoaRoute.Models = {
                     },
                 },
                 path: { dataType: 'string', required: true },
+                colorPaletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 projectMemberAccessRole: {
                     dataType: 'union',
                     subSchemas: [
@@ -18221,6 +18229,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                colorPaletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 projectMemberAccessRole: {
                     dataType: 'union',
                     subSchemas: [
@@ -21240,7 +21255,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21250,7 +21265,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21260,7 +21275,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21273,7 +21288,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10444,6 +10444,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -19126,6 +19139,10 @@
                     "path": {
                         "type": "string"
                     },
+                    "colorPaletteUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "projectMemberAccessRole": {
                         "allOf": [
                             {
@@ -19201,6 +19218,7 @@
                 },
                 "required": [
                     "path",
+                    "colorPaletteUuid",
                     "projectMemberAccessRole",
                     "inheritParentPermissions",
                     "parentSpaceUuid",
@@ -19400,6 +19418,10 @@
             },
             "UpdateSpace": {
                 "properties": {
+                    "colorPaletteUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "projectMemberAccessRole": {
                         "allOf": [
                             {
@@ -22646,22 +22668,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -137,6 +137,7 @@ export const spaceEntry: SpaceTable['base'] = {
     inherit_parent_permissions: true,
     project_member_access_role: null,
     is_default_user_space: false,
+    color_palette_uuid: null,
 
     deleted_at: null,
     deleted_by_user_uuid: null,

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -491,7 +491,7 @@ export class SavedChartModel {
 
     /**
      * Resolves the color palette for a chart by walking up the
-     * chart → dashboard → space → project → organization hierarchy.
+     * chart → dashboard → space → parent space → … → project → organization hierarchy.
      *
      * The lightdashConfig.appearance.overrideColorPalette wins over everything,
      * matching OrganizationModel.get() behaviour.
@@ -514,57 +514,152 @@ export class SavedChartModel {
             };
         }
 
-        // Single query: LEFT JOIN the palettes table twice (project's palette
-        // and org's palette) and discriminate the winning level in JS so we
-        // can surface which entity owns the resolved palette.
-        const result = await this.database(ProjectTableName)
-            .innerJoin(
-                OrganizationTableName,
-                `${OrganizationTableName}.organization_id`,
-                `${ProjectTableName}.organization_id`,
-            )
-            .leftJoin(
-                `${OrganizationColorPaletteTableName} as project_palette`,
-                'project_palette.color_palette_uuid',
-                `${ProjectTableName}.color_palette_uuid`,
-            )
-            .leftJoin(
-                `${OrganizationColorPaletteTableName} as org_palette`,
-                'org_palette.color_palette_uuid',
-                `${OrganizationTableName}.color_palette_uuid`,
-            )
-            .where(`${ProjectTableName}.project_uuid`, args.projectUuid)
-            .select<{
-                project_uuid: string;
-                project_name: string;
-                organization_uuid: string;
-                organization_name: string;
-                project_palette_uuid: string | null;
-                project_palette_name: string | null;
-                project_palette_colors: string[] | null;
-                project_palette_dark_colors: string[] | null;
-                org_palette_uuid: string | null;
-                org_palette_name: string | null;
-                org_palette_colors: string[] | null;
-                org_palette_dark_colors: string[] | null;
-            }>([
-                `${ProjectTableName}.project_uuid as project_uuid`,
-                `${ProjectTableName}.name as project_name`,
-                `${OrganizationTableName}.organization_uuid as organization_uuid`,
-                `${OrganizationTableName}.organization_name as organization_name`,
-                'project_palette.color_palette_uuid as project_palette_uuid',
-                'project_palette.name as project_palette_name',
-                'project_palette.colors as project_palette_colors',
-                'project_palette.dark_colors as project_palette_dark_colors',
-                'org_palette.color_palette_uuid as org_palette_uuid',
-                'org_palette.name as org_palette_name',
-                'org_palette.colors as org_palette_colors',
-                'org_palette.dark_colors as org_palette_dark_colors',
-            ])
-            .first();
+        // Walk the space chain via parent_space_uuid (closest override wins)
+        // and LEFT JOIN palettes for space / project / org so we can surface
+        // which entity owns the resolved palette. When no space is in scope
+        // (embed / unsaved chart explore), skip the CTE — same query plan as
+        // before, with NULL space_* columns to keep the row shape uniform.
+        type ResolverRow = {
+            project_uuid: string;
+            project_name: string;
+            organization_uuid: string;
+            organization_name: string;
+            space_uuid: string | null;
+            space_name: string | null;
+            space_palette_uuid: string | null;
+            space_palette_name: string | null;
+            space_palette_colors: string[] | null;
+            space_palette_dark_colors: string[] | null;
+            project_palette_uuid: string | null;
+            project_palette_name: string | null;
+            project_palette_colors: string[] | null;
+            project_palette_dark_colors: string[] | null;
+            org_palette_uuid: string | null;
+            org_palette_name: string | null;
+            org_palette_colors: string[] | null;
+            org_palette_dark_colors: string[] | null;
+        };
+
+        const result: ResolverRow | undefined = args.spaceUuid
+            ? await this.database
+                  .raw<{ rows: ResolverRow[] }>(
+                      `
+                WITH RECURSIVE space_chain AS (
+                    SELECT space_uuid, name, parent_space_uuid, color_palette_uuid, 0 AS depth
+                    FROM ${SpaceTableName}
+                    WHERE space_uuid = ? AND deleted_at IS NULL
+
+                    UNION ALL
+
+                    SELECT s.space_uuid, s.name, s.parent_space_uuid, s.color_palette_uuid, sc.depth + 1
+                    FROM ${SpaceTableName} s
+                    JOIN space_chain sc ON s.space_uuid = sc.parent_space_uuid
+                    WHERE s.deleted_at IS NULL
+                ),
+                chosen_space AS (
+                    SELECT space_uuid, name, color_palette_uuid
+                    FROM space_chain
+                    WHERE color_palette_uuid IS NOT NULL
+                    ORDER BY depth ASC
+                    LIMIT 1
+                )
+                SELECT
+                    p.project_uuid AS project_uuid,
+                    p.name AS project_name,
+                    o.organization_uuid AS organization_uuid,
+                    o.organization_name AS organization_name,
+                    cs.space_uuid AS space_uuid,
+                    cs.name AS space_name,
+                    sp.color_palette_uuid AS space_palette_uuid,
+                    sp.name AS space_palette_name,
+                    sp.colors AS space_palette_colors,
+                    sp.dark_colors AS space_palette_dark_colors,
+                    pp.color_palette_uuid AS project_palette_uuid,
+                    pp.name AS project_palette_name,
+                    pp.colors AS project_palette_colors,
+                    pp.dark_colors AS project_palette_dark_colors,
+                    op.color_palette_uuid AS org_palette_uuid,
+                    op.name AS org_palette_name,
+                    op.colors AS org_palette_colors,
+                    op.dark_colors AS org_palette_dark_colors
+                FROM ${ProjectTableName} p
+                INNER JOIN ${OrganizationTableName} o
+                    ON o.organization_id = p.organization_id
+                LEFT JOIN chosen_space cs ON true
+                LEFT JOIN ${OrganizationColorPaletteTableName} sp
+                    ON sp.color_palette_uuid = cs.color_palette_uuid
+                LEFT JOIN ${OrganizationColorPaletteTableName} pp
+                    ON pp.color_palette_uuid = p.color_palette_uuid
+                LEFT JOIN ${OrganizationColorPaletteTableName} op
+                    ON op.color_palette_uuid = o.color_palette_uuid
+                WHERE p.project_uuid = ?
+                `,
+                      [args.spaceUuid, args.projectUuid],
+                  )
+                  .then((res) => res.rows[0])
+            : await this.database(ProjectTableName)
+                  .innerJoin(
+                      OrganizationTableName,
+                      `${OrganizationTableName}.organization_id`,
+                      `${ProjectTableName}.organization_id`,
+                  )
+                  .leftJoin(
+                      `${OrganizationColorPaletteTableName} as project_palette`,
+                      'project_palette.color_palette_uuid',
+                      `${ProjectTableName}.color_palette_uuid`,
+                  )
+                  .leftJoin(
+                      `${OrganizationColorPaletteTableName} as org_palette`,
+                      'org_palette.color_palette_uuid',
+                      `${OrganizationTableName}.color_palette_uuid`,
+                  )
+                  .where(`${ProjectTableName}.project_uuid`, args.projectUuid)
+                  .select<ResolverRow>([
+                      `${ProjectTableName}.project_uuid as project_uuid`,
+                      `${ProjectTableName}.name as project_name`,
+                      `${OrganizationTableName}.organization_uuid as organization_uuid`,
+                      `${OrganizationTableName}.organization_name as organization_name`,
+                      this.database.raw('NULL::uuid as space_uuid'),
+                      this.database.raw('NULL::text as space_name'),
+                      this.database.raw('NULL::uuid as space_palette_uuid'),
+                      this.database.raw('NULL::text as space_palette_name'),
+                      this.database.raw('NULL::text[] as space_palette_colors'),
+                      this.database.raw(
+                          'NULL::text[] as space_palette_dark_colors',
+                      ),
+                      'project_palette.color_palette_uuid as project_palette_uuid',
+                      'project_palette.name as project_palette_name',
+                      'project_palette.colors as project_palette_colors',
+                      'project_palette.dark_colors as project_palette_dark_colors',
+                      'org_palette.color_palette_uuid as org_palette_uuid',
+                      'org_palette.name as org_palette_name',
+                      'org_palette.colors as org_palette_colors',
+                      'org_palette.dark_colors as org_palette_dark_colors',
+                  ])
+                  .first();
 
         if (!result) {
             return null;
+        }
+
+        if (
+            result.space_palette_uuid &&
+            result.space_palette_colors &&
+            result.space_palette_name &&
+            result.space_uuid &&
+            result.space_name
+        ) {
+            return {
+                paletteUuid: result.space_palette_uuid,
+                paletteName: result.space_palette_name,
+                colors: result.space_palette_colors,
+                darkColors: result.space_palette_dark_colors,
+                source: {
+                    type: 'space',
+                    uuid: result.space_uuid,
+                    name: result.space_name,
+                },
+            };
         }
 
         if (

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -336,6 +336,7 @@ export class SpaceModel {
             inheritParentPermissions: row.inherit_parent_permissions,
             projectMemberAccessRole:
                 (row.project_member_access_role as SpaceMemberRole) ?? null,
+            colorPaletteUuid: row.color_palette_uuid,
         };
     }
 
@@ -1121,6 +1122,7 @@ export class SpaceModel {
             inheritParentPermissions: space.inherit_parent_permissions,
             projectMemberAccessRole:
                 (space.project_member_access_role as SpaceMemberRole) ?? null,
+            colorPaletteUuid: space.color_palette_uuid,
         };
     }
 
@@ -1329,6 +1331,9 @@ export class SpaceModel {
             updateData.project_member_access_role =
                 space.projectMemberAccessRole;
         }
+        if (space.colorPaletteUuid !== undefined) {
+            updateData.color_palette_uuid = space.colorPaletteUuid;
+        }
         await this.database(SpaceTableName)
             .update(updateData)
             .where('space_uuid', spaceUuid);
@@ -1379,6 +1384,9 @@ export class SpaceModel {
             if (space.projectMemberAccessRole !== undefined) {
                 updateData.project_member_access_role =
                     space.projectMemberAccessRole;
+            }
+            if (space.colorPaletteUuid !== undefined) {
+                updateData.color_palette_uuid = space.colorPaletteUuid;
             }
             await trx(SpaceTableName)
                 .update(updateData)

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -58,6 +58,7 @@ export const space: SpaceTable['base'] = {
     inherit_parent_permissions: false,
     project_member_access_role: null,
     is_default_user_space: false,
+    color_palette_uuid: null,
     deleted_at: null,
     deleted_by_user_uuid: null,
 };
@@ -80,6 +81,7 @@ export const publicSpace: Space = {
     pinnedListOrder: null,
     parentSpaceUuid: null,
     path: 'public-space',
+    colorPaletteUuid: null,
 };
 export const privateSpace: Space = {
     ...publicSpace,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -397,6 +397,7 @@ export const spacesWithSavedCharts: Space[] = [
         childSpaces: [],
         access: [],
         groupsAccess: [],
+        colorPaletteUuid: null,
     },
 ];
 
@@ -419,6 +420,7 @@ export const spacesWithNoSavedCharts: Space[] = [
         access: [],
         groupsAccess: [],
         childSpaces: [],
+        colorPaletteUuid: null,
     },
 ];
 

--- a/packages/backend/src/services/PromoteService/PromoteService.mock.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.mock.ts
@@ -129,6 +129,7 @@ export const upstreamFullSpace: Space = {
             spaceRole: SpaceMemberRole.ADMIN,
         },
     ],
+    colorPaletteUuid: null,
 };
 
 export const promotedChart: PromotedChart = {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -840,6 +840,7 @@ export class ServiceRepository
                     lightdashConfig: this.context.lightdashConfig,
                     projectModel: this.models.getProjectModel(),
                     spaceModel: this.models.getSpaceModel(),
+                    organizationModel: this.models.getOrganizationModel(),
                     pinnedListModel: this.models.getPinnedListModel(),
                     spacePermissionService: this.getSpacePermissionService(),
                     savedChartService: this.getSavedChartService(),

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { OrganizationModel } from '../../models/OrganizationModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -32,6 +33,7 @@ describe('SpaceService', () => {
             lightdashConfig: lightdashConfigMock,
             projectModel: {} as ProjectModel,
             spaceModel: {} as SpaceModel,
+            organizationModel: {} as OrganizationModel,
             pinnedListModel: {} as PinnedListModel,
             spacePermissionService: {
                 getSpaceAccessContext: mockGetSpaceAccessContext,
@@ -902,6 +904,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
             lightdashConfig: lightdashConfigMock,
             projectModel: {} as ProjectModel,
             spaceModel: mockSpaceModel as unknown as SpaceModel,
+            organizationModel: {} as OrganizationModel,
             pinnedListModel: {} as PinnedListModel,
             spacePermissionService:
                 mockSpacePermissionService as unknown as SpacePermissionService,

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -20,6 +20,7 @@ import { Knex } from 'knex';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
 import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
+import { OrganizationModel } from '../../models/OrganizationModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -37,6 +38,7 @@ type SpaceServiceArguments = {
     lightdashConfig: LightdashConfig;
     projectModel: ProjectModel;
     spaceModel: SpaceModel;
+    organizationModel: OrganizationModel;
     pinnedListModel: PinnedListModel;
     spacePermissionService: SpacePermissionService;
     savedChartService: SavedChartService;
@@ -84,6 +86,8 @@ export class SpaceService
 
     private readonly spaceModel: SpaceModel;
 
+    private readonly organizationModel: OrganizationModel;
+
     private readonly pinnedListModel: PinnedListModel;
 
     private readonly spacePermissionService: SpacePermissionService;
@@ -100,6 +104,7 @@ export class SpaceService
         this.lightdashConfig = args.lightdashConfig;
         this.projectModel = args.projectModel;
         this.spaceModel = args.spaceModel;
+        this.organizationModel = args.organizationModel;
         this.pinnedListModel = args.pinnedListModel;
         this.spacePermissionService = args.spacePermissionService;
         this.savedChartService = args.savedChartService;
@@ -290,6 +295,18 @@ export class SpaceService
         }
 
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
+
+        if (updateSpace.colorPaletteUuid) {
+            const palette = await this.organizationModel.findColorPalette(
+                space.organizationUuid,
+                updateSpace.colorPaletteUuid,
+            );
+            if (!palette) {
+                throw new ParameterError(
+                    'Color palette does not belong to this organization',
+                );
+            }
+        }
 
         const { inheritParentPermissions } = updateSpace;
 

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -66,6 +66,7 @@ export type Space = {
     parentSpaceUuid: string | null;
     inheritParentPermissions: boolean;
     projectMemberAccessRole: SpaceMemberRole | null;
+    colorPaletteUuid: string | null;
     // ltree path serialized as string
     path: string;
     breadcrumbs?: {
@@ -121,6 +122,7 @@ export type UpdateSpace = {
     inheritParentPermissions?: boolean;
     /** When set, all project members get this role on the space */
     projectMemberAccessRole?: SpaceMemberRole | null;
+    colorPaletteUuid?: string | null;
 };
 
 export type SpaceAccessUserMetadata = {

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -26,6 +26,7 @@ type Props = {
     label?: string;
     description?: string;
     placeholder?: string;
+    size?: 'xs' | 'sm' | 'md' | 'lg';
 };
 
 type SwatchSet = {
@@ -159,6 +160,7 @@ export const PalettePicker: FC<Props> = ({
     label,
     description,
     placeholder,
+    size = 'xs',
 }) => {
     const data = [
         { value: INHERIT_VALUE, label: `Inherit from ${parentLabel}` },
@@ -182,7 +184,7 @@ export const PalettePicker: FC<Props> = ({
     return (
         <Stack gap="sm">
             <Select
-                size="xs"
+                size={size}
                 label={label}
                 description={description}
                 placeholder={placeholder}

--- a/packages/frontend/src/components/common/SpaceActionModal/UpdateSpaceModalContent.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/UpdateSpaceModalContent.tsx
@@ -1,13 +1,58 @@
-import { TextInput } from '@mantine-8/core';
+import { Stack, TextInput } from '@mantine-8/core';
 import { type FC } from 'react';
 import { type SpaceModalBody } from '.';
+import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
+import useHealth from '../../../hooks/health/useHealth';
+import { useProject } from '../../../hooks/useProject';
+import Callout from '../Callout';
+import { PalettePicker } from '../PalettePicker/PalettePicker';
 
-const UpdateSpaceModalContent: FC<SpaceModalBody> = ({ form }) => (
-    <TextInput
-        {...form.getInputProps('name')}
-        label="Enter a memorable name for your space"
-        placeholder="eg. KPIs"
-    />
-);
+type Props = SpaceModalBody & {
+    projectUuid: string;
+};
+
+const UpdateSpaceModalContent: FC<Props> = ({ form, projectUuid }) => {
+    const { data: project } = useProject(projectUuid);
+    const { data: palettes = [] } = useColorPalettes();
+    const { data: health } = useHealth();
+
+    const overrideActive =
+        !!health?.appearance.overrideColorPalette &&
+        health.appearance.overrideColorPalette.length > 0;
+
+    const parentBreadcrumb =
+        form.values.breadcrumbs && form.values.breadcrumbs.length >= 2
+            ? form.values.breadcrumbs[form.values.breadcrumbs.length - 2]
+            : undefined;
+    const parentLabel = parentBreadcrumb?.name ?? project?.name ?? 'project';
+
+    return (
+        <Stack gap="md">
+            <TextInput
+                {...form.getInputProps('name')}
+                label="Enter a memorable name for your space"
+                placeholder="eg. KPIs"
+            />
+            {overrideActive && (
+                <Callout variant="info">
+                    A color palette override is set in your instance
+                    configuration. Space-level selection is disabled while the
+                    override is active.
+                </Callout>
+            )}
+            <PalettePicker
+                label="Color palette"
+                size="sm"
+                value={form.values.colorPaletteUuid ?? null}
+                onChange={(next) =>
+                    form.setFieldValue('colorPaletteUuid', next)
+                }
+                palettes={palettes}
+                parentLabel={parentLabel}
+                disabled={overrideActive}
+            />
+        </Stack>
+    );
+};
 
 export default UpdateSpaceModalContent;

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -163,7 +163,11 @@ const SpaceModal: FC<ActionModalProps> = ({
                             onInheritanceChange={setInheritanceValue}
                         />
                     ) : actionType === ActionType.UPDATE ? (
-                        <UpdateSpaceModalContent data={data} form={form} />
+                        <UpdateSpaceModalContent
+                            data={data}
+                            form={form}
+                            projectUuid={projectUuid}
+                        />
                     ) : (
                         assertUnreachable(
                             actionType,
@@ -236,6 +240,7 @@ const SpaceActionModal: FC<
                 ...(!parentSpaceUuid && {
                     inheritParentPermissions: state.inheritParentPermissions,
                 }),
+                colorPaletteUuid: state.colorPaletteUuid,
             });
             onSubmitForm?.(result);
         } else if (actionType === ActionType.DELETE) {


### PR DESCRIPTION
## Summary

PR2 of 4 for [PROD-486](https://linear.app/lightdash/issue/PROD-486). Adds space-level color palette assignment with nested-space walk-up so a child space inherits its nearest ancestor's override before falling through to the project, then to the org's active palette.

Stacks on top of PR1 ([#22590](https://github.com/lightdash/lightdash/pull/22590), already merged) which landed the project-level picker and the shared resolver/picker scaffolding.

Closes: https://linear.app/lightdash/issue/PROD-7161

## Changes

**Migration**
- `spaces.color_palette_uuid` → `organization_color_palettes(color_palette_uuid)` (`ON DELETE SET NULL`). Mirrors PR1's migration shape.

**Backend**
- `DbSpace` / `UpdateDbSpace` extended; `SpaceModel.get()`, `createSpace()`, `update()` and `updateWithCopiedPermissions()` round-trip the field.
- `SpaceService.updateSpace` validates that the palette belongs to the space's org via the new `OrganizationModel` dependency. Reuses the existing space-edit ability — no new scope.
- `SavedChartModel.resolveColorPalette`: when called with a `spaceUuid`, runs a recursive CTE on `parent_space_uuid` (filtering soft-deleted) and `COALESCE`s through the closest space → project → org. The no-space branch is unchanged so embed/dashboard-only flows keep PR1's plan.

**Frontend**
- `PalettePicker` gains an optional `size` prop (defaults to `xs` for backward compatibility).
- Space-edit modal renders the picker under the name input. Inherit-label is the parent space's name when nested, the project's name otherwise. Picker uses `size="sm"` to match the `TextInput`.

## Resolver semantics

```
config override → space → parent space → … → root space → project → organization → null
```

The `space → parent → … → root` walk-up runs in a single recursive CTE. Each chart's call site already passes `spaceUuid` (`SavedChartModel.ts:1218`, `EmbedService.ts:542`), so no signature changes were needed.

## Screenshots


#### Baseline. Project palette = Customer Segments Aurora; chart’s space (Jaffle shop) inherits → bars render in Aurora’s dark navy/slate.
<img width="2400" height="2454" alt="01-project-aurora" src="https://github.com/user-attachments/assets/5de077fc-d196-4289-a3c6-57e099089f95" />

#### Space-edit modal with picker on default Inherit from Jaffle shop (matches name-input size — sm).
<img width="2400" height="2454" alt="02-modal-inherit" src="https://github.com/user-attachments/assets/e0e66b3d-80d8-4f4e-8d04-51eeeff7704d" />

#### Picker open: each option shows its colour swatches (light + dark).
<img width="2400" height="2454" alt="03-modal-dropdown" src="https://github.com/user-attachments/assets/82f33d61-4130-45f6-87db-ddc657bd744d" />

#### After selecting Customer Segments Sunrise, the picker renders the live light/dark chart preview below.
<img width="2400" height="2454" alt="04-modal-sunrise-selected" src="https://github.com/user-attachments/assets/6c3ce1d1-c285-435d-b5c1-92955e38fae7" />

#### Same chart, same space — palette swapped on the space → bars now in Sunrise (navy / blue / light cyan). Space override beats the project palette.
<img width="2400" height="2454" alt="05-chart-space-sunrise" src="https://github.com/user-attachments/assets/d236e2ff-d988-48e2-9de8-79898b5bc68c" />

#### Chart moved to nested [Fanouts] space (no palette). [Test SQL Generation] (parent root) = Sunrise. Recursive CTE walks up → renders Sunrise.
<img width="2400" height="2454" alt="06-walkup-parent-sunrise" src="https://github.com/user-attachments/assets/3177252d-83e6-4888-adc0-1781a86ce49e" />

#### Same chart, [Fanouts] now overrides with Aurora. Closest-space-wins → bars flip back to Aurora even though the parent is still Sunrise.
<img width="2400" height="2454" alt="07-walkup-child-aurora" src="https://github.com/user-attachments/assets/6265a438-f060-463a-8af4-7b431c92881d" />


## Test plan

- [x] `pnpm -F common|backend|frontend typecheck`
- [x] `pnpm -F common|backend|frontend lint`
- [x] `pnpm -F common test` (1874 pass)
- [x] `pnpm -F backend test:dev:nowatch` (548 pass)
- [x] `pnpm -F backend migrate` clean against fresh instance DB; `color_palette_uuid` column + FK present
- [x] `pnpm generate-api` — `Space.colorPaletteUuid` and `UpdateSpace.colorPaletteUuid` propagated to swagger
- [x] Manual smoke (Chrome DevTools): root space + nested space modals, picker matches name-input size, preview shows on selection only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
