### PR TITLE
fix: upgrade lodash family to 4.18.1

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -123,7 +123,7 @@
         "jsonwebtoken": "9.0.3",
         "knex": "2.5.1",
         "langchain": "0.3.37",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "marked": "9.0.3",
         "moment": "2.29.4",
         "nanoid": "3.3.8",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "google-auth-library": "9.15.1",
     "inquirer": "8.2.4",
     "js-yaml": "4.1.1",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "node-fetch": "2.7.0",
     "nunjucks": "3.2.3",
     "openid-client": "5.6.4",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -44,7 +44,7 @@
     "handlebars": "4.7.9",
     "js-yaml": "4.1.1",
     "liquidjs": "10.25.7",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "moment": "2.29.4",
     "moment-timezone": "0.5.45",
     "numfmt": "3.2.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -95,7 +95,7 @@
         "jspdf": "4.2.1",
         "leaflet": "1.9.4",
         "leaflet.heat": "0.2.0",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "mantine-form-zod-resolver": "1.1.0",
         "mantine-react-table": "1.3.4",
         "moment": "2.29.4",

--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -34,7 +34,7 @@
     "@duckdb/node-api": "1.4.4-r.1",
     "@google-cloud/bigquery": "7.9.2",
     "@lightdash/common": "workspace:*",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "node-fetch": "2.7.0",
     "pg": "8.13.1",
     "pg-cursor": "2.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,8 +385,8 @@ importers:
         specifier: 0.3.37
         version: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.80.1(encoding@0.1.13)(ws@8.18.0)(zod@3.25.55)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(axios@1.15.2)(encoding@0.1.13)(handlebars@4.7.9)(openai@4.80.1(encoding@0.1.13)(ws@8.18.0)(zod@3.25.55))(ws@8.18.0)
       lodash:
-        specifier: 4.17.23
-        version: 4.17.23
+        specifier: 4.18.1
+        version: 4.18.1
       marked:
         specifier: 9.0.3
         version: 9.0.3
@@ -665,8 +665,8 @@ importers:
         specifier: 4.1.1
         version: 4.1.1
       lodash:
-        specifier: 4.17.23
-        version: 4.17.23
+        specifier: 4.18.1
+        version: 4.18.1
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
@@ -777,8 +777,8 @@ importers:
         specifier: 10.25.7
         version: 10.25.7
       lodash:
-        specifier: 4.17.23
-        version: 4.17.23
+        specifier: 4.18.1
+        version: 4.18.1
       moment:
         specifier: 2.29.4
         version: 2.29.4
@@ -1134,8 +1134,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       lodash:
-        specifier: 4.17.23
-        version: 4.17.23
+        specifier: 4.18.1
+        version: 4.18.1
       mantine-form-zod-resolver:
         specifier: 1.1.0
         version: 1.1.0(@mantine/form@7.5.2(react@19.2.0))(zod@3.25.55)
@@ -1616,8 +1616,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       lodash:
-        specifier: 4.17.23
-        version: 4.17.23
+        specifier: 4.18.1
+        version: 4.18.1
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
@@ -11682,6 +11682,9 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
@@ -16415,7 +16418,7 @@ snapshots:
 
   '@75lb/deep-merge@1.1.2':
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       typical: 7.1.1
 
   '@actions/core@1.11.1':
@@ -22266,7 +22269,7 @@ snapshots:
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       redent: 3.0.0
     optionalDependencies:
       '@jest/globals': 29.7.0
@@ -23903,7 +23906,7 @@ snapshots:
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       normalize-path: 3.0.0
       readable-stream: 4.5.2
 
@@ -24075,7 +24078,7 @@ snapshots:
 
   async@2.6.4:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   async@3.2.6: {}
 
@@ -24192,7 +24195,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.15.4
       '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       babel-plugin-syntax-jsx: 6.18.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       styled-components: 5.3.3(react-dom@19.2.0(react@19.2.0))(react-is@19.2.0)(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -24456,7 +24459,7 @@ snapshots:
       cron-parser: 4.5.0
       get-port: 5.1.1
       ioredis: 5.4.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       msgpackr: 1.11.2
       semver: 7.7.3
       uuid: 8.3.2
@@ -25241,7 +25244,7 @@ snapshots:
       is-installed-globally: 0.4.0
       lazy-ass: 1.6.0
       listr2: 3.13.5(enquirer@2.3.6)
-      lodash: 4.17.23
+      lodash: 4.18.1
       log-symbols: 4.1.0
       minimist: 1.2.8
       ospath: 1.2.2
@@ -26148,7 +26151,7 @@ snapshots:
 
   eslint-plugin-json@3.1.0:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       vscode-json-languageservice: 4.2.0
 
   eslint-plugin-jsx-a11y@6.6.1(eslint@8.57.1):
@@ -26171,7 +26174,7 @@ snapshots:
   eslint-plugin-lodash@8.0.0(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   eslint-plugin-perfectionist@5.6.0(eslint@8.57.1)(typescript@6.0.0-beta):
     dependencies:
@@ -26441,7 +26444,7 @@ snapshots:
   express-winston@4.2.0(winston@3.13.0):
     dependencies:
       chalk: 2.4.2
-      lodash: 4.17.23
+      lodash: 4.18.1
       winston: 3.13.0
 
   express@4.21.2:
@@ -27680,7 +27683,7 @@ snapshots:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -28665,7 +28668,7 @@ snapshots:
       get-package-type: 0.1.0
       getopts: 2.3.0
       interpret: 2.2.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       pg-connection-string: 2.6.1
       rechoir: 0.8.0
       resolve-from: 5.0.0
@@ -28686,7 +28689,7 @@ snapshots:
       get-package-type: 0.1.0
       getopts: 2.3.0
       interpret: 2.2.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       pg-connection-string: 2.6.2
       rechoir: 0.8.0
       resolve-from: 5.0.0
@@ -28956,6 +28959,8 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash@4.17.23: {}
+
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -30448,7 +30453,7 @@ snapshots:
 
   passport-headerapikey@1.2.2:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       passport-strategy: 1.0.0
 
   passport-local@1.0.0:

--- a/sandboxes/data-apps/template/package.json
+++ b/sandboxes/data-apps/template/package.json
@@ -27,7 +27,7 @@
         "d3-cloud": "1.2.9",
         "d3-sankey": "0.12.3",
         "date-fns": "3.6.0",
-        "lodash-es": "4.17.23",
+        "lodash-es": "4.18.1",
         "lucide-react": "0.469.0",
         "react": "19.2.5",
         "react-dom": "19.2.5",


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/security/dependabot/618
Closes: https://github.com/lightdash/lightdash/security/dependabot/620
Closes: https://github.com/lightdash/lightdash/security/dependabot/622
Closes: https://github.com/lightdash/lightdash/security/dependabot/624
Closes: https://github.com/lightdash/lightdash/security/dependabot/626
Closes: https://github.com/lightdash/lightdash/security/dependabot/628
Closes: https://github.com/lightdash/lightdash/security/dependabot/630

### Description:
Upgrade direct `lodash` and `lodash-es` dependencies to `4.18.1` and refresh the root lockfile.