### PR TITLE
fix: remediate ajv ReDoS transitive (CVE-2025-69873) [PROD-3546]

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
             "basic-ftp": "5.2.1",
             "vite@>=7.0.0 <7.3.2": "7.3.2",
             "systeminformation": "5.31.0",
-            "path-to-regexp@0.1.12": "0.1.13"
+            "path-to-regexp@0.1.12": "0.1.13",
+            "ajv@<6.14.0": "6.15.0",
+            "ajv@>=8.0.0 <8.18.0": "8.18.0"
         }
     },
     "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,8 @@ overrides:
   vite@>=7.0.0 <7.3.2: 7.3.2
   systeminformation: 5.31.0
   path-to-regexp@0.1.12: 0.1.13
+  ajv@<6.14.0: 6.15.0
+  ajv@>=8.0.0 <8.18.0: 8.18.0
 
 pnpmfileChecksum: sha256-eQZaSN8dBqsURx9Y0qj3HqXggTVV5DtL6B15n8AQ53E=
 
@@ -7536,7 +7538,7 @@ packages:
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
-      ajv: ^8.5.0
+      ajv: 8.18.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -7544,12 +7546,12 @@ packages:
   ajv-errors@3.0.0:
     resolution: {integrity: sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==}
     peerDependencies:
-      ajv: ^8.0.1
+      ajv: 8.18.0
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: 8.18.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -7557,19 +7559,13 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: 8.18.0
     peerDependenciesMeta:
       ajv:
         optional: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
-
-  ajv@8.12.0:
-    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
-
-  ajv@8.13.0:
-    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -8017,7 +8013,7 @@ packages:
     resolution: {integrity: sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      ajv: 4.11.8 - 8
+      ajv: 6.15.0
 
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
@@ -18999,7 +18995,7 @@ snapshots:
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.15.0
       debug: 4.4.3(supports-color@9.1.0)
       espree: 9.6.1
       globals: 13.24.0
@@ -19933,7 +19929,7 @@ snapshots:
   '@microsoft/tsdoc-config@0.17.1':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
-      ajv: 8.12.0
+      ajv: 8.18.0
       jju: 1.4.0
       resolve: 1.22.11
 
@@ -21356,9 +21352,9 @@ snapshots:
 
   '@rushstack/node-core-library@5.17.0(@types/node@24.3.1)':
     dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
       fs-extra: 11.3.2
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -23976,9 +23972,9 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.55
 
-  ajv-draft-04@1.0.0(ajv@8.13.0):
+  ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.13.0
+      ajv: 8.18.0
 
   ajv-errors@3.0.0(ajv@8.18.0):
     dependencies:
@@ -23988,33 +23984,15 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv-formats@3.0.1(ajv@8.13.0):
-    optionalDependencies:
-      ajv: 8.13.0
-
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv@6.12.6:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
-  ajv@8.12.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-      uri-js: 4.4.1
-
-  ajv@8.13.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
       uri-js: 4.4.1
 
   ajv@8.18.0:
@@ -26515,7 +26493,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.2.1
-      ajv: 6.12.6
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@9.1.0)


### PR DESCRIPTION
## Summary

- Adds `pnpm.overrides` for `ajv` to drag transitive copies onto patched versions:
  - `ajv@<6.14.0` → `6.15.0` (was `6.12.6` via the eslint chain)
  - `ajv@>=8.0.0 <8.18.0` → `8.18.0` (was `8.12.0` and `8.13.0` via `vite-plugin-dts` → `@microsoft/api-extractor` / `@microsoft/tsdoc-config`)
- Closes Dependabot alert [#469](https://github.com/lightdash/lightdash/security/dependabot/469) (GHSA-2g4f-4pwh-qvx6 / CVE-2025-69873).
- Resolves [PROD-3546](https://linear.app/lightdash/issue/PROD-3546).

## Why this is low risk

- Our **direct** `ajv` deps (`@lightdash/cli`, `@lightdash/common`, `backend`) were already pinned to `8.18.0` — the GHSA's `firstPatchedVersion`. The remaining vulnerable copies were only in the lockfile, all reached through devDependencies.
- The CVE only triggers when `Ajv` is constructed with `$data: true`. None of our four `new Ajv(...)` sites enable that flag, so the actual exploit path was zero on day one (`packages/cli/src/ajv.ts`, `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts`, `packages/common/src/utils/loadLightdashProjectConfig.ts`, `packages/common/src/compiler/parameters.ts`).
- `vite-plugin-dts` is declared in `packages/frontend/package.json` but no longer imported anywhere (only referenced in a comment in `rollup.config.mjs`), so the bumped 8.x is even further from any live build.
- `pnpm -r why ajv` now reports only `6.15.0` and `8.18.0` (down from 4 versions, 3 vulnerable).

## Test plan

- [x] `sfw pnpm install` succeeds
- [x] `pnpm -F common typecheck`
- [x] `pnpm -F cli typecheck`
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F frontend typecheck`
- [x] `pnpm -F common test --testPathPattern='dbt|loadLightdashProjectConfig|parameters|DbtSchemaEditor'` — 81/81 passed (these exercise every `new Ajv()` site)
- [x] `pnpm -r why ajv` shows only `6.15.0` and `8.18.0`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CI gate keywords: trigger full e2e suites -->
test-all
