### PR TITLE
docs: account patterns guide for services and controllers

### DIFF
--- a/docs/account-patterns.md
+++ b/docs/account-patterns.md
@@ -1,0 +1,115 @@
+# Account patterns for services and controllers
+
+How to handle the authenticated caller in TSOA controllers and the services they call. Replaces the legacy `req.user` / `SessionUser` style.
+
+This guidance applies to controllers under `packages/backend/src/controllers/` and the services they invoke. Express routers under `packages/backend/src/routers/` are deprecated — new endpoints should be built as TSOA controllers. Don't migrate existing router code to these patterns unless you're already touching it.
+
+The unified `Account` type covers session, PAT, service-account, OAuth, and JWT/embed callers. Reading `req.user` directly only works for session auth and silently degrades for everything else; this doc captures the four rules that keep that surface consistent.
+
+## Concepts glossary
+
+| Term | Meaning |
+|------|---------|
+| **`Account`** | Discriminated union of all auth-method-specific account shapes. Defined in `packages/common/src/types/auth.ts`. |
+| **`RegisteredAccount`** | `Exclude<Account, AnonymousAccount>` — session, PAT, service-account, OAuth. Has a real DB user. |
+| **`AnonymousAccount`** | JWT/embed account. `user` is `ExternalUser`; no DB row. |
+| **`SessionUser`** | Legacy passport-session user shape. Carries no `authentication` discriminant. Avoid in new code. |
+| **`assertRegisteredAccount`** | Type guard that narrows `Account \| undefined` → `RegisteredAccount`, throwing `ForbiddenError` for anonymous/JWT. Defined in `auth.ts:231`. |
+| **`assertIsAccountWithOrg`** | Narrows to "has an organization" — works for both registered and JWT-with-org. |
+| **`createAuditedAbility(account)`** | Helper on `BaseService` that wraps CASL with audit logging. Reads `authentication.type` off the account. |
+
+## The four rules
+
+### 1. Use `req.account`, not `req.user`
+
+```ts
+// ✅
+req.account
+// ❌
+req.user!
+```
+
+`req.user` is set only by the passport session strategy. It is missing or partial for OAuth bearer, JWT/embed, and service-account requests. `req.account` is populated uniformly by `sessionAccountMiddleware` (`packages/backend/src/middlewares/accountMiddleware/`) and `jwtAuthMiddleware` (`packages/backend/src/middlewares/jwtAuthMiddleware/`) for every successful auth path, and carries an `authentication.type` discriminant so handlers can branch on auth method instead of duck-typing.
+
+### 2. Use `assertRegisteredAccount` for registered-only endpoints
+
+```ts
+import { assertRegisteredAccount } from '@lightdash/common';
+
+async listClients(@Request() req: express.Request) {
+    assertRegisteredAccount(req.account);
+    return this.services.getOauthService().listClients(req.account);
+}
+```
+
+Add it as the **first line** of any handler that doesn't intentionally serve embed/JWT traffic. After the assertion, drop the `!` non-null assertion — TypeScript narrows the type for you.
+
+The reasons:
+
+- **Defense in depth at the controller boundary.** Service-level ability checks can accidentally pass for JWT accounts (which legitimately grant view of the embed-bound dashboard). Asserting at the entry point converts a fuzzy "the ability check should deny this" into a hard, explicit denial.
+- **Type narrowing pays for itself.** After the assertion, you can drop `!` non-null assertions and access `account.user.userUuid` without casts.
+- **Self-documenting.** A reader sees the assertion and immediately knows "this endpoint is not part of the embed surface."
+
+### 3. Use `Account` / `RegisteredAccount` in service signatures, not `SessionUser`
+
+| Use | When |
+|---|---|
+| `account: Account` | Service serves both registered and anonymous (e.g. embed-shared `ShareService`). |
+| `account: RegisteredAccount` | Registered-only — pair with `assertRegisteredAccount` in the controller. |
+| `account: SessionAccount` | Session-cookie-only flows (rare). |
+| `user: SessionUser` | **Avoid in new code.** Legacy migration only. |
+
+`SessionUser` lacks the `authentication` discriminant, the organization sub-object, and the request context. `RegisteredAccount` makes "I will not function for anonymous callers" a compile-time contract — bugs where embed users reach a registered-only path become uncompilable, not just possibly caught at runtime by an ability check. `BaseService.createAuditedAbility(account)` also reads the auth method off the account; threading a `SessionUser` would lose it.
+
+If an internal helper or model below still requires `SessionUser`, convert at the boundary with `toSessionUser(account)` (`packages/backend/src/auth/account/account.ts`). Require `RegisteredAccount` at the conversion site so the cast is type-safe.
+
+### 4. Use `account.user.userUuid` only after narrowing to registered
+
+| Account type | `user` shape | `userUuid` | `id` |
+|---|---|---|---|
+| `RegisteredAccount` | `LightdashSessionUser` | ✅ | ✅ (`@deprecated`) |
+| `AnonymousAccount` | `ExternalUser` | ❌ | ✅ (synthesized `external::…`) |
+
+```ts
+// ✅ registered (after assertion)
+assertRegisteredAccount(req.account);
+this.analytics.track({ userId: req.account.user.userUuid, ... });
+
+// ✅ generic (may be anonymous)
+async getByIdOrSlug(account: Account, id: string) {
+    this.logger.info('fetched', { userId: account.user.id });
+}
+```
+
+`id` and `userUuid` are equal on registered accounts but different on anonymous ones — `id` is a synthesized `external::…` string with no DB row. Tables with FKs to `users` (analytics, PATs, audit log) require a real uuid; reading `id` on a registered path silently leaks synthesized ids and explodes when a JWT account hits it. Asserting registered first guarantees `userUuid` exists, and the `@deprecated` tag on `id` for `LightdashSessionUser` codifies that you should not read it on a known-registered account.
+
+## When you genuinely need to allow JWT/anonymous
+
+Don't use `assertRegisteredAccount`. Pick the narrower guard that matches what the handler actually needs:
+
+- `assertIsAccountWithOrg(account)` — narrows to "has an organization", works for registered or JWT-with-org. Used by `ShareService.getShareUrl`.
+- `assertSessionAuth(account)` — narrows to `SessionAccount` (session cookie only).
+
+Embed routes (`/api/v1/embed/...`) expect JWT and don't need any registered assertion — they're the intended JWT surface.
+
+## Migration cheat sheet
+
+When converting an old `user: SessionUser` method:
+
+| Before | After |
+|---|---|
+| `user: SessionUser` | `account: RegisteredAccount` (or `Account` if JWT-reachable) |
+| `req.user!` | `req.account` (after `assertRegisteredAccount`) |
+| `user.userUuid` | `account.user.userUuid` |
+| `user.organizationUuid` | `account.organization.organizationUuid` |
+| `user.organizationName` | `account.organization.name` |
+| `isUserWithOrg(user)` guard | `assertIsAccountWithOrg(account)` |
+| `user.ability.can(...)` | `this.createAuditedAbility(account).can(...)` (audit-logged) |
+
+## Reference
+
+- `packages/common/src/types/auth.ts` — `Account`, `RegisteredAccount`, `AnonymousAccount`, all assertion helpers.
+- `packages/common/src/types/user.ts` — `AccountUser`, `LightdashSessionUser`, `ExternalUser`.
+- `packages/backend/src/auth/account/account.ts` — `fromSession`, `fromApiKey`, `fromJwt`, `fromOauth`, `fromServiceAccount`, `toSessionUser`.
+- `packages/backend/src/middlewares/jwtAuthMiddleware/` — JWT accounts only attach when the URL path contains `embed` or `projects` and the JWT header is present.
+- `docs/audit-logging.md` — how `createAuditedAbility` ties account auth method into audit events.

