### PR TITLE
feat(validations): switch validations PK to UUID (PROD-7386)

### DIFF
--- a/packages/backend/src/controllers/v2/ValidationController.ts
+++ b/packages/backend/src/controllers/v2/ValidationController.ts
@@ -105,19 +105,20 @@ export class ValidationControllerV2 extends BaseController {
     }
 
     /**
-     * Get a single validation result by ID.
+     * Get a single validation result.
      * @summary Get validation result
      * @param projectUuid the projectId for the validation
-     * @param validationId the validation result ID
+     * @param validationIdOrUuid the validation UUID, or a legacy integer id
+     *   for rows created before the UUID migration (PROD-7386).
      * @param req express request
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Get('{validationId}')
+    @Get('{validationIdOrUuid}')
     @OperationId('GetValidationResult')
     async get(
         @Path() projectUuid: string,
-        @Path() validationId: number,
+        @Path() validationIdOrUuid: number | string,
         @Request() req: express.Request,
     ): Promise<ApiSingleValidationResponse> {
         assertRegisteredAccount(req.account);
@@ -126,7 +127,11 @@ export class ValidationControllerV2 extends BaseController {
             status: 'ok',
             results: await this.services
                 .getValidationService()
-                .getById(toSessionUser(req.account), projectUuid, validationId),
+                .getValidation(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    validationIdOrUuid,
+                ),
         };
     }
 }

--- a/packages/backend/src/controllers/validationController.ts
+++ b/packages/backend/src/controllers/validationController.ts
@@ -119,24 +119,29 @@ export class ValidationController extends BaseController {
     /**
      * Deletes a single validation error.
      * @summary Dismiss validation error
-     * @param validationId the projectId for the validation
+     * @param validationIdOrUuid the validation UUID, or a legacy integer id
+     *   for rows created before the UUID migration (PROD-7386).
      * @param req express request
      * @param fromSettings boolean to know if this request is made from the settings page, for analytics
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Delete('/{validationId}')
+    @Delete('/{validationIdOrUuid}')
     @OperationId('DeleteValidationDismiss')
     async dismiss(
         @Path() projectUuid: string,
-        @Path() validationId: number,
+        @Path() validationIdOrUuid: number | string,
         @Request() req: express.Request,
     ): Promise<ApiValidationDismissResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
         await this.services
             .getValidationService()
-            .delete(toSessionUser(req.account), validationId);
+            .deleteValidation(
+                toSessionUser(req.account),
+                projectUuid,
+                validationIdOrUuid,
+            );
         return {
             status: 'ok',
         };

--- a/packages/backend/src/database/entities/validation.ts
+++ b/packages/backend/src/database/entities/validation.ts
@@ -2,7 +2,15 @@ import { ValidationErrorType, ValidationSourceType } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export type DbValidationTable = {
-    validation_id: number;
+    validation_uuid: string;
+    /**
+     * @deprecated Legacy auto-increment integer ID. The IDENTITY/sequence was
+     * removed (see migration 20260501144729_validations_uuid_pk.ts) to prevent
+     * INTEGER sequence exhaustion. Column is retained for back-compat with
+     * downstream replication consumers and legacy URLs; new rows leave it NULL.
+     * Use `validation_uuid` as the canonical identifier.
+     */
+    validation_id: number | null;
     created_at: Date;
     project_uuid: string;
     error: string;

