### PR TITLE
feat: add save chart to space or dashboard option

### DIFF
--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -1,7 +1,11 @@
 import { getItemId, getMetrics } from '@lightdash/common';
-import { Button, Tooltip } from '@mantine-8/core';
-import { IconDeviceFloppy } from '@tabler/icons-react';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { Button, Menu, rgba, Tooltip } from '@mantine-8/core';
+import {
+    IconChevronDown,
+    IconCirclePlus,
+    IconDeviceFloppy,
+} from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import {
     useAmbientAiEnabled,
     useGenerateChartMetadata,
@@ -14,6 +18,7 @@ import {
     selectUnsavedChartVersionForSave,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
@@ -22,10 +27,11 @@ import useSearchParams from '../../../hooks/useSearchParams';
 import MantineIcon from '../../common/MantineIcon';
 import ChartCreateModal from '../../common/modal/ChartCreateModal';
 
-const SaveChartButton: FC<{ isExplorer?: boolean; disabled?: boolean }> = ({
-    isExplorer,
-    disabled,
-}) => {
+const SaveChartButton: FC<{
+    isExplorer?: boolean;
+    disabled?: boolean;
+    onSaveModalOpenChange?: (isOpen: boolean) => void;
+}> = ({ isExplorer, disabled, onSaveModalOpenChange }) => {
     const isAmbientAiEnabled = useAmbientAiEnabled();
     const projectUuid = useProjectUuid();
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
@@ -53,8 +59,25 @@ const SaveChartButton: FC<{ isExplorer?: boolean; disabled?: boolean }> = ({
     const { missingRequiredParameters } = useExplorerQuery();
 
     const [isQueryModalOpen, setIsQueryModalOpen] = useState<boolean>(false);
+    const [forceSpaceOrDashboardChoice, setForceSpaceOrDashboardChoice] =
+        useState(false);
     // Track if user clicked save while metadata is still loading
     const [isPendingOpen, setIsPendingOpen] = useState(false);
+
+    const { getEditingDashboardInfo } = useDashboardStorage();
+    const editingDashboardInfo = getEditingDashboardInfo();
+    const dashboardName = editingDashboardInfo.dashboardUuid
+        ? editingDashboardInfo.name
+        : null;
+
+    useEffect(() => {
+        onSaveModalOpenChange?.(isQueryModalOpen);
+    }, [isQueryModalOpen, onSaveModalOpenChange]);
+
+    const openSaveAsModal = (chooseLocation: boolean) => {
+        setForceSpaceOrDashboardChoice(chooseLocation);
+        setIsQueryModalOpen(true);
+    };
 
     const update = useAddVersionMutation();
     const handleSavedQueryUpdate = () => {
@@ -116,48 +139,132 @@ const SaveChartButton: FC<{ isExplorer?: boolean; disabled?: boolean }> = ({
         }
     };
 
+    const showSaveAsMenu = !!savedChart;
+    const isSaveAsDisabled =
+        !unsavedChartVersion.tableName ||
+        !hasUnsavedChanges ||
+        foundCustomMetricWithDuplicateId ||
+        !!missingRequiredParameters?.length;
+
     return (
         <>
-            <Tooltip
-                label={
-                    'A custom metric ID matches an existing table metric. Rename it to avoid conflicts.'
-                }
-                disabled={!foundCustomMetricWithDuplicateId}
-                withinPortal
-                multiline
-                position={'bottom'}
-                maw={300}
-            >
-                <Button
-                    disabled={isDisabled}
-                    variant={isExplorer ? 'default' : undefined}
-                    color={isExplorer ? 'blue' : 'green.7'}
-                    size="xs"
-                    loading={update.isLoading || isPendingOpen}
-                    leftSection={
-                        isExplorer ? (
-                            <MantineIcon icon={IconDeviceFloppy} />
-                        ) : undefined
+            <Button.Group>
+                <Tooltip
+                    label={
+                        'A custom metric ID matches an existing table metric. Rename it to avoid conflicts.'
                     }
-                    {...(isDisabled && {
-                        'data-disabled': true,
-                    })}
-                    // Trigger metadata generation on mouse enter if available
-                    onMouseEnter={() => {
-                        if (savedChart) return;
-                        if (!isAmbientAiEnabled) return;
-                        triggerMetadataGeneration();
-                    }}
-                    style={{
-                        '&[data-disabled="true"]': {
-                            pointerEvents: 'all',
-                        },
-                    }}
-                    onClick={handleSaveChart}
+                    disabled={!foundCustomMetricWithDuplicateId}
+                    withinPortal
+                    multiline
+                    position={'bottom'}
+                    maw={300}
                 >
-                    {savedChart ? 'Save changes' : 'Save chart'}
-                </Button>
-            </Tooltip>
+                    <Button
+                        disabled={isDisabled}
+                        variant={isExplorer ? 'default' : undefined}
+                        color={isExplorer ? 'blue' : 'green.7'}
+                        size="xs"
+                        loading={update.isLoading || isPendingOpen}
+                        leftSection={
+                            isExplorer ? (
+                                <MantineIcon icon={IconDeviceFloppy} />
+                            ) : undefined
+                        }
+                        {...(isDisabled && {
+                            'data-disabled': true,
+                        })}
+                        // Trigger metadata generation on mouse enter if available
+                        onMouseEnter={() => {
+                            if (savedChart) return;
+                            if (!isAmbientAiEnabled) return;
+                            triggerMetadataGeneration();
+                        }}
+                        style={(theme) => ({
+                            '&[data-disabled="true"]': {
+                                pointerEvents: 'all',
+                            },
+                            ...(showSaveAsMenu && {
+                                borderRight: `1px solid ${rgba(
+                                    theme.colors.dark[3],
+                                    0.4,
+                                )}`,
+                                borderTopRightRadius: 0,
+                                borderBottomRightRadius: 0,
+                            }),
+                        })}
+                        onClick={handleSaveChart}
+                    >
+                        {savedChart ? 'Save changes' : 'Save chart'}
+                    </Button>
+                </Tooltip>
+
+                {showSaveAsMenu && (
+                    <Menu
+                        position="bottom-end"
+                        withArrow
+                        withinPortal
+                        shadow="md"
+                        offset={2}
+                        arrowOffset={10}
+                    >
+                        <Menu.Target>
+                            <Button
+                                variant={isExplorer ? 'default' : undefined}
+                                color={isExplorer ? 'blue' : 'green.7'}
+                                size="xs"
+                                p="xs"
+                                disabled={isSaveAsDisabled}
+                                aria-label="More save options"
+                                style={{
+                                    borderTopLeftRadius: 0,
+                                    borderBottomLeftRadius: 0,
+                                }}
+                                data-testid="SaveChartButton/SaveAsMenu"
+                            >
+                                <MantineIcon icon={IconChevronDown} size="sm" />
+                            </Button>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            {dashboardName ? (
+                                <>
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconCirclePlus}
+                                            />
+                                        }
+                                        disabled={isSaveAsDisabled}
+                                        onClick={() => openSaveAsModal(false)}
+                                    >
+                                        {`Save as new chart in "${dashboardName}"`}
+                                    </Menu.Item>
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconCirclePlus}
+                                            />
+                                        }
+                                        disabled={isSaveAsDisabled}
+                                        onClick={() => openSaveAsModal(true)}
+                                    >
+                                        Save as new chart and choose location
+                                    </Menu.Item>
+                                </>
+                            ) : (
+                                <Menu.Item
+                                    leftSection={
+                                        <MantineIcon icon={IconCirclePlus} />
+                                    }
+                                    disabled={isSaveAsDisabled}
+                                    onClick={() => openSaveAsModal(false)}
+                                >
+                                    Save as new chart
+                                </Menu.Item>
+                            )}
+                        </Menu.Dropdown>
+                    </Menu>
+                )}
+            </Button.Group>
 
             {unsavedChartVersionForSave && (
                 <ChartCreateModal
@@ -165,12 +272,15 @@ const SaveChartButton: FC<{ isExplorer?: boolean; disabled?: boolean }> = ({
                     savedData={unsavedChartVersionForSave}
                     onClose={() => {
                         setIsQueryModalOpen(false);
+                        setForceSpaceOrDashboardChoice(false);
                     }}
                     onConfirm={() => {
                         setIsQueryModalOpen(false);
+                        setForceSpaceOrDashboardChoice(false);
                     }}
                     defaultSpaceUuid={spaceUuid ?? undefined}
                     chartMetadata={generatedMetadata ?? undefined}
+                    forceSpaceOrDashboardChoice={forceSpaceOrDashboardChoice}
                 />
             )}
         </>

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -25,7 +25,6 @@ import {
     IconBell,
     IconCircleCheck,
     IconCircleCheckFilled,
-    IconCirclePlus,
     IconCirclesRelation,
     IconCopy,
     IconDatabaseExport,
@@ -103,7 +102,6 @@ import MantineModal from '../../common/MantineModal';
 const ChangeChartExploreModal = lazy(
     () => import('../../common/modal/ChangeChartExploreModal'),
 );
-import ChartCreateModal from '../../common/modal/ChartCreateModal';
 import ChartDeleteModal from '../../common/modal/ChartDeleteModal';
 import ChartDuplicateModal from '../../common/modal/ChartDuplicateModal';
 import ChartUpdateModal from '../../common/modal/ChartUpdateModal';
@@ -130,7 +128,6 @@ const SavedChartsHeader: FC = () => {
     }>();
     const dashboardUuid = useSearchParams('fromDashboard');
     const isFromDashboard = !!dashboardUuid;
-    const spaceUuid = useSearchParams('fromSpace');
 
     const { data: project } = useProject(projectUuid);
 
@@ -175,7 +172,6 @@ const SavedChartsHeader: FC = () => {
     const { clearDashboardStorage } = useDashboardStorage();
     const [isRenamingChart, setIsRenamingChart] = useState(false);
     const [isMovingChart, setIsMovingChart] = useState(false);
-    const [isQueryModalOpen, queryModalHandlers] = useDisclosure();
     const [isDeleteModalOpen, deleteModalHandlers] = useDisclosure();
     const [isScheduledDeliveriesModalOpen, scheduledDeliveriesModalHandlers] =
         useDisclosure();
@@ -185,6 +181,7 @@ const SavedChartsHeader: FC = () => {
         useDisclosure();
     const [isAddToDashboardModalOpen, addToDashboardModalHandlers] =
         useDisclosure();
+    const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
     const [isChartDuplicateModalOpen, chartDuplicateModalHandlers] =
         useDisclosure();
     const [isChangeExploreModalOpen, changeExploreModalHandlers] =
@@ -302,7 +299,7 @@ const SavedChartsHeader: FC = () => {
         if (
             hasUnsavedChanges &&
             isEditMode &&
-            !isQueryModalOpen &&
+            !isSaveModalOpen &&
             !nextLocation.pathname.includes(
                 `/projects/${projectUuid}/saved/${savedChart?.uuid}`,
             ) &&
@@ -582,7 +579,11 @@ const SavedChartsHeader: FC = () => {
                                     </>
                                 ) : (
                                     <>
-                                        <SaveChartButton />
+                                        <SaveChartButton
+                                            onSaveModalOpenChange={
+                                                setIsSaveModalOpen
+                                            }
+                                        />
                                         <Button
                                             variant="default"
                                             size="xs"
@@ -628,18 +629,6 @@ const SavedChartsHeader: FC = () => {
                         >
                             <Menu.Dropdown>
                                 <Menu.Label>Manage</Menu.Label>
-                                {userCanManageChart && hasUnsavedChanges && (
-                                    <Menu.Item
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={IconCirclePlus}
-                                            />
-                                        }
-                                        onClick={queryModalHandlers.open}
-                                    >
-                                        Save chart as
-                                    </Menu.Item>
-                                )}
                                 {userCanManageChart &&
                                     !hasUnsavedChanges &&
                                     !chartBelongsToDashboard && (
@@ -909,15 +898,6 @@ const SavedChartsHeader: FC = () => {
                 )}
             </PageHeader>
 
-            {unsavedChartVersion && (
-                <ChartCreateModal
-                    opened={isQueryModalOpen}
-                    savedData={unsavedChartVersion}
-                    onClose={queryModalHandlers.close}
-                    onConfirm={queryModalHandlers.close}
-                    defaultSpaceUuid={spaceUuid ?? undefined}
-                />
-            )}
             {savedChart && isAddToDashboardModalOpen && projectUuid && (
                 <AddTilesToDashboardModal
                     isOpen={isAddToDashboardModalOpen}

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -31,6 +31,7 @@ import {
     useUpdateDashboard,
 } from '../../../../hooks/dashboard/useDashboard';
 import { useDashboards } from '../../../../hooks/dashboard/useDashboards';
+import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
 import { useCreateMutation } from '../../../../hooks/useSavedQuery';
 import { useSpaceManagement } from '../../../../hooks/useSpaceManagement';
 import { useSpaceSummaries } from '../../../../hooks/useSpaces';
@@ -89,6 +90,8 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
 
     const { mutateAsync: createChart, isLoading: isSavingChart } =
         useCreateMutation({ redirectOnSuccess });
+
+    const { clearIsEditingDashboardChart } = useDashboardStorage();
 
     const [saveDestination, setSaveDestination] = useState<SaveDestination>(
         SaveDestination.Space,
@@ -336,6 +339,13 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
             }
 
             if (savedQuery) {
+                // Saving as a new chart to a space (or to a different dashboard)
+                // means the editor is no longer editing for the originating
+                // dashboard tile, so clear that context to hide the dashboard
+                // banner in the new chart viewer.
+                if (saveDestination === SaveDestination.Space) {
+                    clearIsEditingDashboardChart();
+                }
                 onConfirm(savedQuery);
                 return savedQuery;
             }
@@ -349,6 +359,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
             updateDashboard,
             handleCreateNewSpace,
             onConfirm,
+            clearIsEditingDashboardChart,
         ],
     );
 

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
@@ -16,6 +16,12 @@ interface ChartCreateModalProps extends Pick<
     defaultSpaceUuid?: string;
     onConfirm: (savedData: CreateSavedChartVersion) => void;
     chartMetadata?: ChartMetadata;
+    /**
+     * When true, ignore the editing-dashboard context and let the user choose a
+     * space or dashboard destination instead of auto-saving to the originating
+     * dashboard.
+     */
+    forceSpaceOrDashboardChoice?: boolean;
 }
 
 enum SaveMode {
@@ -30,6 +36,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
     defaultSpaceUuid,
     onConfirm,
     chartMetadata,
+    forceSpaceOrDashboardChoice = false,
 }) => {
     // Store it in the state to avoid losing the param when the user switches between tables
     const [spaceUuid] = useState(defaultSpaceUuid);
@@ -46,11 +53,14 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
     }, [opened, getEditingDashboardInfo]);
 
     const saveMode = useMemo(() => {
+        if (forceSpaceOrDashboardChoice) {
+            return SaveMode.DEFAULT;
+        }
         if (editingDashboardInfo.name && editingDashboardInfo.dashboardUuid) {
             return SaveMode.TO_DASHBOARD;
         }
         return SaveMode.DEFAULT;
-    }, [editingDashboardInfo]);
+    }, [editingDashboardInfo, forceSpaceOrDashboardChoice]);
 
     const { projectUuid } = useParams<{ projectUuid: string }>();
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-7025

### Description:

Make the "save as new chart" option more obvious. It was in the menu before. 
<img width="231" height="110" alt="Screenshot 2026-05-04 at 18 55 15" src="https://github.com/user-attachments/assets/7be33105-8b23-4c62-a21d-33770f88efcb" />


For charts in dashbaords, give an option to save to a space
<img width="328" height="127" alt="Screenshot 2026-05-04 at 18 54 43" src="https://github.com/user-attachments/assets/b6355287-7bdc-4ec8-ae48-2c5eca4f1b92" />


