### PR TITLE
fix: preserve long dbt YAML descriptions when generating schemas

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -67,6 +67,25 @@ describe('DbtSchemaEditor', () => {
         expect(editor.toJS()).toEqual(EXPECTED_SCHEMA_JSON_WITH_NEW_MODEL);
         expect(editor.toString()).toEqual(EXPECTED_SCHEMA_YML_WITH_NEW_MODEL);
     });
+
+    it('should preserve long single-line descriptions when mutating the schema', () => {
+        const schema = `version: 2
+models:
+  - name: my_model
+    columns:
+      - name: id
+        description: "This is a very long description that should remain on a single line after the schema editor serializes the document back to YAML."`;
+
+        const editor = new DbtSchemaEditor(schema);
+        editor.addColumn('my_model', {
+            name: 'new_column',
+            description: '',
+        });
+
+        expect(editor.toString()).toContain(
+            'description: "This is a very long description that should remain on a single line after the schema editor serializes the document back to YAML."',
+        );
+    });
 });
 
 describe('case-insensitive column matching', () => {

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,7 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Summary
- Disable YAML line wrapping in `DbtSchemaEditor.toString()` so existing long descriptions are preserved as-is
- Add a regression test covering mutation of a schema with a long single-line description

## Testing
- `pnpm -F common test -- --runInBand packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts`
- Verified locally that `lightdash dbt run` no longer reflows long descriptions in a temp dbt project

Closes: https://github.com/lightdash/lightdash/issues/21917