### PR TITLE
fix(pivot): route row-companion sort-only dims to row_index ORDER BY

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8986,11 +8986,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9130,17 +9130,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9169,7 +9169,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9177,7 +9177,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9192,7 +9196,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9200,11 +9204,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9388,17 +9388,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9468,11 +9468,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9487,11 +9487,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9506,11 +9506,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9525,11 +9525,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9544,11 +9544,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15515,6 +15515,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                kind: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['row'] },
+                        { dataType: 'enum', enums: ['column'] },
+                    ],
+                    required: true,
+                },
                 reference: { dataType: 'string', required: true },
             },
             validators: {},
@@ -21115,7 +21123,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21125,7 +21133,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21135,7 +21143,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21148,7 +21156,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21559,7 +21567,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21569,7 +21577,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21579,7 +21587,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21592,7 +21600,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10444,6 +10444,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -10472,10 +10485,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -10484,8 +10497,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10495,16 +10508,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -10592,10 +10605,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -10604,8 +10617,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -16454,13 +16467,17 @@
             },
             "SortOnlyDimension": {
                 "properties": {
+                    "kind": {
+                        "type": "string",
+                        "enum": ["row", "column"]
+                    },
                     "reference": {
                         "type": "string"
                     }
                 },
-                "required": ["reference"],
+                "required": ["kind", "reference"],
                 "type": "object",
-                "description": "A dimension referenced only via sortBy — not a row-axis index, not a pivot\ngroup-by, not a metric. Carried through group_by_query to drive\ncolumn_index ORDER BY without affecting row layout."
+                "description": "A dimension referenced only via sortBy — not a row-axis index, not a pivot\ngroup-by, not a metric. Carried through group_by_query to drive ORDER BY\nwithout surfacing as a chart series.\n\n`kind` decides which DENSE_RANK the dim feeds:\n  - 'row'    — orders the x-axis / row_index (e.g. day-of-year ordering an\n               alphabetical month name xField).\n  - 'column' — orders the pivot columns / column_index (e.g. priority\n               ordering a status groupBy).\n\nThe two intents look identical at the SQL layer but differ for the user;\n`kind` is set by the chart-config layer where the partnership signal lives."
             },
             "PivotConfiguration": {
                 "properties": {
@@ -16476,7 +16493,7 @@
                             ]
                         },
                         "type": "array",
