### PR TITLE
fix: set minimum managed agent schedule to hourly and validate cron frequency

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -304,7 +304,7 @@ export const lightdashConfigMock: LightdashConfig = {
     managedAgent: {
         anthropicApiKey: null,
         skillIds: [],
-        schedule: '*/30 * * * *',
+        schedule: '0 * * * *',
         sessionTimeoutMs: 300000,
     },
     mcp: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2262,7 +2262,7 @@ export const parseConfig = (): LightdashConfig => {
                 .split(',')
                 .map((skillId) => skillId.trim())
                 .filter(Boolean),
-            schedule: process.env.MANAGED_AGENT_SCHEDULE || '*/30 * * * *',
+            schedule: process.env.MANAGED_AGENT_SCHEDULE || '0 * * * *',
             sessionTimeoutMs: parseInt(
                 process.env.MANAGED_AGENT_SESSION_TIMEOUT_MS || '300000',
                 10,

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -1,4 +1,6 @@
 import {
+    getManagedAgentScheduleCron,
+    getManagedAgentScheduleOption,
     type CreateManagedAgentAction,
     type ManagedAgentAction,
     type ManagedAgentActionFilters,
@@ -33,10 +35,13 @@ export class ManagedAgentModel {
     // --- Settings ---
 
     static mapDbSettings(row: DbManagedAgentSettings): ManagedAgentSettings {
+        const scheduleCron = getManagedAgentScheduleCron(
+            getManagedAgentScheduleOption(row.schedule_cron),
+        );
         return {
             projectUuid: row.project_uuid,
             enabled: row.enabled,
-            scheduleCron: row.schedule_cron,
+            scheduleCron,
             enabledByUserUuid: row.enabled_by_user_uuid,
             slackChannelId: row.slack_channel_id,
             toolSettings: row.tool_settings ?? {},
@@ -138,7 +143,7 @@ export class ManagedAgentModel {
             .insert({
                 project_uuid: projectUuid,
                 enabled: update.enabled ?? false,
-                schedule_cron: update.scheduleCron ?? '*/30 * * * *',
+                schedule_cron: getManagedAgentScheduleCron(update.schedule),
                 enabled_by_user_uuid: update.enabled ? userUuid : null,
                 slack_channel_id: update.slackChannelId ?? null,
                 tool_settings: update.toolSettings ?? {},
@@ -147,8 +152,8 @@ export class ManagedAgentModel {
             .onConflict('project_uuid')
             .merge({
                 enabled: update.enabled,
-                ...(update.scheduleCron !== undefined && {
-                    schedule_cron: update.scheduleCron,
+                ...(update.schedule !== undefined && {
+                    schedule_cron: getManagedAgentScheduleCron(update.schedule),
                 }),
                 ...(update.slackChannelId !== undefined && {
                     slack_channel_id: update.slackChannelId,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1201,7 +1201,10 @@ const models: TsoaRoute.Models = {
                         { dataType: 'enum', enums: [null] },
                     ],
                 },
-                scheduleCron: { dataType: 'string' },
+                schedule: {
+                    dataType: 'enum',
+                    enums: ['hourly', 'daily'],
+                },
                 enabled: { dataType: 'boolean' },
             },
             validators: {},

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1249,8 +1249,9 @@
                         "type": "string",
                         "nullable": true
                     },
-                    "scheduleCron": {
-                        "type": "string"
+                    "schedule": {
+                        "type": "string",
+                        "enum": ["hourly", "daily"]
                     },
                     "enabled": {
                         "type": "boolean"

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -15,6 +15,31 @@ export enum ManagedAgentTargetType {
     PROJECT = 'project',
 }
 
+export enum ManagedAgentScheduleOption {
+    HOURLY = 'hourly',
+    DAILY = 'daily',
+}
+
+export const ManagedAgentScheduleCronByOption: Record<
+    ManagedAgentScheduleOption,
+    string
+> = {
+    [ManagedAgentScheduleOption.HOURLY]: '0 * * * *',
+    [ManagedAgentScheduleOption.DAILY]: '0 0 * * *',
+};
+
+export const getManagedAgentScheduleCron = (
+    schedule: ManagedAgentScheduleOption = ManagedAgentScheduleOption.HOURLY,
+) => ManagedAgentScheduleCronByOption[schedule];
+
+export const getManagedAgentScheduleOption = (
+    scheduleCron: string | null | undefined,
+) =>
+    scheduleCron ===
+    ManagedAgentScheduleCronByOption[ManagedAgentScheduleOption.DAILY]
+        ? ManagedAgentScheduleOption.DAILY
+        : ManagedAgentScheduleOption.HOURLY;
+
 export type ManagedAgentSettings = {
     projectUuid: string;
     enabled: boolean;
@@ -43,7 +68,7 @@ export type ManagedAgentAction = {
 
 export type UpdateManagedAgentSettings = {
     enabled?: boolean;
-    scheduleCron?: string;
+    schedule?: ManagedAgentScheduleOption;
     slackChannelId?: string | null;
     toolSettings?: Record<string, boolean>;
 };

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -2,9 +2,11 @@ import {
     type ApiError,
     type ContentVerificationInfo,
     type Dashboard,
+    ManagedAgentScheduleOption,
     type Project,
     type SavedChart,
     type UpdatedByUser,
+    getManagedAgentScheduleOption,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -77,7 +79,7 @@ const updateSettings = async (
     projectUuid: string,
     body: {
         enabled?: boolean;
-        scheduleCron?: string;
+        schedule?: ManagedAgentScheduleOption;
         slackChannelId?: string | null;
         toolSettings?: Record<string, boolean>;
     },
@@ -96,12 +98,8 @@ const runHeartbeat = async (projectUuid: string) =>
     });
 
 const SCHEDULE_OPTIONS = [
-    { value: '*/5 * * * *', label: 'Every 5 min' },
-    { value: '*/15 * * * *', label: 'Every 15 min' },
-    { value: '*/30 * * * *', label: 'Every 30 min' },
-    { value: '0 * * * *', label: 'Hourly' },
-    { value: '0 */6 * * *', label: 'Every 6 hours' },
-    { value: '0 0 * * *', label: 'Daily' },
+    { value: ManagedAgentScheduleOption.HOURLY, label: 'Hourly' },
+    { value: ManagedAgentScheduleOption.DAILY, label: 'Daily' },
 ];
 
 const CAPABILITY_GROUPS = [
@@ -143,10 +141,9 @@ const SetupSection: FC<{
     onRunNow,
     isRunNowLoading,
 }) => {
+    const schedule = getManagedAgentScheduleOption(initialSchedule);
     const scheduleLabel =
-        SCHEDULE_OPTIONS.find(
-            (o) => o.value === initialSchedule,
-        )?.label?.replace(' (recommended)', '') ?? initialSchedule;
+        SCHEDULE_OPTIONS.find((o) => o.value === schedule)?.label ?? 'Hourly';
 
     return (
         <Stack gap={0}>
@@ -810,6 +807,7 @@ const SettingsSidebar: FC<{
     const queryClient = useQueryClient();
     const { data: slackInstallation } = useGetSlack();
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
+    const selectedSchedule = getManagedAgentScheduleOption(schedule);
     const [slackNotificationsEnabled, setSlackNotificationsEnabled] =
         useState(!!slackChannelId);
 
@@ -838,7 +836,9 @@ const SettingsSidebar: FC<{
     const handleScheduleChange = useCallback(
         (value: string | null) => {
             if (value) {
-                mutation.mutate({ scheduleCron: value });
+                mutation.mutate({
+                    schedule: value as ManagedAgentScheduleOption,
+                });
             }
         },
         [mutation],
@@ -926,7 +926,7 @@ const SettingsSidebar: FC<{
                             </Text>
                             <Select
                                 data={SCHEDULE_OPTIONS}
-                                value={schedule}
+                                value={selectedSchedule}
                                 onChange={handleScheduleChange}
                                 size="sm"
                                 disabled={isLoading || mutation.isLoading}
@@ -1213,9 +1213,7 @@ export const ManagedAgentActivityPage: FC = () => {
                         <Stack gap="lg">
                             <SetupSection
                                 enabled={settings?.enabled ?? false}
-                                schedule={
-                                    settings?.scheduleCron ?? '*/30 * * * *'
-                                }
+                                schedule={settings?.scheduleCron ?? '0 * * * *'}
                                 settingsOpen={settingsOpen}
                                 isRunNowLoading={runNowMutation.isLoading}
                                 onRunNow={() => runNowMutation.mutate()}
@@ -1290,7 +1288,7 @@ export const ManagedAgentActivityPage: FC = () => {
                                     projectUuid={projectUuid!}
                                     enabled={settings?.enabled ?? false}
                                     schedule={
-                                        settings?.scheduleCron ?? '*/30 * * * *'
+                                        settings?.scheduleCron ?? '0 * * * *'
                                     }
                                     slackChannelId={
                                         settings?.slackChannelId ?? null

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -1,4 +1,8 @@
-import { FeatureFlags } from '@lightdash/common';
+import {
+    FeatureFlags,
+    ManagedAgentScheduleOption,
+    getManagedAgentScheduleOption,
+} from '@lightdash/common';
 import {
     Box,
     Button,
@@ -40,12 +44,10 @@ const formatRelative = (dateStr: string) => {
 };
 
 const formatSchedule = (cron: string) => {
-    const match = cron.match(/^\*\/(\d+) /);
-    if (match) return `${match[1]}m`;
-    if (cron === '0 * * * *') return '1h';
-    if (cron === '0 */6 * * *') return '6h';
-    if (cron === '0 0 * * *') return '24h';
-    return cron;
+    return getManagedAgentScheduleOption(cron) ===
+        ManagedAgentScheduleOption.DAILY
+        ? '24h'
+        : '1h';
 };
 
 /** Generates a deterministic grid of subtle squares */
@@ -116,7 +118,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
     const isEnabled = settings?.enabled ?? false;
     const actionCount = actions?.length ?? 0;
     const lastActionAt = actions?.[0]?.createdAt ?? null;
-    const schedule = settings?.scheduleCron ?? '*/30 * * * *';
+    const schedule = settings?.scheduleCron ?? '0 * * * *';
 
     // Feature carousel — must be before any early returns (hooks rule)
     const [featureIdx, setFeatureIdx] = useState(0);

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
@@ -1,3 +1,4 @@
+import { ManagedAgentScheduleOption } from '@lightdash/common';
 import { Box, Group, Select, Stack, Text } from '@mantine-8/core';
 import {
     IconBolt,
@@ -14,7 +15,7 @@ import classes from './ManagedAgentSetupModal.module.css';
 
 const updateSettings = async (
     projectUuid: string,
-    body: { enabled: boolean; scheduleCron: string },
+    body: { enabled: boolean; schedule: ManagedAgentScheduleOption },
 ) =>
     lightdashApi({
         url: `/projects/${projectUuid}/managed-agent/settings`,
@@ -23,12 +24,8 @@ const updateSettings = async (
     });
 
 const SCHEDULE_OPTIONS = [
-    { value: '*/5 * * * *', label: 'Every 5 minutes' },
-    { value: '*/15 * * * *', label: 'Every 15 minutes' },
-    { value: '*/30 * * * *', label: 'Every 30 minutes (recommended)' },
-    { value: '0 * * * *', label: 'Every hour' },
-    { value: '0 */6 * * *', label: 'Every 6 hours' },
-    { value: '0 0 * * *', label: 'Daily' },
+    { value: ManagedAgentScheduleOption.HOURLY, label: 'Hourly' },
+    { value: ManagedAgentScheduleOption.DAILY, label: 'Daily' },
 ];
 
 const CAPABILITIES = [
@@ -62,13 +59,13 @@ export const ManagedAgentSetupModal: FC<{
     onEnabled: () => void;
 }> = ({ projectUuid, opened, onClose, onEnabled }) => {
     const queryClient = useQueryClient();
-    const [schedule, setSchedule] = useState('*/30 * * * *');
+    const [schedule, setSchedule] = useState(ManagedAgentScheduleOption.HOURLY);
 
     const mutation = useMutation({
         mutationFn: () =>
             updateSettings(projectUuid, {
                 enabled: true,
-                scheduleCron: schedule,
+                schedule,
             }),
         onSuccess: () => {
             void queryClient.invalidateQueries({
@@ -143,7 +140,10 @@ export const ManagedAgentSetupModal: FC<{
                     <Select
                         data={SCHEDULE_OPTIONS}
                         value={schedule}
-                        onChange={(v) => v && setSchedule(v)}
+                        onChange={(value) =>
+                            value &&
+                            setSchedule(value as ManagedAgentScheduleOption)
+                        }
                         size="sm"
                     />
                     <Text fz="xs" c="dimmed" mt={6}>


### PR DESCRIPTION
Closes:

### Description:

Changes the default and minimum schedule for Managed Agent (Autopilot) from sub-hourly intervals to hourly. Schedules that run every 5, 15, or 30 minutes have been removed from the UI options, with hourly (`0 * * * *`) now being the minimum allowed frequency.

A validation check has been added on the backend to reject any `scheduleCron` value that runs more frequently than once per hour, returning a `ParameterError` if violated. Additionally, when reading settings from the database, any stored cron value that fails the frequency check is silently replaced with the default hourly schedule.