--- a/packages/backend/src/database/migrations/20260501144729_validations_uuid_pk.ts
+++ b/packages/backend/src/database/migrations/20260501144729_validations_uuid_pk.ts
@@ -1,0 +1,76 @@
+import { Knex } from 'knex';
+
+const VALIDATIONS_TABLE = 'validations';
+const PK_NAME = 'validations_pkey';
+const LEGACY_INDEX_NAME = 'validations_validation_id_legacy_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL statement_timeout = 0`);
+
+    await knex.schema.alterTable(VALIDATIONS_TABLE, (table) => {
+        table
+            .uuid('validation_uuid')
+            .notNullable()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+    });
+
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT ??`, [
+        VALIDATIONS_TABLE,
+        PK_NAME,
+    ]);
+    await knex.raw(
+        `ALTER TABLE ?? ALTER COLUMN validation_id DROP IDENTITY IF EXISTS`,
+        [VALIDATIONS_TABLE],
+    );
+    await knex.raw(`ALTER TABLE ?? ALTER COLUMN validation_id DROP NOT NULL`, [
+        VALIDATIONS_TABLE,
+    ]);
+    await knex.raw(
+        `ALTER TABLE ?? ADD CONSTRAINT ?? PRIMARY KEY (validation_uuid)`,
+        [VALIDATIONS_TABLE, PK_NAME],
+    );
+
+    await knex.raw(
+        `CREATE UNIQUE INDEX ?? ON ?? (validation_id) WHERE validation_id IS NOT NULL`,
+        [LEGACY_INDEX_NAME, VALIDATIONS_TABLE],
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL statement_timeout = 0`);
+
+    // Rows inserted after the up() migration have validation_id IS NULL.
+    // Drop them so we can re-add NOT NULL and a fresh IDENTITY sequence.
+    await knex(VALIDATIONS_TABLE).whereNull('validation_id').delete();
+
+    await knex.raw(`DROP INDEX IF EXISTS ??`, [LEGACY_INDEX_NAME]);
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT ??`, [
+        VALIDATIONS_TABLE,
+        PK_NAME,
+    ]);
+    await knex.raw(`ALTER TABLE ?? ALTER COLUMN validation_id SET NOT NULL`, [
+        VALIDATIONS_TABLE,
+    ]);
+    await knex.raw(
+        `ALTER TABLE ?? ALTER COLUMN validation_id ADD GENERATED ALWAYS AS IDENTITY`,
+        [VALIDATIONS_TABLE],
+    );
+    // ADD GENERATED ALWAYS AS IDENTITY starts the sequence at 1 even when
+    // the column already has values. Advance it past the current max so
+    // subsequent inserts don't collide with existing rows.
+    await knex.raw(
+        `SELECT setval(
+            pg_get_serial_sequence(?, 'validation_id'),
+            COALESCE((SELECT MAX(validation_id) FROM ??), 0) + 1,
+            false
+        )`,
+        [VALIDATIONS_TABLE, VALIDATIONS_TABLE],
+    );
+    await knex.raw(
+        `ALTER TABLE ?? ADD CONSTRAINT ?? PRIMARY KEY (validation_id)`,
+        [VALIDATIONS_TABLE, PK_NAME],
+    );
+    await knex.schema.alterTable(VALIDATIONS_TABLE, (table) => {
+        table.dropColumn('validation_uuid');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9081,11 +9081,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9100,11 +9100,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9119,11 +9119,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9138,11 +9138,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9173,29 +9173,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 chartUsage:
                                                                                                     {
                                                                                                         dataType:
@@ -9219,6 +9196,35 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -9230,12 +9236,6 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                fieldType:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9351,11 +9351,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9431,29 +9431,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     chartUsage:
                                                                                                         {
                                                                                                             dataType:
@@ -9477,6 +9454,35 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
+                                                                                                    searchRank:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                        },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -9488,12 +9494,6 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    fieldType:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
-                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9525,11 +9525,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9544,11 +9544,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9563,11 +9563,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9582,11 +9582,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9601,11 +9601,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9620,11 +9620,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9639,11 +9639,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13750,7 +13750,15 @@ const models: TsoaRoute.Models = {
                 error: { dataType: 'string', required: true },
                 name: { dataType: 'string', required: true },
                 createdAt: { dataType: 'datetime', required: true },
-                validationId: { dataType: 'double', required: true },
+                validationId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                validationUuid: { dataType: 'string', required: true },
             },
             validators: {},
         },
@@ -13844,7 +13852,15 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-                validationId: { dataType: 'double', required: true },
+                validationUuid: { dataType: 'string', required: true },
+                validationId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 errorType: { ref: 'ValidationErrorType', required: true },
                 spaceUuid: {
                     dataType: 'union',
@@ -17938,23 +17954,32 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ValidationResponse.error-or-createdAt-or-validationId_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                createdAt: { dataType: 'datetime', required: true },
-                error: { dataType: 'string', required: true },
-                validationId: { dataType: 'double', required: true },
+    'Pick_ValidationResponse.error-or-createdAt-or-validationUuid-or-validationId_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    createdAt: { dataType: 'datetime', required: true },
+                    error: { dataType: 'string', required: true },
+                    validationUuid: { dataType: 'string', required: true },
+                    validationId: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
             },
-            validators: {},
         },
-    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ValidationSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_ValidationResponse.error-or-createdAt-or-validationId_',
+            ref: 'Pick_ValidationResponse.error-or-createdAt-or-validationUuid-or-validationId_',
             validators: {},
         },
     },
@@ -21394,7 +21419,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21404,7 +21429,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21414,7 +21439,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21427,7 +21452,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21838,7 +21863,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21848,7 +21873,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21858,7 +21883,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21871,7 +21896,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -39102,16 +39127,17 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'string',
         },
-        validationId: {
+        validationIdOrUuid: {
             in: 'path',
-            name: 'validationId',
+            name: 'validationIdOrUuid',
             required: true,
-            dataType: 'double',
+            dataType: 'union',
+            subSchemas: [{ dataType: 'double' }, { dataType: 'string' }],
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
     };
     app.delete(
-        '/api/v1/projects/:projectUuid/validate/:validationId',
+        '/api/v1/projects/:projectUuid/validate/:validationIdOrUuid',
         ...fetchMiddlewares<RequestHandler>(ValidationController),
         ...fetchMiddlewares<RequestHandler>(
             ValidationController.prototype.dismiss,
@@ -58079,16 +58105,17 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'string',
         },
-        validationId: {
+        validationIdOrUuid: {
             in: 'path',
-            name: 'validationId',
+            name: 'validationIdOrUuid',
             required: true,
-            dataType: 'double',
+            dataType: 'union',
+            subSchemas: [{ dataType: 'double' }, { dataType: 'string' }],
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
     };
     app.get(
-        '/api/v2/projects/:projectUuid/validate/:validationId',
+        '/api/v2/projects/:projectUuid/validate/:validationIdOrUuid',
         ...fetchMiddlewares<RequestHandler>(ValidationControllerV2),
         ...fetchMiddlewares<RequestHandler>(
             ValidationControllerV2.prototype.get,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10536,34 +10536,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10577,15 +10551,18 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
+                                                                        "fieldType": {
+                                                                            "type": "string"
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10593,17 +10570,14 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
-                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10652,8 +10626,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -10697,15 +10671,18 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
+                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10713,17 +10690,14 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
-                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10751,8 +10725,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14689,7 +14663,12 @@
                     },
                     "validationId": {
                         "type": "number",
-                        "format": "double"
+                        "format": "double",
+                        "nullable": true,
+                        "deprecated": true
+                    },
+                    "validationUuid": {
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -14698,7 +14677,8 @@
                     "error",
                     "name",
                     "createdAt",
-                    "validationId"
+                    "validationId",
+                    "validationUuid"
                 ],
                 "type": "object"
             },
@@ -14801,9 +14781,14 @@
                     "source": {
                         "$ref": "#/components/schemas/ValidationSourceType"
                     },
+                    "validationUuid": {
+                        "type": "string"
+                    },
                     "validationId": {
                         "type": "number",
-                        "format": "double"
+                        "format": "double",
+                        "nullable": true,
+                        "deprecated": true
                     },
                     "errorType": {
                         "$ref": "#/components/schemas/ValidationErrorType"
@@ -14816,6 +14801,7 @@
                     "projectUuid",
                     "createdAt",
                     "error",
+                    "validationUuid",
                     "validationId",
                     "errorType"
                 ],
@@ -19076,7 +19062,7 @@
                 "required": ["firstViewedAt", "views"],
                 "type": "object"
             },
-            "Pick_ValidationResponse.error-or-createdAt-or-validationId_": {
+            "Pick_ValidationResponse.error-or-createdAt-or-validationUuid-or-validationId_": {
                 "properties": {
                     "createdAt": {
                         "type": "string",
@@ -19085,17 +19071,27 @@
                     "error": {
                         "type": "string"
                     },
+                    "validationUuid": {
+                        "type": "string"
+                    },
                     "validationId": {
                         "type": "number",
-                        "format": "double"
+                        "format": "double",
+                        "nullable": true,
+                        "deprecated": true
                     }
                 },
-                "required": ["createdAt", "error", "validationId"],
+                "required": [
+                    "createdAt",
+                    "error",
+                    "validationUuid",
+                    "validationId"
+                ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ValidationSummary": {
-                "$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationId_"
+                "$ref": "#/components/schemas/Pick_ValidationResponse.error-or-createdAt-or-validationUuid-or-validationId_"
             },
             "SpaceQuery": {
                 "allOf": [
@@ -22820,22 +22816,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -23190,22 +23186,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -31673,7 +31669,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2870.0",
+        "version": "0.2870.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -34303,7 +34299,7 @@
                 ]
             }
         },
-        "/api/v1/projects/{projectUuid}/validate/{validationId}": {
+        "/api/v1/projects/{projectUuid}/validate/{validationIdOrUuid}": {
             "delete": {
                 "operationId": "DeleteValidationDismiss",
                 "responses": {
@@ -34342,14 +34338,11 @@
                         }
                     },
                     {
-                        "description": "the projectId for the validation",
+                        "description": "the validation UUID, or a legacy integer id\nfor rows created before the UUID migration (PROD-7386).",
                         "in": "path",
-                        "name": "validationId",
+                        "name": "validationIdOrUuid",
                         "required": true,
-                        "schema": {
-                            "format": "double",
-                            "type": "number"
-                        }
+                        "schema": {}
                     }
                 ]
             }
@@ -49398,7 +49391,7 @@
                 ]
             }
         },
-        "/api/v2/projects/{projectUuid}/validate/{validationId}": {
+        "/api/v2/projects/{projectUuid}/validate/{validationIdOrUuid}": {
             "get": {
                 "operationId": "GetValidationResult",
                 "responses": {
@@ -49423,7 +49416,7 @@
                         }
                     }
                 },
-                "description": "Get a single validation result by ID.",
+                "description": "Get a single validation result.",
                 "summary": "Get validation result",
                 "tags": ["v2", "Validation"],
                 "security": [],
@@ -49438,14 +49431,11 @@
                         }
                     },
                     {
-                        "description": "the validation result ID",
+                        "description": "the validation UUID, or a legacy integer id\nfor rows created before the UUID migration (PROD-7386).",
                         "in": "path",
-                        "name": "validationId",
+                        "name": "validationIdOrUuid",
                         "required": true,
-                        "schema": {
-                            "format": "double",
-                            "type": "number"
-                        }
+                        "schema": {}
                     }
                 ]
             }

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -533,6 +533,7 @@ export class DashboardModel {
                         firstViewedAt: first_viewed_at,
                         validationErrors: validation_errors?.map(
                             (error: DbValidationTable) => ({
+                                validationUuid: error.validation_uuid,
                                 validationId: error.validation_id,
                                 error: error.error,
                                 createdAt: error.created_at,

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -343,20 +343,28 @@ export class SearchModel {
             .whereNull('job_id')
             .whereIn('dashboard_uuid', dashboardUuids)
             .andWhereNot('dashboard_uuid', null)
-            .select('validation_id', 'dashboard_uuid')
+            .select('validation_uuid', 'validation_id', 'dashboard_uuid')
             .then((rows) =>
-                rows.reduce<Record<string, Array<{ validationId: number }>>>(
-                    (acc, row) => {
-                        if (row.dashboard_uuid) {
-                            acc[row.dashboard_uuid] = [
-                                ...(acc[row.dashboard_uuid] ?? []),
-                                { validationId: row.validation_id },
-                            ];
-                        }
-                        return acc;
-                    },
-                    {},
-                ),
+                rows.reduce<
+                    Record<
+                        string,
+                        Array<{
+                            validationUuid: string;
+                            validationId: number | null;
+                        }>
+                    >
+                >((acc, row) => {
+                    if (row.dashboard_uuid) {
+                        acc[row.dashboard_uuid] = [
+                            ...(acc[row.dashboard_uuid] ?? []),
+                            {
+                                validationUuid: row.validation_uuid,
+                                validationId: row.validation_id,
+                            },
+                        ];
+                    }
+                    return acc;
+                }, {}),
             );
 
         const directChartsQuery = this.database(SavedChartsTableName)
@@ -931,20 +939,28 @@ export class SearchModel {
             .whereNull('job_id')
             .whereIn('saved_chart_uuid', chartUuids)
             .andWhereNot('saved_chart_uuid', null)
-            .select('validation_id', 'saved_chart_uuid')
+            .select('validation_uuid', 'validation_id', 'saved_chart_uuid')
             .then((rows) =>
-                rows.reduce<Record<string, Array<{ validationId: number }>>>(
-                    (acc, row) => {
-                        if (row.saved_chart_uuid) {
-                            acc[row.saved_chart_uuid] = [
-                                ...(acc[row.saved_chart_uuid] ?? []),
-                                { validationId: row.validation_id },
-                            ];
-                        }
-                        return acc;
-                    },
-                    {},
-                ),
+                rows.reduce<
+                    Record<
+                        string,
+                        Array<{
+                            validationUuid: string;
+                            validationId: number | null;
+                        }>
+                    >
+                >((acc, row) => {
+                    if (row.saved_chart_uuid) {
+                        acc[row.saved_chart_uuid] = [
+                            ...(acc[row.saved_chart_uuid] ?? []),
+                            {
+                                validationUuid: row.validation_uuid,
+                                validationId: row.validation_id,
+                            },
+                        ];
+                    }
+                    return acc;
+                }, {}),
             );
 
         return savedCharts.map((chart) => ({
@@ -1413,20 +1429,28 @@ export class SearchModel {
             .where('project_uuid', projectUuid)
             .whereNull('job_id')
             .whereNotNull('model_name')
-            .select('validation_id', 'model_name')
+            .select('validation_uuid', 'validation_id', 'model_name')
             .then((rows) =>
-                rows.reduce<Record<string, Array<{ validationId: number }>>>(
-                    (acc, row) => {
-                        if (row.model_name) {
-                            acc[row.model_name] = [
-                                ...(acc[row.model_name] ?? []),
-                                { validationId: row.validation_id },
-                            ];
-                        }
-                        return acc;
-                    },
-                    {},
-                ),
+                rows.reduce<
+                    Record<
+                        string,
+                        Array<{
+                            validationUuid: string;
+                            validationId: number | null;
+                        }>
+                    >
+                >((acc, row) => {
+                    if (row.model_name) {
+                        acc[row.model_name] = [
+                            ...(acc[row.model_name] ?? []),
+                            {
+                                validationUuid: row.validation_uuid,
+                                validationId: row.validation_id,
+                            },
+                        ];
+                    }
+                    return acc;
+                }, {}),
             );
 
         return explores.reduce<TableErrorSearchResult[]>((acc, explore) => {

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -481,6 +481,7 @@ export class SpaceModel {
                 pinnedListOrder: order,
                 validationErrors: validation_errors?.map(
                     (error: DbValidationTable) => ({
+                        validationUuid: error.validation_uuid,
                         validationId: error.validation_id,
                         error: error.error,
                         createdAt: error.created_at,
@@ -824,9 +825,10 @@ export class SpaceModel {
             pinnedListUuid: savedQuery.pinned_list_uuid,
             pinnedListOrder: savedQuery.order,
             validationErrors: savedQuery.validation_errors.map(
-                ({ error, created_at, validation_id }) => ({
+                ({ error, created_at, validation_uuid, validation_id }) => ({
                     error,
                     createdAt: created_at,
+                    validationUuid: validation_uuid,
                     validationId: validation_id,
                 }),
             ),

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -37,7 +37,9 @@ import {
 import Logger from '../../logging/logger';
 
 type NormalizedValidationRow = {
-    validation_id: number;
+    validation_uuid: string;
+    /** @deprecated Use `validation_uuid`. NULL for rows created after the UUID migration (PROD-7386). */
+    validation_id: number | null;
     created_at: Date;
     project_uuid: string;
     error: string;
@@ -163,30 +165,60 @@ export class ValidationModel {
         });
     }
 
-    async getByValidationId(
-        validationId: number,
-    ): Promise<Pick<ValidationResponseBase, 'validationId' | 'projectUuid'>> {
-        const [validation] = await this.database(ValidationTableName).where(
-            'validation_id',
-            validationId,
+    async getByValidationIdOrUuid(
+        validationIdOrUuid: number | string,
+        projectUuid: string,
+    ): Promise<
+        Pick<
+            ValidationResponseBase,
+            'validationUuid' | 'validationId' | 'projectUuid'
+        >
+    > {
+        // Always scope by project so a request for /projects/A/validate/<X>
+        // can never resolve a row that belongs to project B.
+        const query = this.database(ValidationTableName).where(
+            'project_uuid',
+            projectUuid,
         );
+        // Numeric id resolves a pre-UUID-migration row (validation_id IS NOT
+        // NULL is enforced via the partial unique index, but we filter
+        // explicitly so the planner can use it).
+        const [validation] =
+            typeof validationIdOrUuid === 'number'
+                ? await query
+                      .where('validation_id', validationIdOrUuid)
+                      .whereNotNull('validation_id')
+                : await query.where('validation_uuid', validationIdOrUuid);
 
         if (!validation) {
             throw new NotFoundError(
-                `Validation with id ${validationId} not found`,
+                `Validation ${validationIdOrUuid} not found`,
             );
         }
 
         return {
+            validationUuid: validation.validation_uuid,
             validationId: validation.validation_id,
             projectUuid: validation.project_uuid,
         };
     }
 
-    async deleteValidation(validationId: number): Promise<void> {
-        await this.database(ValidationTableName)
-            .where('validation_id', validationId)
-            .delete();
+    async deleteValidationByIdOrUuid(
+        validationIdOrUuid: number | string,
+        projectUuid: string,
+    ): Promise<void> {
+        const query = this.database(ValidationTableName).where(
+            'project_uuid',
+            projectUuid,
+        );
+        if (typeof validationIdOrUuid === 'number') {
+            await query
+                .where('validation_id', validationIdOrUuid)
+                .whereNotNull('validation_id')
+                .delete();
+        } else {
+            await query.where('validation_uuid', validationIdOrUuid).delete();
+        }
     }
 
     async deleteChartValidations(chartUuid: string): Promise<void> {
@@ -382,6 +414,7 @@ export class ValidationModel {
                     ? `${validationError.first_name} ${validationError.last_name}`
                     : undefined,
                 lastUpdatedAt: validationError.last_version_updated_at,
+                validationUuid: validationError.validation_uuid,
                 validationId: validationError.validation_id,
                 spaceUuid: validationError.space_uuid,
                 chartKind:
@@ -484,6 +517,7 @@ export class ValidationModel {
                         ? `${validationError.first_name} ${validationError.last_name}`
                         : undefined,
                     lastUpdatedAt: validationError.last_updated_at,
+                    validationUuid: validationError.validation_uuid,
                     validationId: validationError.validation_id,
                     spaceUuid: validationError.space_uuid,
                     errorType: validationError.error_type,
@@ -519,6 +553,7 @@ export class ValidationModel {
                 projectUuid: validationError.project_uuid,
                 error: validationError.error,
                 name: validationError.model_name ?? undefined,
+                validationUuid: validationError.validation_uuid,
                 validationId: validationError.validation_id,
                 errorType: validationError.error_type,
                 source: ValidationSourceType.Table,
@@ -536,6 +571,7 @@ export class ValidationModel {
     ): ValidationResponse {
         if (row.source === ValidationSourceType.Chart) {
             return {
+                validationUuid: row.validation_uuid,
                 validationId: row.validation_id,
                 createdAt: row.created_at,
                 projectUuid: row.project_uuid,
@@ -563,6 +599,7 @@ export class ValidationModel {
                 row.error,
             );
             return {
+                validationUuid: row.validation_uuid,
                 validationId: row.validation_id,
                 createdAt: row.created_at,
                 projectUuid: row.project_uuid,
@@ -585,6 +622,7 @@ export class ValidationModel {
         }
 
         return {
+            validationUuid: row.validation_uuid,
             validationId: row.validation_id,
             createdAt: row.created_at,
             projectUuid: row.project_uuid,
@@ -595,14 +633,38 @@ export class ValidationModel {
         };
     }
 
-    async getFullById(
-        validationId: number,
+    async getFullByIdOrUuid(
+        validationIdOrUuid: number | string,
+        projectUuid: string,
         options?: {
             allowedSpaceUuids?: string[] | 'all';
         },
     ): Promise<ValidationResponse | undefined> {
         const allowedSpaceUuids = options?.allowedSpaceUuids ?? 'all';
         const dashboardSpaceAlias = 'dashboard_space';
+
+        // Always scope by project so a request for /projects/A/validate/<X>
+        // can never resolve a row that belongs to project B. Pre-UUID-migration
+        // rows are looked up by their integer `validation_id`; post-migration
+        // rows by `validation_uuid`. The `whereNotNull` on the legacy branch
+        // is defensive — without it a future row whose `validation_id` was
+        // somehow re-populated could match unexpectedly.
+        const filterByIdOrUuid = (qb: Knex.QueryBuilder) => {
+            void qb.where(`${ValidationTableName}.project_uuid`, projectUuid);
+            if (typeof validationIdOrUuid === 'number') {
+                void qb
+                    .where(
+                        `${ValidationTableName}.validation_id`,
+                        validationIdOrUuid,
+                    )
+                    .whereNotNull(`${ValidationTableName}.validation_id`);
+            } else {
+                void qb.where(
+                    `${ValidationTableName}.validation_uuid`,
+                    validationIdOrUuid,
+                );
+            }
+        };
 
         const chartSubquery = this.database(ValidationTableName)
             .leftJoin(
@@ -630,12 +692,13 @@ export class ValidationModel {
                 `${SavedChartsTableName}.last_version_updated_by_user_uuid`,
                 `${UserTableName}.user_uuid`,
             )
-            .where(`${ValidationTableName}.validation_id`, validationId)
+            .modify(filterByIdOrUuid)
             .andWhere(
                 `${ValidationTableName}.source`,
                 ValidationSourceType.Chart,
             )
             .select([
+                `${ValidationTableName}.validation_uuid`,
                 `${ValidationTableName}.validation_id`,
                 `${ValidationTableName}.created_at`,
                 `${ValidationTableName}.project_uuid`,
@@ -683,12 +746,13 @@ export class ValidationModel {
                 `${UserTableName}.user_uuid`,
                 `${DashboardVersionsTableName}.updated_by_user_uuid`,
             )
-            .where(`${ValidationTableName}.validation_id`, validationId)
+            .modify(filterByIdOrUuid)
             .andWhere(
                 `${ValidationTableName}.source`,
                 ValidationSourceType.Dashboard,
             )
             .select([
+                `${ValidationTableName}.validation_uuid`,
                 `${ValidationTableName}.validation_id`,
                 `${ValidationTableName}.created_at`,
                 `${ValidationTableName}.project_uuid`,
@@ -716,12 +780,13 @@ export class ValidationModel {
             .limit(1);
 
         const tableSubquery = this.database(ValidationTableName)
-            .where(`${ValidationTableName}.validation_id`, validationId)
+            .modify(filterByIdOrUuid)
             .andWhere(
                 `${ValidationTableName}.source`,
                 ValidationSourceType.Table,
             )
             .select([
+                `${ValidationTableName}.validation_uuid`,
                 `${ValidationTableName}.validation_id`,
                 `${ValidationTableName}.created_at`,
                 `${ValidationTableName}.project_uuid`,
@@ -768,9 +833,7 @@ export class ValidationModel {
             .limit(1);
 
         const row = rows[0];
-        if (!row) {
-            return undefined;
-        }
+        if (!row) return undefined;
 
         return ValidationModel.mapRowToValidationResponse(row);
     }
@@ -844,6 +907,7 @@ export class ValidationModel {
             .andWhere(jobFilter)
             .whereNotNull(`${SavedChartsTableName}.saved_query_uuid`)
             .select([
+                `${ValidationTableName}.validation_uuid`,
                 `${ValidationTableName}.validation_id`,
                 `${ValidationTableName}.created_at`,
                 `${ValidationTableName}.project_uuid`,
@@ -918,6 +982,7 @@ export class ValidationModel {
             .andWhere(jobFilter)
             .whereNotNull(`${DashboardsTableName}.dashboard_uuid`)
             .select([
+                `${ValidationTableName}.validation_uuid`,
                 `${ValidationTableName}.validation_id`,
                 `${ValidationTableName}.created_at`,
                 `${ValidationTableName}.project_uuid`,
@@ -969,6 +1034,7 @@ export class ValidationModel {
             )
             .andWhere(jobFilter)
             .select([
+                `${ValidationTableName}.validation_uuid`,
                 `${ValidationTableName}.validation_id`,
                 `${ValidationTableName}.created_at`,
                 `${ValidationTableName}.project_uuid`,
@@ -1053,7 +1119,7 @@ export class ValidationModel {
                 })
                 .orderBy([
                     { column: sortColumn, order: sortDirection },
-                    { column: 'validation_id', order: 'asc' },
+                    { column: 'validation_uuid', order: 'asc' },
                 ])
                 .limit(paginateArgs.pageSize)
                 .offset((paginateArgs.page - 1) * paginateArgs.pageSize);

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1115,49 +1115,55 @@ export class ValidationService extends BaseService {
         return this.hidePrivateContent(user, projectUuid, validations);
     }
 
-    async getById(
+    private async resolveAllowedSpaceUuids(
         user: SessionUser,
         projectUuid: string,
-        validationId: number,
-    ): Promise<ValidationResponse> {
-        const projectSummary = await this.projectModel.getSummary(projectUuid);
-
+        organizationUuid: string,
+    ): Promise<string[] | 'all'> {
         const auditedAbility = this.createAuditedAbility(user);
-
         if (
             auditedAbility.cannot(
                 'manage',
-                subject('Validation', {
-                    organizationUuid: projectSummary.organizationUuid,
-                    projectUuid,
-                }),
+                subject('Validation', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
         }
 
-        let allowedSpaceUuids: string[] | 'all' = 'all';
-
-        if (user.role !== OrganizationMemberRole.ADMIN) {
-            const spaces = await this.spaceModel.find({ projectUuid });
-            const spaceUuids = spaces.map((s) => s.uuid);
-
-            allowedSpaceUuids =
-                await this.spacePermissionService.getAccessibleSpaceUuids(
-                    'view',
-                    user,
-                    spaceUuids,
-                );
+        if (user.role === OrganizationMemberRole.ADMIN) {
+            return 'all';
         }
+        const spaces = await this.spaceModel.find({ projectUuid });
+        const spaceUuids = spaces.map((s) => s.uuid);
+        return this.spacePermissionService.getAccessibleSpaceUuids(
+            'view',
+            user,
+            spaceUuids,
+        );
+    }
 
-        const validation = await this.validationModel.getFullById(
-            validationId,
+    async getValidation(
+        user: SessionUser,
+        projectUuid: string,
+        validationIdOrUuid: number | string,
+    ): Promise<ValidationResponse> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const allowedSpaceUuids = await this.resolveAllowedSpaceUuids(
+            user,
+            projectUuid,
+            organizationUuid,
+        );
+
+        const validation = await this.validationModel.getFullByIdOrUuid(
+            validationIdOrUuid,
+            projectUuid,
             { allowedSpaceUuids },
         );
 
         if (!validation) {
             throw new NotFoundError(
-                `Validation with id ${validationId} not found`,
+                `Validation ${validationIdOrUuid} not found`,
             );
         }
 
@@ -1257,22 +1263,18 @@ export class ValidationService extends BaseService {
         return this.hidePrivateContent(user, projectUuid, validations);
     }
 
-    async delete(user: SessionUser, validationId: number): Promise<void> {
-        const validation =
-            await this.validationModel.getByValidationId(validationId);
-        const projectSummary = await this.projectModel.getSummary(
-            validation.projectUuid,
-        );
+    private async authorizeAndTrackDismiss(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
 
         const auditedAbility = this.createAuditedAbility(user);
-
         if (
             auditedAbility.cannot(
                 'manage',
-                subject('Validation', {
-                    organizationUuid: projectSummary.organizationUuid,
-                    projectUuid: validation.projectUuid,
-                }),
+                subject('Validation', { organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -1283,11 +1285,29 @@ export class ValidationService extends BaseService {
             userId: user.userUuid,
             properties: {
                 organizationId: user.organizationUuid,
-                projectId: validation.projectUuid,
+                projectId: projectUuid,
             },
         });
+    }
 
-        await this.validationModel.deleteValidation(validationId);
+    async deleteValidation(
+        user: SessionUser,
+        projectUuid: string,
+        validationIdOrUuid: number | string,
+    ): Promise<void> {
+        // Authorize against the URL's projectUuid first, then look up the
+        // validation scoped to that project. If the validation belongs to a
+        // different project the lookup throws NotFoundError, so the caller
+        // can never act on a row outside the project they're authorized for.
+        await this.authorizeAndTrackDismiss(user, projectUuid);
+        await this.validationModel.getByValidationIdOrUuid(
+            validationIdOrUuid,
+            projectUuid,
+        );
+        await this.validationModel.deleteValidationByIdOrUuid(
+            validationIdOrUuid,
+            projectUuid,
+        );
     }
 
     async validateAndUpdateChart(

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -23,6 +23,8 @@ export type DashboardSearchResult = Pick<
     'uuid' | 'name' | 'description' | 'spaceUuid' | 'projectUuid'
 > & {
     validationErrors: {
+        validationUuid: ValidationErrorDashboardResponse['validationUuid'];
+        /** @deprecated Use validationUuid. Null for post-migration validations. */
         validationId: ValidationErrorDashboardResponse['validationId'];
     }[];
     viewsCount: number;
@@ -54,6 +56,8 @@ export type SavedChartSearchResult = Pick<
 > & {
     chartType: ChartKind;
     validationErrors: {
+        validationUuid: ValidationErrorChartResponse['validationUuid'];
+        /** @deprecated Use validationUuid. Null for post-migration validations. */
         validationId: ValidationErrorChartResponse['validationId'];
     }[];
     chartSource: 'saved';
@@ -135,6 +139,8 @@ export type TableErrorSearchResult = Pick<
     'explore' | 'exploreLabel'
 > & {
     validationErrors: {
+        validationUuid: ValidationErrorTableResponse['validationUuid'];
+        /** @deprecated Use validationUuid. Null for post-migration validations. */
         validationId: ValidationErrorTableResponse['validationId'];
     }[];
 };

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -3,7 +3,12 @@ import type { KnexPaginatedData } from './knex-paginate';
 import type { ChartKind } from './savedCharts';
 
 export type ValidationResponseBase = {
-    validationId: number;
+    validationUuid: string;
+    /**
+     * @deprecated Use `validationUuid`. The integer `validationId` is null
+     * for validations created after the UUID migration (PROD-7386).
+     */
+    validationId: number | null;
     createdAt: Date;
     name: string;
     error: string;
@@ -108,7 +113,7 @@ export type ApiDashboardValidationResponse = ApiSuccess<{
 
 export type ValidationSummary = Pick<
     ValidationResponse,
-    'error' | 'createdAt' | 'validationId'
+    'error' | 'createdAt' | 'validationUuid' | 'validationId'
 >;
 
 export enum ValidationErrorType {

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -261,8 +261,8 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
                 Cell: ({ row }) => {
                     const validationError = row.original;
                     const isPinned =
-                        pinnedValidation?.validationId ===
-                        validationError.validationId;
+                        pinnedValidation?.validationUuid ===
+                        validationError.validationUuid;
 
                     return (
                         <Flex
@@ -283,7 +283,7 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
                                             onUnpin();
                                         } else {
                                             deleteValidation(
-                                                validationError.validationId,
+                                                validationError.validationUuid,
                                             );
                                         }
                                         e.stopPropagation();
@@ -347,7 +347,7 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
         enableTopToolbar: true,
         enableBottomToolbar: false,
         enableRowActions: false,
-        getRowId: (row) => String(row.validationId),
+        getRowId: (row) => row.validationUuid,
         renderTopToolbar: () => (
             <ValidatorTableTopToolbar
                 searchQuery={searchQuery}
@@ -380,7 +380,8 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
         },
         mantineTableBodyRowProps: ({ row }) => {
             const isPinned =
-                pinnedValidation?.validationId === row.original.validationId;
+                pinnedValidation?.validationUuid ===
+                row.original.validationUuid;
             return {
                 className: isPinned ? classes.pinnedRow : classes.row,
             };

--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -35,7 +35,7 @@ export const SettingsValidator: FC<{ projectUuid: string }> = ({
     >([]);
     const [showConfigWarnings, setShowConfigWarnings] = useState(false);
 
-    const targetValidationId = useSearchParams('validationId');
+    const targetValidationUuid = useSearchParams('validationUuid');
     const navigate = useNavigate();
     const { pathname } = useLocation();
 
@@ -43,7 +43,7 @@ export const SettingsValidator: FC<{ projectUuid: string }> = ({
 
     const { data: pinnedValidation } = usePinnedValidation(
         projectUuid,
-        targetValidationId ? Number(targetValidationId) : null,
+        targetValidationUuid,
     );
 
     const handleUnpin = useCallback(() => {
@@ -80,7 +80,7 @@ export const SettingsValidator: FC<{ projectUuid: string }> = ({
     const deduplicatedData = useMemo(() => {
         if (!pinnedValidation) return flatData;
         return flatData.filter(
-            (item) => item.validationId !== pinnedValidation.validationId,
+            (item) => item.validationUuid !== pinnedValidation.validationUuid,
         );
     }, [flatData, pinnedValidation]);
 

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -33,7 +33,7 @@ type ResourceValidationErrorIndicatorProps = {
     projectUuid: string;
     canUserManageValidation: boolean;
     children: React.ReactNode;
-    validationId?: number;
+    validationUuid?: string;
 };
 
 /**
@@ -44,9 +44,9 @@ const ResourceValidationErrorIndicator = ({
     projectUuid,
     canUserManageValidation,
     children,
-    validationId,
+    validationUuid,
 }: ResourceValidationErrorIndicatorProps) => {
-    if (!validationId) {
+    if (!validationUuid) {
         return children;
     }
 
@@ -73,7 +73,7 @@ const ResourceValidationErrorIndicator = ({
                             fw={600}
                             to={{
                                 pathname: `/generalSettings/projectManagement/${projectUuid}/validator`,
-                                search: `?validationId=${validationId}`,
+                                search: `?validationUuid=${validationUuid}`,
                             }}
                             color="blue.4"
                             fz="xs"
@@ -156,8 +156,8 @@ const InfiniteResourceTableColumnName = ({
         item.data.validationErrors &&
         item.data.validationErrors.length > 0;
 
-    const validationId = hasValidationErrors
-        ? item.data.validationErrors![0].validationId
+    const validationUuid = hasValidationErrors
+        ? item.data.validationErrors![0].validationUuid
         : undefined;
 
     const verification =
@@ -180,7 +180,7 @@ const InfiniteResourceTableColumnName = ({
                     item={item}
                     projectUuid={projectUuid}
                     canUserManageValidation={canUserManageValidation}
-                    validationId={validationId}
+                    validationUuid={validationUuid}
                 >
                     <ResourceIcon item={item} />
                 </ResourceValidationErrorIndicator>

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -164,7 +164,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                                         fw={600}
                                                         to={{
                                                             pathname: `/generalSettings/projectManagement/${projectUuid}/validator`,
-                                                            search: `?validationId=${item.data.validationErrors[0].validationId}`,
+                                                            search: `?validationUuid=${item.data.validationErrors[0].validationUuid}`,
                                                         }}
                                                         c="blue.4"
                                                         fz="xs"

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
@@ -58,7 +58,7 @@ export const OmnibarItemIconWithIndicator: FC<
                             }
                             to={{
                                 pathname: `/generalSettings/projectManagement/${projectUuid}/validator`,
-                                search: `?validationId=${item.item.validationErrors[0].validationId}`,
+                                search: `?validationUuid=${item.item.validationErrors[0].validationUuid}`,
                             }}
                             c="blue.4"
                             fz="xs"

--- a/packages/frontend/src/hooks/validation/useValidation.ts
+++ b/packages/frontend/src/hooks/validation/useValidation.ts
@@ -41,12 +41,12 @@ const getValidation = async (
         body: undefined,
     });
 
-const getValidationById = async (
+const getValidationByUuid = async (
     projectUuid: string,
-    validationId: number,
+    validationUuid: string,
 ): Promise<ValidationResponse> =>
     lightdashApi<ValidationResponse>({
-        url: `/projects/${projectUuid}/validate/${validationId}`,
+        url: `/projects/${projectUuid}/validate/${validationUuid}`,
         method: 'GET',
         body: undefined,
         version: 'v2',
@@ -54,12 +54,12 @@ const getValidationById = async (
 
 export const usePinnedValidation = (
     projectUuid: string,
-    validationId: number | null,
+    validationUuid: string | null,
 ) =>
     useQuery({
-        queryKey: ['pinnedValidation', projectUuid, validationId],
-        queryFn: () => getValidationById(projectUuid, validationId!),
-        enabled: validationId !== null,
+        queryKey: ['pinnedValidation', projectUuid, validationUuid],
+        queryFn: () => getValidationByUuid(projectUuid, validationUuid!),
+        enabled: validationUuid !== null,
     });
 
 export const useValidation = (
@@ -303,12 +303,12 @@ export const useValidationNotificationChecker = (): [boolean, () => void] => {
     ];
 };
 
-const deleteValidation = async (
+const deleteValidationByUuid = async (
     projectUuid: string,
-    validationId: number,
+    validationUuid: string,
 ): Promise<null> =>
     lightdashApi<null>({
-        url: `/projects/${projectUuid}/validate/${validationId}`,
+        url: `/projects/${projectUuid}/validate/${validationUuid}`,
         method: 'DELETE',
         body: undefined,
     });
@@ -316,8 +316,8 @@ const deleteValidation = async (
 export const useDeleteValidation = (projectUuid: string) => {
     const queryClient = useQueryClient();
     const { showToastApiError, showToastSuccess } = useToaster();
-    return useMutation<null, ApiError, number>(
-        (validationId) => deleteValidation(projectUuid, validationId),
+    return useMutation<null, ApiError, string>(
+        (validationUuid) => deleteValidationByUuid(projectUuid, validationUuid),
         {
             mutationKey: ['delete_validation', projectUuid],
             onSuccess: async () => {


### PR DESCRIPTION
## Summary

- Replaces `validations.validation_id` (INTEGER IDENTITY PK, sequence projected to exhaust within ~12 months) with `validation_uuid` as the new primary key.
- Keeps `validation_id` as a nullable legacy column with a partial unique index, so replication/CDC consumers and bookmarked legacy URLs keep working until those rows turn over.
- Single API endpoint per verb takes `@Path() validationIdOrUuid: number | string`; service + model dispatch on `typeof` to pick the right column. Frontend always sends UUIDs.

Closes: https://linear.app/lightdash/issue/SPK-430/prevent-exhaustion-of-validations-id-sequence

## What changes

**Migration** (`20260501144729_validations_uuid_pk.ts`)
- Adds `validation_uuid uuid NOT NULL DEFAULT uuid_generate_v4()` (in-transaction; safe given the validations table churn keeps row count small)
- Drops the integer PK + IDENTITY + NOT NULL on `validation_id` (the sequence drops with it — bug fix)
- Promotes `validation_uuid` to PK
- Adds partial unique index `validation_id WHERE validation_id IS NOT NULL` for legacy lookups
- `down()` deletes post-migration rows (NULL `validation_id`), restores IDENTITY, and advances the sequence past max(id) so subsequent inserts don't collide

**Backend**
- Entity: `validation_id: number | null` marked `@deprecated`; `validation_uuid: string` added
- `ValidationModel`: unified `getByValidationIdOrUuid` / `getFullByIdOrUuid` / `deleteValidationByIdOrUuid` — branch on `typeof` to pick the column. Legacy id branch filters `WHERE validation_id IS NOT NULL`
- `ValidationService`: single `getValidation` / `deleteValidation` passing the union value straight through
- v1 `DELETE /api/v1/projects/{projectUuid}/validate/{validationIdOrUuid}` — `number | string`
- v2 `GET /api/v2/projects/{projectUuid}/validate/{validationIdOrUuid}` — `number | string`
- `SearchModel`/`SpaceModel`/`DashboardModel`: surface both `validationUuid` and `validationId` in embedded `validationErrors[]` for back-compat

**Common types**
- `ValidationResponseBase.validationUuid: string` added; `validationId: number | null` marked `@deprecated`
- Search result `validationErrors[]` entries gain `validationUuid` alongside the (now nullable) `validationId`

**Frontend**
- Hooks call `/projects/{projectUuid}/validate/{validationUuid}` (no special UUID path needed)
- URL query reads only `?validationUuid=`. Stale `?validationId=<int>` bookmarks land on the validator page with no pinned item — graceful degradation
- Components reference `validationUuid` everywhere (table row id, comparisons, links)

## Backwards compatibility

| Surface | Preserved? |
|---------|-----------|
| `validation_id` DB column exists | ✅ kept (nullable, `@deprecated`) |
| API response `validationId` field | ✅ kept (`number \| null`); `validationUuid` added alongside |
| API URL `/validate/{x}` accepts integer | ✅ legacy ids still resolve (until those rows are replaced) |
| TSOA OpenAPI schema | ⚠️ path-param type widened to `oneOf: [integer, string]`; numeric clients unaffected |

The non-negotiable break: new rows have `validation_id = NULL` (that's how we stop the sequence — there's no other way).

## Test plan

- [x] `pnpm -F common/backend/frontend typecheck` passes
- [x] `pnpm -F common/backend/frontend lint` passes
- [x] `pnpm -F backend test:dev:nowatch` (387 tests, incl. ValidationModel)
- [x] `pnpm -F common test` (1874 tests)
- [x] Migration `up()` round-trip on a temp DB: existing rows keep their integer ids, post-migration row has `validation_id = NULL`, both lookups work
- [x] Migration `down()` round-trip: schema and IDENTITY sequence restored, subsequent inserts pick `max(id) + 1`
- [ ] **Pre-merge**: confirm production validations row count via `SELECT count(*), pg_size_pretty(pg_total_relation_size('validations'))`. The Option A in-transaction migration is appropriate for tables up to a few million rows; if larger, swap to the online `CONCURRENTLY` + batched-backfill pattern from `migrations/20260428153355_add_primary_keys_to_analytics_and_scheduler_log.ts`
- [ ] Smoke in staging: run a validation on a project, dismiss an error via the UI, deep-link to a validation via `?validationUuid=` and confirm pin works

🤖 Generated with [Claude Code](https://claude.com/claude-code)