### PR TITLE
fix: replace `RegisteredAccount` with `Account` in `getJobStatus` and remove redundant assertion

### DIFF
--- a/packages/backend/src/controllers/schedulerController.ts
+++ b/packages/backend/src/controllers/schedulerController.ts
@@ -582,10 +582,9 @@ export class SchedulerController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiJobStatusResponse> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         const { status, details } = await this.services
             .getSchedulerService()
-            .getJobStatus(req.account, jobId);
+            .getJobStatus(req.account!, jobId);
         return {
             status: 'ok',
             results: {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -42,7 +42,7 @@ import {
     UnexpectedGoogleSheetsError,
     UpdateSchedulerAndTargetsWithoutId,
     UserSchedulersSummary,
-    type RegisteredAccount,
+    type Account,
 } from '@lightdash/common';
 import cronstrue from 'cronstrue';
 import {
@@ -1143,7 +1143,7 @@ export class SchedulerService extends BaseService {
     }
 
     async getJobStatus(
-        account: RegisteredAccount,
+        account: Account,
         jobId: string,
     ): Promise<Pick<SchedulerLogDb, 'status' | 'details'>> {
         assertIsAccountWithOrg(account);


### PR DESCRIPTION
Closes: #22639

### Description:

Removes the `assertRegisteredAccount` guard from the `getJobStatus` controller endpoint, replacing it with a non-null assertion on `req.account`. Additionally, updates the `getJobStatus` service method to accept the broader `Account` type instead of `RegisteredAccount`, delegating account validation to `assertIsAccountWithOrg` within the service layer.