### PR TITLE
feat(timezone): tz-aware EXTRACT-based time dimensions

### DIFF
--- a/docs/timezone-handling.md
+++ b/docs/timezone-handling.md
@@ -100,6 +100,16 @@ The SQL differs per warehouse (some have native TZ-aware truncation, others comp
 
 **Truncated intervals on a DATE base dimension skip the round-trip.** A truncated interval whose base column is a DATE (e.g. `order_date_month`) falls back to raw `DATE_TRUNC`. DATE values carry no time component — casting one into `timestamptz` for the round-trip would anchor at midnight and then cross a day boundary whenever the project timezone has a non-zero offset.
 
+### SELECT — EXTRACT-based grouping
+
+EXTRACT/DATE_PART intervals (`DAY_OF_WEEK_INDEX`, `DAY_OF_MONTH_NUM`, `DAY_OF_YEAR_NUM`, `WEEK_NUM`, `MONTH_NUM`, `QUARTER_NUM`, `YEAR_NUM`, `HOUR_OF_DAY_NUM`, `MINUTE_OF_HOUR_NUM`) and the format/name variants (`DAY_OF_WEEK_NAME`, `MONTH_NAME`, `QUARTER_NAME`) compile to UTC-only SQL and are rewritten at query time to extract calendar components in the project timezone. Unlike DATE_TRUNC there is no round-trip — EXTRACT returns a number/string, not a timestamp — so the input is shifted *into* the project zone once before extracting. The shift expression is the same per-warehouse pattern used by DATE_TRUNC's `toProjectTz`, except for BigQuery, whose native form is `<expr> AT TIME ZONE 'tz'` concatenated inside `EXTRACT(... FROM ...)`. Defined in `dateExtractsTimezoneConversions`.
+
+A "Day of week" or "Month number" dimension grouped next to a DATE_TRUNC sibling now buckets rows on the same project-TZ calendar — the previous gap where the two could disagree (e.g. one row showing under "Tue" and the other under "Mon" for the same instant) is closed.
+
+**Filter parity** is the same as DATE_TRUNC: WHERE LHS reuses the wrapped expression so a filter like `day_of_week_index = 1` compares against the same project-TZ DOW the SELECT groups on.
+
+**EXTRACT-based intervals on a DATE base dimension skip the wrap.** Same reason as the DATE_TRUNC bypass: a DATE column has no time component, so EXTRACT is already in the project's calendar by definition.
+
 **Files:** `packages/common/src/utils/timeFrames.ts`, `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts`
 
 ### WHERE — Filter boundaries
@@ -297,7 +307,6 @@ The only remaining hole is NTZ-style columns storing non-UTC data on warehouses 
 
 | Gap                                                              | Description                                                                                                                                                                                                                                                                           | Impact                                                                                                                                            |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **EXTRACT-based time dimensions are not timezone-aware**         | Intervals that use EXTRACT/DATE_PART rather than DATE_TRUNC (e.g. `DAY_OF_WEEK_INDEX`, `MONTH_NUM`, `HOUR_OF_DAY_NUM`, `QUARTER_NUM`) read parts of the raw UTC value                                                                                                                 | "Day of week" and similar slicers bucket rows by UTC components, which can disagree with a project-TZ DATE_TRUNC grouped next to them             |
 | **BigQuery/Athena: no session timezone**                         | These warehouses have no session-timezone plumbing, so the data-timezone setting is inert. NTZ-style columns (BigQuery `DATETIME`, Athena bare `TIMESTAMP`) can't be rebased from their stored zone to UTC                                                                           | Data timezone setting has no effect (UI field is hidden); NTZ columns holding non-UTC data can't be normalized                                    |
 | **Excel exports render DATE/TIMESTAMP cells in UTC**             | `convertRowToExcel` writes raw `Date` objects for field-level DATE and TIMESTAMP values so Excel treats the cell as a native date (sortable, filterable, with column-level `numFmt`). Routing through the timezone-aware formatter returns a string and loses those semantics. `Date` also carries no zone — ExcelJS serializes via UTC components — so there's no clean way to land a project-TZ wall-clock in a real date cell | Excel downloads show UTC wall-clock for DATE/TIMESTAMP columns, so Excel and CSV downloads of the same query disagree when a project timezone is set |
 | **Google Sheets pivot deliveries render TIMESTAMP/DATE cells in UTC** | Gsheet pivot deliveries call `pivotResultsAsCsv({ onlyRaw: true })`, which reads `value.raw` and skips the timezone-formatted output from `formatRows`. Pivot column headers built via `formatItemValue` also omit the timezone args. Kept raw so columns preserve their native types in Google Sheets | Gsheet pivot output renders timestamps in UTC even with `EnableTimezoneSupport` on, so it disagrees with the Explorer view when the project TZ is non-UTC |
@@ -322,7 +331,7 @@ flowchart TD
 ### What "fully working" means
 
 1. **Filters:** all relative operators compute boundaries in project TZ, literals are unambiguously UTC (with the known BigQuery/ClickHouse bare-literal caveat), and comparisons work for both TZ and NTZ columns on every warehouse with session-TZ plumbing.
-2. **DATE_TRUNC:** groups at project-TZ boundaries on every warehouse. Truncated intervals round-trip through project wall-clock. EXTRACT-based intervals still read UTC components — the remaining correctness gap.
+2. **Time dimensions:** groups at project-TZ boundaries on every warehouse. Truncated intervals (DATE_TRUNC) round-trip through project wall-clock; EXTRACT-based intervals (numeric and Name variants) shift their input into the project zone before extracting. Both paths bypass the wrap when the base dimension is a DATE.
 3. **Display:** formatted timestamps reflect the project timezone across Explorer, chart axes, tooltips, and CSV exports, with the resolved zone labelled in the UI. Truncated intervals on a DATE base dimension skip the shift so calendar dates render as-is.
 4. **NTZ normalization:** NTZ columns are interpreted via the data timezone at query time. Today this relies on warehouse session-TZ plumbing — every supported warehouse has it except BigQuery and Athena, where NTZ-style columns with non-UTC data are stuck.
 

--- a/examples/full-jaffle-shop-demo/dbt/models/timezone_test.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/timezone_test.yml
@@ -36,7 +36,12 @@ models:
         meta:
           dimension:
             type: timestamp
-            time_intervals: [RAW, MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR]
+            time_intervals: [
+              RAW, MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR,
+              DAY_OF_WEEK_INDEX, DAY_OF_MONTH_NUM, DAY_OF_YEAR_NUM, WEEK_NUM,
+              MONTH_NUM, QUARTER_NUM, YEAR_NUM, HOUR_OF_DAY_NUM, MINUTE_OF_HOUR_NUM,
+              DAY_OF_WEEK_NAME, MONTH_NAME, QUARTER_NAME,
+            ]
           metrics:
             count:
               type: count
@@ -48,7 +53,12 @@ models:
         meta:
           dimension:
             type: timestamp
-            time_intervals: [RAW, MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR]
+            time_intervals: [
+              RAW, MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR,
+              DAY_OF_WEEK_INDEX, DAY_OF_MONTH_NUM, DAY_OF_YEAR_NUM, WEEK_NUM,
+              MONTH_NUM, QUARTER_NUM, YEAR_NUM, HOUR_OF_DAY_NUM, MINUTE_OF_HOUR_NUM,
+              DAY_OF_WEEK_NAME, MONTH_NAME, QUARTER_NAME,
+            ]
           metrics:
             count_ntz:
               type: count

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -4944,3 +4944,256 @@ describe('Nested aggregate metrics', () => {
         expect(result.query.match(/AS "my_table_sum_of_max"/g)).toHaveLength(1);
     });
 });
