### PR TITLE
revert(backend): getOrganization + OrganizationService.get to Account

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -73,12 +73,11 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiOrganization> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .get(req.account),
+                .get(req.account!),
         };
     }
 

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     AllowedEmailDomains,
     assertIsAccountWithOrg,
     convertProjectRoleToOrganizationRole,
@@ -107,7 +108,7 @@ export class OrganizationService extends BaseService {
         this.featureFlagModel = featureFlagModel;
     }
 
-    async get(account: RegisteredAccount): Promise<Organization> {
+    async get(account: Account): Promise<Organization> {
         assertIsAccountWithOrg(account);
 
         const needsProject = !(await this.projectModel.hasProjects(


### PR DESCRIPTION
## Summary

Reverts the `RegisteredAccount` narrowing applied to `GET /api/v1/org` and `OrganizationService.get` in #22548 (commit b4eb88d542).

## Production impact

`assertRegisteredAccount(req.account)` is throwing `ForbiddenError: Account is not a registered user` on `GET /api/v1/org` — **~18K errors in production** (`lightdash-cloud-beta`, `app-lightdash-backend`). Stack:

```
ForbiddenError: Account is not a registered user
    at assertRegisteredAccount (packages/common/dist/cjs/types/auth.js:37:15)
    at OrganizationController.getOrganization (packages/backend/dist/controllers/organizationController.js:20:46)
```

### Root cause: anonymous (embed/JWT) callers, not unauthenticated requests

The thrown message corresponds to the `account.user.type !== 'registered'` branch of `assertRegisteredAccount` — i.e. `AnonymousAccount` (embed/JWT auth). Truly unauthenticated requests are blocked earlier by the `isAuthenticated` middleware with a 401 and never reach the handler.

Since `RegisteredAccount = Exclude<Account, AnonymousAccount>`, the narrowing explicitly excluded embedded/JWT callers — but those callers do legitimately hit `GET /api/v1/org`. Reverting to `Account` restores their access.

## Changes

- Controller drops `assertRegisteredAccount(req.account)` and restores `req.account!`.
- Service signature reverts from `RegisteredAccount` back to `Account`; re-adds the `Account` import.

Other methods migrated in #22548 (`getProjects`, `getColorPalettes`) and #22598 are left untouched.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [ ] Manual: `GET /api/v1/org` returns the current org for an authenticated user
- [ ] Manual: `GET /api/v1/org` works for an embedded/JWT caller (no 403)
- [ ] Verify ForbiddenError rate on `/api/v1/org` drops post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)