### PR TITLE
fix: correct ClickHouse SECOND, MILLISECOND, WEEK_NUM, and date-part-name SQL expressions

### DIFF
--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -106,6 +106,30 @@ describe('TimeFrames', () => {
                 'addDays(toStartOfWeek(addDays(${TABLE}.created, -0), 1), 0)',
             );
         });
+
+        test('ClickHouse SECOND truncation lifts to DateTime64 (toStartOfSecond rejects plain DateTime)', () => {
+            expect(
+                timeFrameConfigs[TimeFrames.SECOND].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.SECOND,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                ),
+            ).toEqual('toStartOfSecond(toDateTime64(${TABLE}.created, 3))');
+        });
+
+        test('ClickHouse MILLISECOND truncation lifts to DateTime64 (toStartOfMillisecond rejects plain DateTime)', () => {
+            expect(
+                timeFrameConfigs[TimeFrames.MILLISECOND].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.MILLISECOND,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                ),
+            ).toEqual(
+                'toStartOfMillisecond(toDateTime64(${TABLE}.created, 3))',
+            );
+        });
     });
 
     describe('getSqlForDatePart - DAY_OF_WEEK_INDEX with startOfWeek', () => {
@@ -302,6 +326,79 @@ describe('TimeFrames', () => {
                     WeekDay.MONDAY,
                 ),
             ).toEqual(`DATE_PART('DOW', ${col})`);
+        });
+    });
+
+    describe('getSqlForDatePart - ClickHouse WEEK_NUM with startOfWeek', () => {
+        const col = '${TABLE}.created';
+        const tf = TimeFrames.WEEK_NUM;
+        const dt = DimensionType.DATE;
+
+        test('Monday start: toWeek mode 3 (ISO) matches Postgres EXTRACT(WEEK), fixes US-default off-by-one', () => {
+            // toWeek(d) defaults to mode 0 (US, Sunday-base, 0–53). Mode 3 is
+            // ISO 8601 (Monday-base), matching every other warehouse adapter.
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(`toWeek(addDays(${col}, -0), 3)`);
+        });
+
+        test('Wednesday start: shift date back by 2 days before extracting ISO week', () => {
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.WEDNESDAY,
+                ),
+            ).toEqual(`toWeek(addDays(${col}, -2), 3)`);
+        });
+    });
+
+    describe('getSqlForDatePartName - ClickHouse', () => {
+        const col = '${TABLE}.created';
+        const dt = DimensionType.DATE;
+
+        test('DAY_OF_WEEK_NAME uses dateName(weekday, ...) — toDayOfWeekName does not exist in ClickHouse', () => {
+            expect(
+                timeFrameConfigs[TimeFrames.DAY_OF_WEEK_NAME].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.DAY_OF_WEEK_NAME,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(`dateName('weekday', ${col})`);
+        });
+
+        test('MONTH_NAME uses monthName(...) — toMonthName does not exist in ClickHouse', () => {
+            expect(
+                timeFrameConfigs[TimeFrames.MONTH_NAME].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.MONTH_NAME,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(`monthName(${col})`);
+        });
+
+        test('QUARTER_NAME stays as concat(Q, toQuarter(...))', () => {
+            expect(
+                timeFrameConfigs[TimeFrames.QUARTER_NAME].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.QUARTER_NAME,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(`concat('Q', toString(toQuarter(${col})))`);
         });
     });
 

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -476,6 +476,11 @@ const clickhouseConfig: WarehouseConfig = {
                 return `toStartOfHour(${originalSql})`;
             case TimeFrames.MINUTE:
                 return `toStartOfMinute(${originalSql})`;
+            case TimeFrames.SECOND:
+                // toStartOfSecond requires DateTime64; lift Date/DateTime via cast.
+                return `toStartOfSecond(toDateTime64(${originalSql}, 3))`;
+            case TimeFrames.MILLISECOND:
+                return `toStartOfMillisecond(toDateTime64(${originalSql}, 3))`;
             default:
                 throw new ParseError(
                     `Cannot recognise truncate function for ${timeFrame}`,
@@ -510,6 +515,14 @@ const clickhouseConfig: WarehouseConfig = {
             return `modulo(toDayOfWeek(${originalSql}) - ${nativeOffset} + 7, 7) + 1`;
         }
 
+        // ClickHouse toWeek defaults to mode 0 (US, Sunday-base, 0–53). Mode 3 is
+        // ISO 8601 (Monday-base, 1–53), matching Postgres EXTRACT(WEEK) and the
+        // toStartOfWeek(d, 1) used by truncation. The startOfWeek shift mirrors
+        // what other warehouses do on the same path.
+        if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
+            return `toWeek(addDays(${originalSql}, -${startOfWeek}), 3)`;
+        }
+
         const extractFunction = clickhouseTimeFrameMap[timeFrame];
         if (!extractFunction) {
             throw new ParseError(
@@ -521,8 +534,8 @@ const clickhouseConfig: WarehouseConfig = {
     getSqlForDatePartName: (timeFrame: TimeFrames, originalSql: string) => {
         const timeFrameExpressions: Record<TimeFrames, string | null> = {
             ...nullTimeFrameMap,
-            [TimeFrames.DAY_OF_WEEK_NAME]: 'toDayOfWeekName',
-            [TimeFrames.MONTH_NAME]: 'toMonthName',
+            [TimeFrames.DAY_OF_WEEK_NAME]: `dateName('weekday', ${originalSql})`,
+            [TimeFrames.MONTH_NAME]: `monthName(${originalSql})`,
             [TimeFrames.QUARTER_NAME]: `concat('Q', toString(toQuarter(${originalSql})))`,
         };
         const formatExpression = timeFrameExpressions[timeFrame];
@@ -531,10 +544,7 @@ const clickhouseConfig: WarehouseConfig = {
                 `Cannot recognise format expression for ${timeFrame}`,
             );
         }
-        if (timeFrame === TimeFrames.QUARTER_NAME) {
-            return formatExpression;
-        }
-        return `${formatExpression}(${originalSql})`;
+        return formatExpression;
     },
 };
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7402/clickhouse-milisecond-on-dbt-compile
Closes: https://linear.app/lightdash/issue/PROD-7401/todayofweekname-not-working-on-clickhouse
Closes: https://linear.app/lightdash/issue/PROD-6924/start-of-week-setting-off-by-one-for-clickhouse-date-zoom


  Spot-checked all 10 rendered rows against ISO calendar — every cell is internally consistent.

  - ✅ Every `week` value (2020-07-06, -13, -20, -27; 2020-06-29; 2020-08-03, -10) is a Monday — PROD-6924 fix working
  - ✅ `week_num` matches ISO weeks for those Mondays (28, 29, 30, 31, 27, 32, 33) — toWeek mode 3 fix working
  - ✅ `dow_idx=1` ↔ `Monday`, `dow_idx=2` ↔ `Tuesday`
  - ✅ `dow_name` strings render ("Monday", "Tuesday") — `dateName('weekday', ...)` working
  - ✅ `month_name` strings render ("July", "August", "June") — `monthName(...)` working
  - ✅ `month` / `month_num` / `month_name` agree (e.g. `2020-06` ↔ `6` ↔ `June`)
  - ✅ Row 9 quarter flips correctly: timestamp in June (month=6) → `quarter_num=2`, `Q2`
  - ✅ All July/August timestamps → `Q3`
  - ✅ Row 7 & 8: same week (2020-07-06) but `dow_idx=2` / Tuesday — original timestamp was Tuesday 2020-07-07, bucketed into Mon 2020-07-06 week
  (self-consistent)


### Description:

Fixes several ClickHouse time frame SQL generation bugs:

- **SECOND / MILLISECOND truncation**: `toStartOfSecond` and `toStartOfMillisecond` require a `DateTime64` argument and will reject a plain `DateTime`. The generated SQL now wraps the input with `toDateTime64(..., 3)` before calling these functions.

- **WEEK_NUM extraction**: ClickHouse's `toWeek` defaults to mode 0 (US Sunday-based, range 0–53). This caused an off-by-one mismatch compared to other warehouse adapters. The generated SQL now uses mode 3 (ISO 8601, Monday-based, range 1–53), consistent with `EXTRACT(WEEK)` in Postgres and the `toStartOfWeek(d, 1)` used elsewhere. The `startOfWeek` day shift is also applied to mirror behaviour across adapters.

- **DAY_OF_WEEK_NAME / MONTH_NAME**: `toDayOfWeekName` and `toMonthName` do not exist in ClickHouse. These are replaced with `dateName('weekday', ...)` and `monthName(...)` respectively. The special-case branching for `QUARTER_NAME` is also removed since all three expressions are now stored as fully-formed SQL strings rather than bare function names.