### PR TITLE
feat(timezone): honor project tz in pivot deliveries

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2225,6 +2225,7 @@ export default class SchedulerTask {
                     metricQuery: payload.metricQuery,
                     customLabels: payload.customLabels,
                     onlyRaw: true,
+                    timezone: displayTimezone ?? undefined,
                     maxColumnLimit:
                         this.lightdashConfig.pivotTable.maxColumnLimit,
                     pivotDetails,
@@ -2893,6 +2894,7 @@ export default class SchedulerTask {
                         metricQuery: chart.metricQuery,
                         customLabels,
                         onlyRaw: true,
+                        timezone: displayTimezone ?? undefined,
                         maxColumnLimit:
                             this.lightdashConfig.pivotTable.maxColumnLimit,
                         pivotDetails,
@@ -3053,6 +3055,7 @@ export default class SchedulerTask {
                                 metricQuery: chart.metricQuery,
                                 customLabels,
                                 onlyRaw: true,
+                                timezone: displayTimezone ?? undefined,
                                 maxColumnLimit:
                                     this.lightdashConfig.pivotTable
                                         .maxColumnLimit,


### PR DESCRIPTION
## Summary

Wires the resolved `displayTimezone` through the three Google Sheets pivot delivery sites in `SchedulerTask` (single chart, dashboard chart, dashboard chart-tab). With `timezone` supplied, `pivotResultsAsCsv` pulls DATE/TIMESTAMP cells from the tz-aware `formatted` value while numerics stay raw — so Sheets renders project-tz wall-clock for timestamps without losing native types for numbers.

## Silence guarantee

When `displayTimezone` is null (flag off), the `timezone` arg is `undefined` and `pivotResultsAsCsv` produces byte-identical output to today.

Part 3/3.

Closes: https://linear.app/lightdash/issue/GLITCH-395/fix-exports-csvgsheetsxlsx-to-consider-timezones-when-formatting