--- a/packages/backend/src/auth/CLAUDE.md
+++ b/packages/backend/src/auth/CLAUDE.md
@@ -95,6 +95,7 @@ const decoded = await decodeLightdashJwt(jwtToken, encryptedSecret);
 - Account types and interfaces: @packages/common/src/types/auth.ts
 - Permission handling: @packages/common/src/authorization/index.ts
 - Account helper functions: @packages/common/src/authorization/buildAccountHelpers.ts
+- Account patterns for services and controllers: @docs/account-patterns.md
 </links>
 
 <importantToKnow>

--- a/packages/backend/src/controllers/CLAUDE.md
+++ b/packages/backend/src/controllers/CLAUDE.md
@@ -11,12 +11,15 @@ Key patterns:
 - Return `{status: 'ok', results: T}` for success responses
 - Access services via `this.services.get{Service}Service()`
 - Set HTTP status with `this.setStatus(201)` for non-200 responses
+- Pass `req.account` to services. Add `assertRegisteredAccount(req.account)` as the first line of any handler that does not intentionally serve embed/JWT traffic. See `docs/account-patterns.md`.
   </howToUse>
 
 <codeExample>
 
 ```typescript
 // Basic CRUD controller
+import { assertRegisteredAccount } from '@lightdash/common';
+
 @Route('/api/v1/projects')
 @Response<ApiErrorPayload>('default', 'Error')
 @Tags('Projects')
@@ -34,9 +37,10 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Query() includePrivate?: boolean,
     ): Promise<ApiGetCharts> {
+        assertRegisteredAccount(req.account);
         const charts = await this.services
             .getSavedChartService()
-            .getAllSpaces(req.user!, projectUuid, includePrivate);
+            .getAllSpaces(req.account, projectUuid, includePrivate);
         return {
             status: 'ok',
             results: charts,
@@ -55,10 +59,11 @@ export class ProjectController extends BaseController {
         @Body() body: CreateSavedChart,
         @Request() req: express.Request,
     ): Promise<ApiCreateSavedChart> {
+        assertRegisteredAccount(req.account);
         this.setStatus(201);
         const chart = await this.services
             .getSavedChartService()
-            .createSavedChart(req.user!, projectUuid, body);
+            .createSavedChart(req.account, projectUuid, body);
         return {
             status: 'ok',
             results: chart,
@@ -87,7 +92,7 @@ export class ProjectController extends BaseController {
 - Use TSOA decorators for OpenAPI generation and routing
 - Services accessed via `this.services.get{Service}Service()`
 - Consistent response format: `{status: 'ok', results: T}`
-- User object available as `req.user!` in authenticated endpoints
+- Authenticated caller available as `req.account`. Narrow with `assertRegisteredAccount(req.account)` for registered-only endpoints. `req.user!` is the legacy shape — see `docs/account-patterns.md`.
 - All endpoints must have JSDoc comments with description first, then `@summary` tag (2-3 words)
 
 **V2 Differences:**
@@ -111,4 +116,5 @@ export class ProjectController extends BaseController {
 @packages/backend/src/controllers/userController.ts - User management example
 @packages/backend/src/controllers/projectController.ts - Complex resource controller
 @packages/backend/src/controllers/v2/ - V2 API controllers with async patterns
+@docs/account-patterns.md - Patterns for `req.account`, `assertRegisteredAccount`, `RegisteredAccount` vs `SessionUser`
 </links>

--- a/packages/backend/src/services/CLAUDE.md
+++ b/packages/backend/src/services/CLAUDE.md
@@ -82,25 +82,33 @@ export class MyNewService extends BaseService {
         this.config = lightdashConfig;
     }
 
-    async performOperation(user: SessionUser, data: any): Promise<Result> {
-        this.logger.info(`User ${user.userUuid} performing operation`);
+    async performOperation(
+        account: RegisteredAccount,
+        data: any,
+    ): Promise<Result> {
+        this.logger.info(`User ${account.user.userUuid} performing operation`);
 
         try {
-            // Implement business logic
+            // Enforce permissions via the audited ability — never call account.user.ability directly.
+            const ability = this.createAuditedAbility(account);
+            if (ability.cannot('manage', 'MyResource')) {
+                throw new ForbiddenError();
+            }
+
             this.logger.debug('Starting operation with data', { data });
 
             // Call models to persist data
             const result = await this.userModel.someOperation(data);
 
             this.logger.info('Operation completed successfully', {
-                userUuid: user.userUuid,
+                userUuid: account.user.userUuid,
                 resultId: result.id,
             });
 
             return { success: true, result };
         } catch (error) {
             this.logger.error('Operation failed', {
-                userUuid: user.userUuid,
+                userUuid: account.user.userUuid,
                 error: getErrorMessage(error),
             });
             throw error;
@@ -114,6 +122,7 @@ export class MyNewService extends BaseService {
 <importantToKnow>
 - Services are responsible for business logic, while models handle data persistence.
 - Services should validate inputs and enforce access control before performing operations.
+- Service methods should accept `account: RegisteredAccount` (or `Account` if the method legitimately serves embed/JWT callers) — not `user: SessionUser`. Use `account.user.userUuid` for ids and `account.organization.organizationUuid` for org context. Build CASL checks via `this.createAuditedAbility(account)`. See `docs/account-patterns.md` for the migration cheat sheet.
 - Use the logger provided by BaseService for consistent logging across services instead of importing Logger from 'logging/logger'. The logger is available as `this.logger` and supports debug, info, warn, and error levels.
 - Logger best practices:
   - Use `this.logger.debug()` for detailed debugging information
@@ -173,6 +182,7 @@ Permanent delete relies on DB CASCADE for cleanup (schedulers FK to charts/dashb
 <links>
 - Service architecture overview: @/packages/backend/src/services/ServiceRepository.ts
 - Base service class: @/packages/backend/src/services/BaseService.ts
+- Account patterns: @/docs/account-patterns.md
 - Example services:
   - @/packages/backend/src/services/UserService.ts
   - @/packages/backend/src/services/ProjectService/ProjectService.ts


### PR DESCRIPTION
## Summary

Adds a canonical reference doc for handling the authenticated caller in TSOA controllers and the services they call, and updates the relevant CLAUDE files to point at it. Captures the four rules that came out of the SPK-416 / SPK-424 Account migrations:

1. Use `req.account`, not `req.user`
2. Use `assertRegisteredAccount` for registered-only endpoints
3. Use `Account` / `RegisteredAccount` in service signatures, not `SessionUser`
4. Use `account.user.userUuid` only after narrowing to registered (the `id` field is `@deprecated` for registered users and synthesized for JWT/embed)

The doc also covers JWT-allowed alternatives (`assertIsAccountWithOrg`, `assertSessionAuth`) and a migration cheat sheet for converting old `user: SessionUser` methods.

## Scope

- **Applies to** TSOA controllers under `packages/backend/src/controllers/` and the services they invoke.
- **Does not apply to** Express routers under `packages/backend/src/routers/` — those are deprecated; new endpoints should be built as TSOA controllers. Existing router code should not be retrofitted unless it's already being touched.

## Files changed

- `docs/account-patterns.md` (new) — full reference, follows the existing `docs/` style (concepts glossary, rules, code refs, migration cheat sheet).
- `packages/backend/src/controllers/CLAUDE.md` — example uses `assertRegisteredAccount` + `req.account`; conventions and links updated.
- `packages/backend/src/services/CLAUDE.md` — example signature uses `account: RegisteredAccount` and `createAuditedAbility`; conventions and links updated.
- `packages/backend/src/auth/CLAUDE.md` — link added to the doc.

## Test plan

- [x] No code changes — docs/markdown only.
- [ ] CI green