### PR TITLE
fix: rename `created_content` label to "Created" and open target link in new tab

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -244,7 +244,7 @@ const ACTION_CONFIG: Record<
         dotColor: 'var(--mantine-color-teal-5)',
     },
     created_content: {
-        label: 'Suggested',
+        label: 'Created',
         dotColor: 'var(--mantine-color-blue-5)',
     },
     insight: {
@@ -637,6 +637,8 @@ const DetailSidebar: FC<{
                             <ActionIcon
                                 component="a"
                                 href={targetLink}
+                                target="_blank"
+                                rel="noreferrer"
                                 aria-label={`Open ${action.targetType}`}
                                 variant="subtle"
                                 color="gray"


### PR DESCRIPTION
Closes:

### Description:
- Renames the `created_content` action label from "Suggested" to "Created" in the managed agent activity timeline.
- Updates the target link in the detail sidebar to open in a new tab (`target="_blank"`) with the appropriate `rel="noreferrer"` attribute for security.