### PR TITLE
docs: update CASL audit rule to reference createAuditedAbility

### DIFF
--- a/.cursor/rules/backend-service-authorization-permissions.mdc
+++ b/.cursor/rules/backend-service-authorization-permissions.mdc
@@ -6,6 +6,6 @@ alwaysApply: false
 - All permission checks are performed with CASL
 - All permission logic is written in [organizationMemberAbility.ts](mdc:packages/common/src/authorization/organizationMemberAbility.ts) + [projectMemberAbility.ts](mdc:packages/common/src/authorization/projectMemberAbility.ts)
 - All service methods must have permission checks
-- Permission checks should use the [caslAuditWrapper.ts](mdc:packages/backend/src/logging/caslAuditWrapper.ts) for auditing
+- Permission checks should use the `createAuditedAbility` method (instead of accessing `user.ability` / `account.user.ability` directly) — see [audit-logging.md](mdc:docs/audit-logging.md)
 - Permission checks always execute against a subject using fields only from the subject
 - Never insert user properties (including user's org uuid) in the subject field


### PR DESCRIPTION
## Summary
- Update `.cursor/rules/backend-service-authorization-permissions.mdc` to point contributors at the `createAuditedAbility` method on `BaseService`, instead of the lower-level `caslAuditWrapper.ts` implementation.
- Link to `docs/audit-logging.md` for the full design (actor types, event schema, how to add audit logging to a new service).

## Test plan
- [x] Rule renders correctly with the new mdc link to `docs/audit-logging.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)