### PR TITLE
refactor(backend): account-aware project & slack controller stragglers

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -670,10 +670,15 @@ export class ProjectController extends BaseController {
         @Body() body: { colorPaletteUuid: string | null },
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getProjectService()
-            .updateColorPalette(req.user!, projectUuid, body.colorPaletteUuid);
+            .updateColorPalette(
+                toSessionUser(req.account),
+                projectUuid,
+                body.colorPaletteUuid,
+            );
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -147,13 +147,14 @@ export class SlackController extends BaseController {
     async isSlackOpenIdLinked(
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         // This will throw a 404 if not found
         await req.services
             .getUserService()
             .isOpenIdLinked(
-                req.user?.userUuid!,
+                toSessionUser(req.account).userUuid,
                 OpenIdIdentityIssuerType.SLACK,
             );
 


### PR DESCRIPTION
## Summary

- Migrates the two remaining `req.user!` call sites in OSS TSOA controllers (`projectController.updateProjectColorPalette`, `slackController.isSlackOpenIdLinked`) to the `assertRegisteredAccount` + `toSessionUser` pattern established in #22597–#22601.
- Anonymous JWT requests to these endpoints now return a clean `403 Forbidden` instead of crashing with `TypeError` on `req.user!.userUuid`.
- Service signatures untouched — conversion happens at the call boundary.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend test:dev:nowatch` (no related tests changed)
- [ ] Manually exercise `PATCH /api/v1/projects/:uuid/colorPalette` as a registered user — palette updates as before
- [ ] Manually exercise `GET /api/v1/slack/is-authenticated` as a registered user — returns linked status as before
- [ ] Hit either endpoint with an anonymous JWT — returns `403`, not a 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)