-                        "description": "Fields referenced only via sortBy that aren't on any axis or in pivot\ncolumns. Items with `aggregation` are metrics/table calculations merged\ninto valuesColumns for sort-anchor CTEs; items without `aggregation`\nare dimensions that ride through group_by_query to drive column_index\nORDER BY. Both are excluded from pivotDetails so they don't appear as\nchart series."
+                        "description": "Fields referenced only via sortBy that aren't on any axis or in pivot\ncolumns. Items with `aggregation` are metrics/table calculations merged\ninto valuesColumns for sort-anchor CTEs; items without `aggregation`\nare dimensions that ride through group_by_query to drive row_index or\ncolumn_index ORDER BY (per their `kind`). Both are excluded from\npivotDetails so they don't appear as chart series."
                     },
                     "metricsAsRows": {
                         "type": "boolean",
@@ -22501,22 +22518,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -22871,22 +22888,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -31367,7 +31384,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2853.1",
+        "version": "0.2861.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -755,9 +755,10 @@ describe('PivotQueryBuilder', () => {
         });
 
         test('Should drive column_index by sort-only dimension when sort dim is a 1:1 companion', () => {
-            // Frontend flagged event_priority as a sort-only dim (it's not
-            // the x-axis, not a pivot column, not a metric). Backend should
-            // emit it in column_index ORDER BY ahead of the group-by column.
+            // Frontend flagged event_priority as a column-companion sort-only
+            // dim (it's not the x-axis, not a pivot column, not a metric).
+            // Backend should emit it in column_index ORDER BY ahead of the
+            // group-by column.
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -773,7 +774,9 @@ describe('PivotQueryBuilder', () => {
                         direction: SortByDirection.DESC,
                     },
                 ],
-                sortOnlyColumns: [{ reference: 'event_priority' }],
+                sortOnlyColumns: [
+                    { reference: 'event_priority', kind: 'column' as const },
+                ],
             };
 
             const builder = new PivotQueryBuilder(
@@ -792,9 +795,9 @@ describe('PivotQueryBuilder', () => {
         });
 
         test('Should keep sort-only dim ahead of group-by sort when sortBy mixes both', () => {
-            // sortBy lists event_type's sort first, but sort-only dims are
-            // prepended and group-by parts follow groupByColumns declaration
-            // order with the requested direction applied.
+            // Column-companion sort-only dims are prepended ahead of group-by
+            // parts (which follow groupByColumns declaration order with the
+            // requested direction applied).
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -814,7 +817,9 @@ describe('PivotQueryBuilder', () => {
                         direction: SortByDirection.ASC,
                     },
                 ],
-                sortOnlyColumns: [{ reference: 'event_priority' }],
+                sortOnlyColumns: [
+                    { reference: 'event_priority', kind: 'column' as const },
+                ],
             };
 
             const builder = new PivotQueryBuilder(
@@ -849,7 +854,9 @@ describe('PivotQueryBuilder', () => {
                     { reference: 'revenue', direction: SortByDirection.DESC },
                     { reference: 'priority', direction: SortByDirection.ASC },
                 ],
-                sortOnlyColumns: [{ reference: 'priority' }],
+                sortOnlyColumns: [
+                    { reference: 'priority', kind: 'column' as const },
+                ],
             };
 
             const builder = new PivotQueryBuilder(
@@ -4758,6 +4765,206 @@ SELECT * FROM group_by_query LIMIT 50`);
             // Mixing them up is the documented regression path.
             expect(colAnchorBody).not.toContain('MAX(CASE WHEN');
             expect(colAnchorBody).not.toContain('CROSS JOIN anchor_column');
+        });
+
+        test('Column-companion sort-only dim drives column_index, not row_index (#22399)', () => {
+            // https://github.com/lightdash/lightdash/issues/22399
+            // Repro: pivot column = status, sort-only companion =
+            // status_priority. The user wants the status columns ordered by
+            // their priority (a 1:1 numeric companion of status). PR #22458
+            // fixed this by routing sortOnlyColumns into column_index ORDER
+            // BY. This test pins that fix so it cannot regress.
+            // Expectation: status_priority appears in column_index ORDER BY,
+            // never in row_index ORDER BY.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'count',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupByColumns: [{ reference: 'status' }],
+                sortBy: [
+                    {
+                        reference: 'status_priority',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+                sortOnlyColumns: [
+                    { reference: 'status_priority', kind: 'column' as const },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+            const collapsed = replaceWhitespace(result);
+
+            // status_priority drives column_index — that's the column-companion
+            // intent.
+            expect(collapsed).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."status_priority" ASC, g."status" ASC) AS "column_index"',
+            );
+
+            // row_index must NOT mention status_priority — it isn't an
+            // index/x-axis companion, only a column companion.
+            const rowIndexMatch = collapsed.match(
+                /DENSE_RANK\(\) OVER \(ORDER BY ([^)]+)\) AS "row_index"/,
+            );
+            expect(rowIndexMatch).not.toBeNull();
+            expect(rowIndexMatch![1]).not.toContain('status_priority');
+        });
+
+        test('Row-companion sort-only dim drives row_index for rolling-average pivot, not column_index (PR #22458 row-companion regression)', () => {
+            // Reproducer 1 from the customer report: rolling 28-day average
+            // pivoted by year, with the x-axis = `date` and a sort-only
+            // companion `y_day` (day-of-year ordinal of the same date). The
+            // user's intent is "order the x-axis chronologically by day of
+            // year", so y_day is a ROW companion of `date`.
+            //
+            // Bug shipped in PR #22458: every entry in sortOnlyColumns is
+            // prepended into column_index ORDER BY, so y_day ends up driving
+            // column ordering and the bare `date` string is left to drive
+            // row_index. Combined with the latent
+            // `column_index <= floor(maxColumnLimit / valueColumnsCount)` cap,
+            // this also truncates the chart at 200 (y_day, year) tuples.
+            //
+            // Regression: PR #22458 routes row-companion sort dims to
+            // column_index — these assertions fail until the routing is fixed
+            // so row companions land in row_index ORDER BY instead.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'rolling_28_day_average',
+                        aggregation: VizAggregationOptions.AVERAGE,
+                    },
+                ],
+                groupByColumns: [{ reference: 'year' }],
+                sortBy: [
+                    { reference: 'y_day', direction: SortByDirection.ASC },
+                    { reference: 'year', direction: SortByDirection.ASC },
+                ],
+                sortOnlyColumns: [{ reference: 'y_day', kind: 'row' as const }],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+            const collapsed = replaceWhitespace(result);
+
+            // row_index must ORDER BY y_day so the x-axis renders by day of
+            // year, not alphabetically by `date`.
+            const rowIndexMatch = collapsed.match(
+                /DENSE_RANK\(\) OVER \(ORDER BY ([^)]+)\) AS "row_index"/,
+            );
+            expect(rowIndexMatch).not.toBeNull();
+            // Regression: PR #22458 routes row-companion sort dims to
+            // column_index — this assertion fails until fixed.
+            expect(rowIndexMatch![1]).toContain('y_day');
+
+            // column_index must NOT mention y_day — it isn't a column
+            // companion of `year`, putting it there bloats column_index
+            // cardinality past the 200-cap and truncates the chart.
+            const columnIndexMatch = collapsed.match(
+                /DENSE_RANK\(\) OVER \(ORDER BY ([^)]+)\) AS "column_index"/,
+            );
+            expect(columnIndexMatch).not.toBeNull();
+            // Regression: PR #22458 routes row-companion sort dims to
+            // column_index — this assertion fails until fixed.
+            expect(columnIndexMatch![1]).not.toContain('y_day');
+        });
+
+        test('Row-companion sort-only dim drives row_index for cumulative-enrollment pivot, not column_index (PR #22458 row-companion regression)', () => {
+            // Reproducer 2 from the customer report: cumulative enrollments
+            // pivoted by year with x-axis = `summer_month_name_event`
+            // ("December", "January", ...) and a sort-only companion
+            // `summer_month_order_event` (school-year ordinal: Dec=0, Jan=1,
+            // ..., Aug=8). The user's intent is "order x-axis chronologically
+            // in school-year order", so summer_month_order_event is a ROW
+            // companion of summer_month_name_event.
+            //
+            // Bug shipped in PR #22458: summer_month_order_event ends up in
+            // column_index ORDER BY, leaving row_index to sort
+            // summer_month_name_event alphabetically — chart x-axis renders
+            // April, August, December, ... instead of Dec, Jan, ..., Aug.
+            //
+            // Regression: PR #22458 routes row-companion sort dims to
+            // column_index — these assertions fail until the routing is fixed
+            // so row companions land in row_index ORDER BY instead.
+            const pivotConfiguration = {
+                indexColumn: [
+                    {
+                        reference: 'summer_month_name_event',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'cumulative_enrollments',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'year' }],
+                sortBy: [
+                    { reference: 'year', direction: SortByDirection.DESC },
+                    {
+                        reference: 'summer_month_order_event',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+                sortOnlyColumns: [
+                    {
+                        reference: 'summer_month_order_event',
+                        kind: 'row' as const,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+            const collapsed = replaceWhitespace(result);
+
+            // row_index must ORDER BY summer_month_order_event so the x-axis
+            // months render in school-year order, not alphabetically.
+            const rowIndexMatch = collapsed.match(
+                /DENSE_RANK\(\) OVER \(ORDER BY ([^)]+)\) AS "row_index"/,
+            );
+            expect(rowIndexMatch).not.toBeNull();
+            // Regression: PR #22458 routes row-companion sort dims to
+            // column_index — this assertion fails until fixed.
+            expect(rowIndexMatch![1]).toContain('summer_month_order_event');
+            // The bare summer_month_name_event ASC fallback is the bugged
+            // shape — alphabetical x-axis on the customer's chart.
+            expect(collapsed).not.toContain(
+                'DENSE_RANK() OVER (ORDER BY g."summer_month_name_event" ASC) AS "row_index"',
+            );
+
+            // column_index must NOT mention summer_month_order_event — it
+            // isn't a column companion of `year`.
+            const columnIndexMatch = collapsed.match(
+                /DENSE_RANK\(\) OVER \(ORDER BY ([^)]+)\) AS "column_index"/,
+            );
+            expect(columnIndexMatch).not.toBeNull();
+            // Regression: PR #22458 routes row-companion sort dims to
+            // column_index — this assertion fails until fixed.
+            expect(columnIndexMatch![1]).not.toContain(
+                'summer_month_order_event',
+            );
         });
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -2,7 +2,9 @@ import {
     getAggregatedField,
     getItemId,
     getParsedReference,
+    getSortOnlyColumnCompanions,
     getSortOnlyDimensionColumns,
+    getSortOnlyRowCompanions,
     getSortOnlyValuesColumns,
     hasPivotFunctions,
     isCustomBinDimension,
@@ -502,11 +504,16 @@ export class PivotQueryBuilder {
                     (groupCol) => groupCol.reference === reference,
                 );
 
-            const sortOnlyDimensions = getSortOnlyDimensionColumns(
+            // Only column-companion sort-only dims belong in column_index
+            // ORDER BY. Row-companion ones are routed through
+            // buildRowIndexOrderBy so they drive the x-axis instead.
+            const sortOnlyColumnCompanions = getSortOnlyColumnCompanions(
                 this.pivotConfiguration.sortOnlyColumns,
             );
-            const isSortOnlyDimension = ({ reference }: VizSortBy) =>
-                sortOnlyDimensions.some((dim) => dim.reference === reference);
+            const isSortOnlyColumnCompanion = ({ reference }: VizSortBy) =>
+                sortOnlyColumnCompanions.some(
+                    (dim) => dim.reference === reference,
+                );
 
             // Create values order parts
             const valuesOrderByParts = sortBy
@@ -534,12 +541,11 @@ export class PivotQueryBuilder {
                     return acc;
                 }, []);
 
-            // Sort intent on sort-only dimensions (frontend-flagged companion
-            // dims that aren't on the row axis) drives column_index too. They
-            // ride in group_by_query via metricQuery.dimensions, so we just
+            // Sort intent on column-companion sort-only dims drives
+            // column_index. They ride through group_by_query so we just
             // reference them in the ORDER BY.
             const sortOnlyDimensionParts = sortBy
-                .filter(isSortOnlyDimension)
+                .filter(isSortOnlyColumnCompanion)
                 .map((sort) => {
                     const sortExpr = this.resolveSortField(
                         sort.reference,
@@ -616,6 +622,17 @@ export class PivotQueryBuilder {
         >,
         q: string,
     ): string {
+        // Row-companion sort-only dims are user-supplied row-axis ordering
+        // intent — e.g. day-of-year ordering an alphabetical month-name
+        // xField. They live in group_by_query alongside index columns and
+        // participate in row_index DENSE_RANK exactly like an index sort.
+        const sortOnlyRowCompanions = getSortOnlyRowCompanions(
+            this.pivotConfiguration.sortOnlyColumns,
+        );
+        const sortOnlyRowCompanionRefs = new Set(
+            sortOnlyRowCompanions.map((d) => d.reference),
+        );
+
         if (!sortBy?.length) {
             // Default to all index columns with ASC direction
             return indexColumns
@@ -640,6 +657,10 @@ export class PivotQueryBuilder {
                 (valCol) => valCol.reference === sort.reference,
             );
 
+            const isRowCompanionSortOnly = sortOnlyRowCompanionRefs.has(
+                sort.reference,
+            );
+
             if (isValueColumn) {
                 // Use the anchor value from the row anchor CTE
                 const rowAnchorCteName = `${sort.reference}_row_anchor`;
@@ -651,8 +672,7 @@ export class PivotQueryBuilder {
                         `${q}${rowAnchorCteName}${q}.${q}${rowAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
                     );
                 }
-            } else if (isIndexColumn) {
-                // Only include index columns in row ordering
+            } else if (isIndexColumn || isRowCompanionSortOnly) {
                 const sortExpr = this.resolveSortField(
                     sort.reference,
                     sort.direction === SortByDirection.DESC,
@@ -665,7 +685,8 @@ export class PivotQueryBuilder {
                 );
                 orderByParts.push(prefixedExpr);
             }
-            // Skip other column types (like groupBy columns) as they shouldn't affect row ordering
+            // groupBy and column-companion sort-only entries are skipped —
+            // they drive column_index, not row_index.
         }
 
         // Ensure all index columns are included for proper dense_rank calculation

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -652,7 +652,7 @@ describe('derivePivotConfigurationFromChart', () => {
                 },
             ]);
             expect(result?.sortOnlyColumns).toEqual([
-                { reference: 'customers_customer_id' },
+                { reference: 'customers_customer_id', kind: 'column' },
             ]);
             expect(result?.sortBy).toEqual([
                 {

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -285,9 +285,39 @@ function getCartesianPivotConfiguration(
         // they don't conflate row-axis sort with column-ordering intent.
         const valuesRefs = new Set(valuesColumns.map((c) => c.reference));
         const groupByRefs = new Set(groupByColumns.map((c) => c.reference));
+
+        // Classify sort-only dimensions as row vs column companion.
+        //
+        // The shape of metricQuery.sorts can't tell us partnership 1:1 — the
+        // exact sort sequence `[groupBy, sortOnly]` happens for both real
+        // intents (e.g. customer charts that wanted x-axis ordering, AND a
+        // pivot-column tiebreaker). We pick the rule that recovers the most
+        // common intent we've seen and is safe for the original case
+        // PR #22458 fixed:
+        //
+        //   - All sort entries are sort-only dims (no row-side, no groupBy,
+        //     no value sort) → user is clearly asking to order pivot columns
+        //     by these dims → 'column' (#22399 case: `[status_priority]`
+        //     ordering a status groupBy).
+        //   - Otherwise → 'row'. The user already supplied a sort that
+        //     anchors columns (or values), so any companion dim folds into
+        //     the row-axis ordering sequence.
+        const allSortsAreSortOnlyDimensions = metricQuery.sorts.every(
+            (sort) =>
+                sort.fieldId !== xField &&
+                !valuesRefs.has(sort.fieldId) &&
+                !groupByRefs.has(sort.fieldId) &&
+                metricQuery.dimensions.includes(sort.fieldId),
+        );
+        const sortOnlyDimensionKind: 'row' | 'column' =
+            allSortsAreSortOnlyDimensions ? 'column' : 'row';
+
+        type SortOnlyEntry = NonNullable<
+            PivotConfiguration['sortOnlyColumns']
+        >[number];
         const sortOnlyColumns: NonNullable<
             PivotConfiguration['sortOnlyColumns']
-        > = metricQuery.sorts.flatMap((sort) => {
+        > = metricQuery.sorts.flatMap<SortOnlyEntry>((sort) => {
             if (
                 sort.fieldId !== xField &&
                 !valuesRefs.has(sort.fieldId) &&
@@ -309,7 +339,12 @@ function getCartesianPivotConfiguration(
                 !groupByRefs.has(sort.fieldId) &&
                 metricQuery.dimensions.includes(sort.fieldId)
             ) {
-                return [{ reference: sort.fieldId }];
+                return [
+                    {
+                        reference: sort.fieldId,
+                        kind: sortOnlyDimensionKind,
+                    },
+                ];
             }
             return [];
         });

--- a/packages/common/src/pivot/utils.test.ts
+++ b/packages/common/src/pivot/utils.test.ts
@@ -1,3 +1,4 @@
+import type { PivotConfiguration } from '../types/pivot';
 import { VizAggregationOptions } from '../visualizations/types';
 import { isSortedByPivot } from './utils';
 
@@ -55,7 +56,10 @@ describe('isSortedByPivot', () => {
                 sorts: [{ fieldId: 'raw_order_statuses_status_priority' }],
                 pivotDetails: {
                     sortOnlyColumns: [
-                        { reference: 'raw_order_statuses_status_priority' },
+                        {
+                            reference: 'raw_order_statuses_status_priority',
+                            kind: 'column' as const,
+                        },
                     ],
                 },
             }),
@@ -85,7 +89,12 @@ describe('isSortedByPivot', () => {
                 pivotDimensions: ['orders_status'],
                 sorts: [{ fieldId: 'orders_total_revenue' }],
                 pivotDetails: {
-                    sortOnlyColumns: [{ reference: 'some_other_dim' }],
+                    sortOnlyColumns: [
+                        {
+                            reference: 'some_other_dim',
+                            kind: 'column' as const,
+                        },
+                    ],
                 },
             }),
         ).toBe(false);
@@ -131,13 +140,15 @@ describe('isSortedByPivot', () => {
     });
 
     it('mixes sort-only dimensions and metrics in sortOnlyColumns and only treats dimensions as pivot-driving', () => {
-        const pivotDetails = {
+        const pivotDetails: {
+            sortOnlyColumns: PivotConfiguration['sortOnlyColumns'];
+        } = {
             sortOnlyColumns: [
                 {
                     reference: 'hidden_metric',
                     aggregation: VizAggregationOptions.SUM,
                 },
-                { reference: 'companion_dim' },
+                { reference: 'companion_dim', kind: 'column' },
             ],
         };
 

--- a/packages/common/src/pivot/utils.ts
+++ b/packages/common/src/pivot/utils.ts
@@ -31,12 +31,29 @@ export const getSortOnlyValuesColumns = (
     );
 
 // Items in sortOnlyColumns that don't carry an `aggregation` (dimensions
-// that ride through group_by_query to drive column_index ORDER BY).
+// that ride through group_by_query to drive ORDER BY — see `kind` for which
+// DENSE_RANK they feed).
 export const getSortOnlyDimensionColumns = (
     sortOnlyColumns: PivotConfiguration['sortOnlyColumns'],
 ): SortOnlyDimension[] =>
     (sortOnlyColumns ?? []).filter(
         (col): col is SortOnlyDimension => !('aggregation' in col),
+    );
+
+// Sort-only dims meant to order the x-axis / row_index.
+export const getSortOnlyRowCompanions = (
+    sortOnlyColumns: PivotConfiguration['sortOnlyColumns'],
+): SortOnlyDimension[] =>
+    getSortOnlyDimensionColumns(sortOnlyColumns).filter(
+        (col) => col.kind === 'row',
+    );
+
+// Sort-only dims meant to order pivot columns / column_index.
+export const getSortOnlyColumnCompanions = (
+    sortOnlyColumns: PivotConfiguration['sortOnlyColumns'],
+): SortOnlyDimension[] =>
+    getSortOnlyDimensionColumns(sortOnlyColumns).filter(
+        (col) => col.kind === 'column',
     );
 
 // True when the user's sort drives pivot column ordering: the sort field is

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -5,10 +5,22 @@ import type { GroupByColumn, SortBy, ValuesColumn } from './sqlRunner';
 
 /**
  * A dimension referenced only via sortBy — not a row-axis index, not a pivot
- * group-by, not a metric. Carried through group_by_query to drive
- * column_index ORDER BY without affecting row layout.
+ * group-by, not a metric. Carried through group_by_query to drive ORDER BY
+ * without surfacing as a chart series.
+ *
+ * `kind` decides which DENSE_RANK the dim feeds:
+ *   - 'row'    — orders the x-axis / row_index (e.g. day-of-year ordering an
+ *                alphabetical month name xField).
+ *   - 'column' — orders the pivot columns / column_index (e.g. priority
+ *                ordering a status groupBy).
+ *
+ * The two intents look identical at the SQL layer but differ for the user;
+ * `kind` is set by the chart-config layer where the partnership signal lives.
  */
-export type SortOnlyDimension = { reference: string };
+export type SortOnlyDimension = {
+    reference: string;
+    kind: 'row' | 'column';
+};
 
 export type PivotConfig = {
     pivotDimensions: string[];
@@ -37,9 +49,9 @@ export type PivotConfiguration = {
      * Fields referenced only via sortBy that aren't on any axis or in pivot
      * columns. Items with `aggregation` are metrics/table calculations merged
      * into valuesColumns for sort-anchor CTEs; items without `aggregation`
-     * are dimensions that ride through group_by_query to drive column_index
-     * ORDER BY. Both are excluded from pivotDetails so they don't appear as
-     * chart series.
+     * are dimensions that ride through group_by_query to drive row_index or
+     * column_index ORDER BY (per their `kind`). Both are excluded from
+     * pivotDetails so they don't appear as chart series.
      */
     sortOnlyColumns?: Array<ValuesColumn | SortOnlyDimension>;
 };


### PR DESCRIPTION
## Summary

- `SortOnlyDimension` gains a required `kind: 'row' | 'column'` discriminator so the chart-config layer can preserve user intent that's lost at SQL build time.
- `derivePivotConfigFromChart` classifies each sort-only dim: 'column' when **all** sort entries are sort-only dims (preserves #22399); 'row' otherwise.
- `PivotQueryBuilder.buildGroupByOrderBy` now only emits column-companion entries into `column_index` ORDER BY; `buildRowIndexOrderBy` emits row-companion entries alongside index-column sorts.

## Why

PR #22458 prepended every entry in `sortOnlyColumns` into `column_index` ORDER BY. That fixed the column-companion case (#22399 — `status_priority` ordering a `status` groupBy) but broke the row-companion case — sort-only dims that exist to order the x-axis. An investigation into a recent customer pivot-chart report turned up two distinct symptoms with the same root cause:

1. **Alphabetical x-axis**: charts rendered months as `April, August, December, February, ...` because the explicit numeric sort field (`summer_month_order_event`) was misrouted out of `row_index` ORDER BY, leaving only the bare alphabetical `summer_month_name_event` column for ranking.
2. **200-row truncation**: charts cut off at exactly `floor(maxColumnLimit / valueColumnsCount)` because a misrouted day-of-year sort (`y_day`) bloated `column_index` cardinality past the latent `column_index <= 200` cap.

The two intents (row vs column companion) look **identical** at the SQL layer — `[groupBy DESC, sortOnly ASC]` is the same shape regardless of whether the user wants the sort-only dim ordering rows or columns. No positional heuristic can recover meaning, so the type now carries it explicitly.

## What changed

| File | Change |
|---|---|
| `packages/common/src/types/pivot.ts` | Add required `kind: 'row' \| 'column'` to `SortOnlyDimension` |
| `packages/common/src/pivot/utils.ts` | Add `getSortOnlyRowCompanions` / `getSortOnlyColumnCompanions` helpers |
| `packages/common/src/pivot/derivePivotConfigFromChart.ts` | Classify each sort-only dim's `kind` based on the broader sort sequence |
| `packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts` | Route by `kind`: row companions → `row_index` ORDER BY, column companions → `column_index` ORDER BY |
| `packages/backend/src/generated/{routes,swagger}.{ts,json}` | TSOA regen — `kind` is now required in API requests |
| Tests | Update existing fixtures with explicit `kind`; the regression tests at the bottom of `PivotQueryBuilder.test.ts` now pin all three cases |

## Test plan

- [x] `pnpm -F common test` — 1874 passed
- [x] `pnpm -F backend exec jest --testPathPattern '(PivotQuery|derivePivotConfig|MetricQueryBuilder|AsyncQueryService)'` — 323 passed (60 snapshots intact)
- [x] All 115 `PivotQueryBuilder.test.ts` cases pass, including:
  - `Column-companion sort-only dim drives column_index, not row_index (#22399)` — Bruno's fix preserved
  - `Row-companion sort-only dim drives row_index for rolling-average pivot, not column_index` — fixes truncation reproducer
  - `Row-companion sort-only dim drives row_index for cumulative-enrollment pivot, not column_index` — fixes alphabetical-x-axis reproducer
- [x] `pnpm -F common lint`, `pnpm -F backend lint`, `pnpm -F backend typecheck` — clean
- [x] `pnpm generate-api` — re-ran, `kind` flows through to swagger schema

## Notes for reviewer

- The classification rule in `derivePivotConfigFromChart` is best-effort — it preserves Bruno's #22399 case (sole sort-only entries → column) while handling the customer's mixed-sort cases (anything else → row). The position-based heuristics fail on `[groupBy, sortOnly]` because the same shape produces opposite intents in #22399 and the customer's chart, so the rule has to be the broader one. A future UI control on the sort row would let users override this explicitly.
- I considered making `kind` optional with a default, but chose required to force callers to be explicit about intent. There's only one production caller (`derivePivotConfigFromChart`) so no migration burden.
- An existing test (`Should keep sort-only dim ahead of group-by sort when sortBy mixes both`) was added in #22458 to lock the column-companion routing for the `[groupBy, sortOnly]` shape. It still passes here because we tagged its fixture as `kind: 'column'` — but the equivalent shape with `kind: 'row'` (the customer's case) now correctly routes to `row_index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)