### PR TITLE
feat(data-apps): add chart-friendly format helpers

### DIFF
--- a/sandboxes/data-apps/.gitignore
+++ b/sandboxes/data-apps/.gitignore
@@ -11,3 +11,4 @@ template/src/lib/*
 !template/src/lib/theme.ts
 !template/src/lib/filters.tsx
 !template/src/lib/floating.tsx
+!template/src/lib/format.ts

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -318,10 +318,82 @@ Each additional metric needs:
 |---|---|---|
 | `data` | `Row[]` | Flat objects keyed by short field name. Raw values. Use for charts. |
 | `columns` | `Column[]` | Field metadata (`name`, `label`, `type`). Use for table headers. |
-| `format` | `(row, fieldName) => string` | Formatted display value (currency, %, dates). Use for text. |
+| `format` | `(row, fieldName) => string` | Server-side formatted value — preserves currency, %, prefix/suffix from the dbt YAML. **Tabular** form (e.g. `2025-03`, `2025-03-17`) — fine in dense table cells, **not** chart-friendly. For dates, chart axes, and human-readable date columns, prefer the `formatField` / `formatDate` / `formatNumber` helpers from `@/lib/format` (see [Formatting](#formatting)). |
 | `loading` | `boolean` | True while query is in flight. |
 | `error` | `Error \| null` | Query error. |
 | `refetch` | `() => void` | Re-run the query on demand. |
+
+### Formatting
+
+Every Lightdash row carries two views of each value:
+
+- `row[fieldName]` — the **raw** value. Numbers are real numbers; **dates and timestamps are full ISO strings** (e.g. `'2025-03-01T00:00:00Z'`) regardless of the truncation grain. Pass these to charts as data, not as axis labels.
+- `format(row, fieldName)` — the **server-formatted** value. Preserves dbt YAML formatting (currency, percent, prefix/suffix) but is tabular and zero-padded for dates (e.g. `'2025-03'`, `'2025-Q1'`). Fine in dense table cells, ugly on chart axes.
+
+For chart axes and any human-facing date column, use the helpers in `@/lib/format`:
+
+```tsx
+import { formatField, formatDate, formatNumber, getColumn } from '@/lib/format';
+```
+
+| Helper | Use for |
+|---|---|
+| `formatField(row, column, format, variant?)` | Default catch-all for table cells, KPI labels, and tooltip values. Routes dates through human-readable patterns, numbers through compact form on axes, and falls back to the SDK `format()` for currency/% so dbt YAML formatting is preserved. |
+| `formatDate(value, column?, variant?, opts?)` | A `tickFormatter` for date X-axes, or any place you have a raw value (no row). Variant is `'cell'` (default) or `'axis'` (compact). Pass `opts.pattern` to override with a custom date-fns pattern. |
+| `formatNumber(value, variant?)` | A `tickFormatter` for numeric Y-axes. `variant: 'axis'` returns compact form (`24K`, `$1.2M` style) without currency prefix. |
+| `getColumn(columns, name)` | Find a column by short name. Useful for passing column metadata to `formatDate` from a `tickFormatter`. |
+
+`variant: 'axis'` outputs:
+- date / timestamp by grain — `2025` (year), `Q1 '25` (quarter), `Jun '25` (month), `Jun 16 '25` (week / day)
+- number — compact (`24K`, `1.2M`)
+- timestamp without grain — `Jun 16, 14:00`
+
+`variant: 'cell'` outputs:
+- date / timestamp by grain — `2025`, `Q1 2025`, `Jun 2025`, `Jun 16, 2025`
+- number — server-formatted (currency / % / suffix preserved via the SDK `format()` you pass in)
+- timestamp without grain — `Jun 16, 2025 14:00`
+
+**Override** by passing `opts.pattern` to `formatDate`, or by formatting yourself with `date-fns`/`Intl.NumberFormat`:
+
+```tsx
+import { format as formatDateFns, parseISO } from 'date-fns';
+
+formatDate(row.order_date_month, getColumn(columns, 'order_date_month'), 'axis', { pattern: 'MMM yyyy' });
+
+// Or fully manual:
+formatDateFns(parseISO(row.order_date as string), 'EEEE, MMM d');
+```
+
+#### Chart axes
+
+**Every `<XAxis>` and `<YAxis>` in the app must have a `tickFormatter`.** No exceptions — including year axes that "look like they'd be fine" (`race_date_year` is still a full ISO timestamp at the data layer; Recharts will render `2025-01-01T00:00:00Z`, not `2025`).
+
+```tsx
+import { XAxis, YAxis } from 'recharts';
+import { formatDate, formatNumber, getColumn } from '@/lib/format';
+
+const dateCol = getColumn(columns, 'order_date_month');
+
+<XAxis
+    dataKey="order_date_month"
+    tickFormatter={(v) => formatDate(v, dateCol, 'axis')}
+/>
+<YAxis tickFormatter={(v) => formatNumber(v, 'axis')} />
+```
+
+**Self-check before declaring done:** grep the generated app for `<XAxis` and `<YAxis`. Every match must have a `tickFormatter` prop. If any axis is missing one, fix it before reporting the build complete — claiming "all axes formatted" without verifying is the most common way this lands broken.
+
+#### Tables
+
+Use `formatField` for cells so dates render `Jun 16, 2025` instead of `2025-06-16`, while currency/percent metrics still flow through the SDK's server format:
+
+```tsx
+{columns.map((col) => (
+    <TableCell key={col.name}>{formatField(row, col, format, 'cell')}</TableCell>
+))}
+```
+
+For the action-menu label and clipboard copy on a cell, the same helper applies — pass `format` so the per-field server format wins for currency/percent.
 
 ### Filters
 
@@ -639,7 +711,7 @@ function copyToClipboard(text: string) {
 function tableToCsv(columns: Column[], data: Row[], format: FormatFn): string {
     const header = columns.map((c) => c.label).join(',');
     const rows = data.map((row) =>
-        columns.map((c) => `"${format(row, c.name).replace(/"/g, '""')}"`).join(','),
+        columns.map((c) => `"${formatField(row, c, format, 'cell').replace(/"/g, '""')}"`).join(','),
     );
     return [header, ...rows].join('\n');
 }
@@ -665,9 +737,9 @@ function tableToCsv(columns: Column[], data: Row[], format: FormatFn): string {
                         <TableCell
                             key={col.name}
                             className="cursor-pointer"
-                            onClick={() => copyToClipboard(format(row, col.name))}
+                            onClick={() => copyToClipboard(formatField(row, col, format, 'cell'))}
                         >
-                            {format(row, col.name)}
+                            {formatField(row, col, format, 'cell')}
                         </TableCell>
                     ))}
                 </TableRow>
@@ -806,7 +878,7 @@ function DrillResults({ query: q }) {
                     {data.map((row, i) => (
                         <TableRow key={i}>
                             {columns.map((col) => (
-                                <TableCell key={col.name}>{format(row, col.name)}</TableCell>
+                                <TableCell key={col.name}>{formatField(row, col, format, 'cell')}</TableCell>
                             ))}
                         </TableRow>
                     ))}
@@ -840,6 +912,10 @@ function DrillResults({ query: q }) {
 | Building the filtered query inline (not memoized) | New query identity every render → infinite re-fetch | `useMemo(() => baseQuery.filters(filtersFor(EXPLORE)), [filtersFor])` |
 | Action menu missing "Filter by &lt;value&gt;" | Default UX requirement violated — users have no way to drill in | Every data-powered chart/table must include the option, calling `addFilter({ field, operator: 'equals', value, explore: EXPLORE })` |
 | Using a formatted display value in `addFilter` | Filter never matches raw rows (e.g. `"$1,234"` vs `1234`) | Pass the raw row value into `addFilter`; only use `format()` for the menu label |
+| `<XAxis dataKey="order_date_month" />` with no `tickFormatter` | Recharts renders the raw ISO timestamp (e.g. `2025-03-01T00:00:00Z`) as labels | `tickFormatter={(v) => formatDate(v, getColumn(columns, 'order_date_month'), 'axis')}` from `@/lib/format` |
+| Skipping `tickFormatter` on a year axis because "year is just a number" | Year dimensions (`*_year`) are still full ISO timestamps at the data layer, so the axis renders `2025-01-01T00:00:00Z` | Apply the same `formatDate(...)` `tickFormatter` to year axes — `formatDate` will collapse to `2025` for year-grain columns |
+| Using `format(row, 'order_date')` for a date column in a table cell | Renders `2025-03-17` (zero-padded tabular) — readable but ugly in dashboards | `formatField(row, col, format, 'cell')` from `@/lib/format` — renders `Mar 17, 2025` while still routing currency/% metrics through the server format |
+| Treating `row.order_date_month` as a `Date` or short string | It's a full ISO timestamp string (`2025-03-01T00:00:00Z`) for every grain | Pass through `formatDate` / `formatField`, or `parseISO` it before doing date math |
 | Building drill query inside render | Infinite re-fetching | Build in onClick handler, store in state |
 | Drilling by a dimension already in the source query | Pointless — same grouping | Pick a different, more granular dimension |
 | Using `e.chartX`/`e.chartY` for menu position | Chart-relative coords — menu appears at wrong position | Recharts `onClick` has no native event; capture `clientX`/`clientY` from a wrapper `<div onPointerDown>` via `useRef` — pointerdown fires before onClick so the ref is ready (see action menu example) |

--- a/sandboxes/data-apps/template/src/lib/format.ts
+++ b/sandboxes/data-apps/template/src/lib/format.ts
@@ -1,0 +1,143 @@
+import { format as formatDateFns, parseISO } from 'date-fns';
+import type { Column, FormatFunction, Row } from '@lightdash/query-sdk';
+
+export type FormatVariant = 'cell' | 'axis';
+
+type DateGranularity = 'year' | 'quarter' | 'month' | 'week' | 'day';
+
+const DATE_GRANULARITIES: DateGranularity[] = [
+    'year',
+    'quarter',
+    'month',
+    'week',
+    'day',
+];
+
+// Column metadata is grain-less (always `date`/`timestamp`); recover grain from the suffix.
+function inferGranularity(name: string): DateGranularity | undefined {
+    for (const g of DATE_GRANULARITIES) {
+        if (name.endsWith(`_${g}`)) return g;
+    }
+    return undefined;
+}
+
+function toDate(value: unknown): Date | null {
+    if (value === null || value === undefined || value === '') return null;
+    if (value instanceof Date)
+        return Number.isNaN(value.getTime()) ? null : value;
+    if (typeof value === 'number') {
+        const d = new Date(value);
+        return Number.isNaN(d.getTime()) ? null : d;
+    }
+    if (typeof value === 'string') {
+        const d = parseISO(value);
+        return Number.isNaN(d.getTime()) ? null : d;
+    }
+    return null;
+}
+
+// Axis patterns include a 2-digit year so multi-year ranges aren't ambiguous
+// (`Mar 8` alone could be 2025 or 2026). Cell variants always carry the full year.
+const DATE_PATTERNS: Record<DateGranularity, Record<FormatVariant, string>> = {
+    year: { axis: 'yyyy', cell: 'yyyy' },
+    quarter: { axis: "QQQ ''yy", cell: 'QQQ yyyy' },
+    month: { axis: "MMM ''yy", cell: 'MMM yyyy' },
+    week: { axis: "MMM d ''yy", cell: 'MMM d, yyyy' },
+    day: { axis: "MMM d ''yy", cell: 'MMM d, yyyy' },
+};
+
+const DEFAULT_DATE_PATTERN: Record<FormatVariant, string> = {
+    axis: "MMM d ''yy",
+    cell: 'MMM d, yyyy',
+};
+
+const DEFAULT_TIMESTAMP_PATTERN: Record<FormatVariant, string> = {
+    axis: 'MMM d, HH:mm',
+    cell: 'MMM d, yyyy HH:mm',
+};
+
+export type FormatDateOptions = {
+    pattern?: string;
+};
+
+export function formatDate(
+    value: unknown,
+    column?: Column,
+    variant: FormatVariant = 'cell',
+    opts: FormatDateOptions = {},
+): string {
+    const date = toDate(value);
+    if (!date) return '';
+    if (opts.pattern) return formatDateFns(date, opts.pattern);
+    const pattern = column?.name
+        ? DATE_PATTERNS[inferGranularity(column.name) ?? 'day'][variant]
+        : DEFAULT_DATE_PATTERN[variant];
+    return formatDateFns(date, pattern);
+}
+
+export function formatTimestamp(
+    value: unknown,
+    column?: Column,
+    variant: FormatVariant = 'cell',
+    opts: FormatDateOptions = {},
+): string {
+    const date = toDate(value);
+    if (!date) return '';
+    if (opts.pattern) return formatDateFns(date, opts.pattern);
+    // Truncated timestamps drop the time portion.
+    const granularity = column?.name
+        ? inferGranularity(column.name)
+        : undefined;
+    if (granularity && granularity !== 'day') {
+        return formatDate(value, column, variant);
+    }
+    return formatDateFns(date, DEFAULT_TIMESTAMP_PATTERN[variant]);
+}
+
+const compactNumberFormatter = new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+});
+const fullNumberFormatter = new Intl.NumberFormat('en-US');
+
+export function formatNumber(
+    value: unknown,
+    variant: FormatVariant = 'cell',
+): string {
+    if (value === null || value === undefined || value === '') return '';
+    const n = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(n)) return String(value);
+    return variant === 'axis'
+        ? compactNumberFormatter.format(n)
+        : fullNumberFormatter.format(n);
+}
+
+// Numbers in `cell` defer to `format()` so currency/% from the dbt YAML are preserved.
+export function formatField(
+    row: Row,
+    column: Column,
+    format: FormatFunction,
+    variant: FormatVariant = 'cell',
+): string {
+    const value = row[column.name];
+    if (value === null || value === undefined || value === '') return '';
+    switch (column.type) {
+        case 'date':
+            return formatDate(value, column, variant);
+        case 'timestamp':
+            return formatTimestamp(value, column, variant);
+        case 'number':
+            return variant === 'axis'
+                ? formatNumber(value, 'axis')
+                : format(row, column.name);
+        default:
+            return format(row, column.name);
+    }
+}
+
+export function getColumn(
+    columns: Column[],
+    name: string,
+): Column | undefined {
+    return columns.find((c) => c.name === name);
+}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-381/improve-formatter

### Description:
Generated data apps rendered dates as tabular zero-padded strings on chart axes and in cells (`2025-03`, `2025-03-17`) — readable but ugly. The SDK exposed two views per cell (a full ISO timestamp as raw, a tabular server-formatted string), with no chart-friendly path between them and no guidance to Claude on which to use where.

New `@/lib/format` module:
- `formatField` — catch-all that routes by column type. Number cells fall through to the SDK's server `format()` so currency/% and other dbt-YAML formatting are preserved.
- `formatDate`/`formatTimestamp` — chart-friendly date patterns inferred from the field-name grain suffix. Defaults: `Jun '25` for month, `Q1 '25` for quarter, `Mar 8 '26` for week/day, with full year on cell-variant outputs. Override per call via `opts.pattern` or by formatting yourself with date-fns.
- `formatNumber` — compact form (`1.2M`, `24K`) for axes, full thousands-separated form for cells.
- `getColumn(columns, name)` — column lookup so `tickFormatter` callsites can pass the column metadata in.

`skill.md`:
- New `Formatting` section documenting the raw-vs-formatted shape, the helpers, and per-variant outputs.
- Hard rule that every `<XAxis>` and `<YAxis>` must have a `tickFormatter`, with a self-check (grep the generated code; every match must have one) — added after a validation run regressed the year axis.
- Four new Common Pitfalls entries: raw ISO surprise on date columns, missing `tickFormatter` on a "year is just a number" axis, tabular dates in cells, and treating `row.order_date_month` as a Date.
- Existing table examples now use `formatField(row, col, format, 'cell')`.
