### PR TITLE
refactor(prod-7424): drop service-account audit attribution caveat

### DIFF
--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -119,9 +119,6 @@ export const fromJwt = ({
     });
 };
 
-// TODO: This uses the hacky method of copying over an admin user. Long-term, we'll want to have a proper
-// service-account/principle-user unrelated to a real admin-user.
-// @see https://github.com/lightdash/lightdash/issues/15466
 export const fromServiceAccount = (
     sessionUser: SessionUser,
     source: string,
@@ -140,8 +137,6 @@ export const fromServiceAccount = (
             serviceAccountUuid: sessionUser.serviceAccount.uuid,
             serviceAccountDescription:
                 sessionUser.serviceAccount.description ?? '',
-            attributedUserUuid: sessionUser.userUuid,
-            attributedUserEmail: sessionUser.serviceAccount.attributedUserEmail,
         },
         organization,
         user: {
@@ -183,8 +178,6 @@ export const toSessionUser = (account: RegisteredAccount): SessionUser => ({
             ? {
                   uuid: account.authentication.serviceAccountUuid,
                   description: account.authentication.serviceAccountDescription,
-                  attributedUserEmail:
-                      account.authentication.attributedUserEmail,
               }
             : undefined,
 });

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14984,8 +14984,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                attributedUserEmail: { dataType: 'string' },
-                attributedUserUuid: { dataType: 'string', required: true },
                 serviceAccountDescription: {
                     dataType: 'string',
                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15898,12 +15898,6 @@
             },
             "ServiceAccountAuth": {
                 "properties": {
-                    "attributedUserEmail": {
-                        "type": "string"
-                    },
-                    "attributedUserUuid": {
-                        "type": "string"
-                    },
                     "serviceAccountDescription": {
                         "type": "string"
                     },
@@ -15920,7 +15914,6 @@
                     }
                 },
                 "required": [
-                    "attributedUserUuid",
                     "serviceAccountDescription",
                     "serviceAccountUuid",
                     "source",

--- a/packages/backend/src/logging/auditLog.ts
+++ b/packages/backend/src/logging/auditLog.ts
@@ -33,18 +33,16 @@ export const UserAuditActorSchema = BaseUserActorSchema.extend({
     type: z.enum(['session', 'pat', 'oauth']),
 });
 
-// `uuid` is the service-account UUID — the actual actor.
-// `attributedUserUuid` is the admin user the action gets recorded against
-// due to an FK on the users table; surfaced so auditors can reconcile with
-// user-level activity views. @see https://github.com/lightdash/lightdash/issues/15466
+// `uuid` is the service-account UUID — the actual actor. Service accounts
+// now have a dedicated `users` row, so writes attribute the SA directly via
+// `created_by_user_uuid` / `updated_by_user_uuid`; no separate "attributed
+// user" plumbing is required.
 export const ServiceAccountAuditActorSchema = z.object({
     type: z.literal('service-account'),
     uuid: z.string(),
     description: z.string().optional(),
     organizationUuid: z.string(),
     organizationRole: z.string(),
-    attributedUserUuid: z.string(),
-    attributedUserEmail: z.string().optional(),
 });
 
 export const AnonymousAuditActorSchema = z.object({

--- a/packages/backend/src/logging/caslAuditWrapper.test.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.test.ts
@@ -553,8 +553,6 @@ describe('CaslAuditWrapper', () => {
                               source: 'src',
                               serviceAccountUuid: 'sa-uuid',
                               serviceAccountDescription: 'ci-deploy',
-                              attributedUserUuid: 'user-789',
-                              attributedUserEmail: 'user@example.com',
                           }
                         : { type: overrides.authType, source: 'src' },
                 organization: { organizationUuid: 'org-uuid' },
@@ -627,7 +625,7 @@ describe('CaslAuditWrapper', () => {
             expect(actor.impersonatedBy).toBeUndefined();
         });
 
-        it('should map service-account UUID, description and attributed user from authentication', () => {
+        it('should map service-account UUID and description from authentication', () => {
             const account = buildSessionAccount({
                 authType: 'service-account',
                 withImpersonation: false,
@@ -638,8 +636,6 @@ describe('CaslAuditWrapper', () => {
             if (actor.type !== 'service-account') return;
             expect(actor.uuid).toBe('sa-uuid');
             expect(actor.description).toBe('ci-deploy');
-            expect(actor.attributedUserUuid).toBe('user-789');
-            expect(actor.attributedUserEmail).toBe('user@example.com');
             expect(actor.organizationUuid).toBe('org-uuid');
             expect(actor.organizationRole).toBe(OrganizationMemberRole.VIEWER);
         });

--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -73,12 +73,8 @@ export const createActorFromAccount = (account: Account): AuditActor => {
 
     if (account.isServiceAccount()) {
         const svcAccount = account as ServiceAcctAccount;
-        const {
-            serviceAccountUuid,
-            serviceAccountDescription,
-            attributedUserUuid,
-            attributedUserEmail,
-        } = svcAccount.authentication;
+        const { serviceAccountUuid, serviceAccountDescription } =
+            svcAccount.authentication;
         return {
             type: 'service-account',
             uuid: serviceAccountUuid,
@@ -86,8 +82,6 @@ export const createActorFromAccount = (account: Account): AuditActor => {
             organizationUuid:
                 svcAccount.organization.organizationUuid || 'unknown',
             organizationRole: svcAccount.user.role || 'unknown',
-            attributedUserUuid,
-            attributedUserEmail,
         };
     }
 
@@ -140,9 +134,8 @@ export const createActorFromAccount = (account: Account): AuditActor => {
  * @deprecated Prefer createActorFromAccount with Account type
  */
 export const createActorFromUser = (user: AuditableUser): AuditActor => {
-    // Service-account requests stamp `req.user.serviceAccount` alongside the
-    // attributed admin user, so the legacy SessionUser path can still produce
-    // a service-account audit actor.
+    // Service-account requests stamp `req.user.serviceAccount`, so the legacy
+    // SessionUser path can still produce a service-account audit actor.
     if (user.serviceAccount) {
         return {
             type: 'service-account',
@@ -150,8 +143,6 @@ export const createActorFromUser = (user: AuditableUser): AuditActor => {
             description: user.serviceAccount.description || undefined,
             organizationUuid: user.organizationUuid || 'unknown',
             organizationRole: user.role || 'unknown',
-            attributedUserUuid: user.userUuid,
-            attributedUserEmail: user.serviceAccount.attributedUserEmail,
         };
     }
 

--- a/packages/backend/src/logging/winston.test.ts
+++ b/packages/backend/src/logging/winston.test.ts
@@ -75,7 +75,6 @@ describe('formatAuditActor', () => {
                 description: 'ci-deploy',
                 organizationUuid: 'org-uuid',
                 organizationRole: 'admin',
-                attributedUserUuid: 'admin-uuid',
             }),
         ).toBe('service-account "ci-deploy"');
     });
@@ -87,7 +86,6 @@ describe('formatAuditActor', () => {
                 uuid: 'sa-uuid',
                 organizationUuid: 'org-uuid',
                 organizationRole: 'admin',
-                attributedUserUuid: 'admin-uuid',
             }),
         ).toBe('service-account sa-uuid');
     });
@@ -230,7 +228,7 @@ describe('formatAuditMessage', () => {
         );
     });
 
-    it('formats service account event with attribution caveat (email)', () => {
+    it('formats service account event without attribution caveat', () => {
         expect(
             formatAuditMessage({
                 ...baseEvent,
@@ -240,8 +238,6 @@ describe('formatAuditMessage', () => {
                     description: 'ci-deploy',
                     organizationUuid: 'org-uuid',
                     organizationRole: 'admin',
-                    attributedUserUuid: 'admin-uuid',
-                    attributedUserEmail: 'admin@company.com',
                 },
                 action: 'manage',
                 resource: {
@@ -254,31 +250,7 @@ describe('formatAuditMessage', () => {
                 },
             }),
         ).toBe(
-            'service-account "ci-deploy" managed Group -> groupUuid: group-uuid, groupName: Engineering (allowed) (recorded against user admin@company.com)',
-        );
-    });
-
-    it('formats service account event with attribution caveat falling back to uuid', () => {
-        expect(
-            formatAuditMessage({
-                ...baseEvent,
-                actor: {
-                    type: 'service-account',
-                    uuid: 'sa-uuid',
-                    description: 'ci-deploy',
-                    organizationUuid: 'org-uuid',
-                    organizationRole: 'admin',
-                    attributedUserUuid: 'admin-uuid',
-                },
-                action: 'manage',
-                resource: {
-                    type: 'Group',
-                    metadata: { groupUuid: 'group-uuid' },
-                    organizationUuid: 'org-uuid',
-                },
-            }),
-        ).toBe(
-            'service-account "ci-deploy" managed Group -> groupUuid: group-uuid (allowed) (recorded against user admin-uuid)',
+            'service-account "ci-deploy" managed Group -> groupUuid: group-uuid, groupName: Engineering (allowed)',
         );
     });
 

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -213,17 +213,7 @@ export const formatAuditMessage = (event: AuditLogEvent): string => {
     const resource = formatAuditResource(event.resource);
     const status = `(${event.status})`;
     const reason = event.reason ? ` - ${event.reason}` : '';
-    // Service-account actions are recorded against an admin user due to an FK
-    // constraint; flag this so auditors can reconcile with user-level views.
-    // @see https://github.com/lightdash/lightdash/issues/15466
-    const caveat =
-        event.actor.type === 'service-account'
-            ? ` (recorded against user ${
-                  event.actor.attributedUserEmail ||
-                  event.actor.attributedUserUuid
-              })`
-            : '';
-    return `${actor} ${action} ${resource} ${status}${reason}${caveat}`;
+    return `${actor} ${action} ${resource} ${status}${reason}`;
 };
 
 export const logAuditEvent = (event: AuditLogEvent): void => {

--- a/packages/backend/src/services/AdminNotificationService/AdminNotificationService.mock.ts
+++ b/packages/backend/src/services/AdminNotificationService/AdminNotificationService.mock.ts
@@ -116,8 +116,6 @@ const createMockAccount = (
                   serviceAccountUuid: 'mock-service-account-uuid',
                   serviceAccountDescription:
                       overrides.serviceAccountDescription ?? '',
-                  attributedUserUuid: overrides.userUuid ?? 'changer-uuid',
-                  attributedUserEmail: overrides.email ?? 'changer@example.com',
               }
             : { type: 'session' as const, source: 'mock-session-cookie' },
         user: {

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -49,11 +49,6 @@ export type ServiceAccountAuth = {
     source: string; // The service account token
     serviceAccountUuid: string;
     serviceAccountDescription: string;
-    // Admin user UUID/email the action is recorded against due to an FK on the
-    // users table. Used by audit logs to flag the attribution caveat.
-    // @see https://github.com/lightdash/lightdash/issues/15466
-    attributedUserUuid: string;
-    attributedUserEmail?: string;
 };
 
 export type OauthAuth = {

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -95,25 +95,14 @@ export interface SessionUser extends LightdashUserWithAbilityRules {
     impersonation?: ImpersonationContext;
     /**
      * Set only when the request was authenticated via a service-account token.
-     * `req.user` is the admin user the action is recorded against (FK
-     * constraint on `users`), and this field carries the actual service-account
-     * identity so audit logging can attribute correctly even when call sites
-     * receive SessionUser rather than Account.
-     *
-     * `attributedUserEmail` holds the *real* admin user's email. We can't read
-     * it from `email` on this SessionUser because the service-account auth
-     * middleware overwrites `email` with the placeholder
-     * `service-account@lightdash.com` (and `firstName`/`lastName` similarly) so
-     * downstream code that surfaces the actor sees a service-account label
-     * rather than leaking the admin user's identity. The audit log still needs
-     * the real admin email to flag the FK attribution caveat, so we stash it
-     * here at middleware time.
-     * @see https://github.com/lightdash/lightdash/issues/15466
+     * `req.user` is loaded from the SA's dedicated `users` row (linked via
+     * `service_accounts.service_account_user_uuid`), so writes attribute the
+     * service account itself. This field carries the SA identity for code
+     * paths that receive `SessionUser` rather than `Account`.
      */
     serviceAccount?: {
         uuid: string;
         description?: string;
-        attributedUserEmail?: string;
     };
 }
 


### PR DESCRIPTION
Stacked on #22690. Closes: https://linear.app/lightdash/issue/PROD-7423

Now that SA writes attribute the service account directly via \`created_by_user_uuid\` / \`updated_by_user_uuid\` (no FK redirection through an admin), the audit-log "recorded against user X" caveat is no longer accurate or needed.

### Changes

- Drop \`attributedUserUuid\` / \`attributedUserEmail\` from \`ServiceAccountAuth\`, \`LightdashSessionUser.serviceAccount\`, \`ServiceAccountAuditActorSchema\`, \`createActorFromAccount\`, \`createActorFromUser\`, \`fromServiceAccount\`, and \`toSessionUser\`.
- Drop the trailing \`(recorded against user …)\` caveat from \`formatAuditMessage\`.
- Remove the \`#15466\` TODO references that documented the original FK workaround.
- Update audit-log mocks/tests to match the new shape.

### Test plan
- [x] \`pnpm -F common build && pnpm -F backend typecheck && pnpm -F backend lint && pnpm -F backend test:dev:nowatch\`
- [x] \`pnpm generate-api\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)