### PR TITLE
fix: tile header actions flicker near chart title hover



### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -59,6 +59,7 @@
         position: absolute;
         top: 0;
         left: 0;
+        right: 0;
         z-index: 10;
         white-space: normal;
         overflow: visible;


### PR DESCRIPTION
Closes: [PROD-7428: fix: tile header actions flicker near chart title hover](https://linear.app/lightdash/issue/PROD-7428/fix-tile-header-actions-flicker-near-chart-title-hover)

### Description:

Fixes an issue with dashboard tile headers where the title overlay was not stretching to the full width of the tile. Added `right: 0` to the absolutely positioned element in `TileBase`, ensuring the header spans the entire tile width rather than being constrained to its content width.