+
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+describe('Timezone-aware EXTRACT-based time dimensions', () => {
+    const buildExtractExplore = (
+        baseType: DimensionType,
+        adapter: SupportedDbtAdapter = SupportedDbtAdapter.POSTGRES,
+    ): Explore => ({
+        targetDatabase: adapter,
+        name: 'events',
+        label: 'events',
+        baseTable: 'events',
+        tags: [],
+        joinedTables: [],
+        tables: {
+            events: {
+                name: 'events',
+                label: 'events',
+                database: 'db',
+                schema: 's',
+                sqlTable: '"events"',
+                primaryKey: ['id'],
+                dimensions: {
+                    id: {
+                        type: DimensionType.NUMBER,
+                        name: 'id',
+                        label: 'id',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: '${TABLE}.id',
+                        compiledSql: '"events".id',
+                        tablesReferences: ['events'],
+                        hidden: false,
+                    },
+                    occurred_at: {
+                        type: baseType,
+                        name: 'occurred_at',
+                        label: 'occurred_at',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: '${TABLE}.occurred_at',
+                        compiledSql: '"events".occurred_at',
+                        tablesReferences: ['events'],
+                        hidden: false,
+                    },
+                    occurred_at_day_of_week_index: {
+                        type: DimensionType.NUMBER,
+                        name: 'occurred_at_day_of_week_index',
+                        label: 'occurred_at_day_of_week_index',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: `DATE_PART('DOW', \${TABLE}.occurred_at)`,
+                        // Compile-time UTC-only SQL (matches today's behavior)
+                        compiledSql: `DATE_PART('DOW', "events".occurred_at)`,
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        timeInterval: TimeFrames.DAY_OF_WEEK_INDEX,
+                        timeIntervalBaseDimensionName: 'occurred_at',
+                    },
+                    occurred_at_week_num: {
+                        type: DimensionType.NUMBER,
+                        name: 'occurred_at_week_num',
+                        label: 'occurred_at_week_num',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: `DATE_PART('WEEK', \${TABLE}.occurred_at)`,
+                        compiledSql: `DATE_PART('WEEK', "events".occurred_at)`,
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        timeInterval: TimeFrames.WEEK_NUM,
+                        timeIntervalBaseDimensionName: 'occurred_at',
+                    },
+                    occurred_at_day_of_week_name: {
+                        type: DimensionType.STRING,
+                        name: 'occurred_at_day_of_week_name',
+                        label: 'occurred_at_day_of_week_name',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: `TO_CHAR(\${TABLE}.occurred_at, 'FMDay')`,
+                        compiledSql: `TO_CHAR("events".occurred_at, 'FMDay')`,
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        timeInterval: TimeFrames.DAY_OF_WEEK_NAME,
+                        timeIntervalBaseDimensionName: 'occurred_at',
+                    },
+                },
+                metrics: {
+                    event_count: {
+                        type: MetricType.COUNT,
+                        fieldType: FieldType.METRIC,
+                        table: 'events',
+                        tableLabel: 'events',
+                        name: 'event_count',
+                        label: 'event_count',
+                        sql: '${TABLE}.id',
+                        compiledSql: 'COUNT("events".id)',
+                        tablesReferences: ['events'],
+                        hidden: false,
+                    },
+                },
+                lineageGraph: {},
+            },
+        },
+    });
+
+    const baseDowQuery = (filterValues?: number[]): CompiledMetricQuery => ({
+        exploreName: 'events',
+        dimensions: ['events_occurred_at_day_of_week_index'],
+        metrics: ['events_event_count'],
+        filters: filterValues
+            ? {
+                  dimensions: {
+                      id: 'root',
+                      and: [
+                          {
+                              id: 'dow-eq',
+                              target: {
+                                  fieldId:
+                                      'events_occurred_at_day_of_week_index',
+                              },
+                              operator: FilterOperator.EQUALS,
+                              values: filterValues,
+                          },
+                      ],
+                  },
+              }
+            : {},
+        sorts: [],
+        limit: 100,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    });
+
+    test('TIMESTAMP base + flag on + non-UTC TZ wraps SELECT (Postgres)', () => {
+        const { query } = buildQuery({
+            explore: buildExtractExplore(DimensionType.TIMESTAMP),
+            compiledMetricQuery: baseDowQuery(),
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            useTimezoneAwareDateTrunc: true,
+        });
+        expect(query).toContain(
+            `DATE_PART('DOW', ("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York')`,
+        );
+        // Bare UTC SQL must not be present
+        expect(query).not.toMatch(/DATE_PART\('DOW', "events"\.occurred_at\)/);
+    });
+
+    test('TIMESTAMP base + flag on + non-UTC TZ wraps WHERE filter LHS (Postgres)', () => {
+        const { query } = buildQuery({
+            explore: buildExtractExplore(DimensionType.TIMESTAMP),
+            compiledMetricQuery: baseDowQuery([1]),
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            useTimezoneAwareDateTrunc: true,
+        });
+        // Both SELECT and WHERE LHS must use the wrapped expression so they
+        // agree on what counts as e.g. Monday in the project zone.
+        const wrappedSql = `DATE_PART('DOW', ("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York')`;
+        expect(
+            query.match(new RegExp(escapeRegExp(wrappedSql), 'g')),
+        ).not.toBeNull();
+        expect(
+            query.match(new RegExp(escapeRegExp(wrappedSql), 'g'))!.length,
+        ).toBeGreaterThanOrEqual(2);
+    });
+
+    test('DATE base dimension + flag on + non-UTC TZ short-circuits (bare EXTRACT)', () => {
+        const { query } = buildQuery({
+            explore: buildExtractExplore(DimensionType.DATE),
+            compiledMetricQuery: baseDowQuery(),
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            useTimezoneAwareDateTrunc: true,
+        });
+        expect(query).toContain(`DATE_PART('DOW', "events".occurred_at)`);
+        expect(query).not.toContain('AT TIME ZONE');
+    });
+
+    test('TIMESTAMP base + flag off → bare EXTRACT', () => {
+        const { query } = buildQuery({
+            explore: buildExtractExplore(DimensionType.TIMESTAMP),
+            compiledMetricQuery: baseDowQuery(),
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            useTimezoneAwareDateTrunc: false,
+        });
+        expect(query).toContain(`DATE_PART('DOW', "events".occurred_at)`);
+        expect(query).not.toContain('AT TIME ZONE');
+    });
+
+    test('Name variant (DAY_OF_WEEK_NAME) wraps with the project TZ', () => {
+        const { query } = buildQuery({
+            explore: buildExtractExplore(DimensionType.TIMESTAMP),
+            compiledMetricQuery: {
+                ...baseDowQuery(),
+                dimensions: ['events_occurred_at_day_of_week_name'],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            useTimezoneAwareDateTrunc: true,
+        });
+        expect(query).toContain(
+            `TO_CHAR(("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York', 'FMDay')`,
+        );
+    });
+
+    test('WEEK_NUM with non-default startOfWeek composes with the TZ wrap (Postgres)', () => {
+        // Build an explore overriding startOfWeek for the events table.
+        const explore = buildExtractExplore(DimensionType.TIMESTAMP);
+        explore.tables.events = {
+            ...explore.tables.events,
+            orderFieldsBy: undefined,
+        };
+        const { query } = buildQuery({
+            explore: {
+                ...explore,
+                tables: {
+                    ...explore.tables,
+                    events: {
+                        ...explore.tables.events,
+                    },
+                },
+            },
+            compiledMetricQuery: {
+                ...baseDowQuery(),
+                dimensions: ['events_occurred_at_week_num'],
+            },
+            warehouseSqlBuilder: {
+                ...warehouseClientMock,
+                getStartOfWeek: () => 2 /* Wednesday */,
+            },
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            useTimezoneAwareDateTrunc: true,
+        });
+        expect(query).toContain(
+            `DATE_PART('WEEK', (("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York' - interval '2 days'))`,
+        );
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -5164,22 +5164,8 @@ describe('Timezone-aware EXTRACT-based time dimensions', () => {
     });
 
     test('WEEK_NUM with non-default startOfWeek composes with the TZ wrap (Postgres)', () => {
-        // Build an explore overriding startOfWeek for the events table.
-        const explore = buildExtractExplore(DimensionType.TIMESTAMP);
-        explore.tables.events = {
-            ...explore.tables.events,
-            orderFieldsBy: undefined,
-        };
         const { query } = buildQuery({
-            explore: {
-                ...explore,
-                tables: {
-                    ...explore.tables,
-                    events: {
-                        ...explore.tables.events,
-                    },
-                },
-            },
+            explore: buildExtractExplore(DimensionType.TIMESTAMP),
             compiledMetricQuery: {
                 ...baseDowQuery(),
                 dimensions: ['events_occurred_at_week_num'],

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -583,9 +583,7 @@ export class MetricQueryBuilder {
         );
     }
 
-    /** Regenerates timestamp-derived SQL with timezone conversion: DATE_TRUNC
-     *  for truncatable intervals, EXTRACT/DATE_PART (and format/name) for
-     *  extractable ones. */
+    /** Rewrites `compiledSql` with the project-TZ wrap for truncatable and extractable intervals. */
     private getTimezoneAwareDimensionSql(
         dimension: CompiledDimension,
         adapterType: SupportedDbtAdapter,
@@ -603,7 +601,6 @@ export class MetricQueryBuilder {
             return dimension.compiledSql;
         }
 
-        // Get base dimension's compiledSql (before DATE_TRUNC / EXTRACT)
         const baseDimensionId = dimension.timeIntervalBaseDimensionName
             ? `${dimension.table}_${dimension.timeIntervalBaseDimensionName}`
             : undefined;
@@ -612,9 +609,7 @@ export class MetricQueryBuilder {
             ? this.exploreDimensions[baseDimensionId]
             : undefined;
 
-        // DATE base dimensions short-circuit: DATE has no time component, so
-        // EXTRACT is already in the project's calendar and DATE_TRUNC's tz
-        // round-trip would either error or anchor at midnight UTC and drift.
+        // DATE base: no time component to shift, so the wrap would drift at midnight.
         if (
             !baseDimension?.compiledSql ||
             baseDimension.type !== DimensionType.TIMESTAMP
@@ -633,8 +628,6 @@ export class MetricQueryBuilder {
             );
         }
 
-        // Extract/format path — timeFrameConfigs.getSql dispatches to
-        // getSqlForDatePart (numeric) or getSqlForDatePartName (Name variants).
         return timeFrameConfigs[dimension.timeInterval].getSql(
             adapterType,
             dimension.timeInterval,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -10,6 +10,7 @@ import {
     DimensionType,
     Explore,
     ExploreCompiler,
+    extractableTimeFrames,
     extractTotalReferences,
     FieldReferenceError,
     FieldType,
@@ -58,6 +59,7 @@ import {
     sqlContainsAggregation,
     SupportedDbtAdapter,
     TableCalculationFunctionCompiler,
+    timeFrameConfigs,
     TimeFrames,
     truncatableTimeFrames,
     UserAttributeValueMap,
@@ -581,7 +583,9 @@ export class MetricQueryBuilder {
         );
     }
 
-    /** Regenerates DATE_TRUNC with timezone conversion for truncatable timestamp dimensions. */
+    /** Regenerates timestamp-derived SQL with timezone conversion: DATE_TRUNC
+     *  for truncatable intervals, EXTRACT/DATE_PART (and format/name) for
+     *  extractable ones. */
     private getTimezoneAwareDimensionSql(
         dimension: CompiledDimension,
         adapterType: SupportedDbtAdapter,
@@ -589,17 +593,17 @@ export class MetricQueryBuilder {
     ): string {
         const { timezone, useTimezoneAwareDateTrunc } = this.args;
 
-        // Skip non-truncatable intervals (DAY_OF_WEEK_INDEX, MONTH_NUM, etc.)
-        // which use EXTRACT/DATE_PART, not DATE_TRUNC.
-        if (
-            !useTimezoneAwareDateTrunc ||
-            !dimension.timeInterval ||
-            !truncatableTimeFrames.has(dimension.timeInterval)
-        ) {
+        if (!useTimezoneAwareDateTrunc || !dimension.timeInterval) {
             return dimension.compiledSql;
         }
 
-        // Get base dimension's compiledSql (before DATE_TRUNC)
+        const isTruncatable = truncatableTimeFrames.has(dimension.timeInterval);
+        const isExtractable = extractableTimeFrames.has(dimension.timeInterval);
+        if (!isTruncatable && !isExtractable) {
+            return dimension.compiledSql;
+        }
+
+        // Get base dimension's compiledSql (before DATE_TRUNC / EXTRACT)
         const baseDimensionId = dimension.timeIntervalBaseDimensionName
             ? `${dimension.table}_${dimension.timeIntervalBaseDimensionName}`
             : undefined;
@@ -608,6 +612,9 @@ export class MetricQueryBuilder {
             ? this.exploreDimensions[baseDimensionId]
             : undefined;
 
+        // DATE base dimensions short-circuit: DATE has no time component, so
+        // EXTRACT is already in the project's calendar and DATE_TRUNC's tz
+        // round-trip would either error or anchor at midnight UTC and drift.
         if (
             !baseDimension?.compiledSql ||
             baseDimension.type !== DimensionType.TIMESTAMP
@@ -615,7 +622,20 @@ export class MetricQueryBuilder {
             return dimension.compiledSql;
         }
 
-        return getSqlForTruncatedDate(
+        if (isTruncatable) {
+            return getSqlForTruncatedDate(
+                adapterType,
+                dimension.timeInterval,
+                baseDimension.compiledSql,
+                baseDimension.type,
+                startOfWeek,
+                timezone,
+            );
+        }
+
+        // Extract/format path — timeFrameConfigs.getSql dispatches to
+        // getSqlForDatePart (numeric) or getSqlForDatePartName (Name variants).
+        return timeFrameConfigs[dimension.timeInterval].getSql(
             adapterType,
             dimension.timeInterval,
             baseDimension.compiledSql,

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -665,12 +665,12 @@ describe('TimeFrames', () => {
     });
 
     describe('dateExtractsTimezoneConversions', () => {
-        test('BigQuery emits AT TIME ZONE inside the EXTRACT input', () => {
+        test('BigQuery coerces to TIMESTAMP and emits AT TIME ZONE inside the EXTRACT input', () => {
             expect(
                 dateExtractsTimezoneConversions[
                     SupportedDbtAdapter.BIGQUERY
                 ].toExtractInputTz('col', 'America/New_York'),
-            ).toEqual(`col AT TIME ZONE 'America/New_York'`);
+            ).toEqual(`TIMESTAMP(col) AT TIME ZONE 'America/New_York'`);
         });
 
         test('Snowflake uses CONVERT_TIMEZONE', () => {
@@ -741,7 +741,7 @@ describe('TimeFrames', () => {
         test.each([
             [
                 SupportedDbtAdapter.BIGQUERY,
-                `EXTRACT(DAYOFWEEK FROM ${col} AT TIME ZONE '${tz}')`,
+                `EXTRACT(DAYOFWEEK FROM TIMESTAMP(${col}) AT TIME ZONE '${tz}')`,
             ],
             [
                 SupportedDbtAdapter.SNOWFLAKE,
@@ -792,7 +792,7 @@ describe('TimeFrames', () => {
         test.each([
             [
                 SupportedDbtAdapter.BIGQUERY,
-                `EXTRACT(MONTH FROM ${col} AT TIME ZONE '${tz}')`,
+                `EXTRACT(MONTH FROM TIMESTAMP(${col}) AT TIME ZONE '${tz}')`,
             ],
             [
                 SupportedDbtAdapter.SNOWFLAKE,
@@ -887,7 +887,7 @@ describe('TimeFrames', () => {
                     tz,
                 ),
             ).toEqual(
-                `EXTRACT(WEEK(WEDNESDAY) FROM ${col} AT TIME ZONE '${tz}')`,
+                `EXTRACT(WEEK(WEDNESDAY) FROM TIMESTAMP(${col}) AT TIME ZONE '${tz}')`,
             );
         });
 
@@ -914,7 +914,7 @@ describe('TimeFrames', () => {
         test.each([
             [
                 SupportedDbtAdapter.BIGQUERY,
-                `FORMAT_TIMESTAMP('%A', ${col}, '${tz}')`,
+                `FORMAT_TIMESTAMP('%A', TIMESTAMP(${col}), '${tz}')`,
             ],
             [
                 SupportedDbtAdapter.POSTGRES,
@@ -989,7 +989,9 @@ describe('TimeFrames', () => {
                         null,
                         tz,
                     ),
-                ).toEqual(`FORMAT_TIMESTAMP('${format}', ${col}, '${tz}')`);
+                ).toEqual(
+                    `FORMAT_TIMESTAMP('${format}', TIMESTAMP(${col}), '${tz}')`,
+                );
             },
         );
     });

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -925,6 +925,21 @@ describe('TimeFrames', () => {
                 `MOD(CAST(DATE_PART('DOW', (${col})::timestamptz AT TIME ZONE '${tz}') AS INT) - 1 + 7, 7) + 1`,
             );
         });
+
+        test('DAY_OF_WEEK_INDEX with startOfWeek composes mod arithmetic with tz wrap (BigQuery)', () => {
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.DAY_OF_WEEK_INDEX,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    WeekDay.MONDAY,
+                    tz,
+                ),
+            ).toEqual(
+                `MOD(EXTRACT(DAYOFWEEK FROM TIMESTAMP(${col}) AT TIME ZONE '${tz}') - 2 + 7, 7) + 1`,
+            );
+        });
     });
 
     describe('getSqlForDatePartName with timezone (Name variants)', () => {

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -2,8 +2,12 @@ import { SupportedDbtAdapter } from '../types/dbt';
 import { DimensionType } from '../types/field';
 import { DateGranularity, TimeFrames } from '../types/timeFrames';
 import {
+    dateExtractsTimezoneConversions,
     dateTruncTimezoneConversions,
+    extractableTimeFrames,
     getDateDimension,
+    getSqlForDatePart,
+    getSqlForDatePartName,
     getSqlForTruncatedDate,
     isSubDayGranularity,
     SUB_DAY_GRANULARITIES,
@@ -634,6 +638,331 @@ describe('TimeFrames', () => {
             ).toEqual(
                 `CONVERT_TIMEZONE('${tz}', 'UTC', DATE_TRUNC('DAY', CONVERT_TIMEZONE('UTC', '${tz}', ${col})))`,
             );
+        });
+    });
+
+    describe('extractableTimeFrames', () => {
+        test('contains numeric and Name EXTRACT-style intervals, not truncatable ones', () => {
+            expect(
+                extractableTimeFrames.has(TimeFrames.DAY_OF_WEEK_INDEX),
+            ).toBe(true);
+            expect(extractableTimeFrames.has(TimeFrames.MONTH_NUM)).toBe(true);
+            expect(extractableTimeFrames.has(TimeFrames.HOUR_OF_DAY_NUM)).toBe(
+                true,
+            );
+            expect(extractableTimeFrames.has(TimeFrames.DAY_OF_WEEK_NAME)).toBe(
+                true,
+            );
+            expect(extractableTimeFrames.has(TimeFrames.MONTH_NAME)).toBe(true);
+            expect(extractableTimeFrames.has(TimeFrames.QUARTER_NAME)).toBe(
+                true,
+            );
+
+            expect(extractableTimeFrames.has(TimeFrames.DAY)).toBe(false);
+            expect(extractableTimeFrames.has(TimeFrames.WEEK)).toBe(false);
+            expect(extractableTimeFrames.has(TimeFrames.RAW)).toBe(false);
+        });
+    });
+
+    describe('dateExtractsTimezoneConversions', () => {
+        test('BigQuery emits AT TIME ZONE inside the EXTRACT input', () => {
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.BIGQUERY
+                ].toExtractInputTz('col', 'America/New_York'),
+            ).toEqual(`col AT TIME ZONE 'America/New_York'`);
+        });
+
+        test('Snowflake uses CONVERT_TIMEZONE', () => {
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.SNOWFLAKE
+                ].toExtractInputTz('col', 'America/New_York'),
+            ).toEqual(`CONVERT_TIMEZONE('UTC', 'America/New_York', col)`);
+        });
+
+        test('Postgres / Redshift / DuckDB share the timestamptz cast form', () => {
+            const expected = `(col)::timestamptz AT TIME ZONE 'America/New_York'`;
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.POSTGRES
+                ].toExtractInputTz('col', 'America/New_York'),
+            ).toEqual(expected);
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.REDSHIFT
+                ].toExtractInputTz('col', 'America/New_York'),
+            ).toEqual(expected);
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.DUCKDB
+                ].toExtractInputTz('col', 'America/New_York'),
+            ).toEqual(expected);
+        });
+
+        test('Trino / Athena cast back to naive timestamp', () => {
+            const expected = `CAST(col AT TIME ZONE 'America/New_York' AS timestamp)`;
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.TRINO
+                ].toExtractInputTz('col', 'America/New_York'),
+            ).toEqual(expected);
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.ATHENA
+                ].toExtractInputTz('col', 'America/New_York'),
+            ).toEqual(expected);
+        });
+
+        test('Databricks composes from_utc/to_utc with current_timezone', () => {
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.DATABRICKS
+                ].toExtractInputTz('col', 'America/New_York'),
+            ).toEqual(
+                `from_utc_timestamp(to_utc_timestamp(col, current_timezone()), 'America/New_York')`,
+            );
+        });
+
+        test('ClickHouse wraps with toTimeZone (mirrors DATE_TRUNC pattern)', () => {
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.CLICKHOUSE
+                ].toExtractInputTz('col', 'America/New_York'),
+            ).toEqual(`toTimeZone(col, 'America/New_York')`);
+        });
+    });
+
+    describe('getSqlForDatePart with timezone', () => {
+        const tz = 'America/New_York';
+        const col = 'event_ts';
+
+        // DAY_OF_WEEK_INDEX (no startOfWeek) — exercises the bare extract path.
+        test.each([
+            [
+                SupportedDbtAdapter.BIGQUERY,
+                `EXTRACT(DAYOFWEEK FROM ${col} AT TIME ZONE '${tz}')`,
+            ],
+            [
+                SupportedDbtAdapter.SNOWFLAKE,
+                `DATE_PART('DOW', CONVERT_TIMEZONE('UTC', '${tz}', ${col}))`,
+            ],
+            [
+                SupportedDbtAdapter.POSTGRES,
+                `DATE_PART('DOW', (${col})::timestamptz AT TIME ZONE '${tz}')`,
+            ],
+            [
+                SupportedDbtAdapter.REDSHIFT,
+                `DATE_PART('DOW', (${col})::timestamptz AT TIME ZONE '${tz}')`,
+            ],
+            [
+                SupportedDbtAdapter.DUCKDB,
+                `DATE_PART('DOW', (${col})::timestamptz AT TIME ZONE '${tz}')`,
+            ],
+            [
+                SupportedDbtAdapter.DATABRICKS,
+                `DATE_PART('DOW', from_utc_timestamp(to_utc_timestamp(${col}, current_timezone()), '${tz}'))`,
+            ],
+            [
+                SupportedDbtAdapter.TRINO,
+                `EXTRACT(DOW FROM CAST(${col} AT TIME ZONE '${tz}' AS timestamp))`,
+            ],
+            [
+                SupportedDbtAdapter.ATHENA,
+                `EXTRACT(DOW FROM CAST(${col} AT TIME ZONE '${tz}' AS timestamp))`,
+            ],
+            [
+                SupportedDbtAdapter.CLICKHOUSE,
+                `toDayOfWeek(toTimeZone(${col}, '${tz}'))`,
+            ],
+        ])('%s: DAY_OF_WEEK_INDEX wraps input in tz', (adapter, expected) => {
+            expect(
+                getSqlForDatePart(
+                    adapter,
+                    TimeFrames.DAY_OF_WEEK_INDEX,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    tz,
+                ),
+            ).toEqual(expected);
+        });
+
+        // MONTH_NUM — exercises the standard EXTRACT(part FROM ...) path.
+        test.each([
+            [
+                SupportedDbtAdapter.BIGQUERY,
+                `EXTRACT(MONTH FROM ${col} AT TIME ZONE '${tz}')`,
+            ],
+            [
+                SupportedDbtAdapter.SNOWFLAKE,
+                `DATE_PART('MONTH', CONVERT_TIMEZONE('UTC', '${tz}', ${col}))`,
+            ],
+            [
+                SupportedDbtAdapter.POSTGRES,
+                `DATE_PART('MONTH', (${col})::timestamptz AT TIME ZONE '${tz}')`,
+            ],
+            [
+                SupportedDbtAdapter.CLICKHOUSE,
+                `toMonth(toTimeZone(${col}, '${tz}'))`,
+            ],
+        ])('%s: MONTH_NUM wraps input in tz', (adapter, expected) => {
+            expect(
+                getSqlForDatePart(
+                    adapter,
+                    TimeFrames.MONTH_NUM,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    tz,
+                ),
+            ).toEqual(expected);
+        });
+
+        test('flag-off (no timezone arg): byte-identical to bare EXTRACT', () => {
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.DAY_OF_WEEK_INDEX,
+                    col,
+                    DimensionType.TIMESTAMP,
+                ),
+            ).toEqual(`DATE_PART('DOW', ${col})`);
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.MONTH_NUM,
+                    col,
+                    DimensionType.TIMESTAMP,
+                ),
+            ).toEqual(`EXTRACT(MONTH FROM ${col})`);
+        });
+
+        test('DATE base dimension with timezone short-circuits (no wrap)', () => {
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.DAY_OF_WEEK_INDEX,
+                    col,
+                    DimensionType.DATE,
+                    null,
+                    tz,
+                ),
+            ).toEqual(`DATE_PART('DOW', ${col})`);
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.MONTH_NUM,
+                    col,
+                    DimensionType.DATE,
+                    null,
+                    tz,
+                ),
+            ).toEqual(`EXTRACT(MONTH FROM ${col})`);
+        });
+
+        test('WEEK_NUM with non-default startOfWeek composes with the tz wrap (Postgres)', () => {
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.WEEK_NUM,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    WeekDay.WEDNESDAY,
+                    tz,
+                ),
+            ).toEqual(
+                `DATE_PART('WEEK', ((${col})::timestamptz AT TIME ZONE '${tz}' - interval '2 days'))`,
+            );
+        });
+
+        test('WEEK_NUM with non-default startOfWeek composes with the tz wrap (BigQuery)', () => {
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.WEEK_NUM,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    WeekDay.WEDNESDAY,
+                    tz,
+                ),
+            ).toEqual(
+                `EXTRACT(WEEK(WEDNESDAY) FROM ${col} AT TIME ZONE '${tz}')`,
+            );
+        });
+
+        test('DAY_OF_WEEK_INDEX with startOfWeek composes mod arithmetic with tz wrap (Postgres)', () => {
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.DAY_OF_WEEK_INDEX,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    WeekDay.MONDAY,
+                    tz,
+                ),
+            ).toEqual(
+                `MOD(CAST(DATE_PART('DOW', (${col})::timestamptz AT TIME ZONE '${tz}') AS INT) - 1 + 7, 7) + 1`,
+            );
+        });
+    });
+
+    describe('getSqlForDatePartName with timezone (Name variants)', () => {
+        const tz = 'America/New_York';
+        const col = 'event_ts';
+
+        test.each([
+            [
+                SupportedDbtAdapter.BIGQUERY,
+                `FORMAT_DATETIME('%A', ${col} AT TIME ZONE '${tz}')`,
+            ],
+            [
+                SupportedDbtAdapter.POSTGRES,
+                `TO_CHAR((${col})::timestamptz AT TIME ZONE '${tz}', 'FMDay')`,
+            ],
+            [
+                SupportedDbtAdapter.CLICKHOUSE,
+                `dateName('weekday', toTimeZone(${col}, '${tz}'))`,
+            ],
+            [
+                SupportedDbtAdapter.TRINO,
+                `date_format(CAST(${col} AT TIME ZONE '${tz}' AS timestamp), '%W')`,
+            ],
+        ])('%s: DAY_OF_WEEK_NAME wraps input in tz', (adapter, expected) => {
+            expect(
+                getSqlForDatePartName(
+                    adapter,
+                    TimeFrames.DAY_OF_WEEK_NAME,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    tz,
+                ),
+            ).toEqual(expected);
+        });
+
+        test('DATE base dimension with timezone short-circuits (Postgres)', () => {
+            expect(
+                getSqlForDatePartName(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.MONTH_NAME,
+                    col,
+                    DimensionType.DATE,
+                    null,
+                    tz,
+                ),
+            ).toEqual(`TO_CHAR(${col}, 'FMMonth')`);
+        });
+
+        test('flag-off: byte-identical to bare format', () => {
+            expect(
+                getSqlForDatePartName(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.MONTH_NAME,
+                    col,
+                    DimensionType.TIMESTAMP,
+                ),
+            ).toEqual(`TO_CHAR(${col}, 'FMMonth')`);
         });
     });
 });

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -941,6 +941,14 @@ describe('TimeFrames', () => {
                 `TO_CHAR((${col})::timestamptz AT TIME ZONE '${tz}', 'FMDay')`,
             ],
             [
+                SupportedDbtAdapter.SNOWFLAKE,
+                `DECODE(TO_CHAR(CONVERT_TIMEZONE('UTC', '${tz}', ${col}), 'DY'), 'Mon', 'Monday', 'Tue', 'Tuesday', 'Wed', 'Wednesday', 'Thu', 'Thursday', 'Fri', 'Friday', 'Sat', 'Saturday', 'Sun', 'Sunday')`,
+            ],
+            [
+                SupportedDbtAdapter.DATABRICKS,
+                `DATE_FORMAT(from_utc_timestamp(to_utc_timestamp(${col}, current_timezone()), '${tz}'), 'EEEE')`,
+            ],
+            [
                 SupportedDbtAdapter.CLICKHOUSE,
                 `dateName('weekday', toTimeZone(${col}, '${tz}'))`,
             ],

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -914,7 +914,7 @@ describe('TimeFrames', () => {
         test.each([
             [
                 SupportedDbtAdapter.BIGQUERY,
-                `FORMAT_DATETIME('%A', ${col} AT TIME ZONE '${tz}')`,
+                `FORMAT_TIMESTAMP('%A', ${col}, '${tz}')`,
             ],
             [
                 SupportedDbtAdapter.POSTGRES,
@@ -963,6 +963,34 @@ describe('TimeFrames', () => {
                     DimensionType.TIMESTAMP,
                 ),
             ).toEqual(`TO_CHAR(${col}, 'FMMonth')`);
+            expect(
+                getSqlForDatePartName(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.MONTH_NAME,
+                    col,
+                    DimensionType.TIMESTAMP,
+                ),
+            ).toEqual(`FORMAT_DATETIME('%B', ${col})`);
         });
+
+        test.each([
+            [TimeFrames.DAY_OF_WEEK_NAME, '%A'],
+            [TimeFrames.MONTH_NAME, '%B'],
+            [TimeFrames.QUARTER_NAME, 'Q%Q'],
+        ])(
+            'BigQuery %s: native FORMAT_TIMESTAMP with tz arg (no AT TIME ZONE)',
+            (timeFrame, format) => {
+                expect(
+                    getSqlForDatePartName(
+                        SupportedDbtAdapter.BIGQUERY,
+                        timeFrame,
+                        col,
+                        DimensionType.TIMESTAMP,
+                        null,
+                        tz,
+                    ),
+                ).toEqual(`FORMAT_TIMESTAMP('${format}', ${col}, '${tz}')`);
+            },
+        );
     });
 });

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -803,6 +803,26 @@ describe('TimeFrames', () => {
                 `DATE_PART('MONTH', (${col})::timestamptz AT TIME ZONE '${tz}')`,
             ],
             [
+                SupportedDbtAdapter.REDSHIFT,
+                `DATE_PART('MONTH', (${col})::timestamptz AT TIME ZONE '${tz}')`,
+            ],
+            [
+                SupportedDbtAdapter.DUCKDB,
+                `DATE_PART('MONTH', (${col})::timestamptz AT TIME ZONE '${tz}')`,
+            ],
+            [
+                SupportedDbtAdapter.DATABRICKS,
+                `DATE_PART('MONTH', from_utc_timestamp(to_utc_timestamp(${col}, current_timezone()), '${tz}'))`,
+            ],
+            [
+                SupportedDbtAdapter.TRINO,
+                `EXTRACT(MONTH FROM CAST(${col} AT TIME ZONE '${tz}' AS timestamp))`,
+            ],
+            [
+                SupportedDbtAdapter.ATHENA,
+                `EXTRACT(MONTH FROM CAST(${col} AT TIME ZONE '${tz}' AS timestamp))`,
+            ],
+            [
                 SupportedDbtAdapter.CLICKHOUSE,
                 `toMonth(toTimeZone(${col}, '${tz}'))`,
             ],

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -66,9 +66,6 @@ type WarehouseConfig = {
         startOfWeek?: WeekDay | null,
         timezone?: string,
     ) => string;
-    // `timezone`, when provided, swaps `originalSql` for the project-TZ
-    // shifted value (`dateExtractsTimezoneConversions[adapter].toExtractInputTz`)
-    // before composing the EXTRACT/DATE_PART expression.
     getSqlForDatePart: (
         timeFrame: TimeFrames,
         originalSql: string,
@@ -148,9 +145,7 @@ export const dateTruncTimezoneConversions: Record<
     },
 };
 
