### PR TITLE
fix(backend): tail services + 6 controllers RegisteredAccount migration (#22548)

### DIFF
--- a/packages/backend/src/controllers/ChangesetController.ts
+++ b/packages/backend/src/controllers/ChangesetController.ts
@@ -3,7 +3,6 @@ import {
     ApiErrorPayload,
     ApiGetChangeResponseTSOACompat,
     ApiRevertChangeResponse,
-    assertRegisteredAccount,
 } from '@lightdash/common';
 import {
     Get,
@@ -37,11 +36,10 @@ export class ChangesetController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiChangesetsResponseTSOACompat> {
-        assertRegisteredAccount(req.account);
         const changesets = await this.services
             .getChangesetService()
             .findActiveChangesetWithChangesByProjectUuid(
-                req.account,
+                req.account!,
                 projectUuid,
             );
 
@@ -65,10 +63,9 @@ export class ChangesetController extends BaseController {
         @Path() changeUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetChangeResponseTSOACompat> {
-        assertRegisteredAccount(req.account);
         const change = await this.services
             .getChangesetService()
-            .getChange(req.account, projectUuid, changeUuid);
+            .getChange(req.account!, projectUuid, changeUuid);
 
         return {
             status: 'ok',
@@ -90,10 +87,9 @@ export class ChangesetController extends BaseController {
         @Path() changeUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiRevertChangeResponse> {
-        assertRegisteredAccount(req.account);
         await this.services
             .getChangesetService()
-            .revertChange(req.account, projectUuid, changeUuid);
+            .revertChange(req.account!, projectUuid, changeUuid);
 
         return {
             status: 'ok',
@@ -113,10 +109,9 @@ export class ChangesetController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiRevertChangeResponse> {
-        assertRegisteredAccount(req.account);
         await this.services
             .getChangesetService()
-            .revertAllChanges(req.account, projectUuid);
+            .revertAllChanges(req.account!, projectUuid);
 
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -185,12 +185,11 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiOrganizationProjects> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .getProjects(req.account),
+                .getProjects(req.account!),
         };
     }
 
@@ -547,12 +546,11 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiColorPalettesResponse> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .getColorPalettes(req.account),
+                .getColorPalettes(req.account!),
         };
     }
 

--- a/packages/backend/src/controllers/spotlightController.ts
+++ b/packages/backend/src/controllers/spotlightController.ts
@@ -1,6 +1,5 @@
 import {
     ApiErrorPayload,
-    assertRegisteredAccount,
     NotFoundError,
     type ApiGetSpotlightTableConfig,
     type ApiSuccessEmpty,
@@ -49,10 +48,9 @@ export class SpotlightController extends BaseController {
         @Body() body: Pick<SpotlightTableConfig, 'columnConfig'>,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        assertRegisteredAccount(req.account);
         await this.services
             .getSpotlightService()
-            .createSpotlightTableConfig(req.account, projectUuid, body);
+            .createSpotlightTableConfig(req.account!, projectUuid, body);
 
         this.setStatus(201);
         return {
@@ -73,10 +71,9 @@ export class SpotlightController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiGetSpotlightTableConfig> {
-        assertRegisteredAccount(req.account);
         const { columnConfig } = await this.services
             .getSpotlightService()
-            .getSpotlightTableConfig(req.account, projectUuid);
+            .getSpotlightTableConfig(req.account!, projectUuid);
 
         this.setStatus(200);
         return {
@@ -103,10 +100,9 @@ export class SpotlightController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
-        assertRegisteredAccount(req.account);
         await this.services
             .getSpotlightService()
-            .resetSpotlightTableConfig(req.account, projectUuid);
+            .resetSpotlightTableConfig(req.account!, projectUuid);
 
         this.setStatus(200);
         return {

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -554,12 +554,11 @@ export class SqlRunnerController extends BaseController {
         @Body() body: CreateVirtualViewPayload,
     ): Promise<ApiCreateVirtualView> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         const { name, sql, columns, parameterValues } = body;
 
         const virtualViewName = await this.services
             .getProjectService()
-            .createVirtualView(req.account, projectUuid, {
+            .createVirtualView(req.account!, projectUuid, {
                 name,
                 sql,
                 columns,
@@ -587,10 +586,9 @@ export class SqlRunnerController extends BaseController {
         @Body() body: UpdateVirtualViewPayload,
     ): Promise<ApiCreateVirtualView> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         const { name: virtualViewName } = await this.services
             .getProjectService()
-            .updateVirtualView(req.account, projectUuid, name, body);
+            .updateVirtualView(req.account!, projectUuid, name, body);
 
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/v2/DeployController.ts
+++ b/packages/backend/src/controllers/v2/DeployController.ts
@@ -49,10 +49,9 @@ export class DeployController extends BaseController {
         @Path() projectUuid: string,
     ): Promise<ApiStartDeploySessionResponse> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         const result = await this.services
             .getDeployService()
-            .startDeploySession(req.account, projectUuid);
+            .startDeploySession(req.account!, projectUuid);
         return {
             status: 'ok',
             results: result,

--- a/packages/backend/src/controllers/v2/ProjectDefaultsController.ts
+++ b/packages/backend/src/controllers/v2/ProjectDefaultsController.ts
@@ -42,10 +42,9 @@ export class ProjectDefaultsController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSuccess<ProjectDefaults | undefined>> {
-        assertRegisteredAccount(req.account);
         const project = await this.services
             .getProjectService()
-            .getProject(projectUuid, req.account);
+            .getProject(projectUuid, req.account!);
 
         return {
             status: 'ok',

--- a/packages/backend/src/ee/controllers/OrganizationWarehouseCredentialsController.ts
+++ b/packages/backend/src/ee/controllers/OrganizationWarehouseCredentialsController.ts
@@ -4,7 +4,6 @@ import {
     ApiOrganizationWarehouseCredentialsResponse,
     ApiOrganizationWarehouseCredentialsSummaryListResponse,
     ApiSuccessEmpty,
-    assertRegisteredAccount,
     CreateOrganizationWarehouseCredentials,
     UpdateOrganizationWarehouseCredentials,
 } from '@lightdash/common';
@@ -53,14 +52,13 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         | ApiOrganizationWarehouseCredentialsSummaryListResponse
     > {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
 
         if (summary) {
             return {
                 status: 'ok',
                 results:
                     await this.getOrganizationWarehouseCredentialsService().getAllSummaries(
-                        req.account,
+                        req.account!,
                     ),
             };
         }
@@ -69,7 +67,7 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
             status: 'ok',
             results:
                 await this.getOrganizationWarehouseCredentialsService().getAll(
-                    req.account,
+                    req.account!,
                 ),
         };
     }
@@ -88,12 +86,11 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         @Path() credentialsUuid: string,
     ): Promise<ApiOrganizationWarehouseCredentialsResponse> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results:
                 await this.getOrganizationWarehouseCredentialsService().get(
-                    req.account,
+                    req.account!,
                     credentialsUuid,
                 ),
         };
@@ -117,12 +114,11 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         @Body() body: CreateOrganizationWarehouseCredentials,
     ): Promise<ApiOrganizationWarehouseCredentialsResponse> {
         this.setStatus(201);
-        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results:
                 await this.getOrganizationWarehouseCredentialsService().create(
-                    req.account,
+                    req.account!,
                     body,
                 ),
         };
@@ -148,12 +144,11 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         @Body() body: UpdateOrganizationWarehouseCredentials,
     ): Promise<ApiOrganizationWarehouseCredentialsResponse> {
         this.setStatus(200);
-        assertRegisteredAccount(req.account);
         return {
             status: 'ok',
             results:
                 await this.getOrganizationWarehouseCredentialsService().update(
-                    req.account,
+                    req.account!,
                     credentialsUuid,
                     body,
                 ),
@@ -177,9 +172,8 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
         @Request() req: express.Request,
         @Path() credentialsUuid: string,
     ): Promise<ApiSuccessEmpty> {
-        assertRegisteredAccount(req.account);
         await this.getOrganizationWarehouseCredentialsService().delete(
-            req.account,
+            req.account!,
             credentialsUuid,
         );
         this.setStatus(200);

--- a/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
+++ b/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     CreateOrganizationWarehouseCredentials,
     CreateWarehouseCredentials,
     ForbiddenError,
@@ -7,7 +8,6 @@ import {
     OpenIdIdentityIssuerType,
     OrganizationWarehouseCredentials,
     OrganizationWarehouseCredentialsSummary,
-    RegisteredAccount,
     SnowflakeAuthenticationType,
     UpdateOrganizationWarehouseCredentials,
     WarehouseTypes,
@@ -43,7 +43,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         this.userModel = userModel;
     }
 
-    private canManage(account: RegisteredAccount) {
+    private canManage(account: Account) {
         const auditedAbility = this.createAuditedAbility(account);
         const { organizationUuid } = account.organization;
         if (!organizationUuid) {
@@ -64,7 +64,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async getAll(
-        account: RegisteredAccount,
+        account: Account,
     ): Promise<OrganizationWarehouseCredentials[]> {
         this.canManage(account);
         const organizationUuid = account.organization.organizationUuid!;
@@ -79,7 +79,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
      * Returns only non-sensitive information: name, description, and warehouse type
      */
     async getAllSummaries(
-        account: RegisteredAccount,
+        account: Account,
     ): Promise<OrganizationWarehouseCredentialsSummary[]> {
         const auditedAbility = this.createAuditedAbility(account);
         const { organizationUuid } = account.organization;
@@ -116,7 +116,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async get(
-        account: RegisteredAccount,
+        account: Account,
         credentialsUuid: string,
     ): Promise<OrganizationWarehouseCredentials> {
         this.canManage(account);
@@ -172,12 +172,12 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async create(
-        account: RegisteredAccount,
+        account: Account,
         data: CreateOrganizationWarehouseCredentials,
     ): Promise<OrganizationWarehouseCredentials> {
         this.canManage(account);
         const organizationUuid = account.organization.organizationUuid!;
-        const { userUuid } = account.user;
+        const userUuid = account.user.id;
         const credentialsWithTokens = await this.updateCredentialTokens(
             userUuid,
             data,
@@ -204,13 +204,13 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async update(
-        account: RegisteredAccount,
+        account: Account,
         credentialsUuid: string,
         data: UpdateOrganizationWarehouseCredentials,
     ): Promise<OrganizationWarehouseCredentials> {
         this.canManage(account);
         const organizationUuid = account.organization.organizationUuid!;
-        const { userUuid } = account.user;
+        const userUuid = account.user.id;
 
         // Verify ownership before update
         const existing =
@@ -249,13 +249,10 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         return updated;
     }
 
-    async delete(
-        account: RegisteredAccount,
-        credentialsUuid: string,
-    ): Promise<void> {
+    async delete(account: Account, credentialsUuid: string): Promise<void> {
         this.canManage(account);
         const organizationUuid = account.organization.organizationUuid!;
-        const { userUuid } = account.user;
+        const userUuid = account.user.id;
 
         // Verify ownership before delete
         const existing =

--- a/packages/backend/src/services/ChangesetService.ts
+++ b/packages/backend/src/services/ChangesetService.ts
@@ -1,9 +1,9 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     Change,
     ChangesetWithChanges,
     ForbiddenError,
-    RegisteredAccount,
 } from '@lightdash/common';
 import { CatalogModel } from '../models/CatalogModel/CatalogModel';
 import { ChangesetModel } from '../models/ChangesetModel';
@@ -31,7 +31,7 @@ export class ChangesetService extends BaseService {
     }
 
     async findActiveChangesetWithChangesByProjectUuid(
-        account: RegisteredAccount,
+        account: Account,
         projectUuid: string,
     ): Promise<ChangesetWithChanges | undefined> {
         const auditedAbility = this.createAuditedAbility(account);
@@ -55,7 +55,7 @@ export class ChangesetService extends BaseService {
     }
 
     async getChange(
-        account: RegisteredAccount,
+        account: Account,
         projectUuid: string,
         changeUuid: string,
     ): Promise<Change> {
@@ -79,7 +79,7 @@ export class ChangesetService extends BaseService {
     }
 
     async revertChange(
-        account: RegisteredAccount,
+        account: Account,
         projectUuid: string,
         changeUuid: string,
     ): Promise<void> {
@@ -132,7 +132,7 @@ export class ChangesetService extends BaseService {
     }
 
     async revertAllChanges(
-        account: RegisteredAccount,
+        account: Account,
         projectUuid: string,
     ): Promise<void> {
         const auditedAbility = this.createAuditedAbility(account);

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     calculateExploreWarningReport,
     DeploySessionStatus,
     Explore,
@@ -7,7 +8,6 @@ import {
     ForbiddenError,
     NotFoundError,
     ProjectType,
-    RegisteredAccount,
     SessionUser,
     type ApiDeployExploresResults,
 } from '@lightdash/common';
@@ -60,7 +60,7 @@ export class DeployService extends BaseService {
     }
 
     async startDeploySession(
-        account: RegisteredAccount,
+        account: Account,
         projectUuid: string,
     ): Promise<{ deploySessionUuid: string }> {
         // Check deploy permission
@@ -93,7 +93,7 @@ export class DeployService extends BaseService {
         // Create a new deploy session
         const sessionUuid = await this.deploySessionModel.createSession(
             projectUuid,
-            account.user.userUuid,
+            account.user.id,
         );
 
         this.logger.info(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -26,7 +26,6 @@ import {
     OrganizationMemberRole,
     OrganizationProject,
     ParameterError,
-    RegisteredAccount,
     SessionUser,
     UpdateAllowedEmailDomains,
     UpdateColorPalette,
@@ -302,9 +301,7 @@ export class OrganizationService extends BaseService {
         };
     }
 
-    async getProjects(
-        account: RegisteredAccount,
-    ): Promise<OrganizationProject[]> {
+    async getProjects(account: Account): Promise<OrganizationProject[]> {
         const { organizationUuid } = account.organization;
         if (organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');
@@ -696,7 +693,7 @@ export class OrganizationService extends BaseService {
     }
 
     async getColorPalettes(
-        account: RegisteredAccount,
+        account: Account,
     ): Promise<OrganizationColorPaletteWithIsActive[]> {
         const { organizationUuid } = account.organization;
 

--- a/packages/backend/src/services/SpotlightService/SpotlightService.ts
+++ b/packages/backend/src/services/SpotlightService/SpotlightService.ts
@@ -2,7 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     NotFoundError,
-    type RegisteredAccount,
+    type Account,
     type SpotlightTableConfig,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -35,7 +35,7 @@ export class SpotlightService extends BaseService {
     }
 
     async createSpotlightTableConfig(
-        account: RegisteredAccount,
+        account: Account,
         projectUuid: string,
         tableConfig: Pick<SpotlightTableConfig, 'columnConfig'>,
     ): Promise<void> {
@@ -64,7 +64,7 @@ export class SpotlightService extends BaseService {
     }
 
     async getSpotlightTableConfig(
-        account: RegisteredAccount,
+        account: Account,
         projectUuid: string,
     ): Promise<SpotlightTableConfig> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
@@ -100,7 +100,7 @@ export class SpotlightService extends BaseService {
     }
 
     async resetSpotlightTableConfig(
-        account: RegisteredAccount,
+        account: Account,
         projectUuid: string,
     ): Promise<void> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);


### PR DESCRIPTION
## Summary

Reverts #22548 ([SPK-424](https://linear.app/lightdash/issue/SPK-424)).

Restores the prior `Account` parameter type and `req.account!` non-null assertions on the controllers/services that PR #22548 narrowed to `RegisteredAccount`. Also reverts the `account.user.id` → `account.user.userUuid` migrations introduced in that PR.

Builds on #22657, which reverted the `getOrganization` + `OrganizationService.get` slice. This PR reverts the remainder.

## Files reverted

**Controllers**
- `ChangesetController` (4 methods)
- `spotlightController` (3 methods)
- `organizationController` (`getProjects`, `getColorPalettes`)
- `sqlRunnerController` (`createVirtualView`, `updateVirtualView`)
- `v2/DeployController.startDeploySession`
- `v2/ProjectDefaultsController.getProjectDefaults`
- **EE:** `OrganizationWarehouseCredentialsController` (5 methods)

**Services**
- `ChangesetService` (4 method signatures)
- `SpotlightService` (3 method signatures)
- `OrganizationService.getProjects` / `.getColorPalettes`
- `DeployService.startDeploySession`
- **EE:** `OrganizationWarehouseCredentialsService` (canManage + 5 public methods)

## Conflict resolution

The mechanical `git revert b4eb88d` produced one conflict and several typecheck failures because later PRs added `assertRegisteredAccount` calls to other methods in the same files PR #22548 had introduced the import to. To keep those later PRs working, the `assertRegisteredAccount` import is preserved in:

- `organizationController.ts`
- `sqlRunnerController.ts`
- `v2/DeployController.ts`
- `v2/ProjectDefaultsController.ts`

`AuthorizationError` was not re-added to `organizationController.ts` because no remaining code in the file references it.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [ ] Manual: changeset list / get / revert / revert-all
- [ ] Manual: spotlight table config create/get/reset
- [ ] Manual: organization projects list / color palettes list
- [ ] Manual: SQL Runner virtual view create/update
- [ ] Manual: `lightdash deploy` (start deploy session via v2 endpoint)
- [ ] Manual: project defaults v2 GET
- [ ] Manual: EE org warehouse credentials CRUD (admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)