### PR TITLE
fix(palette): wire Explore through the color palette resolver

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -12,6 +12,7 @@ import {
     ApiGetProjectGroupAccesses,
     ApiGetProjectMemberResponse,
     ApiProjectAccessListResponse,
+    ApiProjectColorPaletteResponse,
     ApiProjectResponse,
     ApiSpaceSummaryListResponse,
     ApiSqlChartAsCodeListResponse,
@@ -649,6 +650,40 @@ export class ProjectController extends BaseController {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    /**
+     * Get the resolved color palette for a project, walking the
+     * chart -> dashboard -> space -> project -> organization fallback chain
+     * (matches saved-chart resolution). The optional UUIDs let unsaved
+     * renderers (Explore, AI viz, sql runner) opt into deeper layers as
+     * they become available.
+     * @summary Get project color palette
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{projectUuid}/colorPalette')
+    @OperationId('getProjectColorPalette')
+    async getProjectColorPalette(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Query() spaceUuid?: string,
+        @Query() dashboardUuid?: string,
+        @Query() chartUuid?: string,
+    ): Promise<ApiProjectColorPaletteResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const palette = await this.services
+            .getProjectService()
+            .getResolvedColorPalette(toSessionUser(req.account), projectUuid, {
+                spaceUuid,
+                dashboardUuid,
+                chartUuid,
+            });
+        return {
+            status: 'ok',
+            results: palette,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8986,11 +8986,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9468,11 +9468,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9487,11 +9487,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9506,11 +9506,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9525,11 +9525,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9544,11 +9544,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -20179,6 +20179,148 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ColorPaletteSource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: {
+                            dataType: 'enum',
+                            enums: ['config'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: {
+                            dataType: 'enum',
+                            enums: ['default'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['organization'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['project'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['space'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['dashboard'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['chart'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResolvedProjectColorPalette: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                source: { ref: 'ColorPaletteSource', required: true },
+                paletteName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                paletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                darkColors: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                colors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiProjectColorPaletteResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ResolvedProjectColorPalette', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardBasicDetailsWithTileTypes: {
         dataType: 'refAlias',
         type: {
@@ -21098,7 +21240,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21108,7 +21250,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21118,7 +21260,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21131,7 +21273,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -46904,6 +47046,72 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateDefaultUserSpaces',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_getProjectColorPalette: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        spaceUuid: { in: 'query', name: 'spaceUuid', dataType: 'string' },
+        dashboardUuid: {
+            in: 'query',
+            name: 'dashboardUuid',
+            dataType: 'string',
+        },
+        chartUuid: { in: 'query', name: 'chartUuid', dataType: 'string' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/colorPalette',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getProjectColorPalette,
+        ),
+
+        async function ProjectController_getProjectColorPalette(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_getProjectColorPalette,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getProjectColorPalette',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10444,19 +10444,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -21598,6 +21585,168 @@
                 "required": ["hasDefaultUserSpaces"],
                 "type": "object"
             },
+            "ColorPaletteSource": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["config"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["default"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["organization"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["project"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["space"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["dashboard"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["chart"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    }
+                ],
+                "description": "Where a resolved colour palette came from. The `config` and `default` cases\ncarry no entity reference; the rest expose the UUID and human-readable name\nof the entity (organization, project, space, dashboard or chart) that owns\nthe winning palette in the resolution chain."
+            },
+            "ResolvedProjectColorPalette": {
+                "properties": {
+                    "source": {
+                        "$ref": "#/components/schemas/ColorPaletteSource"
+                    },
+                    "paletteName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "paletteUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "darkColors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true
+                    },
+                    "colors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "source",
+                    "paletteName",
+                    "paletteUuid",
+                    "darkColors",
+                    "colors"
+                ],
+                "type": "object"
+            },
+            "ApiProjectColorPaletteResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ResolvedProjectColorPalette"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "DashboardBasicDetailsWithTileTypes": {
                 "allOf": [
                     {
@@ -22497,22 +22646,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -31350,7 +31499,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2865.0",
+        "version": "0.2867.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -40481,6 +40630,69 @@
             }
         },
         "/api/v1/projects/{projectUuid}/colorPalette": {
+            "get": {
+                "operationId": "getProjectColorPalette",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiProjectColorPaletteResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the resolved color palette for a project, walking the\nchart -> dashboard -> space -> project -> organization fallback chain\n(matches saved-chart resolution). The optional UUIDs let unsaved\nrenderers (Explore, AI viz, sql runner) opt into deeper layers as\nthey become available.",
+                "summary": "Get project color palette",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "spaceUuid",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "dashboardUuid",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "chartUuid",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
             "patch": {
                 "operationId": "updateProjectColorPalette",
                 "responses": {

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -36,6 +36,7 @@ import {
     NotFoundError,
     Organization,
     Project,
+    ResolvedProjectColorPalette,
     SavedChartDAO,
     SessionUser,
     SortField,
@@ -501,19 +502,21 @@ export class SavedChartModel {
         spaceUuid?: string;
         projectUuid: string;
         organizationUuid: string;
-    }): Promise<{
-        paletteUuid: string | null;
-        colors: string[];
-        darkColors: string[] | null;
-    } | null> {
+    }): Promise<ResolvedProjectColorPalette | null> {
         const override = this.lightdashConfig.appearance.overrideColorPalette;
         if (override && override.length > 0) {
-            return { paletteUuid: null, colors: override, darkColors: null };
+            return {
+                paletteUuid: null,
+                paletteName: null,
+                colors: override,
+                darkColors: null,
+                source: { type: 'config' },
+            };
         }
 
         // Single query: LEFT JOIN the palettes table twice (project's palette
-        // and org's palette) and COALESCE so the project palette wins when set
-        // and falls back to the org's active palette otherwise.
+        // and org's palette) and discriminate the winning level in JS so we
+        // can surface which entity owns the resolved palette.
         const result = await this.database(ProjectTableName)
             .innerJoin(
                 OrganizationTableName,
@@ -532,27 +535,71 @@ export class SavedChartModel {
             )
             .where(`${ProjectTableName}.project_uuid`, args.projectUuid)
             .select<{
-                color_palette_uuid: string | null;
-                colors: string[] | null;
-                dark_colors: string[] | null;
+                project_uuid: string;
+                project_name: string;
+                organization_uuid: string;
+                organization_name: string;
+                project_palette_uuid: string | null;
+                project_palette_name: string | null;
+                project_palette_colors: string[] | null;
+                project_palette_dark_colors: string[] | null;
+                org_palette_uuid: string | null;
+                org_palette_name: string | null;
+                org_palette_colors: string[] | null;
+                org_palette_dark_colors: string[] | null;
             }>([
-                this.database.raw(
-                    'COALESCE(project_palette.color_palette_uuid, org_palette.color_palette_uuid) as color_palette_uuid',
-                ),
-                this.database.raw(
-                    'COALESCE(project_palette.colors, org_palette.colors) as colors',
-                ),
-                this.database.raw(
-                    'COALESCE(project_palette.dark_colors, org_palette.dark_colors) as dark_colors',
-                ),
+                `${ProjectTableName}.project_uuid as project_uuid`,
+                `${ProjectTableName}.name as project_name`,
+                `${OrganizationTableName}.organization_uuid as organization_uuid`,
+                `${OrganizationTableName}.organization_name as organization_name`,
+                'project_palette.color_palette_uuid as project_palette_uuid',
+                'project_palette.name as project_palette_name',
+                'project_palette.colors as project_palette_colors',
+                'project_palette.dark_colors as project_palette_dark_colors',
+                'org_palette.color_palette_uuid as org_palette_uuid',
+                'org_palette.name as org_palette_name',
+                'org_palette.colors as org_palette_colors',
+                'org_palette.dark_colors as org_palette_dark_colors',
             ])
             .first();
 
-        if (result?.color_palette_uuid && result.colors) {
+        if (!result) {
+            return null;
+        }
+
+        if (
+            result.project_palette_uuid &&
+            result.project_palette_colors &&
+            result.project_palette_name
+        ) {
             return {
-                paletteUuid: result.color_palette_uuid,
-                colors: result.colors,
-                darkColors: result.dark_colors,
+                paletteUuid: result.project_palette_uuid,
+                paletteName: result.project_palette_name,
+                colors: result.project_palette_colors,
+                darkColors: result.project_palette_dark_colors,
+                source: {
+                    type: 'project',
+                    uuid: result.project_uuid,
+                    name: result.project_name,
+                },
+            };
+        }
+
+        if (
+            result.org_palette_uuid &&
+            result.org_palette_colors &&
+            result.org_palette_name
+        ) {
+            return {
+                paletteUuid: result.org_palette_uuid,
+                paletteName: result.org_palette_name,
+                colors: result.org_palette_colors,
+                darkColors: result.org_palette_dark_colors,
+                source: {
+                    type: 'organization',
+                    uuid: result.organization_uuid,
+                    name: result.organization_name,
+                },
             };
         }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -55,6 +55,7 @@ import {
     DefaultSupportedDbtVersion,
     DimensionType,
     DownloadFileType,
+    ECHARTS_DEFAULT_COLORS,
     Explore,
     ExploreError,
     ExploreType,
@@ -131,6 +132,7 @@ import {
     ReplaceCustomFieldsPayload,
     replaceDimensionInExplore,
     RequestMethod,
+    ResolvedProjectColorPalette,
     resolveQueryTimezone,
     resolveToBaseTimeDimension,
     ResultRow,
@@ -6549,6 +6551,46 @@ export class ProjectService extends BaseService {
         await this.projectModel.updateColorPalette(
             projectUuid,
             colorPaletteUuid,
+        );
+    }
+
+    async getResolvedColorPalette(
+        user: SessionUser,
+        projectUuid: string,
+        context: {
+            spaceUuid?: string;
+            dashboardUuid?: string;
+            chartUuid?: string;
+        } = {},
+    ): Promise<ResolvedProjectColorPalette> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const resolved = await this.savedChartModel.resolveColorPalette({
+            projectUuid,
+            organizationUuid,
+            spaceUuid: context.spaceUuid,
+            dashboardUuid: context.dashboardUuid,
+            chartUuid: context.chartUuid,
+        });
+
+        return (
+            resolved ?? {
+                colors: ECHARTS_DEFAULT_COLORS,
+                darkColors: null,
+                paletteUuid: null,
+                paletteName: null,
+                source: { type: 'default' },
+            }
         );
     }
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -130,6 +130,7 @@ import {
 } from './openIdIdentity';
 import {
     type AllowedEmailDomains,
+    type ApiProjectColorPaletteResponse,
     type OnboardingStatus,
     type Organization,
     type OrganizationProject,
@@ -1035,6 +1036,7 @@ type ApiResults =
     | ApiMyAppsResponse['results']
     | ApiPreviewTokenResponse['results']
     | ApiAppImageUploadResponse['results']
+    | ApiProjectColorPaletteResponse['results']
     | DashboardPreAggregateAudit;
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -191,3 +191,31 @@ export type ApiCreatedColorPaletteResponse = {
     status: 'ok';
     results: OrganizationColorPalette;
 };
+
+/**
+ * Where a resolved colour palette came from. The `config` and `default` cases
+ * carry no entity reference; the rest expose the UUID and human-readable name
+ * of the entity (organization, project, space, dashboard or chart) that owns
+ * the winning palette in the resolution chain.
+ */
+export type ColorPaletteSource =
+    | { type: 'config' }
+    | { type: 'default' }
+    | { type: 'organization'; uuid: string; name: string }
+    | { type: 'project'; uuid: string; name: string }
+    | { type: 'space'; uuid: string; name: string }
+    | { type: 'dashboard'; uuid: string; name: string }
+    | { type: 'chart'; uuid: string; name: string };
+
+export type ResolvedProjectColorPalette = {
+    colors: string[];
+    darkColors: string[] | null;
+    paletteUuid: string | null;
+    paletteName: string | null;
+    source: ColorPaletteSource;
+};
+
+export type ApiProjectColorPaletteResponse = {
+    status: 'ok';
+    results: ResolvedProjectColorPalette;
+};

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -8,13 +8,20 @@ import {
     type PivotChartLayout,
     type ValueLabelPositionOptions,
 } from '@lightdash/common';
-import { Accordion, SegmentedControl, Stack, Text } from '@mantine/core';
+import {
+    Accordion,
+    SegmentedControl,
+    Stack,
+    Text,
+    useMantineColorScheme,
+} from '@mantine/core';
 import { useMemo } from 'react';
 import {
     useAppSelector,
     useAppDispatch as useVizDispatch,
 } from '../../../features/sqlRunner/store/hooks';
-import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { selectProjectUuid } from '../../../features/sqlRunner/store/sqlRunnerSlice';
+import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
 import { Config } from '../../VisualizationConfigs/common/Config';
 import { type BarChartActionsType } from '../store/barChartSlice';
 import { type LineChartActionsType } from '../store/lineChartSlice';
@@ -35,8 +42,15 @@ export const CartesianChartSeries = ({
     selectedChartType: ChartKind;
     actions: BarChartActionsType | LineChartActionsType;
 }) => {
-    const { data: org } = useOrganization();
-    const colors = org?.chartColors ?? ECHARTS_DEFAULT_COLORS;
+    const projectUuid = useAppSelector(selectProjectUuid);
+    const { data: resolvedPalette } = useProjectColorPalette(
+        projectUuid || undefined,
+    );
+    const { colorScheme } = useMantineColorScheme();
+    const colors =
+        colorScheme === 'dark' && resolvedPalette?.darkColors?.length
+            ? resolvedPalette.darkColors
+            : (resolvedPalette?.colors ?? ECHARTS_DEFAULT_COLORS);
     const dispatch = useVizDispatch();
 
     const currentConfig = useAppSelector((state) =>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -39,6 +39,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplore } from '../../../hooks/useExplore';
@@ -83,15 +84,22 @@ const VisualizationCard: FC<Props> = memo((props) => {
     const { colorScheme } = useMantineColorScheme();
     const dispatch = useExplorerDispatch();
 
-    const colorPalette = useMemo(() => {
-        if (colorScheme === 'dark' && org?.chartDarkColors) {
-            return org.chartDarkColors;
-        }
-        return org?.chartColors ?? ECHARTS_DEFAULT_COLORS;
-    }, [colorScheme, org?.chartColors, org?.chartDarkColors]);
-
     // Get savedChart from Redux
     const savedChart = useExplorerSelector(selectSavedChart);
+
+    const projectUuid = savedChart?.projectUuid || fallBackUUid;
+    const { data: resolvedPalette } = useProjectColorPalette(projectUuid, {
+        chartUuid: savedChart?.uuid,
+        dashboardUuid: savedChart?.dashboardUuid ?? undefined,
+        spaceUuid: savedChart?.spaceUuid,
+    });
+
+    const colorPalette = useMemo(() => {
+        if (colorScheme === 'dark' && resolvedPalette?.darkColors) {
+            return resolvedPalette.darkColors;
+        }
+        return resolvedPalette?.colors ?? ECHARTS_DEFAULT_COLORS;
+    }, [colorScheme, resolvedPalette]);
 
     const {
         query,
@@ -159,8 +167,6 @@ const VisualizationCard: FC<Props> = memo((props) => {
         () => toggleExpandedSection(ExplorerSection.VISUALIZATION),
         [toggleExpandedSection],
     );
-
-    const projectUuid = savedChart?.projectUuid || fallBackUUid;
 
     const { data: explore } = useExplore(unsavedChartVersion.tableName);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -25,6 +25,7 @@ import {
 import { IconExclamationCircle } from '@tabler/icons-react';
 import { type QueryObserverSuccessResult } from '@tanstack/react-query';
 import { useCallback, useMemo, useState, type FC, type ReactNode } from 'react';
+import { useParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { SeriesContextMenu } from '../../../../../components/Explorer/VisualizationCard/SeriesContextMenu';
 import LightdashVisualization from '../../../../../components/LightdashVisualization';
@@ -34,8 +35,8 @@ import MetricQueryDataProvider from '../../../../../components/MetricQueryData/M
 import UnderlyingDataModal from '../../../../../components/MetricQueryData/UnderlyingDataModal';
 import { type EchartsSeriesClickEvent } from '../../../../../components/SimpleChart';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
+import { useProjectColorPalette } from '../../../../../hooks/appearance/useProjectColorPalette';
 import useHealth from '../../../../../hooks/health/useHealth';
-import { useOrganization } from '../../../../../hooks/organization/useOrganization';
 import { useExplore } from '../../../../../hooks/useExplore';
 import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import { AgentVisualizationChartTypeSwitcher } from './AgentVisualizationChartTypeSwitcher';
@@ -68,15 +69,16 @@ export const AiVisualizationRenderer: FC<Props> = ({
     onDashboardChartConfigChange: onDashboardChartConfigChangeProp,
 }) => {
     const { data: health } = useHealth();
-    const { data: organization } = useOrganization();
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { data: resolvedPalette } = useProjectColorPalette(projectUuid);
     const { colorScheme } = useMantineColorScheme();
 
     const colorPalette = useMemo(() => {
-        if (colorScheme === 'dark' && organization?.chartDarkColors) {
-            return organization.chartDarkColors;
+        if (colorScheme === 'dark' && resolvedPalette?.darkColors) {
+            return resolvedPalette.darkColors;
         }
-        return organization?.chartColors ?? ECHARTS_DEFAULT_COLORS;
-    }, [colorScheme, organization?.chartColors, organization?.chartDarkColors]);
+        return resolvedPalette?.colors ?? ECHARTS_DEFAULT_COLORS;
+    }, [colorScheme, resolvedPalette]);
 
     const { metricQuery, fields, resolvedTimezone } =
         queryExecutionHandle.data.query;

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -16,7 +16,7 @@ import { captureException } from '@sentry/react';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import getChartDataModel from '../../../components/DataViz/transformers/getChartDataModel';
-import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
 import { useQueryRetryConfig } from '../../../hooks/useQueryRetry';
 import {
     getDashboardSqlChartPivotChartData,
@@ -64,10 +64,11 @@ export const useSavedSqlChartResults = (
     args: UseSavedSqlChartResultsArguments,
 ) => {
     const retryConfig = useQueryRetryConfig();
-    // Needed for organization colors
-    const { data: organization } = useOrganization();
 
     const { savedSqlUuid, slug, projectUuid, context, parameters } = args;
+    const { data: resolvedPalette } = useProjectColorPalette(projectUuid, {
+        dashboardUuid: isDashboardArgs(args) ? args.dashboardUuid : undefined,
+    });
 
     // Step 1: Get the chart
     const chartQuery = useQuery<SqlChart, Partial<ApiError>>(
@@ -139,7 +140,7 @@ export const useSavedSqlChartResults = (
                     queryUuid: pivotChartData.queryUuid,
                     chartSpec: vizDataModel.getSpec(
                         chart.config.display,
-                        organization?.chartColors,
+                        resolvedPalette?.colors,
                     ),
                     fileUrl: vizDataModel.getDataDownloadUrl()!, // TODO: this is known if the results have been fetched - can we improve the types on vizdatamodel?
                     resultsRunner,

--- a/packages/frontend/src/hooks/appearance/useProjectColorPalette.ts
+++ b/packages/frontend/src/hooks/appearance/useProjectColorPalette.ts
@@ -1,0 +1,48 @@
+import {
+    type ApiError,
+    type ApiProjectColorPaletteResponse,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+
+type ResolvedPalette = ApiProjectColorPaletteResponse['results'];
+
+export type ProjectColorPaletteContext = {
+    spaceUuid?: string;
+    dashboardUuid?: string;
+    chartUuid?: string;
+};
+
+const getProjectColorPalette = (
+    projectUuid: string,
+    context: ProjectColorPaletteContext,
+) => {
+    const params = new URLSearchParams();
+    if (context.spaceUuid) params.set('spaceUuid', context.spaceUuid);
+    if (context.dashboardUuid)
+        params.set('dashboardUuid', context.dashboardUuid);
+    if (context.chartUuid) params.set('chartUuid', context.chartUuid);
+    const qs = params.toString();
+    return lightdashApi<ResolvedPalette>({
+        url: `/projects/${projectUuid}/colorPalette${qs ? `?${qs}` : ''}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useProjectColorPalette = (
+    projectUuid: string | undefined,
+    context: ProjectColorPaletteContext = {},
+) =>
+    useQuery<ResolvedPalette, ApiError>({
+        queryKey: [
+            'project',
+            projectUuid,
+            'color-palette',
+            context.spaceUuid ?? null,
+            context.dashboardUuid ?? null,
+            context.chartUuid ?? null,
+        ],
+        queryFn: () => getProjectColorPalette(projectUuid!, context),
+        enabled: Boolean(projectUuid),
+    });


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/projects/{projectUuid}/colorPalette` that proxies `SavedChartModel.resolveColorPalette` so unsaved Explore (and other ad-hoc renderers) see the project's palette instead of always falling back to the org's active palette.
- Extends the resolver's return shape with a `source` discriminator (`config | default | organization | project | space | dashboard | chart`) plus the source entity's `uuid` and `name`, so future space/dashboard/chart-level overrides can light up without changing the API surface.
- Frontend: new `useProjectColorPalette` hook, swapped into `VisualizationCard`, `AiVisualizationRenderer`, `CartesianChartSeries`, and `useSavedSqlChartResults`. The endpoint accepts optional `spaceUuid`/`dashboardUuid`/`chartUuid` query params; callers pass whatever context they have.

Closes [PROD-7396](https://linear.app/lightdash/issue/PROD-7396/explore-mode-bypasses-the-color-palette-resolver-uses-org-palette).

## Screenshots

Demo: org has `Customer Segments Sunrise` active; project palette toggled between *inherit* and `Customer Segments Aurora`. Pivoted bar chart (`orders` × `status` × `tax_rate`) so you get four distinct series.

<!-- Drop screenshots in via GitHub's web UI -->
| | Project = inherit (org Sunrise) | Project = Aurora override |
|---|---|---|
| **Saved chart** | strokes `#1D3557` + `#457B9D` (Sunrise 1+2) <img width="2400" height="2454" alt="01-explore-with-org-sunrise" src="https://github.com/user-attachments/assets/c052e883-0453-4e62-8cd3-073870f94e21" /> | strokes `#0B132B` + `#1C2541` (Aurora 1+2) <img width="2400" height="2454" alt="02-explore-with-project-aurora" src="https://github.com/user-attachments/assets/2dce54c7-3d0c-40b4-b2b0-651e5db67bde" />|
| **Fresh ad-hoc Explore** (the bug scenario) | bar `#1D3557` (Sunrise 1) <img width="2400" height="2454" alt="05-pivoted-org-sunrise" src="https://github.com/user-attachments/assets/4e917c1d-34c4-422e-8a73-65e43a74990e" />| bar `#0B132B` (Aurora 1) <img width="2400" height="2454" alt="06-pivoted-project-aurora" src="https://github.com/user-attachments/assets/ed97e118-9c6e-4ad2-9ea0-55c043198119" />|


## API shape

```ts
GET /api/v1/projects/{projectUuid}/colorPalette
  ?spaceUuid=...&dashboardUuid=...&chartUuid=...

{
  "status": "ok",
  "results": {
    "colors": string[],
    "darkColors": string[] | null,
    "paletteUuid": string | null,
    "paletteName": string | null,
    "source":
      | { "type": "config" }
      | { "type": "default" }
      | { "type": "organization", "uuid": string, "name": string }
      | { "type": "project",      "uuid": string, "name": string }
      | { "type": "space",        "uuid": string, "name": string }
      | { "type": "dashboard",    "uuid": string, "name": string }
      | { "type": "chart",        "uuid": string, "name": string }
  }
}
```

## Test plan

- [x] `pnpm -F common typecheck && pnpm -F backend typecheck && pnpm -F frontend typecheck` — clean
- [x] `pnpm -F common lint && pnpm -F backend lint && pnpm -F frontend lint` — clean
- [x] `pnpm -F backend test:dev:nowatch` — 333/333 passing
- [x] `pnpm generate-api` — committed
- [x] **Manual via demo seed (Chrome DevTools MCP):** see screenshots above; DOM verification confirmed SVG `stroke`/`fill` attributes match the resolved palette
- [x] `lightdashConfig.appearance.overrideColorPalette` short-circuit preserved (returns `source: { type: "config" }`)
- [x] Authorization mirrors existing patterns: `view` ability check on `Project` subject; users without project access get `403`

🤖 Generated with [Claude Code](https://claude.com/claude-code)