### PR TITLE
fix(ai-search): drop autoFocus on home AI search box

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -112,7 +112,6 @@ export const SearchDropdown: FC<Props> = ({
                                 </ActionIcon>
                             ) : null
                         }
-                        autoFocus
                         classNames={{
                             root: styles.searchRoot,
                             input: styles.searchInput,


### PR DESCRIPTION
### Description:
The AiSearchBox's TextInput auto-focused on mount via React's
`autoFocus`, which yanked focus from any other input the user had
already started typing into (e.g. the projects search box) once the
component finished loading. Drop the autoFocus (as agreed with @joaoviana) — landing on the home
page doesn't imply the user wants to start in this input.

### Testing:
I noticed this behavior mainly on our analytics instance. To repro it locally I had to add an artificial sleep.

#### Before:

https://github.com/user-attachments/assets/31a6f775-1a45-4453-9f74-6102bec1b2b6



#### After:


https://github.com/user-attachments/assets/91d47cb8-e961-42bd-aedd-168954ec74a1

