### PR TITLE
feat(prod-7424): load service account user from middleware

### DIFF
--- a/packages/api-tests/tests/serviceAccounts.test.ts
+++ b/packages/api-tests/tests/serviceAccounts.test.ts
@@ -603,18 +603,14 @@ describe('Service Account scope matrix', () => {
     });
 });
 
-describe('Service Account identity (current admin-spoofing behavior)', () => {
-    // These assertions intentionally pin down the placeholder identity that
-    // `authenticateServiceAccount` synthesizes today by copying the seeded
-    // admin user. The refactor will replace this with a dedicated SA user
-    // record; expect this describe to need updating then.
+describe('Service Account identity', () => {
     let admin: ApiClient;
 
     beforeAll(async () => {
         admin = await login();
     });
 
-    it('GET /api/v1/user returns the spoofed service-account identity', async () => {
+    it('GET /api/v1/user returns the dedicated service-account identity', async () => {
         const description = `identity-test ${Date.now()}`;
         const createResp = await admin.post<Body<{ token: string }>>(
             `${apiUrl}/service-accounts`,
@@ -637,23 +633,18 @@ describe('Service Account identity (current admin-spoofing behavior)', () => {
             }>
         >(`${apiUrl}/user`);
         expect(resp.status).toBe(200);
-        // Today the middleware borrows the admin user's UUID (FK requirement)
-        // and overwrites email/firstName/lastName with placeholders.
-        expect(resp.body.results.userUuid).toBe(SEED_ORG_1_ADMIN.user_uuid);
-        expect(resp.body.results.email).toBe('service-account@lightdash.com');
-        expect(resp.body.results.firstName).toBe('service account');
-        expect(resp.body.results.lastName).toBe(description);
+        // The middleware loads the SA's own `users` row (linked via
+        // `service_accounts.service_account_user_uuid`) so the identity
+        // surfaces the SA — not a fallback admin.
+        expect(resp.body.results.userUuid).not.toBe(SEED_ORG_1_ADMIN.user_uuid);
+        expect(resp.body.results.firstName).toBe(description);
         expect(resp.body.results.organizationUuid).toBe(
             SEED_ORG_1.organization_uuid,
         );
     });
 });
 
-describe('Service Account content attribution (current admin-spoofing behavior)', () => {
-    // Today, content created by an SA gets stamped with the seeded admin's
-    // UUID in `created_by_user_uuid` columns, because the middleware fakes a
-    // SessionUser around an admin user. After the refactor, the SA's own
-    // dedicated user UUID will appear here.
+describe('Service Account content attribution', () => {
     let admin: ApiClient;
     const projectUuid = SEED_PROJECT.project_uuid;
     const createdSpaceUuids: string[] = [];
@@ -672,7 +663,7 @@ describe('Service Account content attribution (current admin-spoofing behavior)'
         }
     });
 
-    it('a space created by an SA reports the admin user as creator', async () => {
+    it('a space created by an SA reports the SA as creator, not the admin', async () => {
         const { token } = await createServiceAccountToken(admin, [
             ServiceAccountScope.ORG_EDIT,
         ]);
@@ -688,7 +679,6 @@ describe('Service Account content attribution (current admin-spoofing behavior)'
         const spaceUuid = createResp.body.results.uuid;
         createdSpaceUuids.push(spaceUuid);
 
-        // Admin reads back to inspect the createdBy attribution
         const detailResp = await admin.get<
             Body<{
                 uuid: string;
@@ -699,12 +689,10 @@ describe('Service Account content attribution (current admin-spoofing behavior)'
             }>
         >(`${apiUrl}/projects/${projectUuid}/spaces/${spaceUuid}`);
         expect(detailResp.status).toBe(200);
-        // Whichever way the API surfaces "creator", it should match the
-        // admin user (today's behavior). We check both the explicit field
-        // (if present) and the auto-granted access entry the API gives the
-        // creator.
+        // The seeded admin should NOT be the recorded creator anymore — the
+        // SA's own dedicated user row is.
         const access = detailResp.body.results.access ?? [];
         const accessUuids = access.map((a) => a.userUuid);
-        expect(accessUuids).toContain(SEED_ORG_1_ADMIN.user_uuid);
+        expect(accessUuids).not.toContain(SEED_ORG_1_ADMIN.user_uuid);
     });
 });

--- a/packages/backend/src/controllers/authentication/middlewares.ts
+++ b/packages/backend/src/controllers/authentication/middlewares.ts
@@ -20,7 +20,15 @@ import Logger from '../../logging/logger';
 
 export const isAuthenticated: RequestHandler = (req, res, next) => {
     if (req.account?.isAuthenticated() || req.user?.userUuid) {
-        if (req.account?.user?.isActive || req.user?.isActive) {
+        // Service-account principals run on a dedicated user row that is
+        // intentionally `is_active = false` (defense-in-depth against any
+        // login path). The `isActive` gate is for human deactivation, so
+        // skip it for the service-account auth type.
+        if (
+            req.account?.authentication?.type === 'service-account' ||
+            req.account?.user?.isActive ||
+            req.user?.isActive
+        ) {
             next();
         } else {
             // Destroy session if user is deactivated and return error

--- a/packages/backend/src/ee/authentication/middleware.mock.ts
+++ b/packages/backend/src/ee/authentication/middleware.mock.ts
@@ -1,7 +1,11 @@
+import { Ability } from '@casl/ability';
 import {
+    OrganizationMemberRole,
+    PossibleAbilities,
     ServiceAccount,
     ServiceAccountScope,
     SessionServiceAccount,
+    SessionUser,
 } from '@lightdash/common';
 import express from 'express';
 import { BaseService } from '../../services/BaseService';
@@ -16,18 +20,29 @@ export const mockServiceAccount: ServiceAccount = {
     lastUsedAt: null,
     rotatedAt: null,
     scopes: [ServiceAccountScope.SCIM_MANAGE],
+    userUuid: 'sa-user-uuid',
 };
 
-const mockOrganization = {
+const mockSaSessionUser = {
+    userUuid: 'sa-user-uuid',
+    userId: 42,
+    email: undefined,
+    firstName: 'test scim token',
+    lastName: '',
     organizationUuid: 'test-org-uuid',
-    name: 'Test Org',
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    role: OrganizationMemberRole.ADMIN,
+    isActive: false,
+    isPending: false,
     createdAt: new Date('2024-01-01T00:00:00.000Z'),
-};
-
-const mockAdminUser = {
-    userUuid: 'admin-user-uuid',
-    userId: 1,
-};
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    ability: new Ability<PossibleAbilities>([]),
+    abilityRules: [],
+} as unknown as SessionUser;
 
 export const mockRequest = {
     headers: {
@@ -42,13 +57,10 @@ export const mockRequest = {
         getServiceAccountService: jest.fn().mockReturnValue({
             authenticateScim: jest.fn().mockResolvedValue(mockServiceAccount),
         }),
-        getOrganizationService: jest.fn().mockReturnValue({
-            getOrganizationByUuid: jest
-                .fn()
-                .mockResolvedValue(mockOrganization),
-        }),
         getUserService: jest.fn().mockReturnValue({
-            getAdminUser: jest.fn().mockResolvedValue(mockAdminUser),
+            getSessionUserForServiceAccount: jest
+                .fn()
+                .mockResolvedValue(mockSaSessionUser),
         }),
     },
 } as unknown as express.Request;

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -1,12 +1,7 @@
-import { Ability, AbilityBuilder } from '@casl/ability';
 import {
-    applyServiceAccountAbilities,
     AuthorizationError,
     getErrorMessage,
-    OrganizationMemberRole,
     ScimError,
-    ServiceAccountScope,
-    type MemberAbility,
 } from '@lightdash/common';
 import { RequestHandler } from 'express';
 import { fromServiceAccount } from '../../auth/account/account';
@@ -42,15 +37,6 @@ const logServiceAccountAuthFailure = (
     }
 };
 
-const getRoleForScopes = (scopes: ServiceAccountScope[]) => {
-    if (
-        scopes.includes(ServiceAccountScope.SCIM_MANAGE) ||
-        scopes.includes(ServiceAccountScope.ORG_ADMIN)
-    ) {
-        return OrganizationMemberRole.ADMIN;
-    }
-    return OrganizationMemberRole.MEMBER;
-};
 // Middleware to extract SCIM user details
 export const isScimAuthenticated: RequestHandler = async (req, res, next) => {
     // Check for SCIM headers or payload (assuming SCIM details are in the headers for this example)
@@ -90,51 +76,19 @@ export const isScimAuthenticated: RequestHandler = async (req, res, next) => {
         }
         req.serviceAccount = serviceAccount;
 
-        // Build CASL abilities from the service account scopes so that
-        // SCIM operations go through the same audited authorization path
-        // as regular service-account API requests.
-        const builder = new AbilityBuilder<MemberAbility>(Ability);
-        applyServiceAccountAbilities({
-            scopes: serviceAccount.scopes,
-            organizationUuid: serviceAccount.organizationUuid,
-            builder,
-        });
-        const organization = await req.services
-            .getOrganizationService()
-            .getOrganizationByUuid(serviceAccount.organizationUuid);
-
-        const adminUser = await req.services
+        // Load the SA's dedicated `users` row. Abilities are derived from the
+        // SA's scopes via `applyServiceAccountAbilities` inside
+        // `UserModel.generateUserAbilityBuilder`, which detects internal users
+        // and bypasses the role/project ability builder.
+        const sessionUser = await req.services
             .getUserService()
-            .getAdminUser(
-                serviceAccount.createdByUserUuid,
-                serviceAccount.organizationUuid,
-            );
+            .getSessionUserForServiceAccount(serviceAccount);
 
-        // TODO: This uses the hacky method of copying over an admin user. Long-term, we'll want to have a proper
-        // service-account/principle-user unrelated to a real admin-user.
-        // @see https://github.com/lightdash/lightdash/issues/15466
         req.user = {
-            userUuid: adminUser.userUuid,
-            email: 'service-account@lightdash.com',
-            firstName: 'service account',
-            lastName: serviceAccount.description,
-            organizationUuid: serviceAccount.organizationUuid,
-            organizationName: organization.name,
-            organizationCreatedAt: serviceAccount.createdAt,
-            isTrackingAnonymized: false,
-            isMarketingOptedIn: false,
-            isSetupComplete: true,
-            userId: adminUser.userId,
-            role: getRoleForScopes(serviceAccount.scopes),
-            ability: builder.build(),
-            isActive: true,
-            abilityRules: builder.rules,
-            createdAt: serviceAccount.createdAt,
-            updatedAt: serviceAccount.createdAt,
+            ...sessionUser,
             serviceAccount: {
                 uuid: serviceAccount.uuid,
                 description: serviceAccount.description,
-                attributedUserEmail: adminUser.email,
             },
         };
 
@@ -210,50 +164,20 @@ export const authenticateServiceAccount: RequestHandler = async (
             );
         }
         req.serviceAccount = serviceAccount;
-        // Create a SessionUser with abilities based on service account scopes
-        // Scope validation is done on casl abitly checks
-        const builder = new AbilityBuilder<MemberAbility>(Ability);
-        applyServiceAccountAbilities({
-            scopes: serviceAccount.scopes,
-            organizationUuid: serviceAccount.organizationUuid,
-            builder,
-        });
-        const organization = await req.services
-            .getOrganizationService()
-            .getOrganizationByUuid(serviceAccount.organizationUuid);
 
-        const adminUser = await req.services
+        // Load the SA's dedicated `users` row. Abilities are derived from the
+        // SA's scopes via `applyServiceAccountAbilities` inside
+        // `UserModel.generateUserAbilityBuilder`, which detects internal users
+        // and bypasses the role/project ability builder.
+        const sessionUser = await req.services
             .getUserService()
-            .getAdminUser(
-                serviceAccount.createdByUserUuid,
-                serviceAccount.organizationUuid,
-            );
+            .getSessionUserForServiceAccount(serviceAccount);
 
-        // TODO: This uses the hacky method of copying over an admin user. Long-term, we'll want to have a proper
-        // service-account/principle-user unrelated to a real admin-user.
-        // @see https://github.com/lightdash/lightdash/issues/15466
         req.user = {
-            userUuid: adminUser.userUuid,
-            email: 'service-account@lightdash.com',
-            firstName: 'service account',
-            lastName: serviceAccount.description,
-            organizationUuid: serviceAccount.organizationUuid,
-            organizationName: organization.name,
-            organizationCreatedAt: serviceAccount.createdAt, // TODO replace with organization.createdAt,
-            isTrackingAnonymized: false,
-            isMarketingOptedIn: false,
-            isSetupComplete: true,
-            userId: adminUser.userId,
-            role: getRoleForScopes(serviceAccount.scopes),
-            ability: builder.build(),
-            isActive: true,
-            abilityRules: builder.rules,
-            createdAt: serviceAccount.createdAt,
-            updatedAt: serviceAccount.createdAt,
+            ...sessionUser,
             serviceAccount: {
                 uuid: serviceAccount.uuid,
                 description: serviceAccount.description,
-                attributedUserEmail: adminUser.email,
             },
         };
 

--- a/packages/backend/src/ee/authentication/serviceAccount.mock.ts
+++ b/packages/backend/src/ee/authentication/serviceAccount.mock.ts
@@ -1,7 +1,14 @@
 /*
 Service accounts
 */
-import { ServiceAccount, ServiceAccountScope } from '@lightdash/common';
+import { Ability } from '@casl/ability';
+import {
+    OrganizationMemberRole,
+    PossibleAbilities,
+    ServiceAccount,
+    ServiceAccountScope,
+    SessionUser,
+} from '@lightdash/common';
 import express from 'express';
 
 // Mock service account data
@@ -15,6 +22,7 @@ export const mockServiceAccount: ServiceAccount = {
     lastUsedAt: null,
     rotatedAt: null,
     scopes: [ServiceAccountScope.ORG_ADMIN],
+    userUuid: 'sa-dedicated-user-uuid',
 };
 
 export const mockExpiredServiceAccount: ServiceAccount = {
@@ -27,11 +35,26 @@ export const mockOrganization = {
     organizationUuid: 'test-org-uuid',
 };
 
-export const mockAdminUser = {
-    userUuid: 'test-user-uuid',
-    userId: 1,
-    email: 'admin@example.com',
-};
+export const mockSaSessionUser = {
+    userUuid: 'sa-dedicated-user-uuid',
+    userId: 42,
+    email: undefined,
+    firstName: 'Test service account',
+    lastName: '',
+    organizationUuid: 'test-org-uuid',
+    organizationName: 'Test Organization',
+    organizationCreatedAt: new Date('2024-01-01'),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    role: OrganizationMemberRole.ADMIN,
+    isActive: false,
+    isPending: false,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ability: new Ability<PossibleAbilities>([]),
+    abilityRules: [],
+} as unknown as SessionUser;
 
 // Mock requests for different scenarios
 export const mockRequestWithValidToken = {
@@ -44,13 +67,10 @@ export const mockRequestWithValidToken = {
                 .fn()
                 .mockResolvedValue(mockServiceAccount),
         }),
-        getOrganizationService: jest.fn().mockReturnValue({
-            getOrganizationByUuid: jest
-                .fn()
-                .mockResolvedValue(mockOrganization),
-        }),
         getUserService: jest.fn().mockReturnValue({
-            getAdminUser: jest.fn().mockResolvedValue(mockAdminUser),
+            getSessionUserForServiceAccount: jest
+                .fn()
+                .mockResolvedValue(mockSaSessionUser),
         }),
     },
 } as unknown as express.Request;

--- a/packages/backend/src/ee/authentication/serviceAccount.test.ts
+++ b/packages/backend/src/ee/authentication/serviceAccount.test.ts
@@ -1,22 +1,16 @@
-import {
-    AuthorizationError,
-    ServiceAccount,
-    ServiceAccountScope,
-    SessionUser,
-} from '@lightdash/common';
+import { AuthorizationError, SessionUser } from '@lightdash/common';
 import express from 'express';
 import { ServiceAccountService } from '../services/ServiceAccountService/ServiceAccountService';
 import { mockNext, mockResponse } from './middleware.mock';
 import { authenticateServiceAccount } from './middlewares';
 import {
-    mockAdminUser,
     mockRequestWithEmptyToken,
-    mockRequestWithExpiredToken,
     mockRequestWithInvalidToken,
     mockRequestWithMalformedToken,
     mockRequestWithNonBearerToken,
     mockRequestWithNoToken,
     mockRequestWithValidToken,
+    mockSaSessionUser,
     mockServiceAccount,
 } from './serviceAccount.mock';
 
@@ -43,12 +37,14 @@ describe('Service Account Authentication Middleware', () => {
         expect(mockRequestWithValidToken.user).toBeDefined();
 
         const user = mockRequestWithValidToken.user as SessionUser;
-        expect(user.userUuid).toBe(mockAdminUser.userUuid);
-        expect(user.email).toBe('service-account@lightdash.com');
-        expect(user.firstName).toBe('service account');
-        expect(user.lastName).toBe(mockServiceAccount.description);
+        expect(user.userUuid).toBe(mockSaSessionUser.userUuid);
+        expect(user.firstName).toBe(mockSaSessionUser.firstName);
         expect(user.organizationUuid).toBe(mockServiceAccount.organizationUuid);
-        expect(user.userId).toBe(mockAdminUser.userId);
+        expect(user.userId).toBe(mockSaSessionUser.userId);
+        expect(user.serviceAccount).toEqual({
+            uuid: mockServiceAccount.uuid,
+            description: mockServiceAccount.description,
+        });
         expect(user.ability).toBeDefined();
         expect(mockNext).toHaveBeenCalledWith();
     });
@@ -149,7 +145,6 @@ describe('Service Account Authentication Middleware', () => {
 
         expect(user.ability).toBeDefined();
         expect(user.abilityRules).toBeDefined();
-        expect(user.isActive).toBe(true);
         expect(user.isTrackingAnonymized).toBe(false);
         expect(user.isMarketingOptedIn).toBe(false);
         expect(user.isSetupComplete).toBe(true);

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -27,6 +27,16 @@ export class ServiceAccountModel {
     static mapDbObjectToServiceAccount(
         data: DbServiceAccounts,
     ): ServiceAccount {
+        if (!data.service_account_user_uuid) {
+            // Backfill migration populates this for every existing row, and
+            // `ServiceAccountModel.save` always sets it for new rows. A null
+            // here means the row predates the backfill and should never reach
+            // runtime — fail loudly rather than silently fall back to an
+            // admin spoof.
+            throw new UnexpectedDatabaseError(
+                `Service account ${data.service_account_uuid} is missing service_account_user_uuid`,
+            );
+        }
         return {
             uuid: data.service_account_uuid,
             organizationUuid: data.organization_uuid,
@@ -37,6 +47,7 @@ export class ServiceAccountModel {
             rotatedAt: data.rotated_at,
             createdByUserUuid: data.created_by_user_uuid,
             scopes: data.scopes as ServiceAccountScope[],
+            userUuid: data.service_account_user_uuid,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -205,6 +205,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                userUuid: { dataType: 'string', required: true },
                 scopes: {
                     dataType: 'array',
                     array: { dataType: 'refEnum', ref: 'ServiceAccountScope' },
@@ -1188,6 +1189,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ManagedAgentScheduleOption: {
+        dataType: 'refEnum',
+        enums: ['hourly', 'daily'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpdateManagedAgentSettings: {
         dataType: 'refAlias',
         type: {
@@ -1201,10 +1207,7 @@ const models: TsoaRoute.Models = {
                         { dataType: 'enum', enums: [null] },
                     ],
                 },
-                schedule: {
-                    dataType: 'enum',
-                    enums: ['hourly', 'daily'],
-                },
+                schedule: { ref: 'ManagedAgentScheduleOption' },
                 enabled: { dataType: 'boolean' },
             },
             validators: {},
@@ -8825,6 +8828,14 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        chartKind: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'ChartKind' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
                         runtimeOverrides: {
                             dataType: 'union',
                             subSchemas: [
@@ -9103,11 +9114,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9122,11 +9133,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9141,11 +9152,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9176,29 +9187,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                chartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 searchRank:
                                                                                                     {
                                                                                                         dataType:
@@ -9222,11 +9210,28 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
                                                                                                     },
                                                                                                 tableName:
                                                                                                     {
@@ -9239,6 +9244,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9354,11 +9365,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9434,29 +9445,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    chartUsage:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     searchRank:
                                                                                                         {
                                                                                                             dataType:
@@ -9480,11 +9468,28 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
                                                                                                         },
                                                                                                     tableName:
                                                                                                         {
@@ -9497,6 +9502,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9528,11 +9539,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9547,11 +9558,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -21422,7 +21433,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21432,7 +21443,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21442,7 +21453,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21455,7 +21466,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -63,6 +63,9 @@
             },
             "ServiceAccount": {
                 "properties": {
+                    "userUuid": {
+                        "type": "string"
+                    },
                     "scopes": {
                         "items": {
                             "$ref": "#/components/schemas/ServiceAccountScope"
@@ -103,6 +106,7 @@
                     }
                 },
                 "required": [
+                    "userUuid",
                     "scopes",
                     "rotatedAt",
                     "lastUsedAt",
@@ -1240,6 +1244,10 @@
                 ],
                 "type": "object"
             },
+            "ManagedAgentScheduleOption": {
+                "enum": ["hourly", "daily"],
+                "type": "string"
+            },
             "UpdateManagedAgentSettings": {
                 "properties": {
                     "toolSettings": {
@@ -1250,8 +1258,7 @@
                         "nullable": true
                     },
                     "schedule": {
-                        "type": "string",
-                        "enum": ["hourly", "daily"]
+                        "$ref": "#/components/schemas/ManagedAgentScheduleOption"
                     },
                     "enabled": {
                         "type": "boolean"
@@ -10253,6 +10260,14 @@
                 "anyOf": [
                     {
                         "properties": {
+                            "chartKind": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/ChartKind"
+                                    }
+                                ],
+                                "nullable": true
+                            },
                             "runtimeOverrides": {
                                 "allOf": [
                                     {
@@ -10279,6 +10294,7 @@
                             }
                         },
                         "required": [
+                            "chartKind",
                             "runtimeOverrides",
                             "displayName",
                             "pinnedVersionUuid",
@@ -10547,23 +10563,33 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10571,14 +10597,17 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
+                                                                        "fieldType": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10627,8 +10656,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10672,18 +10701,15 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
-                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10691,14 +10717,17 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
+                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10726,8 +10755,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -22817,22 +22846,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -31670,7 +31699,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2870.1",
+        "version": "0.2872.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -1,7 +1,8 @@
-import { AbilityBuilder } from '@casl/ability';
+import { Ability, AbilityBuilder } from '@casl/ability';
 import {
     ActivateUser,
     AlreadyExistsError,
+    applyServiceAccountAbilities,
     CreateUserArgs,
     CreateUserWithRole,
     ForbiddenError,
@@ -22,6 +23,7 @@ import {
     ProjectMemberRole,
     Role,
     RoleWithScopes,
+    ServiceAccountScope,
     SessionUser,
     UpdateUserArgs,
     validatePassword,
@@ -80,6 +82,7 @@ export type DbUserDetails = {
     role?: OrganizationMemberRole;
     role_uuid?: string;
     is_active: boolean;
+    is_internal: boolean;
     updated_at: Date;
 };
 
@@ -612,6 +615,30 @@ export class UserModel {
             hasAuthentication,
         );
 
+        // Service accounts get a dedicated `users` row marked `is_internal`.
+        // Their runtime authorization comes from `applyServiceAccountAbilities`
+        // (driven by the SA's scopes), not the role/project ability builder
+        // — so this branch covers both live SA requests and worker
+        // re-hydration (schedulers, async queries) without a scope→role
+        // regression. v2 will unify this onto the standard role-based path.
+        if (user.is_internal) {
+            const serviceAccount = await this.findServiceAccountByUserUuid(
+                user.user_uuid,
+            );
+            if (serviceAccount) {
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                applyServiceAccountAbilities({
+                    scopes: serviceAccount.scopes,
+                    organizationUuid: serviceAccount.organizationUuid,
+                    builder,
+                });
+                return {
+                    abilityBuilder: builder,
+                    lightdashUser,
+                };
+            }
+        }
+
         // Fetch scopes for custom roles
         const customRoleUuids = [...projectRoles, ...groupProjectRoles]
             .map((role) => role.roleUuid)
@@ -631,6 +658,31 @@ export class UserModel {
         return {
             abilityBuilder,
             lightdashUser,
+        };
+    }
+
+    private async findServiceAccountByUserUuid(userUuid: string): Promise<
+        | {
+              scopes: ServiceAccountScope[];
+              organizationUuid: string;
+          }
+        | undefined
+    > {
+        const row = await this.database('service_accounts')
+            .where('service_account_user_uuid', userUuid)
+            .select<
+                {
+                    scopes: string[];
+                    organization_uuid: string;
+                }[]
+            >('scopes', 'organization_uuid')
+            .first();
+        if (!row) {
+            return undefined;
+        }
+        return {
+            scopes: row.scopes as ServiceAccountScope[],
+            organizationUuid: row.organization_uuid,
         };
     }
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -39,6 +39,7 @@ import {
     PasswordReset,
     ProjectMemberRole,
     RegisterOrActivateUser,
+    ServiceAccount,
     SessionUser,
     SnowflakeAuthenticationType,
     SpaceMemberRole,
@@ -2457,6 +2458,21 @@ export class UserService extends BaseService {
             forceRedirect: false,
             redirectUri: undefined,
         };
+    }
+
+    /**
+     * Loads the SessionUser for the dedicated `users` row provisioned for this
+     * service account. Abilities are derived from the SA's scopes via
+     * `applyServiceAccountAbilities` inside
+     * `UserModel.generateUserAbilityBuilder`.
+     */
+    async getSessionUserForServiceAccount(
+        serviceAccount: ServiceAccount,
+    ): Promise<SessionUser> {
+        return this.userModel.findSessionUserAndOrgByUuid(
+            serviceAccount.userUuid,
+            serviceAccount.organizationUuid,
+        );
     }
 
     /*

--- a/packages/common/src/ee/serviceAccounts/types.ts
+++ b/packages/common/src/ee/serviceAccounts/types.ts
@@ -15,6 +15,11 @@ export type ServiceAccount = {
     lastUsedAt: Date | null;
     rotatedAt: Date | null;
     scopes: ServiceAccountScope[];
+    // The dedicated `users` row provisioned for this service account. Auth
+    // middleware loads this user to build `req.user`, so writes attribute the
+    // service account itself (not a fallback admin) on `created_by_user_uuid`
+    // / `updated_by_user_uuid` and audit logs.
+    userUuid: string;
 };
 
 export type ServiceAccountWithToken = ServiceAccount & {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7424

Stops the SA auth middleware from spoofing an admin user. `req.user` is now built from the SA's own `users` row (linked via `service_accounts.service_account_user_uuid`, provisioned in #22661) so `createdBy` / `updatedBy` / audit logs attribute the service account itself.

### Changes

- `ServiceAccount.userUuid` (non-null) — surfaces the SA's dedicated user UUID; `ServiceAccountModel.mapDbObjectToServiceAccount` throws if a DB row is missing the link rather than silently falling back to a spoof.
- `UserModel.generateUserAbilityBuilder` — single branch on `user.is_internal`: SA users get abilities from `applyServiceAccountAbilities` (driven by SA scopes), regular users keep the role/project ability path. Covers live requests **and** worker re-hydration (schedulers, async queries) — no scope→role regression.
- `UserService.getSessionUserForServiceAccount` — thin wrapper the middleware calls instead of `getAdminUser`.
- `authenticateServiceAccount` / `isScimAuthenticated` — replaces the admin-load + manual `SessionUser` synthesis with a single `userModel.findSessionUserAndOrgByUuid` call.

### Out of scope (follow-ups in this stack)

- Cleanup of `getAdminUser` / `findOldestAdminUserUuid` and placeholder email/firstName — #22690
- Drop `attributedUserUuid`/`attributedUserEmail` and audit-log caveat (closes PROD-7423) — #22691

### Test plan
- [x] \`pnpm -F backend typecheck && pnpm -F backend lint && pnpm -F backend test:dev:nowatch\`
- [x] \`pnpm -F common build && pnpm generate-api\`
- [ ] Manual: \`PATCH /api/v1/saved/{uuid}\` with an SA token → \`updatedByUser\` shows the SA, not David Attenborough

🤖 Generated with [Claude Code](https://claude.com/claude-code)