-/** Per-warehouse SQL for shifting an EXTRACT/DATE_PART input from UTC into
- *  the project zone before extracting a calendar component. EXTRACT returns
- *  a number/string, not a timestamp, so there is no inverse `toUTC`. */
+// EXTRACT returns a number/string, so no `toUTC` inverse — one-way shift only.
 type DateExtractTimezoneConversion = {
     toExtractInputTz: (sql: string, tz: string) => string;
 };
@@ -159,8 +154,7 @@ export const dateExtractsTimezoneConversions: Record<
     SupportedDbtAdapter,
     DateExtractTimezoneConversion
 > = {
-    // BigQuery: `AT TIME ZONE 'tz'` is only valid concatenated inside
-    // `EXTRACT(... FROM ...)`. The shape diverges from DATE_TRUNC's no-op.
+    // BigQuery: `AT TIME ZONE` only parses inside `EXTRACT(... FROM ...)`.
     [SupportedDbtAdapter.BIGQUERY]: {
         toExtractInputTz: (sql, tz) => `${sql} AT TIME ZONE '${tz}'`,
     },
@@ -750,13 +744,7 @@ export const getSqlForTruncatedDate = (
     return toUTC(truncated, timezone);
 };
 
-/**
- * Generates EXTRACT/DATE_PART SQL. When a timezone is provided on a TIMESTAMP
- * base dimension, the input is shifted into the project zone before the
- * calendar component is read, so the result agrees with sibling DATE_TRUNC
- * dimensions. DATE base dimensions short-circuit since they have no time
- * component to shift.
- */
+// DATE base dimensions short-circuit: no time component to shift.
 export const getSqlForDatePart = (
     adapterType: SupportedDbtAdapter,
     timeFrame: TimeFrames,
@@ -1013,9 +1001,7 @@ export const truncatableTimeFrames: ReadonlySet<TimeFrames> = new Set([
     TimeFrames.YEAR,
 ]);
 
-/** Time frames that use EXTRACT/DATE_PART (numeric) or format/name functions
- *  (string), as opposed to DATE_TRUNC. The TZ-aware path wraps the input via
- *  dateExtractsTimezoneConversions before extracting. */
+/** Time frames that use EXTRACT/DATE_PART or format/name functions, not DATE_TRUNC. */
 export const extractableTimeFrames: ReadonlySet<TimeFrames> = new Set([
     TimeFrames.DAY_OF_WEEK_INDEX,
     TimeFrames.DAY_OF_MONTH_NUM,

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -722,6 +722,9 @@ export const getSqlForDatePart = (
     );
 };
 
+// Unlike getSqlForDatePart, the wrap is applied per-adapter rather than
+// centrally — BigQuery's name path uses native FORMAT_TIMESTAMP(fmt, ts, tz)
+// and can't accept a pre-wrapped `... AT TIME ZONE` input.
 export const getSqlForDatePartName = (
     adapterType: SupportedDbtAdapter,
     timeFrame: TimeFrames,

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -296,12 +296,10 @@ const bigqueryConfig: WarehouseConfig = {
             );
         }
         if (type === DimensionType.TIMESTAMP) {
-            const sql = timezone
-                ? dateExtractsTimezoneConversions[
-                      SupportedDbtAdapter.BIGQUERY
-                  ].toExtractInputTz(originalSql, timezone)
-                : originalSql;
-            return `FORMAT_DATETIME('${formatExpression}', ${sql})`;
+            if (timezone) {
+                return `FORMAT_TIMESTAMP('${formatExpression}', ${originalSql}, '${timezone}')`;
+            }
+            return `FORMAT_DATETIME('${formatExpression}', ${originalSql})`;
         }
         return `FORMAT_DATE('${formatExpression}', ${originalSql})`;
     },

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -316,7 +316,7 @@ const snowflakeConfig: WarehouseConfig = {
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
         originalSql: string,
-        _,
+        _type,
         timezone,
     ) => {
         const sql = timezone
@@ -385,7 +385,7 @@ const postgresConfig: WarehouseConfig = {
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
         originalSql: string,
-        _,
+        _type,
         timezone,
     ) => {
         const sql = timezone
@@ -449,7 +449,7 @@ const databricksConfig: WarehouseConfig = {
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
         originalSql: string,
-        _,
+        _type,
         timezone,
     ) => {
         const sql = timezone
@@ -518,7 +518,7 @@ const trinoConfig: WarehouseConfig = {
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
         originalSql: string,
-        _,
+        _type,
         timezone,
     ) => {
         const sql = timezone
@@ -628,7 +628,7 @@ const clickhouseConfig: WarehouseConfig = {
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
         originalSql: string,
-        _,
+        _type,
         timezone,
     ) => {
         const sql = timezone

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -66,16 +66,21 @@ type WarehouseConfig = {
         startOfWeek?: WeekDay | null,
         timezone?: string,
     ) => string;
+    // `timezone`, when provided, swaps `originalSql` for the project-TZ
+    // shifted value (`dateExtractsTimezoneConversions[adapter].toExtractInputTz`)
+    // before composing the EXTRACT/DATE_PART expression.
     getSqlForDatePart: (
         timeFrame: TimeFrames,
         originalSql: string,
         type: DimensionType,
         startOfWeek?: WeekDay | null,
+        timezone?: string,
     ) => string;
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
         originalSql: string,
         type: DimensionType,
+        timezone?: string,
     ) => string;
 };
 
@@ -143,6 +148,55 @@ export const dateTruncTimezoneConversions: Record<
     },
 };
 
+/** Per-warehouse SQL for shifting an EXTRACT/DATE_PART input from UTC into
+ *  the project zone before extracting a calendar component. EXTRACT returns
+ *  a number/string, not a timestamp, so there is no inverse `toUTC`. */
+type DateExtractTimezoneConversion = {
+    toExtractInputTz: (sql: string, tz: string) => string;
+};
+
+export const dateExtractsTimezoneConversions: Record<
+    SupportedDbtAdapter,
+    DateExtractTimezoneConversion
+> = {
+    // BigQuery: `AT TIME ZONE 'tz'` is only valid concatenated inside
+    // `EXTRACT(... FROM ...)`. The shape diverges from DATE_TRUNC's no-op.
+    [SupportedDbtAdapter.BIGQUERY]: {
+        toExtractInputTz: (sql, tz) => `${sql} AT TIME ZONE '${tz}'`,
+    },
+    [SupportedDbtAdapter.SNOWFLAKE]: {
+        toExtractInputTz: (sql, tz) =>
+            `CONVERT_TIMEZONE('UTC', '${tz}', ${sql})`,
+    },
+    [SupportedDbtAdapter.POSTGRES]: {
+        toExtractInputTz: (sql, tz) =>
+            `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
+    },
+    [SupportedDbtAdapter.REDSHIFT]: {
+        toExtractInputTz: (sql, tz) =>
+            `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
+    },
+    [SupportedDbtAdapter.DUCKDB]: {
+        toExtractInputTz: (sql, tz) =>
+            `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
+    },
+    [SupportedDbtAdapter.DATABRICKS]: {
+        toExtractInputTz: (sql, tz) =>
+            `from_utc_timestamp(to_utc_timestamp(${sql}, current_timezone()), '${tz}')`,
+    },
+    [SupportedDbtAdapter.TRINO]: {
+        toExtractInputTz: (sql, tz) =>
+            `CAST(${sql} AT TIME ZONE '${tz}' AS timestamp)`,
+    },
+    [SupportedDbtAdapter.ATHENA]: {
+        toExtractInputTz: (sql, tz) =>
+            `CAST(${sql} AT TIME ZONE '${tz}' AS timestamp)`,
+    },
+    [SupportedDbtAdapter.CLICKHOUSE]: {
+        toExtractInputTz: (sql, tz) => `toTimeZone(${sql}, '${tz}')`,
+    },
+};
+
 export const SUB_DAY_TIME_FRAMES: ReadonlySet<TimeFrames> = new Set([
     TimeFrames.MILLISECOND,
     TimeFrames.SECOND,
@@ -194,7 +248,13 @@ const bigqueryConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
+        timezone,
     ) => {
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.BIGQUERY
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
         const bigqueryTimeFrameExpressions: Record<TimeFrames, string | null> =
             {
                 ...timeFrameToDatePartMap,
@@ -208,7 +268,7 @@ const bigqueryConfig: WarehouseConfig = {
         }
 
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
-            return `EXTRACT(${datePart}(${bigqueryStartOfWeekMap[startOfWeek]}) FROM ${originalSql})`;
+            return `EXTRACT(${datePart}(${bigqueryStartOfWeekMap[startOfWeek]}) FROM ${sql})`;
         }
 
         // BigQuery DAYOFWEEK: 1=Sunday, 2=Monday, ..., 7=Saturday
@@ -217,15 +277,16 @@ const bigqueryConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = ((startOfWeek + 1) % 7) + 1;
-            return `MOD(EXTRACT(DAYOFWEEK FROM ${originalSql}) - ${nativeOffset} + 7, 7) + 1`;
+            return `MOD(EXTRACT(DAYOFWEEK FROM ${sql}) - ${nativeOffset} + 7, 7) + 1`;
         }
 
-        return `EXTRACT(${datePart} FROM ${originalSql})`;
+        return `EXTRACT(${datePart} FROM ${sql})`;
     },
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
         originalSql: string,
         type: DimensionType,
+        timezone,
     ) => {
         // https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements#format_elements_date_time
         const timeFrameExpressions: Record<TimeFrames, string | null> = {
@@ -241,7 +302,12 @@ const bigqueryConfig: WarehouseConfig = {
             );
         }
         if (type === DimensionType.TIMESTAMP) {
-            return `FORMAT_DATETIME('${formatExpression}', ${originalSql})`;
+            const sql = timezone
+                ? dateExtractsTimezoneConversions[
+                      SupportedDbtAdapter.BIGQUERY
+                  ].toExtractInputTz(originalSql, timezone)
+                : originalSql;
+            return `FORMAT_DATETIME('${formatExpression}', ${sql})`;
         }
         return `FORMAT_DATE('${formatExpression}', ${originalSql})`;
     },
@@ -251,16 +317,37 @@ const bigqueryConfig: WarehouseConfig = {
 const snowflakeConfig: WarehouseConfig = {
     getSqlForTruncatedDate: (timeFrame, originalSql) =>
         `DATE_TRUNC('${timeFrame}', ${originalSql})`,
-    getSqlForDatePart: (timeFrame: TimeFrames, originalSql: string) => {
+    getSqlForDatePart: (
+        timeFrame: TimeFrames,
+        originalSql: string,
+        _,
+        __,
+        timezone,
+    ) => {
         const datePart = timeFrameToDatePartMap[timeFrame];
 
         if (!datePart) {
             throw new ParseError(`Cannot recognise date part for ${timeFrame}`);
         }
 
-        return `DATE_PART('${datePart}', ${originalSql})`;
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.SNOWFLAKE
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
+        return `DATE_PART('${datePart}', ${sql})`;
     },
-    getSqlForDatePartName: (timeFrame: TimeFrames, originalSql: string) => {
+    getSqlForDatePartName: (
+        timeFrame: TimeFrames,
+        originalSql: string,
+        _,
+        timezone,
+    ) => {
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.SNOWFLAKE
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
         // https://docs.snowflake.com/en/sql-reference/functions/to_char.html
         const timeFrameExpressionsFn: Record<
             TimeFrames,
@@ -268,10 +355,10 @@ const snowflakeConfig: WarehouseConfig = {
         > = {
             ...nullTimeFrameMap,
             [TimeFrames.DAY_OF_WEEK_NAME]: () =>
-                `DECODE(TO_CHAR(${originalSql}, 'DY'), 'Mon', 'Monday', 'Tue', 'Tuesday', 'Wed', 'Wednesday', 'Thu', 'Thursday', 'Fri', 'Friday', 'Sat', 'Saturday', 'Sun', 'Sunday')`,
-            [TimeFrames.MONTH_NAME]: () => `TO_CHAR(${originalSql}, 'MMMM')`,
+                `DECODE(TO_CHAR(${sql}, 'DY'), 'Mon', 'Monday', 'Tue', 'Tuesday', 'Wed', 'Wednesday', 'Thu', 'Thursday', 'Fri', 'Friday', 'Sat', 'Saturday', 'Sun', 'Sunday')`,
+            [TimeFrames.MONTH_NAME]: () => `TO_CHAR(${sql}, 'MMMM')`,
             [TimeFrames.QUARTER_NAME]: () =>
-                `CONCAT('Q', DATE_PART('QUARTER', ${originalSql}))`,
+                `CONCAT('Q', DATE_PART('QUARTER', ${sql}))`,
         };
         const formatExpressionFn = timeFrameExpressionsFn[timeFrame];
         if (!formatExpressionFn) {
@@ -296,6 +383,7 @@ const postgresConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
+        timezone,
     ) => {
         const datePart = timeFrameToDatePartMap[timeFrame];
 
@@ -303,9 +391,15 @@ const postgresConfig: WarehouseConfig = {
             throw new ParseError(`Cannot recognise date part for ${timeFrame}`);
         }
 
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.POSTGRES
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
+
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
             const intervalDiff = `${startOfWeek} days`;
-            return `DATE_PART('${datePart}', (${originalSql} - interval '${intervalDiff}'))`;
+            return `DATE_PART('${datePart}', (${sql} - interval '${intervalDiff}'))`;
         }
 
         // PostgreSQL DOW: 0=Sunday, 1=Monday, ..., 6=Saturday
@@ -314,12 +408,22 @@ const postgresConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = (startOfWeek + 1) % 7;
-            return `MOD(CAST(DATE_PART('DOW', ${originalSql}) AS INT) - ${nativeOffset} + 7, 7) + 1`;
+            return `MOD(CAST(DATE_PART('DOW', ${sql}) AS INT) - ${nativeOffset} + 7, 7) + 1`;
         }
 
-        return `DATE_PART('${datePart}', ${originalSql})`;
+        return `DATE_PART('${datePart}', ${sql})`;
     },
-    getSqlForDatePartName: (timeFrame: TimeFrames, originalSql: string) => {
+    getSqlForDatePartName: (
+        timeFrame: TimeFrames,
+        originalSql: string,
+        _,
+        timezone,
+    ) => {
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.POSTGRES
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
         // https://www.postgresql.org/docs/current/functions-formatting.html
         const timeFrameExpressions: Record<TimeFrames, string | null> = {
             ...nullTimeFrameMap,
@@ -333,7 +437,7 @@ const postgresConfig: WarehouseConfig = {
                 `Cannot recognise format expression for ${timeFrame}`,
             );
         }
-        return `TO_CHAR(${originalSql}, 'FM${formatExpression}')`;
+        return `TO_CHAR(${sql}, 'FM${formatExpression}')`;
     },
 };
 
@@ -350,6 +454,7 @@ const databricksConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
+        timezone,
     ) => {
         const datePart = timeFrameToDatePartMap[timeFrame];
 
@@ -357,9 +462,15 @@ const databricksConfig: WarehouseConfig = {
             throw new ParseError(`Cannot recognise date part for ${timeFrame}`);
         }
 
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.DATABRICKS
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
+
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
             const intervalDiff = `${startOfWeek} days`;
-            return `DATE_PART('${datePart}', (${originalSql} - interval '${intervalDiff}'))`;
+            return `DATE_PART('${datePart}', (${sql} - interval '${intervalDiff}'))`;
         }
 
         // Databricks DOW: 0=Sunday, 1=Monday, ..., 6=Saturday
@@ -368,12 +479,22 @@ const databricksConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = (startOfWeek + 1) % 7;
-            return `MOD(CAST(DATE_PART('DOW', ${originalSql}) AS INT) - ${nativeOffset} + 7, 7) + 1`;
+            return `MOD(CAST(DATE_PART('DOW', ${sql}) AS INT) - ${nativeOffset} + 7, 7) + 1`;
         }
 
-        return `DATE_PART('${datePart}', ${originalSql})`;
+        return `DATE_PART('${datePart}', ${sql})`;
     },
-    getSqlForDatePartName: (timeFrame: TimeFrames, originalSql: string) => {
+    getSqlForDatePartName: (
+        timeFrame: TimeFrames,
+        originalSql: string,
+        _,
+        timezone,
+    ) => {
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.DATABRICKS
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
         // https://docs.databricks.com/spark/latest/spark-sql/language-manual/functions/date_format.html
         const timeFrameExpressions: Record<TimeFrames, string | null> = {
             ...nullTimeFrameMap,
@@ -387,7 +508,7 @@ const databricksConfig: WarehouseConfig = {
                 `Cannot recognise format expression for ${timeFrame}`,
             );
         }
-        return `DATE_FORMAT(${originalSql}, '${formatExpression}')`;
+        return `DATE_FORMAT(${sql}, '${formatExpression}')`;
     },
 };
 
@@ -410,15 +531,22 @@ const trinoConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
+        timezone,
     ) => {
         const datePart = timeFrameToDatePartMap[timeFrame];
         if (!datePart) {
             throw new ParseError(`Cannot recognise date part for ${timeFrame}`);
         }
 
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.TRINO
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
+
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
             const intervalDiff = `'${startOfWeek}' day`;
-            return `EXTRACT(${datePart} FROM (${originalSql} - interval ${intervalDiff}))`;
+            return `EXTRACT(${datePart} FROM (${sql} - interval ${intervalDiff}))`;
         }
 
         // Trino DOW (ISO): 1=Monday, 2=Tuesday, ..., 7=Sunday
@@ -427,22 +555,31 @@ const trinoConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = startOfWeek + 1;
-            return `MOD(EXTRACT(DOW FROM ${originalSql}) - ${nativeOffset} + 7, 7) + 1`;
+            return `MOD(EXTRACT(DOW FROM ${sql}) - ${nativeOffset} + 7, 7) + 1`;
         }
 
-        return `EXTRACT(${datePart} FROM ${originalSql})`;
+        return `EXTRACT(${datePart} FROM ${sql})`;
     },
-    getSqlForDatePartName: (timeFrame: TimeFrames, originalSql: string) => {
+    getSqlForDatePartName: (
+        timeFrame: TimeFrames,
+        originalSql: string,
+        _,
+        timezone,
+    ) => {
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.TRINO
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
         const timeFrameExpressionsFn: Record<
             TimeFrames,
             (() => string) | null
         > = {
             ...nullTimeFrameMap,
-            [TimeFrames.DAY_OF_WEEK_NAME]: () =>
-                `date_format(${originalSql}, '%W')`,
-            [TimeFrames.MONTH_NAME]: () => `date_format(${originalSql}, '%M')`,
+            [TimeFrames.DAY_OF_WEEK_NAME]: () => `date_format(${sql}, '%W')`,
+            [TimeFrames.MONTH_NAME]: () => `date_format(${sql}, '%M')`,
             [TimeFrames.QUARTER_NAME]: () =>
-                `CONCAT('Q', cast(extract(QUARTER from ${originalSql}) as varchar))`,
+                `CONCAT('Q', cast(extract(QUARTER from ${sql}) as varchar))`,
         };
         const formatExpressionFn = timeFrameExpressionsFn[timeFrame];
         if (!formatExpressionFn) {
@@ -494,7 +631,14 @@ const clickhouseConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
+        timezone,
     ) => {
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.CLICKHOUSE
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
+
         const clickhouseTimeFrameMap: Record<TimeFrames, string | null> = {
             ...timeFrameToDatePartMap,
             [TimeFrames.DAY_OF_WEEK_INDEX]: 'toDayOfWeek',
@@ -514,7 +658,7 @@ const clickhouseConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = startOfWeek + 1;
-            return `modulo(toDayOfWeek(${originalSql}) - ${nativeOffset} + 7, 7) + 1`;
+            return `modulo(toDayOfWeek(${sql}) - ${nativeOffset} + 7, 7) + 1`;
         }
 
         // ClickHouse toWeek defaults to mode 0 (US, Sunday-base, 0–53). Mode 3 is
@@ -522,7 +666,7 @@ const clickhouseConfig: WarehouseConfig = {
         // toStartOfWeek(d, 1) used by truncation. The startOfWeek shift mirrors
         // what other warehouses do on the same path.
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
-            return `toWeek(addDays(${originalSql}, -${startOfWeek}), 3)`;
+            return `toWeek(addDays(${sql}, -${startOfWeek}), 3)`;
         }
 
         const extractFunction = clickhouseTimeFrameMap[timeFrame];
@@ -531,14 +675,24 @@ const clickhouseConfig: WarehouseConfig = {
                 `Cannot recognise extract function for ${timeFrame}`,
             );
         }
-        return `${extractFunction}(${originalSql})`;
+        return `${extractFunction}(${sql})`;
     },
-    getSqlForDatePartName: (timeFrame: TimeFrames, originalSql: string) => {
+    getSqlForDatePartName: (
+        timeFrame: TimeFrames,
+        originalSql: string,
+        _,
+        timezone,
+    ) => {
+        const sql = timezone
+            ? dateExtractsTimezoneConversions[
+                  SupportedDbtAdapter.CLICKHOUSE
+              ].toExtractInputTz(originalSql, timezone)
+            : originalSql;
         const timeFrameExpressions: Record<TimeFrames, string | null> = {
             ...nullTimeFrameMap,
-            [TimeFrames.DAY_OF_WEEK_NAME]: `dateName('weekday', ${originalSql})`,
-            [TimeFrames.MONTH_NAME]: `monthName(${originalSql})`,
-            [TimeFrames.QUARTER_NAME]: `concat('Q', toString(toQuarter(${originalSql})))`,
+            [TimeFrames.DAY_OF_WEEK_NAME]: `dateName('weekday', ${sql})`,
+            [TimeFrames.MONTH_NAME]: `monthName(${sql})`,
+            [TimeFrames.QUARTER_NAME]: `concat('Q', toString(toQuarter(${sql})))`,
         };
         const formatExpression = timeFrameExpressions[timeFrame];
         if (!formatExpression) {
@@ -596,30 +750,60 @@ export const getSqlForTruncatedDate = (
     return toUTC(truncated, timezone);
 };
 
-const getSqlForDatePart: TimeFrameConfig['getSql'] = (
-    adapterType,
-    timeFrame,
-    originalSql,
-    type,
-    startOfWeek,
-) =>
-    warehouseConfigs[adapterType].getSqlForDatePart(
+/**
+ * Generates EXTRACT/DATE_PART SQL. When a timezone is provided on a TIMESTAMP
+ * base dimension, the input is shifted into the project zone before the
+ * calendar component is read, so the result agrees with sibling DATE_TRUNC
+ * dimensions. DATE base dimensions short-circuit since they have no time
+ * component to shift.
+ */
+export const getSqlForDatePart = (
+    adapterType: SupportedDbtAdapter,
+    timeFrame: TimeFrames,
+    originalSql: string,
+    type: DimensionType,
+    startOfWeek?: WeekDay | null,
+    timezone?: string,
+): string => {
+    if (!timezone || type !== DimensionType.TIMESTAMP) {
+        return warehouseConfigs[adapterType].getSqlForDatePart(
+            timeFrame,
+            originalSql,
+            type,
+            startOfWeek,
+        );
+    }
+    return warehouseConfigs[adapterType].getSqlForDatePart(
         timeFrame,
         originalSql,
         type,
         startOfWeek,
+        timezone,
     );
-const getSqlForDatePartName: TimeFrameConfig['getSql'] = (
-    adapterType,
-    timeFrame,
-    originalSql,
-    type,
-) =>
-    warehouseConfigs[adapterType].getSqlForDatePartName(
+};
+
+export const getSqlForDatePartName = (
+    adapterType: SupportedDbtAdapter,
+    timeFrame: TimeFrames,
+    originalSql: string,
+    type: DimensionType,
+    _startOfWeek?: WeekDay | null,
+    timezone?: string,
+): string => {
+    if (!timezone || type !== DimensionType.TIMESTAMP) {
+        return warehouseConfigs[adapterType].getSqlForDatePartName(
+            timeFrame,
+            originalSql,
+            type,
+        );
+    }
+    return warehouseConfigs[adapterType].getSqlForDatePartName(
         timeFrame,
         originalSql,
         type,
+        timezone,
     );
+};
 
 type TimeFrameConfig = {
     getLabel: () => string;
@@ -630,6 +814,7 @@ type TimeFrameConfig = {
         originalSql: string,
         type: DimensionType,
         startOfWeek?: WeekDay | null,
+        timezone?: string,
     ) => string;
     getAxisMinInterval: () => number | null;
     getAxisLabelFormatter: () => Record<string, string> | null;
@@ -826,6 +1011,24 @@ export const truncatableTimeFrames: ReadonlySet<TimeFrames> = new Set([
     TimeFrames.MONTH,
     TimeFrames.QUARTER,
     TimeFrames.YEAR,
+]);
+
+/** Time frames that use EXTRACT/DATE_PART (numeric) or format/name functions
+ *  (string), as opposed to DATE_TRUNC. The TZ-aware path wraps the input via
+ *  dateExtractsTimezoneConversions before extracting. */
+export const extractableTimeFrames: ReadonlySet<TimeFrames> = new Set([
+    TimeFrames.DAY_OF_WEEK_INDEX,
+    TimeFrames.DAY_OF_MONTH_NUM,
+    TimeFrames.DAY_OF_YEAR_NUM,
+    TimeFrames.WEEK_NUM,
+    TimeFrames.MONTH_NUM,
+    TimeFrames.QUARTER_NUM,
+    TimeFrames.YEAR_NUM,
+    TimeFrames.HOUR_OF_DAY_NUM,
+    TimeFrames.MINUTE_OF_HOUR_NUM,
+    TimeFrames.DAY_OF_WEEK_NAME,
+    TimeFrames.MONTH_NAME,
+    TimeFrames.QUARTER_NAME,
 ]);
 
 export const isTimeInterval = (value: string): value is TimeFrames =>

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -71,7 +71,6 @@ type WarehouseConfig = {
         originalSql: string,
         type: DimensionType,
         startOfWeek?: WeekDay | null,
-        timezone?: string,
     ) => string;
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
@@ -154,9 +153,10 @@ export const dateExtractsTimezoneConversions: Record<
     SupportedDbtAdapter,
     DateExtractTimezoneConversion
 > = {
-    // BigQuery: `AT TIME ZONE` only parses inside `EXTRACT(... FROM ...)`.
+    // `AT TIME ZONE` parses only inside `EXTRACT(... FROM ...)` and requires
+    // TIMESTAMP, so coerce DATETIME-shaped inputs.
     [SupportedDbtAdapter.BIGQUERY]: {
-        toExtractInputTz: (sql, tz) => `${sql} AT TIME ZONE '${tz}'`,
+        toExtractInputTz: (sql, tz) => `TIMESTAMP(${sql}) AT TIME ZONE '${tz}'`,
     },
     [SupportedDbtAdapter.SNOWFLAKE]: {
         toExtractInputTz: (sql, tz) =>
@@ -242,13 +242,7 @@ const bigqueryConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
-        timezone,
     ) => {
-        const sql = timezone
-            ? dateExtractsTimezoneConversions[
-                  SupportedDbtAdapter.BIGQUERY
-              ].toExtractInputTz(originalSql, timezone)
-            : originalSql;
         const bigqueryTimeFrameExpressions: Record<TimeFrames, string | null> =
             {
                 ...timeFrameToDatePartMap,
@@ -262,7 +256,7 @@ const bigqueryConfig: WarehouseConfig = {
         }
 
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
-            return `EXTRACT(${datePart}(${bigqueryStartOfWeekMap[startOfWeek]}) FROM ${sql})`;
+            return `EXTRACT(${datePart}(${bigqueryStartOfWeekMap[startOfWeek]}) FROM ${originalSql})`;
         }
 
         // BigQuery DAYOFWEEK: 1=Sunday, 2=Monday, ..., 7=Saturday
@@ -271,10 +265,10 @@ const bigqueryConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = ((startOfWeek + 1) % 7) + 1;
-            return `MOD(EXTRACT(DAYOFWEEK FROM ${sql}) - ${nativeOffset} + 7, 7) + 1`;
+            return `MOD(EXTRACT(DAYOFWEEK FROM ${originalSql}) - ${nativeOffset} + 7, 7) + 1`;
         }
 
-        return `EXTRACT(${datePart} FROM ${sql})`;
+        return `EXTRACT(${datePart} FROM ${originalSql})`;
     },
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
@@ -297,7 +291,8 @@ const bigqueryConfig: WarehouseConfig = {
         }
         if (type === DimensionType.TIMESTAMP) {
             if (timezone) {
-                return `FORMAT_TIMESTAMP('${formatExpression}', ${originalSql}, '${timezone}')`;
+                // FORMAT_TIMESTAMP requires TIMESTAMP; coerce DATETIME-shaped inputs.
+                return `FORMAT_TIMESTAMP('${formatExpression}', TIMESTAMP(${originalSql}), '${timezone}')`;
             }
             return `FORMAT_DATETIME('${formatExpression}', ${originalSql})`;
         }
@@ -309,25 +304,14 @@ const bigqueryConfig: WarehouseConfig = {
 const snowflakeConfig: WarehouseConfig = {
     getSqlForTruncatedDate: (timeFrame, originalSql) =>
         `DATE_TRUNC('${timeFrame}', ${originalSql})`,
-    getSqlForDatePart: (
-        timeFrame: TimeFrames,
-        originalSql: string,
-        _,
-        __,
-        timezone,
-    ) => {
+    getSqlForDatePart: (timeFrame: TimeFrames, originalSql: string) => {
         const datePart = timeFrameToDatePartMap[timeFrame];
 
         if (!datePart) {
             throw new ParseError(`Cannot recognise date part for ${timeFrame}`);
         }
 
-        const sql = timezone
-            ? dateExtractsTimezoneConversions[
-                  SupportedDbtAdapter.SNOWFLAKE
-              ].toExtractInputTz(originalSql, timezone)
-            : originalSql;
-        return `DATE_PART('${datePart}', ${sql})`;
+        return `DATE_PART('${datePart}', ${originalSql})`;
     },
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
@@ -375,7 +359,6 @@ const postgresConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
-        timezone,
     ) => {
         const datePart = timeFrameToDatePartMap[timeFrame];
 
@@ -383,15 +366,9 @@ const postgresConfig: WarehouseConfig = {
             throw new ParseError(`Cannot recognise date part for ${timeFrame}`);
         }
 
-        const sql = timezone
-            ? dateExtractsTimezoneConversions[
-                  SupportedDbtAdapter.POSTGRES
-              ].toExtractInputTz(originalSql, timezone)
-            : originalSql;
-
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
             const intervalDiff = `${startOfWeek} days`;
-            return `DATE_PART('${datePart}', (${sql} - interval '${intervalDiff}'))`;
+            return `DATE_PART('${datePart}', (${originalSql} - interval '${intervalDiff}'))`;
         }
 
         // PostgreSQL DOW: 0=Sunday, 1=Monday, ..., 6=Saturday
@@ -400,10 +377,10 @@ const postgresConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = (startOfWeek + 1) % 7;
-            return `MOD(CAST(DATE_PART('DOW', ${sql}) AS INT) - ${nativeOffset} + 7, 7) + 1`;
+            return `MOD(CAST(DATE_PART('DOW', ${originalSql}) AS INT) - ${nativeOffset} + 7, 7) + 1`;
         }
 
-        return `DATE_PART('${datePart}', ${sql})`;
+        return `DATE_PART('${datePart}', ${originalSql})`;
     },
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
@@ -446,7 +423,6 @@ const databricksConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
-        timezone,
     ) => {
         const datePart = timeFrameToDatePartMap[timeFrame];
 
@@ -454,15 +430,9 @@ const databricksConfig: WarehouseConfig = {
             throw new ParseError(`Cannot recognise date part for ${timeFrame}`);
         }
 
-        const sql = timezone
-            ? dateExtractsTimezoneConversions[
-                  SupportedDbtAdapter.DATABRICKS
-              ].toExtractInputTz(originalSql, timezone)
-            : originalSql;
-
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
             const intervalDiff = `${startOfWeek} days`;
-            return `DATE_PART('${datePart}', (${sql} - interval '${intervalDiff}'))`;
+            return `DATE_PART('${datePart}', (${originalSql} - interval '${intervalDiff}'))`;
         }
 
         // Databricks DOW: 0=Sunday, 1=Monday, ..., 6=Saturday
@@ -471,10 +441,10 @@ const databricksConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = (startOfWeek + 1) % 7;
-            return `MOD(CAST(DATE_PART('DOW', ${sql}) AS INT) - ${nativeOffset} + 7, 7) + 1`;
+            return `MOD(CAST(DATE_PART('DOW', ${originalSql}) AS INT) - ${nativeOffset} + 7, 7) + 1`;
         }
 
-        return `DATE_PART('${datePart}', ${sql})`;
+        return `DATE_PART('${datePart}', ${originalSql})`;
     },
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
@@ -523,22 +493,15 @@ const trinoConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
-        timezone,
     ) => {
         const datePart = timeFrameToDatePartMap[timeFrame];
         if (!datePart) {
             throw new ParseError(`Cannot recognise date part for ${timeFrame}`);
         }
 
-        const sql = timezone
-            ? dateExtractsTimezoneConversions[
-                  SupportedDbtAdapter.TRINO
-              ].toExtractInputTz(originalSql, timezone)
-            : originalSql;
-
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
             const intervalDiff = `'${startOfWeek}' day`;
-            return `EXTRACT(${datePart} FROM (${sql} - interval ${intervalDiff}))`;
+            return `EXTRACT(${datePart} FROM (${originalSql} - interval ${intervalDiff}))`;
         }
 
         // Trino DOW (ISO): 1=Monday, 2=Tuesday, ..., 7=Sunday
@@ -547,10 +510,10 @@ const trinoConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = startOfWeek + 1;
-            return `MOD(EXTRACT(DOW FROM ${sql}) - ${nativeOffset} + 7, 7) + 1`;
+            return `MOD(EXTRACT(DOW FROM ${originalSql}) - ${nativeOffset} + 7, 7) + 1`;
         }
 
-        return `EXTRACT(${datePart} FROM ${sql})`;
+        return `EXTRACT(${datePart} FROM ${originalSql})`;
     },
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
@@ -623,14 +586,7 @@ const clickhouseConfig: WarehouseConfig = {
         originalSql: string,
         _,
         startOfWeek,
-        timezone,
     ) => {
-        const sql = timezone
-            ? dateExtractsTimezoneConversions[
-                  SupportedDbtAdapter.CLICKHOUSE
-              ].toExtractInputTz(originalSql, timezone)
-            : originalSql;
-
         const clickhouseTimeFrameMap: Record<TimeFrames, string | null> = {
             ...timeFrameToDatePartMap,
             [TimeFrames.DAY_OF_WEEK_INDEX]: 'toDayOfWeek',
@@ -650,7 +606,7 @@ const clickhouseConfig: WarehouseConfig = {
             isWeekDay(startOfWeek)
         ) {
             const nativeOffset = startOfWeek + 1;
-            return `modulo(toDayOfWeek(${sql}) - ${nativeOffset} + 7, 7) + 1`;
+            return `modulo(toDayOfWeek(${originalSql}) - ${nativeOffset} + 7, 7) + 1`;
         }
 
         // ClickHouse toWeek defaults to mode 0 (US, Sunday-base, 0–53). Mode 3 is
@@ -658,7 +614,7 @@ const clickhouseConfig: WarehouseConfig = {
         // toStartOfWeek(d, 1) used by truncation. The startOfWeek shift mirrors
         // what other warehouses do on the same path.
         if (timeFrame === TimeFrames.WEEK_NUM && isWeekDay(startOfWeek)) {
-            return `toWeek(addDays(${sql}, -${startOfWeek}), 3)`;
+            return `toWeek(addDays(${originalSql}, -${startOfWeek}), 3)`;
         }
 
         const extractFunction = clickhouseTimeFrameMap[timeFrame];
@@ -667,7 +623,7 @@ const clickhouseConfig: WarehouseConfig = {
                 `Cannot recognise extract function for ${timeFrame}`,
             );
         }
-        return `${extractFunction}(${sql})`;
+        return `${extractFunction}(${originalSql})`;
     },
     getSqlForDatePartName: (
         timeFrame: TimeFrames,
@@ -751,20 +707,18 @@ export const getSqlForDatePart = (
     startOfWeek?: WeekDay | null,
     timezone?: string,
 ): string => {
-    if (!timezone || type !== DimensionType.TIMESTAMP) {
-        return warehouseConfigs[adapterType].getSqlForDatePart(
-            timeFrame,
-            originalSql,
-            type,
-            startOfWeek,
-        );
-    }
+    const wrappedSql =
+        timezone && type === DimensionType.TIMESTAMP
+            ? dateExtractsTimezoneConversions[adapterType].toExtractInputTz(
+                  originalSql,
+                  timezone,
+              )
+            : originalSql;
     return warehouseConfigs[adapterType].getSqlForDatePart(
         timeFrame,
-        originalSql,
+        wrappedSql,
         type,
         startOfWeek,
-        timezone,
     );
 };
 

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -1,4 +1,5 @@
 import {
+    extractableTimeFrames,
     isDimension,
     TimeFrames,
     type CartesianChart,
@@ -76,7 +77,12 @@ const detectTimezoneShiftedField = ({
     if (!field || !isDimension(field)) return undefined;
     const timeInterval = field.timeInterval;
     if (!timeInterval) return undefined;
-    if (TIME_INTERVALS_FOR_CATEGORY_AXIS.includes(timeInterval)) {
+    // Skip non-timestamp axis values: category-axis intervals render as
+    // strings, EXTRACT-based intervals return ints/names.
+    if (
+        TIME_INTERVALS_FOR_CATEGORY_AXIS.includes(timeInterval) ||
+        extractableTimeFrames.has(timeInterval)
+    ) {
         return undefined;
     }
     return { fieldId: timeFieldId, timezone: resolvedTimezone, flipAxes };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-330/make-extract-based-time-dimensions-timezone-aware-day-of-week-index

## Summary

EXTRACT-based time dimensions (Day of week, Month number, Hour of day, plus the Name variants like Day of week name) compiled to UTC-only SQL. With a non-UTC project timezone on, a "Day of week" slicer could disagree with a sibling DATE_TRUNC dimension on the day for an instant near midnight.

This PR shifts the input into the project timezone before extracting the calendar component, behind the existing `EnableTimezoneSupport` flag. Same gating, same DATE-base bypass, and same WHERE-LHS parity as the DATE_TRUNC round-trip already in place.

The shift is per-warehouse:

- BigQuery: `<col> AT TIME ZONE 'tz'` inside `EXTRACT(... FROM ...)`
- Snowflake: `CONVERT_TIMEZONE('UTC', 'tz', col)`
- Postgres / Redshift / DuckDB: `(col)::timestamptz AT TIME ZONE 'tz'`
- Databricks: `from_utc_timestamp(to_utc_timestamp(col, current_timezone()), 'tz')`
- Trino / Athena: `CAST(col AT TIME ZONE 'tz' AS timestamp)`
- ClickHouse: `toTimeZone(col, 'tz')`

**Project TZ set to America/New_York**
**Before**

<img width="2121" height="1077" alt="before_fix" src="https://github.com/user-attachments/assets/9266fb5e-4b93-40b6-b03c-7ac4fca49752" />

Notice that even though we set the project timezone, the raw timestamp gets shifted but the day of week is in UTC

<img width="891" height="70" alt="CleanShot 2026-05-05 at 11 01 16" src="https://github.com/user-attachments/assets/53a9e897-b17b-43a6-8333-ebbdb8cc1d24" />


**After**
<img width="2115" height="1052" alt="after_fix" src="https://github.com/user-attachments/assets/c0e53b07-b1f2-4041-8ea3-82aa98fc2e60" />

## Manual test results

Tested across all 6 locally deployed warehouses (Postgres, BigQuery, Snowflake, ClickHouse, Databricks, Trino) using the `timezone_test` model via the v2 async query API.

### Baseline (flag OFF) — bug captured

| Witness | Project TZ | Expected (UTC bug) | Result |
|---|---|---|---|
| **B1** Day-of-week count, `event_id ≤ 10` | `America/New_York` | `Mon=6, Tue=4` | ✅ all 6 reproduce UTC buckets |
| **B2** Day-of-week, `event_id = 12` | `America/New_York` | UTC Mon | ✅ all 6 return Mon |
| **B3** Month, `event_id = 17` | `Pacific/Pago_Pago` | UTC Jan | ✅ all 6 return Jan 2024 |

EXTRACT path silently drops project TZ on every warehouse — bug confirmed.

### Fixed (flag ON) — every query matches expectation

| # | Query | Project TZ | Expected | Result |
|---|---|---|---|---|
| 1 | DOW, `id ≤ 10` | NY | Mon=6, Tue=3, **Sun=1** appears | ✅ 6/6 |
| 2 | DOW, `id ≤ 10` | Tokyo | Mon=5, Tue=4, Wed=1 | ✅ 6/6 |
| 3 | DOW, `id ≤ 10` | Pago_Pago | Mon=4, Tue=2, Sun=4 | ✅ 6/6 |
| 4 | DOW, `id ≤ 10`, **no TZ** | — | byte-identical to flag-OFF | ✅ 6/6 |
| 5 | Hour, `id ≤ 10` | NY | 7 distinct hours (0,3,5,7,13,21,22) | ✅ 6/6 |
| 6 | Month + Year, `id = 17` | Pago_Pago | **Month=12, Year=2023** | ✅ 6/6 |
| 7 | Month, `id = 18` | Tokyo | **Month=2** | ✅ 6/6 |
| 8 | DOW, `id = 12` | NY | **Sunday** (single-row witness flips) | ✅ 6/6 |
| 9 | WHERE `dow = 1` + `id ≤ 10` | NY | filter + select use same TZ wrap | ✅ 6/6 |
| 10 | DOW **name**, `id ≤ 10` | NY | Sunday=1, Monday=6, Tuesday=3 | ✅ 6/6 |
| DST | Hour, `id = 13/14` | NY | 01:00 EST → 03:00 EDT (gap honored) | ✅ 6/6 |

### Notes

- DOW indexing differs by warehouse (PG/SF: 0=Sun..6=Sat; BQ/DB: 1=Sun..7=Sat; CH/TR: 1=Mon..7=Sun) — driven by each project's `startOfWeek` setting. The fix wraps the timestamp input only and preserves whichever convention each project is configured for.
- Q4 (no project TZ) is byte-identical to today's bare-EXTRACT output → flag-off path unchanged.
- Q9 confirms WHERE-clause LHS uses the same TZ wrap as SELECT — no filter/group inconsistency.
- Q10 covers Name variants (`DAY_OF_WEEK_NAME`, etc.) — included in scope, working on every warehouse.
- Frontend regression caught during testing (EXTRACT integers being treated as timestamp ms by the ECharts wall-clock shift) is fixed in the follow-up commit on this branch.
