### PR TITLE
refactor(ee/controllers): assertRegisteredAccount + toSessionUser at handler boundaries

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -7,6 +7,7 @@ import {
     ApiAiOrganizationSettingsResponse,
     ApiErrorPayload,
     ApiUpdateAiOrganizationSettingsResponse,
+    assertRegisteredAccount,
     KnexPaginateArgs,
     UpdateAiOrganizationSettings,
 } from '@lightdash/common';
@@ -24,6 +25,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -62,6 +64,7 @@ export class AiAgentAdminController extends BaseController {
         @Query() sortField?: AiAgentAdminSort['field'],
         @Query() sortDirection?: AiAgentAdminSort['direction'],
     ): Promise<ApiAiAgentAdminConversationsResponse> {
+        assertRegisteredAccount(req.account);
         const paginateArgs: KnexPaginateArgs | undefined =
             page !== undefined || pageSize !== undefined
                 ? {
@@ -92,7 +95,7 @@ export class AiAgentAdminController extends BaseController {
             : undefined;
 
         const threads = await this.getAiAgentAdminService().getAllThreads(
-            req.user!,
+            toSessionUser(req.account),
             paginateArgs,
             filters,
             sort,
@@ -116,10 +119,13 @@ export class AiAgentAdminController extends BaseController {
     async getAllAgents(
         @Request() req: express.Request,
     ): Promise<ApiAiAgentSummaryResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await this.getAiAgentAdminService().listAgents(req.user!),
+            results: await this.getAiAgentAdminService().listAgents(
+                toSessionUser(req.account),
+            ),
         };
     }
 
@@ -131,8 +137,9 @@ export class AiAgentAdminController extends BaseController {
     async getEmbedToken(
         @Request() req: express.Request,
     ): Promise<{ status: string; results: { token: string; url: string } }> {
+        assertRegisteredAccount(req.account);
         const results = await this.getAiAgentAdminService().generateEmbedToken(
-            req.user!,
+            toSessionUser(req.account),
         );
 
         this.setStatus(200);
@@ -153,9 +160,10 @@ export class AiAgentAdminController extends BaseController {
     async getSettings(
         @Request() req: express.Request,
     ): Promise<ApiAiOrganizationSettingsResponse> {
+        assertRegisteredAccount(req.account);
         const settings =
             await this.getAiOrganizationSettingsService().getSettings(
-                req.user!,
+                toSessionUser(req.account),
             );
 
         this.setStatus(200);
@@ -181,9 +189,10 @@ export class AiAgentAdminController extends BaseController {
         @Request() req: express.Request,
         @Body() body: UpdateAiOrganizationSettings,
     ): Promise<ApiUpdateAiOrganizationSettingsResponse> {
+        assertRegisteredAccount(req.account);
         const settings =
             await this.getAiOrganizationSettingsService().upsertSettings(
-                req.user!,
+                toSessionUser(req.account),
                 body,
             );
 

--- a/packages/backend/src/ee/controllers/PreAggregateController.ts
+++ b/packages/backend/src/ee/controllers/PreAggregateController.ts
@@ -1,6 +1,6 @@
 import {
     ApiErrorPayload,
-    AuthorizationError,
+    assertRegisteredAccount,
     type ApiGetDashboardPreAggregateAuditResponse,
     type ApiGetPreAggregateMaterializationsResponse,
     type ApiGetPreAggregateStatsResponse,
@@ -21,6 +21,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -86,19 +87,17 @@ export class PreAggregateController extends BaseController {
         @Path() dashboardUuidOrSlug: string,
         @Request() req: express.Request,
     ): Promise<ApiGetDashboardPreAggregateAuditResponse> {
-        if (!req.user?.userUuid) {
-            throw new AuthorizationError(
-                'Pre-aggregate audit requires a logged-in user',
-            );
-        }
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const dashboard = await this.services
             .getDashboardService()
-            .getByIdOrSlug(req.user, dashboardUuidOrSlug, { projectUuid });
+            .getByIdOrSlug(toSessionUser(req.account), dashboardUuidOrSlug, {
+                projectUuid,
+            });
         const results = await this.services
             .getAsyncQueryService()
             .getDashboardPreAggregateAudit(
-                req.account!,
+                req.account,
                 projectUuid,
                 dashboard.uuid,
             );
@@ -119,19 +118,17 @@ export class PreAggregateController extends BaseController {
         @Body() body: ApiRunDashboardPreAggregateAuditBody,
         @Request() req: express.Request,
     ): Promise<ApiGetDashboardPreAggregateAuditResponse> {
-        if (!req.user?.userUuid) {
-            throw new AuthorizationError(
-                'Pre-aggregate audit requires a logged-in user',
-            );
-        }
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const dashboard = await this.services
             .getDashboardService()
-            .getByIdOrSlug(req.user, dashboardUuidOrSlug, { projectUuid });
+            .getByIdOrSlug(toSessionUser(req.account), dashboardUuidOrSlug, {
+                projectUuid,
+            });
         const results = await this.services
             .getAsyncQueryService()
             .getDashboardPreAggregateAudit(
-                req.account!,
+                req.account,
                 projectUuid,
                 dashboard.uuid,
                 body.dashboardFilters,

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -39,6 +39,7 @@ import {
     ApiUpdateEvaluationRequest,
     ApiUpdateUserAgentPreferences,
     ApiUpdateUserAgentPreferencesResponse,
+    assertRegisteredAccount,
     KnexPaginateArgs,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -59,6 +60,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -80,12 +82,13 @@ export class AiAgentController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
     ): Promise<ApiAiAgentSummaryResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
             status: 'ok',
             results: await this.getAiAgentService().listAgents(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
             ),
         };
@@ -99,11 +102,12 @@ export class AiAgentController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
     ): Promise<ApiGetUserAgentPreferencesResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const userPreferences =
             await this.getAiAgentService().getUserAgentPreferences(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
             );
         return {
@@ -121,9 +125,10 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: ApiUpdateUserAgentPreferences,
     ): Promise<ApiUpdateUserAgentPreferencesResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.getAiAgentService().updateUserAgentPreferences(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             body,
         );
@@ -141,9 +146,10 @@ export class AiAgentController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.getAiAgentService().deleteUserAgentPreferences(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
         );
         return {
@@ -161,9 +167,10 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Path() agentUuid: string,
     ): Promise<ApiAiAgentResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const agent = await this.getAiAgentService().getAgent(
-            req.user!,
+            toSessionUser(req.account),
             agentUuid,
             projectUuid,
         );
@@ -182,9 +189,10 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Path() agentUuid: string,
     ): Promise<ApiAiAgentModelOptionsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const models = await this.getAiAgentService().getModelOptions(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
         );
@@ -203,10 +211,11 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Path() agentUuid: string,
     ): Promise<ApiAgentReadinessScoreResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const readinessScore = await this.getAiAgentService().evaluateReadiness(
-            req.user!,
+            toSessionUser(req.account),
             { agentUuid, projectUuid },
         );
 
@@ -227,6 +236,7 @@ export class AiAgentController extends BaseController {
         @Query() page?: KnexPaginateArgs['page'],
         @Query() pageSize?: KnexPaginateArgs['pageSize'],
     ): Promise<ApiAiAgentVerifiedArtifactsResponse> {
+        assertRegisteredAccount(req.account);
         const paginateArgs: KnexPaginateArgs | undefined =
             page !== undefined || pageSize !== undefined
                 ? {
@@ -239,7 +249,7 @@ export class AiAgentController extends BaseController {
                   };
 
         const result = await this.getAiAgentService().getVerifiedArtifacts(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             paginateArgs,
@@ -261,11 +271,12 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Path() agentUuid: string,
     ): Promise<ApiAiAgentVerifiedQuestionsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiAgentService().getVerifiedQuestions(
-                req.user!,
+                toSessionUser(req.account),
                 agentUuid,
             ),
         };
@@ -284,11 +295,15 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: ApiCreateAiAgent,
     ): Promise<ApiCreateAiAgentResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(201);
-        const agent = await this.getAiAgentService().createAgent(req.user!, {
-            ...body,
-            projectUuid,
-        });
+        const agent = await this.getAiAgentService().createAgent(
+            toSessionUser(req.account),
+            {
+                ...body,
+                projectUuid,
+            },
+        );
         return {
             status: 'ok',
             results: agent,
@@ -309,9 +324,10 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Body() body: ApiUpdateAiAgent,
     ): Promise<ApiAiAgentResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const agent = await this.getAiAgentService().updateAgent(
-            req.user!,
+            toSessionUser(req.account),
             agentUuid,
             { ...body, projectUuid },
         );
@@ -334,8 +350,12 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Path() agentUuid: string,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
-        await this.getAiAgentService().deleteAgent(req.user!, agentUuid);
+        await this.getAiAgentService().deleteAgent(
+            toSessionUser(req.account),
+            agentUuid,
+        );
 
         return {
             status: 'ok',
@@ -353,11 +373,12 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Query() allUsers?: boolean,
     ): Promise<ApiAiAgentThreadSummaryListResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiAgentService().listAgentThreads(
-                req.user!,
+                toSessionUser(req.account),
                 agentUuid,
                 allUsers,
             ),
@@ -374,11 +395,12 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() threadUuid: string,
     ): Promise<ApiAiAgentThreadResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiAgentService().getAgentThread(
-                req.user!,
+                toSessionUser(req.account),
                 agentUuid,
                 threadUuid,
             ),
@@ -395,11 +417,12 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Body() body: ApiAiAgentThreadCreateRequest,
     ): Promise<ApiAiAgentThreadCreateResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiAgentService().createAgentThread(
-                req.user!,
+                toSessionUser(req.account),
                 agentUuid,
                 body,
             ),
@@ -417,11 +440,12 @@ export class AiAgentController extends BaseController {
         @Path() threadUuid: string,
         @Body() body: ApiAiAgentThreadMessageCreateRequest,
     ): Promise<ApiAiAgentThreadMessageCreateResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiAgentService().createAgentThreadMessage(
-                req.user!,
+                toSessionUser(req.account),
                 agentUuid,
                 threadUuid,
                 body,
@@ -439,8 +463,9 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() threadUuid: string,
     ): Promise<void> {
+        assertRegisteredAccount(req.account);
         const stream = await this.getAiAgentService().streamAgentThreadResponse(
-            req.user!,
+            toSessionUser(req.account),
             {
                 agentUuid,
                 threadUuid,
@@ -507,11 +532,12 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() threadUuid: string,
     ): Promise<ApiAiAgentThreadGenerateResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const response =
             await this.getAiAgentService().generateAgentThreadResponse(
-                req.user!,
+                toSessionUser(req.account),
                 {
                     agentUuid,
                     threadUuid,
@@ -536,10 +562,11 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() threadUuid: string,
     ): Promise<ApiAiAgentThreadGenerateTitleResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const title = await this.getAiAgentService().generateThreadTitle(
-            req.user!,
+            toSessionUser(req.account),
             {
                 agentUuid,
                 threadUuid,
@@ -566,10 +593,11 @@ export class AiAgentController extends BaseController {
         @Path() promptUuid: string,
         @Query() createdFrom?: 'web_app' | 'evals',
     ): Promise<ApiCloneThreadResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const clonedThread = await this.getAiAgentService().cloneThread(
-            req.user!,
+            toSessionUser(req.account),
             agentUuid,
             threadUuid,
             promptUuid,
@@ -596,14 +624,18 @@ export class AiAgentController extends BaseController {
         @Path() messageUuid: string,
         @Body() body: { savedQueryUuid: string | null },
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
-        await this.getAiAgentService().updateMessageSavedQuery(req.user!, {
-            savedQueryUuid: body.savedQueryUuid,
-            agentUuid,
-            threadUuid,
-            messageUuid,
-        });
+        await this.getAiAgentService().updateMessageSavedQuery(
+            toSessionUser(req.account),
+            {
+                savedQueryUuid: body.savedQueryUuid,
+                agentUuid,
+                threadUuid,
+                messageUuid,
+            },
+        );
 
         return {
             status: 'ok',
@@ -623,9 +655,10 @@ export class AiAgentController extends BaseController {
         @Path() messageUuid: string,
         @Body() body: { humanScore: number; humanFeedback?: string | null },
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.getAiAgentService().updateHumanScoreForMessage(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             threadUuid,
@@ -648,12 +681,13 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: { tags: string[] | null },
     ): Promise<ApiAiAgentExploreAccessSummaryResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results:
                 await this.getAiAgentService().getAgentExploreAccessSummary(
-                    req.user!,
+                    toSessionUser(req.account),
                     projectUuid,
                     body.tags,
                 ),
@@ -670,12 +704,13 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() artifactUuid: string,
     ): Promise<ApiAiAgentArtifactResponseTSOACompat> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
             status: 'ok',
             results: (await this.getAiAgentService().getArtifact(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 agentUuid,
                 artifactUuid,
@@ -694,6 +729,7 @@ export class AiAgentController extends BaseController {
         @Path() artifactUuid: string,
         @Path() versionUuid: string,
     ): Promise<ApiAiAgentArtifactResponseTSOACompat> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         return {
@@ -701,7 +737,7 @@ export class AiAgentController extends BaseController {
             // Use simplified type for TSOA Compat
 
             results: (await this.getAiAgentService().getArtifact(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 agentUuid,
                 artifactUuid,
@@ -723,11 +759,12 @@ export class AiAgentController extends BaseController {
         @Path() artifactUuid: string,
         @Path() versionUuid: string,
     ): Promise<ApiAiAgentThreadMessageVizQueryResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiAgentService().getArtifactVizQuery(
-                req.user!,
+                toSessionUser(req.account),
                 {
                     projectUuid,
                     agentUuid,
@@ -752,12 +789,13 @@ export class AiAgentController extends BaseController {
         @Path() versionUuid: string,
         @Path() chartIndex: number,
     ): Promise<ApiAiAgentThreadMessageVizQueryResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results:
                 await this.getAiAgentService().getDashboardArtifactChartVizQuery(
-                    req.user!,
+                    toSessionUser(req.account),
                     {
                         projectUuid,
                         agentUuid,
@@ -783,14 +821,18 @@ export class AiAgentController extends BaseController {
         @Path() versionUuid: string,
         @Body() body: { savedDashboardUuid: string | null },
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
-        await this.getAiAgentService().updateArtifactVersion(req.user!, {
-            agentUuid,
-            artifactUuid,
-            versionUuid,
-            savedDashboardUuid: body.savedDashboardUuid,
-        });
+        await this.getAiAgentService().updateArtifactVersion(
+            toSessionUser(req.account),
+            {
+                agentUuid,
+                artifactUuid,
+                versionUuid,
+                savedDashboardUuid: body.savedDashboardUuid,
+            },
+        );
 
         return {
             status: 'ok',
@@ -816,14 +858,18 @@ export class AiAgentController extends BaseController {
         @Path() versionUuid: string,
         @Body() body: { verified: boolean },
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
-        await this.getAiAgentService().setArtifactVersionVerified(req.user!, {
-            agentUuid,
-            artifactUuid,
-            versionUuid,
-            verified: body.verified,
-        });
+        await this.getAiAgentService().setArtifactVersionVerified(
+            toSessionUser(req.account),
+            {
+                agentUuid,
+                artifactUuid,
+                versionUuid,
+                verified: body.verified,
+            },
+        );
 
         return {
             status: 'ok',
@@ -845,10 +891,11 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Body() body: ApiCreateEvaluationRequest,
     ): Promise<ApiCreateEvaluationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(201);
 
         const evaluation = await this.getAiAgentService().createEval(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             body,
@@ -874,10 +921,11 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() evalUuid: string,
     ): Promise<ApiAiAgentEvaluationRunResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const evalRun = await this.getAiAgentService().runEval(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             evalUuid,
@@ -898,10 +946,11 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Path() agentUuid: string,
     ): Promise<ApiAiAgentEvaluationSummaryListResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const evaluations = await this.getAiAgentService().getEvalsByAgent(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
         );
@@ -922,10 +971,11 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() evalUuid: string,
     ): Promise<ApiAiAgentEvaluationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const evaluation = await this.getAiAgentService().getEval(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             evalUuid,
@@ -949,6 +999,7 @@ export class AiAgentController extends BaseController {
         @Query() page?: KnexPaginateArgs['page'],
         @Query() pageSize?: KnexPaginateArgs['pageSize'],
     ): Promise<ApiAiAgentEvaluationRunSummaryListResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const paginateArgs: KnexPaginateArgs | undefined =
@@ -960,7 +1011,7 @@ export class AiAgentController extends BaseController {
                 : undefined;
 
         const runs = await this.getAiAgentService().getEvalRuns(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             evalUuid,
@@ -984,10 +1035,11 @@ export class AiAgentController extends BaseController {
         @Path() evalUuid: string,
         @Path() runUuid: string,
     ): Promise<ApiAiAgentEvaluationRunResultsResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const runResults = await this.getAiAgentService().getEvalRunWithResults(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             evalUuid,
@@ -1016,10 +1068,11 @@ export class AiAgentController extends BaseController {
         @Body()
         body: ApiUpdateEvaluationRequest,
     ): Promise<ApiAiAgentEvaluationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const evaluation = await this.getAiAgentService().updateEval(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             evalUuid,
@@ -1047,10 +1100,11 @@ export class AiAgentController extends BaseController {
         @Path() evalUuid: string,
         @Body() body: ApiAppendEvaluationRequest,
     ): Promise<ApiAiAgentEvaluationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const evaluation = await this.getAiAgentService().appendToEval(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             evalUuid,
@@ -1077,10 +1131,11 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() evalUuid: string,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         await this.getAiAgentService().deleteEval(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             agentUuid,
             evalUuid,
@@ -1106,11 +1161,12 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Body() body: ApiAppendInstructionRequest,
     ): Promise<ApiAppendInstructionResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         const updatedInstruction =
             await this.getAiAgentService().appendInstruction(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 agentUuid,
                 body.instruction,
@@ -1142,14 +1198,18 @@ export class AiAgentController extends BaseController {
         @Path() promptUuid: string,
         @Body() body: ApiRevertChangeRequest,
     ): Promise<ApiRevertChangeResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
-        await this.getAiAgentService().revertChange(req.user!, {
-            agentUuid,
-            threadUuid,
-            promptUuid,
-            changeUuid: body.changeUuid,
-        });
+        await this.getAiAgentService().revertChange(
+            toSessionUser(req.account),
+            {
+                agentUuid,
+                threadUuid,
+                promptUuid,
+                changeUuid: body.changeUuid,
+            },
+        );
 
         return {
             status: 'ok',

--- a/packages/backend/src/ee/controllers/aiController.ts
+++ b/packages/backend/src/ee/controllers/aiController.ts
@@ -7,6 +7,7 @@ import {
     ApiAiGenerateTooltipResponse,
     ApiAiGetDashboardSummaryResponse,
     ApiErrorPayload,
+    assertRegisteredAccount,
     DashboardSummary,
     GenerateChartMetadataRequest,
     GenerateFormulaTableCalculationRequest,
@@ -28,6 +29,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -49,11 +51,12 @@ export class AiController extends BaseController {
         @Path() dashboardUuid: string,
         @Body() body: Pick<DashboardSummary, 'context' | 'tone' | 'audiences'>,
     ): Promise<ApiAiDashboardSummaryResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiService().createDashboardSummary(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 dashboardUuid,
                 body,
@@ -70,11 +73,12 @@ export class AiController extends BaseController {
         @Path() projectUuid: string,
         @Path() dashboardUuidOrSlug: string,
     ): Promise<ApiAiGetDashboardSummaryResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiService().getDashboardSummary(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 dashboardUuidOrSlug,
             ),
@@ -98,11 +102,12 @@ export class AiController extends BaseController {
             currentVizConfig: string;
         },
     ): Promise<ApiAiGenerateCustomVizResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiService().generateCustomViz({
-                user: req.user!,
+                user: toSessionUser(req.account),
                 projectUuid,
                 ...body,
             }),
@@ -118,11 +123,12 @@ export class AiController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: GenerateChartMetadataRequest,
     ): Promise<ApiAiGenerateChartMetadataResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiService().generateChartMetadata(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 body,
             ),
@@ -138,11 +144,12 @@ export class AiController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: GenerateTableCalculationRequest,
     ): Promise<ApiAiGenerateTableCalculationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiService().generateTableCalculation(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 body,
             ),
@@ -158,11 +165,12 @@ export class AiController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: GenerateFormulaTableCalculationRequest,
     ): Promise<ApiAiGenerateFormulaTableCalculationResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiService().generateFormulaTableCalculation(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 body,
             ),
@@ -178,11 +186,12 @@ export class AiController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: GenerateTooltipRequest,
     ): Promise<ApiAiGenerateTooltipResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getAiService().generateTooltip(
-                req.user!,
+                toSessionUser(req.account),
                 projectUuid,
                 body,
             ),

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    assertRegisteredAccount,
     ParameterError,
     type ApiAppImageUploadResponse,
     type ApiAppImageUrlResponse,
@@ -33,6 +34,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -53,9 +55,10 @@ export class AppGenerateController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: GenerateAppRequestBody,
     ): Promise<ApiGenerateAppResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const result = await this.getAppGenerateService().generateApp(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             body.prompt,
             body.imageIds ?? [],
@@ -87,9 +90,10 @@ export class AppGenerateController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: ApiClarifyAppRequest,
     ): Promise<ApiClarifyAppResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const result = await this.getAppGenerateService().clarifyApp(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             body.prompt,
             body.template,
@@ -115,6 +119,7 @@ export class AppGenerateController extends BaseController {
         @Path() projectUuid: string,
         @Path() appUuid: string,
     ): Promise<ApiAppImageUploadResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const mimeType = req.headers['content-type'];
         if (!mimeType) {
@@ -130,7 +135,7 @@ export class AppGenerateController extends BaseController {
             );
         }
         const result = await this.getAppGenerateService().uploadImage(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             mimeType,
             req,
@@ -158,8 +163,9 @@ export class AppGenerateController extends BaseController {
         @Query() beforeVersion?: number,
         @Query() limit?: number,
     ): Promise<ApiGetAppResponse> {
+        assertRegisteredAccount(req.account);
         const result = await this.getAppGenerateService().getAppVersions(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             appUuid,
             { beforeVersion, limit },
@@ -185,9 +191,10 @@ export class AppGenerateController extends BaseController {
         @Path() appUuid: string,
         @Body() body: GenerateAppRequestBody,
     ): Promise<ApiGenerateAppResponse> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const result = await this.getAppGenerateService().iterateApp(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             appUuid,
             body.prompt,
@@ -215,8 +222,9 @@ export class AppGenerateController extends BaseController {
         @Path() appUuid: string,
         @Path() version: number,
     ): Promise<ApiCancelAppVersionResponse> {
+        assertRegisteredAccount(req.account);
         await this.getAppGenerateService().cancelVersion(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             appUuid,
             version,
@@ -241,8 +249,9 @@ export class AppGenerateController extends BaseController {
         @Path() appUuid: string,
         @Body() body: ApiUpdateAppRequest,
     ): Promise<ApiUpdateAppResponse> {
+        assertRegisteredAccount(req.account);
         const result = await this.getAppGenerateService().updateApp(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             appUuid,
             body,
@@ -268,8 +277,9 @@ export class AppGenerateController extends BaseController {
         @Path() projectUuid: string,
         @Path() appUuid: string,
     ): Promise<ApiDeleteAppResponse> {
+        assertRegisteredAccount(req.account);
         await this.getAppGenerateService().deleteApp(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             appUuid,
         );
@@ -292,8 +302,9 @@ export class AppGenerateController extends BaseController {
         @Path() projectUuid: string,
         @Path() appUuid: string,
     ): Promise<ApiTogglePinnedItem> {
+        assertRegisteredAccount(req.account);
         const result = await this.getAppGenerateService().togglePinning(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             appUuid,
         );
@@ -317,8 +328,9 @@ export class AppGenerateController extends BaseController {
         @Path() appUuid: string,
         @Path() version: number,
     ): Promise<ApiPreviewTokenResponse> {
+        assertRegisteredAccount(req.account);
         const token = await this.getAppGenerateService().getPreviewToken(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             appUuid,
             version,
@@ -339,8 +351,9 @@ export class AppGenerateController extends BaseController {
         @Path() appUuid: string,
         @Path() imageId: string,
     ): Promise<ApiAppImageUrlResponse> {
+        assertRegisteredAccount(req.account);
         const result = await this.getAppGenerateService().getImageUrl(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             appUuid,
             imageId,
@@ -373,10 +386,11 @@ export class UserAppsController extends BaseController {
         @Query() page?: number,
         @Query() pageSize?: number,
     ): Promise<ApiMyAppsResponse> {
+        assertRegisteredAccount(req.account);
         const result = await this.services
             .getAppGenerateService<AppGenerateService>()
             .listMyApps(
-                req.user!,
+                toSessionUser(req.account),
                 page && pageSize ? { page, pageSize } : undefined,
             );
         return {

--- a/packages/backend/src/ee/controllers/databricksSSOController.ts
+++ b/packages/backend/src/ee/controllers/databricksSSOController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiSuccessEmpty,
+    assertRegisteredAccount,
     DatabricksAuthenticationType,
     NotFoundError,
     WarehouseTypes,
@@ -16,6 +17,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -35,6 +37,7 @@ export class DatabricksSSOController extends BaseController {
     @Get('/is-authenticated')
     @OperationId('getDatabricksAccessToken')
     async get(@Request() req: express.Request): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         const projectUuid =
             typeof req.query.projectUuid === 'string'
@@ -47,7 +50,10 @@ export class DatabricksSSOController extends BaseController {
         if (projectUuid) {
             const authInfo = await this.services
                 .getProjectService()
-                .getProjectWarehouseAuthInfo(req.user!, projectUuid);
+                .getProjectWarehouseAuthInfo(
+                    toSessionUser(req.account),
+                    projectUuid,
+                );
             // M2M auth uses project-level credentials, so no per-user SSO is expected.
             if (
                 authInfo.type === WarehouseTypes.DATABRICKS &&
@@ -61,7 +67,10 @@ export class DatabricksSSOController extends BaseController {
             }
             const credentials = await this.services
                 .getProjectService()
-                .getProjectCredentialsPreference(req.user!, projectUuid);
+                .getProjectCredentialsPreference(
+                    toSessionUser(req.account),
+                    projectUuid,
+                );
             if (credentials?.credentials.type !== WarehouseTypes.DATABRICKS) {
                 throw new NotFoundError(
                     'Databricks credentials not found for this project',
@@ -70,7 +79,10 @@ export class DatabricksSSOController extends BaseController {
         } else if (serverHostName) {
             const hasHostCredential = await this.services
                 .getUserService()
-                .hasDatabricksOAuthCredentialForHost(req.user!, serverHostName);
+                .hasDatabricksOAuthCredentialForHost(
+                    toSessionUser(req.account),
+                    serverHostName,
+                );
             if (!hasHostCredential) {
                 throw new NotFoundError(
                     'Databricks credentials not found for this workspace',
@@ -80,7 +92,7 @@ export class DatabricksSSOController extends BaseController {
             // Fallback for non-project scoped checks
             await this.services
                 .getUserService()
-                .getAccessToken(req.user!, 'databricks');
+                .getAccessToken(toSessionUser(req.account), 'databricks');
         }
         return {
             status: 'ok',

--- a/packages/backend/src/ee/controllers/managedAgentController.ts
+++ b/packages/backend/src/ee/controllers/managedAgentController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    assertRegisteredAccount,
     ManagedAgentAction,
     ManagedAgentActionType,
     ManagedAgentSettings,
@@ -21,6 +22,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -44,8 +46,9 @@ export class ManagedAgentController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
     ): Promise<{ status: 'ok'; results: ManagedAgentSettings | null }> {
+        assertRegisteredAccount(req.account);
         const results = await this.getManagedAgentService().getSettings(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
         );
         this.setStatus(200);
@@ -60,10 +63,11 @@ export class ManagedAgentController extends BaseController {
         @Path() projectUuid: string,
         @Body() body: UpdateManagedAgentSettings,
     ): Promise<{ status: 'ok'; results: ManagedAgentSettings }> {
+        assertRegisteredAccount(req.account);
         const results = await this.getManagedAgentService().updateSettings(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
-            req.user!.userUuid,
+            toSessionUser(req.account).userUuid,
             body,
         );
         this.setStatus(200);
@@ -77,8 +81,9 @@ export class ManagedAgentController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
     ): Promise<{ status: 'ok'; results: undefined }> {
+        assertRegisteredAccount(req.account);
         await this.getManagedAgentService().startHeartbeat(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
         );
         this.setStatus(202);
@@ -95,8 +100,9 @@ export class ManagedAgentController extends BaseController {
         @Query() actionType?: string,
         @Query() sessionId?: string,
     ): Promise<{ status: 'ok'; results: ManagedAgentAction[] }> {
+        assertRegisteredAccount(req.account);
         const results = await this.getManagedAgentService().getActions(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             {
                 date,
@@ -116,11 +122,12 @@ export class ManagedAgentController extends BaseController {
         @Path() projectUuid: string,
         @Path() actionUuid: string,
     ): Promise<{ status: 'ok'; results: ManagedAgentAction }> {
+        assertRegisteredAccount(req.account);
         const results = await this.getManagedAgentService().reverseAction(
-            req.user!,
+            toSessionUser(req.account),
             projectUuid,
             actionUuid,
-            req.user!.userUuid,
+            toSessionUser(req.account).userUuid,
         );
         this.setStatus(200);
         return { status: 'ok', results };

--- a/packages/backend/src/ee/controllers/scimOrganizationAccessTokenController.ts
+++ b/packages/backend/src/ee/controllers/scimOrganizationAccessTokenController.ts
@@ -1,6 +1,7 @@
 import {
     ApiCreateScimServiceAccountRequest,
     ApiErrorPayload,
+    assertRegisteredAccount,
     AuthTokenPrefix,
     ScimErrorPayload,
     ServiceAccount,
@@ -24,6 +25,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -51,8 +53,9 @@ export class ScimOrganizationAccessTokenController extends BaseController {
     async getOrganizationAccessTokens(
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ServiceAccount[] }> {
+        assertRegisteredAccount(req.account);
         const results = await this.getServiceAccountService().list(
-            req.user!,
+            toSessionUser(req.account),
             SCIM_SCOPES,
         );
         this.setStatus(200);
@@ -77,11 +80,13 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ApiCreateScimServiceAccountRequest, // Service account request without scopes
     ): Promise<{ status: 'ok'; results: ServiceAccount }> {
+        assertRegisteredAccount(req.account);
         const token = await this.getServiceAccountService().create({
-            user: req.user!,
+            user: toSessionUser(req.account),
             tokenDetails: {
                 ...body,
-                organizationUuid: req.user?.organizationUuid as string,
+                organizationUuid: req.account.organization
+                    .organizationUuid as string,
                 scopes: SCIM_SCOPES,
             },
             prefix: AuthTokenPrefix.SCIM,
@@ -108,8 +113,9 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         @Request() req: express.Request,
         @Path() tokenUuid: string,
     ): Promise<{ status: 'ok'; results: undefined }> {
+        assertRegisteredAccount(req.account);
         await this.getServiceAccountService().delete({
-            user: req.user!,
+            user: toSessionUser(req.account),
             tokenUuid,
         });
         return {
@@ -134,11 +140,12 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         @Path() tokenUuid: string,
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ServiceAccount }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getServiceAccountService().get({
-                user: req.user!,
+                user: toSessionUser(req.account),
                 tokenUuid,
             }),
         };
@@ -167,11 +174,12 @@ export class ScimOrganizationAccessTokenController extends BaseController {
         status: 'ok';
         results: ServiceAccountWithToken;
     }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getServiceAccountService().rotate({
-                user: req.user!,
+                user: toSessionUser(req.account),
                 tokenUuid,
                 update: body,
                 prefix: AuthTokenPrefix.SCIM,

--- a/packages/backend/src/ee/controllers/serviceAccountsController.ts
+++ b/packages/backend/src/ee/controllers/serviceAccountsController.ts
@@ -1,6 +1,7 @@
 import {
     ApiCreateServiceAccountRequest,
     ApiErrorPayload,
+    assertRegisteredAccount,
     AuthTokenPrefix,
     ServiceAccount,
     ServiceAccountScope,
@@ -20,6 +21,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -44,12 +46,13 @@ export class ServiceAccountsController extends BaseController {
     async getServiceAccounts(
         @Request() req: express.Request,
     ): Promise<{ status: 'ok'; results: ServiceAccount[] }> {
+        assertRegisteredAccount(req.account);
         // Here all scopes but scim to get all non scim service accounts
         const scopes = Object.values(ServiceAccountScope).filter(
             (scope) => scope !== ServiceAccountScope.SCIM_MANAGE,
         );
         const results = await this.getServiceAccountService().list(
-            req.user!,
+            toSessionUser(req.account),
             scopes,
         );
         this.setStatus(200);
@@ -73,11 +76,13 @@ export class ServiceAccountsController extends BaseController {
         @Request() req: express.Request,
         @Body() body: ApiCreateServiceAccountRequest,
     ): Promise<{ status: 'ok'; results: ServiceAccount }> {
+        assertRegisteredAccount(req.account);
         const token = await this.getServiceAccountService().create({
-            user: req.user!,
+            user: toSessionUser(req.account),
             tokenDetails: {
                 ...body,
-                organizationUuid: req.user?.organizationUuid as string,
+                organizationUuid: req.account.organization
+                    .organizationUuid as string,
             },
             prefix: AuthTokenPrefix.SERVICE_ACCOUNT,
         });
@@ -102,8 +107,9 @@ export class ServiceAccountsController extends BaseController {
         @Request() req: express.Request,
         @Path() tokenUuid: string,
     ): Promise<{ status: 'ok'; results: undefined }> {
+        assertRegisteredAccount(req.account);
         await this.getServiceAccountService().delete({
-            user: req.user!,
+            user: toSessionUser(req.account),
             tokenUuid,
         });
         return {

--- a/packages/backend/src/ee/controllers/snowflakeController.ts
+++ b/packages/backend/src/ee/controllers/snowflakeController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiSuccessEmpty,
+    assertRegisteredAccount,
     ForbiddenError,
 } from '@lightdash/common';
 import {
@@ -15,6 +16,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import { lightdashConfig } from '../../config/lightdashConfig';
 import {
     allowApiKeyAuthentication,
@@ -37,6 +39,7 @@ export class SnowflakeController extends BaseController {
     async ssoIsAuthenticated(
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         if (!lightdashConfig.license.licenseKey) {
@@ -48,7 +51,7 @@ export class SnowflakeController extends BaseController {
         // This will throw an error if the user is not authenticated with snowflake scopes
         const accessToken = await this.services
             .getUserService()
-            .getAccessToken(req.user!, 'snowflake');
+            .getAccessToken(toSessionUser(req.account), 'snowflake');
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/ee/controllers/supportController.ts
+++ b/packages/backend/src/ee/controllers/supportController.ts
@@ -1,4 +1,8 @@
-import { AnyType, ApiErrorPayload } from '@lightdash/common';
+import {
+    AnyType,
+    ApiErrorPayload,
+    assertRegisteredAccount,
+} from '@lightdash/common';
 import {
     Body,
     Hidden,
@@ -11,6 +15,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -42,10 +47,11 @@ export class SupportController extends BaseController {
             network: AnyType[];
         },
     ): Promise<{ status: 'ok' }> {
+        assertRegisteredAccount(req.account);
         this.setStatus(200);
 
         await this.getSupportService().shareWithSupport(
-            req.user!,
+            toSessionUser(req.account),
             body,
             req.headers,
         );


### PR DESCRIPTION
### Description

Applies the [Controller refactor: SessionUser → Account-aware via toSessionUser](https://www.notion.so/lightdash/Controller-refactor-SessionUser-Account-aware-via-toSessionUser-352a63207a7a81cda7d9ec0549a874b7) pattern to every EE controller. Localizes the `SessionUser` → `Account` migration to the controller layer — services keep accepting `SessionUser`, controllers narrow `req.account` once at the top of each handler and convert at the call site via `toSessionUser`.

### Pattern applied per handler

```ts
async someHandler(@Request() req: express.Request) {
    assertRegisteredAccount(req.account);   // 1. assert FIRST
    this.setStatus(200);                    // 2. status AFTER assert

    return {
        status: 'ok',
        results: await this.services.getXService()
            .doThing(toSessionUser(req.account), ...),   // 3. convert at call site
    };
}
```

- `assertRegisteredAccount(req.account)` is the first statement of every gated handler.
- Every `req.user!` is replaced with `toSessionUser(req.account)` inline at the call site (no local `const user = ...`).
- No service signatures changed.

### Files refactored (10)

| Controller | Notes |
|---|---|
| `AiAgentAdminController.ts` | 5 handlers gated |
| `aiAgentController.ts` | 40 handlers gated (large file) |
| `aiController.ts` | 7 handlers gated |
| `appGenerateController.ts` | 12 handlers gated (incl. `UserAppsController`) |
| `managedAgentController.ts` | 5 handlers gated; `req.user!.userUuid` → `toSessionUser(req.account).userUuid` |
| `databricksSSOController.ts` | 1 handler gated, 4 internal calls converted |
| `snowflakeController.ts` | 1 handler gated |
| `scimOrganizationAccessTokenController.ts` | 5 handlers gated; `req.user?.organizationUuid as string` → `req.account.organization.organizationUuid as string` |
| `serviceAccountsController.ts` | 3 handlers gated |
| `supportController.ts` | 1 handler gated |
| `PreAggregateController.ts` | **mixed** — 2 handlers gated (`getDashboardPreAggregateAudit`, `runDashboardPreAggregateAudit`), `getPreAggregateStats` left as-is (only takes `Account`); the now-redundant `if (!req.user?.userUuid) throw AuthorizationError` checks were removed since `assertRegisteredAccount` covers them, and the `AuthorizationError` import is dropped |

### Files intentionally left untouched

Per the [Skip handlers that already accept `Account`](https://www.notion.so/lightdash/Controller-refactor-SessionUser-Account-aware-via-toSessionUser-352a63207a7a81cda7d9ec0549a874b7) rule:

- `embedController.ts` — uses `assertSessionAuth` / `assertEmbeddedAuth`; intentionally supports anonymous JWT/embed accounts.
- `scimGroupController.ts`, `scimUserController.ts` — pass `req.account!` to a service that accepts `Account`; gating these would break SCIM service-account auth.
- `CustomRolesController.ts`, `OrganizationWarehouseCredentialsController.ts` — already use the new pattern.
- `scimRoleController.ts`, `scimRootController.ts` — no `req.user`/`req.account` references.

### Behavior change

- Endpoints that took `SessionUser` (admin / registered-only): anonymous JWT requests now return a clean `403 Forbidden` instead of crashing on `req.user!.userUuid`.
- Endpoints that took `Account` (embed/SCIM): untouched — embed flows still work.
- Audit logs: `requestContext` and `serviceAccount` flow through `toSessionUser`, so `createAuditedAbility` keeps full attribution.

### Verification

- `pnpm -F backend typecheck` — no new errors in EE controllers (5 pre-existing errors on main about `colorPaletteUuid` are unrelated to this PR).
- `pnpm -F backend lint` — passes.
- `grep "req.user!" packages/backend/src/ee/controllers/` — zero matches in gated handlers.
- `grep "req.account!" packages/backend/src/ee/controllers/` — only matches handlers intentionally left as-is (embed, SCIM, `getPreAggregateStats`).

## Test plan

- [ ] Sign in as a registered user and exercise an AI agent endpoint, an app generate endpoint, and the support share endpoint to confirm no regression in normal flows.
- [ ] Hit a SCIM endpoint with a SCIM service-account token to confirm SCIM auth still works (untouched).
- [ ] Hit an embed/JWT endpoint to confirm the embed flow still works (untouched).
- [ ] Confirm CI typecheck/lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)