### PR TITLE
feat(table-calculations): announce upcoming custom SQL permission move

### DIFF
--- a/packages/frontend/src/components/common/Callout.tsx
+++ b/packages/frontend/src/components/common/Callout.tsx
@@ -40,6 +40,7 @@ interface CalloutProps extends Omit<AlertProps, 'title' | 'icon'> {
     title?: ReactNode;
     children?: ReactNode;
     hideIcon?: boolean;
+    icon?: ReactNode;
 }
 
 /**
@@ -62,17 +63,19 @@ const Callout: FC<CalloutProps> = ({
     title,
     children,
     hideIcon,
+    icon,
     ...alertProps
 }) => {
     const config = CALLOUT_CONFIG[variant];
     const IconComponent = config.icon;
+    const resolvedIcon = icon ?? <MantineIcon icon={IconComponent} size="lg" />;
 
     return (
         <Alert
             color={config.color}
             variant="light"
             radius="md"
-            icon={!hideIcon && <MantineIcon icon={IconComponent} size="lg" />}
+            icon={!hideIcon && resolvedIcon}
             title={title}
             {...alertProps}
         >

--- a/packages/frontend/src/features/tableCalculation/components/FormulaConversionPreview.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaConversionPreview.module.css
@@ -8,22 +8,26 @@
     padding: 6px 8px;
     border-radius: var(--mantine-radius-md);
     background-color: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-dark-7)
+        var(--mantine-color-indigo-0),
+        var(--mantine-color-indigo-9)
     );
-    border: 1px solid var(--mantine-color-ldGray-3);
+    border: 1px solid
+        light-dark(var(--mantine-color-indigo-3), var(--mantine-color-indigo-7));
+    color: light-dark(
+        var(--mantine-color-indigo-9),
+        var(--mantine-color-indigo-1)
+    );
     white-space: pre-wrap;
     word-break: break-word;
     overflow-y: auto;
     min-width: 0;
     box-sizing: border-box;
-
-    @mixin dark {
-        border-color: var(--mantine-color-ldDark-4);
-    }
 }
 
 .equalsPrefix {
-    color: var(--mantine-color-dimmed);
+    color: light-dark(
+        var(--mantine-color-indigo-5),
+        var(--mantine-color-indigo-3)
+    );
     margin-right: 0.25em;
 }

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.module.css
@@ -1,0 +1,5 @@
+.editorBlurred {
+    opacity: 0.55;
+    pointer-events: none;
+    transition: opacity 200ms ease;
+}

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -27,6 +27,7 @@ import { useAmbientAiEnabled } from '../../../ee/features/ambientAi/hooks/useAmb
 import { useTableCalculationAceEditorCompleter } from '../../../hooks/useExplorerAceEditorCompleter';
 import { type TableCalculationForm } from '../types';
 import FormulaConversionPreviewBody from './FormulaConversionPreview';
+import classes from './SqlForm.module.css';
 import 'ace-builds/src-noconflict/mode-sql';
 import 'ace-builds/src-noconflict/theme-github';
 import 'ace-builds/src-noconflict/theme-tomorrow_night';
@@ -179,7 +180,10 @@ export const SqlForm: FC<Props> = ({
 
     return (
         <Flex direction="column" h="100%">
-            <ScrollArea style={{ flex: 1 }}>
+            <ScrollArea
+                style={{ flex: 1 }}
+                className={conversionState ? classes.editorBlurred : undefined}
+            >
                 <SqlEditor
                     mode="sql"
                     theme={

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -30,9 +30,11 @@ import { useForm } from '@mantine/form';
 import {
     IconAlertTriangle,
     IconCalculator,
+    IconHelpCircle,
     IconMaximize,
     IconMinimize,
     IconSparkles,
+    IconSpeakerphone,
     IconWand,
 } from '@tabler/icons-react';
 import {
@@ -48,6 +50,7 @@ import {
 import { useParams } from 'react-router';
 import { useToggle } from 'react-use';
 import { type ValueOf } from 'type-fest';
+import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import {
@@ -62,6 +65,7 @@ import useToaster from '../../../hooks/toaster/useToaster';
 import { useConvertSqlToFormula } from '../../../hooks/useConvertSqlToFormula';
 import { useExplore } from '../../../hooks/useExplore';
 import { useProject } from '../../../hooks/useProject';
+import { useCannotAuthorCustomSql } from '../../../hooks/user/useCannotAuthorCustomSql';
 import { getUniqueTableCalculationName } from '../utils';
 import { FormatRow } from './FormatRow/FormatRow';
 import { FormulaForm, type FormulaFormHandle } from './FormulaForm/FormulaForm';
@@ -298,11 +302,27 @@ const TableCalculationModal: FC<Props> = ({
 
     const isExistingSqlCalc =
         !!tableCalculation && isSqlTableCalculation(tableCalculation);
-    const showConvertToFormulaButton =
+
+    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
+    const showSqlDeprecationCallout =
+        cannotAuthorCustomSql === true && editMode !== EditMode.TEMPLATE;
+    const canConvertExistingSqlToFormula =
         isExistingSqlCalc &&
         isFormulaSupported &&
         isAmbientAiEnabled &&
         editMode === EditMode.SQL;
+    const showConvertToFormulaButton =
+        canConvertExistingSqlToFormula && !showSqlDeprecationCallout;
+    const showConvertInCallout =
+        showSqlDeprecationCallout && canConvertExistingSqlToFormula;
+    const showTryFormulasInCallout =
+        showSqlDeprecationCallout &&
+        editMode === EditMode.SQL &&
+        isNewCalculation &&
+        isFormulaSupported;
+    const handleTryFormulasClick = useCallback(() => {
+        setEditMode(EditMode.FORMULA);
+    }, []);
 
     const showConversionPreview =
         editMode === EditMode.SQL &&
@@ -547,6 +567,95 @@ const TableCalculationModal: FC<Props> = ({
             }}
         >
             <Stack gap="xs">
+                {showSqlDeprecationCallout && (
+                    <Callout
+                        variant="warning"
+                        title={
+                            <Group gap={6} wrap="nowrap" align="center">
+                                <Text
+                                    fw={700}
+                                    size="sm"
+                                    c="light-dark(var(--mantine-color-ldDark-9), var(--mantine-color-yellow-1))"
+                                    inherit
+                                >
+                                    Coming soon: Editors won't be able to create
+                                    new SQL table calculations
+                                </Text>
+                                <Tooltip
+                                    label="Existing SQL calculations stay editable — just convert them to formula first. They're easier to read and reuse that way."
+                                    multiline
+                                    w={280}
+                                    withArrow
+                                    position="top"
+                                >
+                                    <Box style={{ display: 'flex' }}>
+                                        <MantineIcon
+                                            icon={IconHelpCircle}
+                                            color="light-dark(var(--mantine-color-ldDark-7), var(--mantine-color-yellow-3))"
+                                            size="sm"
+                                        />
+                                    </Box>
+                                </Tooltip>
+                            </Group>
+                        }
+                        fz="sm"
+                        icon={<MantineIcon icon={IconSpeakerphone} size="lg" />}
+                        bd="1px solid light-dark(var(--mantine-color-yellow-3), var(--mantine-color-yellow-9))"
+                        bg="light-dark(var(--mantine-color-yellow-0), var(--mantine-color-dark-7))"
+                        p="xs"
+                    >
+                        <Stack gap="xs">
+                            <Text
+                                size="xs"
+                                c="light-dark(var(--mantine-color-ldDark-9), var(--mantine-color-yellow-1))"
+                            >
+                                We're moving custom SQL behind a new permission.
+                                Use formulas instead — no SQL required,
+                                validated as you type, and they work in any
+                                warehouse.
+                            </Text>
+                            <Group gap="xs" mt={4} justify="flex-end">
+                                {showConvertInCallout &&
+                                    !showConversionPreview && (
+                                        <Button
+                                            size="compact-xs"
+                                            variant="default"
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconWand}
+                                                    size="sm"
+                                                />
+                                            }
+                                            loading={isConvertingSql}
+                                            onClick={handleConvertClick}
+                                        >
+                                            Convert to formula
+                                        </Button>
+                                    )}
+                                {showTryFormulasInCallout && (
+                                    <Button
+                                        size="compact-xs"
+                                        variant="default"
+                                        onClick={handleTryFormulasClick}
+                                    >
+                                        Try formulas now
+                                    </Button>
+                                )}
+                                <Anchor
+                                    size="xs"
+                                    c="light-dark(var(--mantine-color-ldDark-9), var(--mantine-color-yellow-1))"
+                                    fw={500}
+                                    href="https://docs.lightdash.com/guides/formula-table-calculations"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    underline="always"
+                                >
+                                    Learn more
+                                </Anchor>
+                            </Group>
+                        </Stack>
+                    </Callout>
+                )}
                 <Stack gap={2}>
                     <Group className={classes.inputModeHeader}>
                         <Group gap={6} wrap="nowrap">


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/ZAP-363/in-app-announcement-callout-custom-sql-is-moving-behind-a-permission

## Summary

Adds a pre-activation announcement callout to the Table Calculation modal warning editors that custom SQL TCs are moving behind a new permission. First PR in the ZAP-363 → ZAP-361 → ZAP-362 stack — the actual permission gate and the migration UX ship in #22701 next.

The callout is editor-targeted, surfaces formula benefits ("no SQL required, validated as you type, work in any warehouse"), and offers contextual CTAs:
- **New TC in SQL mode** → `Try formulas now` (switches mode)
- **Existing SQL TC** → `Convert to formula` (extends the existing AI-driven conversion path that today only admins/devs use, by surfacing it inside the callout)
- **All cases** → `Learn more` link to formula docs

Includes some polish on the conversion preview UI (indigo-tinted "Suggested formula" box + dimmed source SQL) so the AI suggestion reads as a clearly-distinct surface.

## Visibility matrix (regression analysis)

| Scenario | Callout | Primary CTA |
|---|---|---|
| Editor (or below), new TC, formula mode | shown | Learn more |
| Editor, new TC, SQL mode | shown | Learn more · Try formulas now |
| Editor, **existing SQL** TC | shown | Learn more · Convert to formula |
| Editor, existing formula TC | shown | Learn more |
| Editor, existing template TC | hidden | — |
| Admin / developer, any TC | hidden | (existing top-right Convert button unchanged) |

**Targeting** uses the existing `useCannotAuthorCustomSql` hook (proxy for "editor and below" today, since editors don't currently have `manage:CustomFields`). #22701 swaps targeting to the dedicated `manage:CustomSqlTableCalculations` scope check once it lands.

**Affected users:** editors and below — they see a new informational callout.
**Unaffected:** admins, developers, service accounts. No backend behavior changes; no permission enforcement yet (that ships in #22701). The existing `Convert to formula` button at the top-right of the SQL editor stays in place for admins/devs (only suppressed when the callout takes its place for editors, to avoid duplication).

## Conversion preview polish

- `FormulaConversionPreview.module.css`: formula preview box → light indigo background + indigo border (clearer "AI suggestion" surface, dark-mode aware via `light-dark()`)
- `SqlForm.module.css` (new): when conversion preview is active, dims the source SQL editor (opacity 0.55) so the suggested formula reads as the focal element

## Reusable Callout improvement

`Callout` now accepts an optional `icon` prop that overrides the variant default — used here to swap the warning triangle for a megaphone, since announcement framing reads better than alarm framing.

## Test plan

Manually tested in dev with `demo2@lightdash.com` (editor) and `demo@lightdash.com` (admin):

- [x] Editor opening new TC modal → callout shown in formula mode (default)
- [x] Editor switching to SQL → callout still shown, "Try formulas now" CTA appears
- [x] Editor clicking "Try formulas now" → flips back to formula mode
- [x] Editor editing existing SQL TC → callout shown with "Convert to formula" CTA (top-right convert button suppressed to avoid duplication)
- [x] Editor editing existing formula TC → callout shown (no CTA except Learn more)
- [x] Admin opening new/existing TC modal → no callout, top-right Convert button unaffected
- [x] Conversion preview triggered → SQL editor dims, indigo formula preview displayed
- [x] Dark mode: callout bg/border/text all theme-aware via `light-dark()`
- [x] `pnpm -F frontend typecheck` passes
- [x] `pnpm -F frontend lint` passes (0 warnings, 0 errors)

## Out of scope

- Permission gate enforcement → #22701 (ZAP-361)
- Migration UX for blocked editors (request-help path, conversion-failure fallbacks, formula onboarding) → #22701 (ZAP-362)
- Admin/dev variant of the callout (deferred — the inbound "Request help" flow from ZAP-362 is the right channel for admins to learn about specific access requests, rather than a generic "you can manage roles" in-modal callout)

🔗 [ZAP-363](https://linear.app/lightdash/issue/ZAP-363/in-app-announcement-callout-custom-sql-is-moving-behind-a-permission)