### PR TITLE
fix(timezone): coerce inner expr to TIMESTAMP for BigQuery 3-arg TIMESTAMP_TRUNC

### DIFF
--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -92,6 +92,32 @@ describe('TimeFrames', () => {
             );
         });
 
+        test('BigQuery 3-arg TIMESTAMP_TRUNC wraps inner expr in TIMESTAMP() so DATETIME inputs coerce', () => {
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    undefined,
+                    'UTC',
+                ),
+            ).toEqual(
+                "TIMESTAMP_TRUNC(TIMESTAMP(${TABLE}.created), DAY, 'UTC')",
+            );
+        });
+
+        test('BigQuery 2-arg TIMESTAMP_TRUNC keeps original expr unchanged (DATETIME overload still applies)', () => {
+            expect(
+                timeFrameConfigs[TimeFrames.DAY].getSql(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                ),
+            ).toEqual('TIMESTAMP_TRUNC(${TABLE}.created, DAY)');
+        });
+
         test('should get sql where start of the week is Monday for ClickHouse', () => {
             // Monday (startOfWeek=0): must pass mode 1 to toStartOfWeek() so it returns Monday not Sunday
             expect(

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -181,7 +181,9 @@ const bigqueryConfig: WarehouseConfig = {
                 : timeFrame;
         if (type === DimensionType.TIMESTAMP) {
             if (timezone) {
-                return `TIMESTAMP_TRUNC(${originalSql}, ${datePart}, '${timezone}')`;
+                // 3-arg overload requires TIMESTAMP; coerce in case the
+                // declared TIMESTAMP dim emits DATETIME at runtime.
+                return `TIMESTAMP_TRUNC(TIMESTAMP(${originalSql}), ${datePart}, '${timezone}')`;
             }
             return `TIMESTAMP_TRUNC(${originalSql}, ${datePart})`;
         }


### PR DESCRIPTION
### What
BigQuery rejects timezone-aware `TIMESTAMP_TRUNC` when the inner expression is a `DATETIME` instead of a `TIMESTAMP`. This happens when a dimension declared `type: timestamp` actually emits `DATETIME` at runtime — e.g. `timestamp_add(...)` over a `DATE` column.

<img width="980" height="493" alt="CleanShot 2026-05-04 at 11 21 39" src="https://github.com/user-attachments/assets/6026c536-526a-4f9d-8814-02e86f7b1abd" />

### Fix
Wrap the inner expression in `TIMESTAMP(...)` for the 3-arg `TIMESTAMP_TRUNC` path. No-op for real timestamps, valid coercion for DATETIME (interpreted as UTC, which matches the truncation zone). Other adapters already absorb the same drift via their explicit casts (`::timestamptz`, `convert_timezone`, `CAST AS timestamp`); this just brings BigQuery in line.

### Flag scope
Fully gated behind `EnableTimezoneSupport`. The new `TIMESTAMP(...)` wrap only fires inside the `if (timezone)` branch, and `timezone` is only ever forwarded when `useTimezoneAwareDateTrunc` is true (set from the flag). Flag-off SQL is byte-identical to before.