### PR TITLE
feat(data-apps): add refresh preview button [GLITCH-380]

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -137,6 +137,15 @@ This means Claude can see what it built previously and make targeted changes rat
 Users can cancel a building version. This atomically marks it as `status='error'` in the database and pauses the sandbox
 (interrupting any running commands). The sandbox remains resumable for subsequent iterations.
 
+### Refreshing the preview
+
+A refresh button in the preview header reloads the iframe to re-execute the app's metric queries against the warehouse,
+without kicking off a new code-gen iteration. The motivating use case is "I just pushed a semantic-layer change while
+Claude is still iterating in the sidebar — show me what the queries look like now." Implementation: `AppGenerate` owns
+a `previewRefreshKey` counter that gets baked into the iframe URL as `&r={key}`. Bumping the counter changes the URL,
+which forces the browser to reload the iframe; the served bundle and the JWT are unaffected. The query inspector panel
+is cleared on refresh so the new query run isn't mixed with stale entries from the previous load.
+
 ### Deletion
 
 Deleting an app goes through a single `DELETE /apps/{appUuid}` endpoint that routes to one of two modes based on the

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -7,6 +7,12 @@ import {
 
 type Props = {
     src: string;
+    /** Stable identity for the served bundle (e.g. `${appUuid}:${version}`).
+     *  Drives the inspector-availability reset — changes here mean a new
+     *  bundle whose SDK capabilities are unknown, so we re-await an announce.
+     *  A pure URL bump (e.g. the manual refresh counter) keeps this stable
+     *  so the Inspect button doesn't flash off and back on. */
+    identityKey: string;
     onQueryEvent?: (event: QueryEvent) => void;
     onElementSelected?: (event: ElementSelectedEvent) => void;
     /** When true, the iframe-side inspector overlay is active and clicks
@@ -16,7 +22,7 @@ type Props = {
      *  inspector capability. Stays `false` until the SDK posts
      *  `lightdash:inspect:available`, so older sandboxes (resumed with a
      *  pre-inspector SDK) keep this `false` and let the parent hide the
-     *  Inspect button. Resets to `false` on every iframe `src` change. */
+     *  Inspect button. Resets to `false` on every `identityKey` change. */
     onInspectorAvailabilityChange?: (available: boolean) => void;
     /** Called when the user presses Esc to leave inspect mode. The handler
      *  lives on the parent's window because that's where focus actually
@@ -38,6 +44,7 @@ type Props = {
  */
 const AppIframePreview: FC<Props> = ({
     src,
+    identityKey,
     onQueryEvent,
     onElementSelected,
     inspectorEnabled,
@@ -59,13 +66,16 @@ const AppIframePreview: FC<Props> = ({
             handleAnnounce,
         );
 
-    // Reset availability to false on every iframe URL change. This fires
-    // before the browser starts loading the new content, so the new SDK's
-    // `available` announce will flip it back to true if it's wired up. Old
-    // SDKs in resumed sandboxes never announce, so it stays false.
+    // Reset availability to false when the served bundle changes (new app or
+    // new version). Fires before the browser starts loading the new content,
+    // so the new SDK's `available` announce will flip it back to true if it's
+    // wired up. Old SDKs in resumed sandboxes never announce, so it stays
+    // false. Keyed on `identityKey` rather than `src` so that pure URL bumps
+    // (manual preview refresh) don't reset — same bundle means same SDK
+    // capability, and resetting would briefly hide the Inspect button.
     useEffect(() => {
         onInspectorAvailabilityChange?.(false);
-    }, [src, onInspectorAvailabilityChange]);
+    }, [identityKey, onInspectorAvailabilityChange]);
 
     // Toggling the prop while the iframe is alive — push the change through.
     useEffect(() => {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -25,6 +25,7 @@ import {
     Textarea,
     ThemeIcon,
     Title,
+    Tooltip,
 } from '@mantine-8/core';
 import {
     IconAppsOff,
@@ -37,6 +38,7 @@ import {
     IconPencil,
     IconLayoutDashboard,
     IconPlayerStop,
+    IconRefresh,
     IconSparkles,
     IconTrash,
 } from '@tabler/icons-react';
@@ -155,6 +157,11 @@ const AppPreview: FC<{
     projectUuid: string;
     appUuid: string;
     version: number;
+    /** Bumping this re-mounts the iframe URL to force a reload (and a
+     *  re-run of the app's metric queries). Same version → identical app
+     *  bundle, but the new query string defeats any caching and flushes
+     *  whatever in-iframe state was running. */
+    refreshKey: number;
     onQueryEvent?: (event: QueryEvent) => void;
     inspectorEnabled?: boolean;
     onElementSelected?: (event: { label: string }) => void;
@@ -164,6 +171,7 @@ const AppPreview: FC<{
     projectUuid,
     appUuid,
     version,
+    refreshKey,
     onQueryEvent,
     inspectorEnabled,
     onElementSelected,
@@ -178,7 +186,7 @@ const AppPreview: FC<{
 
     const baseUrl = window.location.origin;
     const previewUrl = token
-        ? `${baseUrl}/api/apps/${appUuid}/versions/${version}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${baseUrl}/api/apps/${appUuid}/versions/${version}/?token=${token}&r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
 
     if (isLoading) {
@@ -206,6 +214,7 @@ const AppPreview: FC<{
     return (
         <AppIframePreview
             src={previewUrl}
+            identityKey={`${appUuid}:${version}`}
             onQueryEvent={onQueryEvent}
             inspectorEnabled={inspectorEnabled}
             onElementSelected={onElementSelected}
@@ -653,6 +662,17 @@ const AppGenerate: FC = () => {
             setPreviewApp(latestReadyPreview);
         }
     }, [latestReadyPreview, previewApp?.appUuid, previewApp?.version]);
+
+    // Manual refresh counter for the preview iframe. The iframe URL embeds
+    // this value, so bumping it forces the browser to reload the iframe and
+    // re-execute the app's metric queries. Used after the user pushes a
+    // semantic-layer change and wants to see it reflected without waiting
+    // on the in-progress code-gen iteration.
+    const [previewRefreshKey, setPreviewRefreshKey] = useState(0);
+    const handleRefreshPreview = useCallback(() => {
+        setPreviewRefreshKey((k) => k + 1);
+        setTrackedQueries([]);
+    }, []);
 
     const scrollToBottom = useCallback(() => {
         messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -1741,6 +1761,26 @@ const AppGenerate: FC = () => {
                                         </Text>
                                     )}
                                 </Box>
+                                <Tooltip
+                                    label="Refresh preview to re-run queries"
+                                    withArrow
+                                    position="bottom"
+                                >
+                                    <ActionIcon
+                                        variant="subtle"
+                                        size="sm"
+                                        color="ldGray.6"
+                                        ml="auto"
+                                        disabled={!previewApp}
+                                        onClick={handleRefreshPreview}
+                                        aria-label="Refresh preview"
+                                    >
+                                        <MantineIcon
+                                            icon={IconRefresh}
+                                            size={16}
+                                        />
+                                    </ActionIcon>
+                                </Tooltip>
                                 <Menu
                                     position="bottom-end"
                                     shadow="md"
@@ -1753,7 +1793,6 @@ const AppGenerate: FC = () => {
                                             variant="subtle"
                                             size="sm"
                                             color="ldGray.6"
-                                            ml="auto"
                                             aria-label="App actions"
                                         >
                                             <IconDots size={16} />
@@ -1903,6 +1942,7 @@ const AppGenerate: FC = () => {
                                     projectUuid={projectUuid}
                                     appUuid={previewApp.appUuid}
                                     version={previewApp.version}
+                                    refreshKey={previewRefreshKey}
                                     onQueryEvent={handleQueryEvent}
                                     inspectorEnabled={inspectorEnabled}
                                     onElementSelected={handleElementSelected}

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -195,7 +195,10 @@ export default function AppPreviewTest() {
                     </Menu>
                 </Box>
             )}
-            <AppIframePreview src={previewUrl} />
+            <AppIframePreview
+                src={previewUrl}
+                identityKey={`${appUuid}:${version}`}
+            />
         </Box>
     );
 }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-380/refresh-preview-button

### Description:
Reloads the preview iframe so the app's metric queries re-execute against the warehouse — useful after pushing a semantic-layer change while a code-gen iteration is in flight. Implemented as a refresh counter baked into the iframe URL; clears the query inspector on refresh.