### PR TITLE
fix: add hint to invite @Lightdash to private Slack channels

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -966,12 +966,27 @@ const SettingsSidebar: FC<{
                             </Group>
                             {organizationHasSlack ? (
                                 slackNotificationsEnabled && (
-                                    <SlackChannelSelect
-                                        placeholder="Search channels..."
-                                        size="sm"
-                                        value={slackChannelId}
-                                        onChange={handleSlackChannelChange}
-                                    />
+                                    <Stack gap={6}>
+                                        <SlackChannelSelect
+                                            placeholder="Search channels..."
+                                            size="sm"
+                                            value={slackChannelId}
+                                            onChange={handleSlackChannelChange}
+                                        />
+                                        <Text fz="xs" c="dimmed">
+                                            Please invite Lightdash to this
+                                            channel — we can&apos;t post
+                                            messages until you do. (
+                                            <Text
+                                                component="span"
+                                                inherit
+                                                ff="monospace"
+                                            >
+                                                /invite @Lightdash
+                                            </Text>
+                                            )
+                                        </Text>
+                                    </Stack>
                                 )
                             ) : (
                                 <Stack gap="xs">


### PR DESCRIPTION
Closes:

### Description:
Adds a note in the Autopilot Slack settings sidebar informing users that for private channels, they must invite @Lightdash first, otherwise messages will not be delivered.