### PR TITLE
feat(data-apps): improve queries panel UX

### DIFF
--- a/packages/frontend/src/features/apps/QueryInspector.module.css
+++ b/packages/frontend/src/features/apps/QueryInspector.module.css
@@ -65,6 +65,13 @@
     flex-direction: column;
 }
 
+.emptyState {
+    padding: var(--mantine-spacing-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .queryRow {
     @mixin light {
         border-bottom: 1px solid var(--mantine-color-ldGray-1);

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -9,7 +9,9 @@ import {
     CopyButton,
     Group,
     ScrollArea,
+    Switch,
     Text,
+    Tooltip,
 } from '@mantine-8/core';
 import {
     IconChevronDown,
@@ -17,6 +19,7 @@ import {
     IconCopy,
     IconDatabase,
     IconExternalLink,
+    IconTrash,
     IconX,
 } from '@tabler/icons-react';
 import { useCallback, useRef, useState, type FC } from 'react';
@@ -32,6 +35,9 @@ type TrackedQuery = QueryEvent & {
 type Props = {
     queries: TrackedQuery[];
     projectUuid: string;
+    onClear: () => void;
+    persistLogs: boolean;
+    onPersistLogsChange: (value: boolean) => void;
 };
 
 const statusColor = (status: TrackedQuery['status']): string => {
@@ -324,7 +330,13 @@ const MIN_HEIGHT = 100;
 const MAX_HEIGHT = 600;
 const DEFAULT_HEIGHT = 300;
 
-const QueryInspector: FC<Props> = ({ queries, projectUuid }) => {
+const QueryInspector: FC<Props> = ({
+    queries,
+    projectUuid,
+    onClear,
+    persistLogs,
+    onPersistLogsChange,
+}) => {
     const [collapsed, setCollapsed] = useState(true);
     const [dismissed, setDismissed] = useState(false);
     const [height, setHeight] = useState(DEFAULT_HEIGHT);
@@ -367,8 +379,19 @@ const QueryInspector: FC<Props> = ({ queries, projectUuid }) => {
         setCollapsed(true);
     }, []);
 
-    // Nothing to show
-    if (queries.length === 0) return null;
+    const handleClear = useCallback(
+        (e: React.MouseEvent) => {
+            e.stopPropagation();
+            onClear();
+        },
+        [onClear],
+    );
+
+    // Hide the panel entirely only when there's nothing to show *and* the
+    // user hasn't engaged with it. If they've expanded it (e.g. cleared the
+    // log to wait for fresh queries), keep it mounted with an empty state so
+    // the next query lands somewhere visible.
+    if (queries.length === 0 && collapsed) return null;
 
     // Dismissed — show a small icon to reopen
     if (dismissed) {
@@ -401,14 +424,37 @@ const QueryInspector: FC<Props> = ({ queries, projectUuid }) => {
                 </Text>
                 <Box ml="auto" />
                 {!collapsed && (
-                    <ActionIcon
-                        variant="subtle"
-                        size="xs"
-                        color="gray"
-                        onClick={handleDismiss}
-                    >
-                        <MantineIcon icon={IconX} size={12} />
-                    </ActionIcon>
+                    <>
+                        <Tooltip label="Clear queries" withArrow position="top">
+                            <ActionIcon
+                                variant="subtle"
+                                size="xs"
+                                color="gray"
+                                onClick={handleClear}
+                                aria-label="Clear queries"
+                            >
+                                <MantineIcon icon={IconTrash} size={12} />
+                            </ActionIcon>
+                        </Tooltip>
+                        <Tooltip
+                            label="Preserve queries across iframe refreshes and new app versions"
+                            withArrow
+                            position="top"
+                        >
+                            <Box onClick={(e) => e.stopPropagation()}>
+                                <Switch
+                                    size="xs"
+                                    label="Persist"
+                                    checked={persistLogs}
+                                    onChange={(e) =>
+                                        onPersistLogsChange(
+                                            e.currentTarget.checked,
+                                        )
+                                    }
+                                />
+                            </Box>
+                        </Tooltip>
+                    </>
                 )}
                 <ActionIcon variant="subtle" size="xs" color="gray">
                     {collapsed ? (
@@ -417,6 +463,17 @@ const QueryInspector: FC<Props> = ({ queries, projectUuid }) => {
                         <MantineIcon icon={IconChevronDown} size={12} />
                     )}
                 </ActionIcon>
+                {!collapsed && (
+                    <ActionIcon
+                        variant="subtle"
+                        size="xs"
+                        color="gray"
+                        onClick={handleDismiss}
+                        aria-label="Close queries panel"
+                    >
+                        <MantineIcon icon={IconX} size={12} />
+                    </ActionIcon>
+                )}
             </Group>
             <Collapse in={!collapsed}>
                 <Box
@@ -427,13 +484,21 @@ const QueryInspector: FC<Props> = ({ queries, projectUuid }) => {
                 />
                 <ScrollArea h={height}>
                     <Box className={classes.queryList}>
-                        {queries.map((q) => (
-                            <QueryRow
-                                key={q.queryUuid ?? q.id}
-                                query={q}
-                                projectUuid={projectUuid}
-                            />
-                        ))}
+                        {queries.length === 0 ? (
+                            <Box className={classes.emptyState}>
+                                <Text size="xs" c="dimmed">
+                                    No queries yet
+                                </Text>
+                            </Box>
+                        ) : (
+                            queries.map((q) => (
+                                <QueryRow
+                                    key={q.queryUuid ?? q.id}
+                                    query={q}
+                                    projectUuid={projectUuid}
+                                />
+                            ))
+                        )}
                     </Box>
                 </ScrollArea>
             </Collapse>

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -27,6 +27,7 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
+import { useLocalStorage } from '@mantine-8/hooks';
 import {
     IconAppsOff,
     IconAppWindow,
@@ -105,6 +106,8 @@ import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
 import useApp from '../providers/App/useApp';
 import classes from './AppGenerate.module.css';
+
+const PERSIST_LOGS_STORAGE_KEY = 'data-apps:persist-logs';
 
 /**
  * Parse `[tag "text" @loc]` (or `[tag @loc]`, `[tag "text"]`, `[tag]`) from
@@ -298,6 +301,47 @@ const AppGenerate: FC = () => {
     // that never announces, in which case the toggle stays hidden.
     const [inspectorAvailable, setInspectorAvailable] = useState(false);
     const [trackedQueries, setTrackedQueries] = useState<QueryEvent[]>([]);
+    // Mirrors Chrome DevTools "Preserve log". When off (default), the queries
+    // panel is cleared on iframe refresh and on new-version load — fresh
+    // bundles re-run their queries, so stale entries would only confuse the
+    // user. Stored in localStorage so the preference survives a tab close
+    // and stays consistent across tabs.
+    const [persistLogs, setPersistLogs] = useLocalStorage<boolean>({
+        key: PERSIST_LOGS_STORAGE_KEY,
+        defaultValue: false,
+    });
+    // Request IDs of queries we marked as interrupted on iframe reload. The
+    // bridge's parent-side fetch keeps running after the iframe dies and will
+    // emit a late `running` event for them — without this guard that event
+    // would resurrect the entry as 'running', or (if not matched) get appended
+    // as a fresh ghost entry. The set grows for the page session; entries are
+    // short request IDs, so the footprint is negligible.
+    const interruptedRequestIdsRef = useRef<Set<string>>(new Set());
+    const handleClearQueries = useCallback(() => {
+        setTrackedQueries([]);
+    }, []);
+    // Move pending/running entries into a terminal `error` state. Used when
+    // the preview iframe reloads with persistLogs on — the iframe that would
+    // have polled their queryUuids is dead, so they would otherwise sit
+    // non-terminal forever.
+    const interruptInFlightQueries = useCallback(() => {
+        setTrackedQueries((prev) => {
+            let mutated = false;
+            const next = prev.map((q) => {
+                if (q.status !== 'pending' && q.status !== 'running') {
+                    return q;
+                }
+                mutated = true;
+                interruptedRequestIdsRef.current.add(q.id);
+                return {
+                    ...q,
+                    status: 'error' as const,
+                    error: 'Interrupted by reload',
+                };
+            });
+            return mutated ? next : prev;
+        });
+    }, []);
     const handleElementSelected = useCallback((event: { label: string }) => {
         const ref = parseElementRefLabel(event.label);
         if (!ref) {
@@ -315,6 +359,12 @@ const AppGenerate: FC = () => {
         setInspectorEnabled(false);
     }, []);
     const handleQueryEvent = useCallback((event: QueryEvent) => {
+        // Drop late events (typically the POST-resolution `running` event)
+        // for requests we already marked interrupted — without this they
+        // either un-terminal the entry or get appended as a ghost.
+        if (interruptedRequestIdsRef.current.has(event.id)) {
+            return;
+        }
         setTrackedQueries((prev) => {
             // If this event has a queryUuid, merge it with an existing entry
             if (event.queryUuid) {
@@ -322,6 +372,16 @@ const AppGenerate: FC = () => {
                     (q) => q.queryUuid === event.queryUuid,
                 );
                 if (existing) {
+                    // Don't resurrect a terminal entry. Covers the rare race
+                    // where iframe-1 managed to issue a poll GET before
+                    // dying, so a late `ready` event arrives keyed on the
+                    // (already-interrupted) queryUuid.
+                    if (
+                        existing.status === 'ready' ||
+                        existing.status === 'error'
+                    ) {
+                        return prev;
+                    }
                     return prev.map((q) =>
                         q.queryUuid === event.queryUuid
                             ? {
@@ -660,8 +720,24 @@ const AppGenerate: FC = () => {
                 latestReadyPreview.version !== previewApp?.version)
         ) {
             setPreviewApp(latestReadyPreview);
+            // The new bundle re-runs its queries from scratch, so the
+            // previous version's entries are stale. With "Persist" on we
+            // flip in-flight ones to a terminal "interrupted" state instead
+            // of clearing — the iframe that would have polled their
+            // queryUuids is gone, so they'd otherwise sit non-terminal.
+            if (persistLogs) {
+                interruptInFlightQueries();
+            } else {
+                setTrackedQueries([]);
+            }
         }
-    }, [latestReadyPreview, previewApp?.appUuid, previewApp?.version]);
+    }, [
+        latestReadyPreview,
+        previewApp?.appUuid,
+        previewApp?.version,
+        persistLogs,
+        interruptInFlightQueries,
+    ]);
 
     // Manual refresh counter for the preview iframe. The iframe URL embeds
     // this value, so bumping it forces the browser to reload the iframe and
@@ -671,8 +747,12 @@ const AppGenerate: FC = () => {
     const [previewRefreshKey, setPreviewRefreshKey] = useState(0);
     const handleRefreshPreview = useCallback(() => {
         setPreviewRefreshKey((k) => k + 1);
-        setTrackedQueries([]);
-    }, []);
+        if (persistLogs) {
+            interruptInFlightQueries();
+        } else {
+            setTrackedQueries([]);
+        }
+    }, [persistLogs, interruptInFlightQueries]);
 
     const scrollToBottom = useCallback(() => {
         messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -1964,6 +2044,9 @@ const AppGenerate: FC = () => {
                             <QueryInspector
                                 queries={trackedQueries}
                                 projectUuid={projectUuid!}
+                                onClear={handleClearQueries}
+                                persistLogs={persistLogs}
+                                onPersistLogsChange={setPersistLogs}
                             />
                         </Box>
                     </Box>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-379/reset-clear-the-queries-pane

### Description:
Reorder header controls so minimize sits left of close, add a clear button + "Persist" toggle (Chrome DevTools "Preserve log" semantics), and auto-clear queries when the preview iframe swaps to a new app version unless persistence is on.

https://github.com/user-attachments/assets/98292e0c-219d-4f3a-bc5d-c0e13988e576
