### PR TITLE
feat: Service accounts support custom org roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ data/
 
 CLAUDE.local.md
 AGENTS.override.md
+.playwright-mcp 
 
 http-client.private.env.json
 

--- a/docs/authentication-and-roles.md
+++ b/docs/authentication-and-roles.md
@@ -1,0 +1,203 @@
+# Authentication and roles
+
+How a request gets authenticated, how the resulting principal's CASL ability is
+built, and how system roles and custom roles fit together. Companion to
+[`authorization-scopes.md`](./authorization-scopes.md) (which goes deeper on
+how to add or split a scope) and [`account-patterns.md`](./account-patterns.md)
+(which focuses on `req.account` shapes).
+
+## Authentication shapes
+
+Every request lands on one of these auth paths. Each one resolves a `req.user`
+(SessionUser) and `req.account`; CASL is then built from `req.user`'s
+membership rows. The differences are who minted the credential and how it's
+delivered.
+
+| Shape | Header / cookie | Token prefix | Code path | Notes |
+|---|---|---|---|---|
+| **Session** (browser) | `Cookie: connect.sid=…` | n/a | `passport` session middleware | Set by `POST /api/v1/login`. The default for the web app. |
+| **Personal access token** (PAT) | `Authorization: ApiKey <token>` | `ldpat_` | `allowApiKeyAuthentication` | Mints as the **owning user** — same identity, same role, same project memberships. Used by the CLI, scripts, ad-hoc API calls. |
+| **Service account** (SA) | `Authorization: Bearer <token>` | `ldsvc_` | `authenticateServiceAccount` middleware | Authenticates as a **dedicated SA user** (not a human). See [`service-accounts.md`](./service-accounts.md) for the full lifecycle and permission model. |
+| **SCIM token** | `Authorization: Bearer <token>` | `ldscim_` | `isScimAuthenticated` middleware | A constrained service account with the legacy `scim:manage` scope. Only the `/api/v1/scim/v2/*` routes accept it. Minted from the dedicated SCIM token UI in org settings. |
+| **Embed JWT** | URL-signed JWT | n/a | `embed` auth strategy | A dashboard-scoped principal with no org membership. Different code path; out of scope here. |
+
+The authenticated principal is the same shape downstream: `SessionUser` for
+the user record, `Account` for narrowed CASL/identity. See
+[`account-patterns.md`](./account-patterns.md) for which to use where.
+
+## Role layers
+
+A user's CASL ability is assembled from **two independent layers** that get
+merged with `Ability.update([...orgRules, ...projectRules])`:
+
+```
+                ┌──────────────────────┐
+   org-level ──▶│ organization_         │── via organizationMemberAbility
+                │ memberships row       │   OR buildAbilityFromScopes
+                └──────────────────────┘   (if role_uuid set)
+                          +
+                ┌──────────────────────┐
+project-level ─▶│ project_memberships   │── via projectMemberAbility
+                │ row(s)                │   OR buildAbilityFromScopes
+                └──────────────────────┘   (if role_uuid set)
+```
+
+CASL is **additive**: the project layer cannot revoke anything granted at the
+org layer. Anything you want to be able to gate via custom roles must live at
+the project layer (which is why most fine-grained permissions are checked
+against project-scoped subjects).
+
+## System roles
+
+The 6 hard-coded roles. Each one is a TypeScript function that calls `can(...)`
+on a CASL `AbilityBuilder`:
+
+| Role | Where defined |
+|---|---|
+| `member` | `organizationMemberAbility.ts` (only org-level) |
+| `viewer` | `organizationMemberAbility.ts` + `projectMemberAbility.ts` |
+| `interactive_viewer` | both |
+| `editor` | both |
+| `developer` | both |
+| `admin` | both |
+
+System roles do **not** exist as rows in the `roles` table — they're returned
+by `GET /api/v2/orgs/{org}/roles?roleTypeFilter=system` with synthetic
+`roleUuid` values like `"admin"`, `"editor"`, etc., and resolved entirely in
+code (see `applyOrganizationMemberStaticAbilities` /
+`applyProjectMemberStaticAbilities`).
+
+When a membership row has `role_uuid IS NULL`, the layer falls back to the
+system role driven by the `role` column.
+
+## Custom roles
+
+Stored in `roles` (one row per role) + `scoped_roles` (many rows per role,
+one per scope). Built via `buildAbilityFromScopes(scopes, ...)` which walks
+the scope vocabulary in `packages/common/src/authorization/scopes.ts` and
+calls `can(...)` once per scope.
+
+Two assignment surfaces:
+
+1. **Project-level custom roles** (the original use case). Set
+   `project_memberships.role_uuid` to a custom role uuid. Used today by both
+   human users and project-scoped automation.
+2. **Organization-level custom roles**. Set
+   `organization_memberships.role_uuid`. The same `roles` row can be assigned
+   either way — there's no project-vs-org distinction at the role level, only
+   at the assignment.
+
+The custom-roles UI under **Settings → Custom roles** edits both surfaces
+through the same controllers (`CustomRolesController`, `OrganizationRolesController`).
+The org-level scope vocabulary (`view:Organization`, `manage:OrganizationMemberProfile`,
+`manage:InviteLink`, `manage:Group`, …) is grouped under
+`ScopeGroup.ORGANIZATION_MANAGEMENT` in `scopes.ts` so admins can build a
+custom role that grants exactly the org-level abilities they need (e.g.,
+"team-onboarding bot" with only `manage:InviteLink`).
+
+## Where each principal type lands in the layers
+
+| Principal | Org layer | Project layer |
+|---|---|---|
+| Human user | system role from `om.role`, OR custom role from `om.role_uuid` | per project: same logic via `pm.role` / `pm.role_uuid` |
+| PAT | inherits everything from the underlying user (PAT has no own role) | same |
+| Service account | system role via `om.role`, custom role via `om.role_uuid`, **OR** legacy scope via `service_accounts.scopes` (back-compat path — see [`service-accounts.md`](./service-accounts.md)) | none — SAs are org-scoped principals |
+| SCIM token | hardcoded `scim:manage` legacy scope (manage on `OrganizationMemberProfile` and `Group` only) | none |
+| Embed JWT | n/a | dashboard-scoped subject; rules built per-token (see embed code) |
+
+## Adding a new permission
+
+The full checklist for adding a CASL subject + scope is in the root
+`CLAUDE.md` under "Authorization & Custom Roles". The short version:
+
+1. Add the subject to `CaslSubjectNames` (`types.ts`).
+2. Add the scope to `scopes.ts` (controls custom-role coverage).
+3. Add `can(...)` calls to the relevant system role functions
+   (`projectMemberAbility.ts`, `organizationMemberAbility.ts`).
+4. Update `roleToScopeMapping.ts` so system roles still map to the same scope
+   sets (the parity test enforces this).
+5. Decide whether service accounts need it: add to
+   `serviceAccountAbility.ts` (legacy scope path) and/or rely on the system-role
+   delegation (`SYSTEM_*` SA scopes inherit from `applyOrganizationMemberStaticAbilities`).
+
+### Sources of truth and how `system:*` SA scopes avoid drift
+
+The `system:*` SA scopes (`system:admin`, `system:developer`, …) **delegate**
+to `applyOrganizationMemberStaticAbilities[role]` — the same function that
+defines abilities for human users with that org role. So a new permission
+added to `organizationMemberAbility.ts` flows automatically into:
+
+- Human users with that role
+- Service accounts with the matching `system:*` scope
+- Custom roles that include the equivalent scope (after the
+  `roleToScopeMapping.ts` update)
+
+**No parallel SA-side mapping** is required for the `system:*` path — that's
+the deliberate point of the alias.
+
+The legacy `org:admin/edit/read` SA scopes in `serviceAccountAbility.ts` are
+the exception: they're hand-coded `can(...)` lists that have always drifted
+from the human-role definitions on purpose. There's no parity test today
+between `applyServiceAccountAbilities[ORG_*]` and the matching
+`applyOrganizationMemberStaticAbilities` blocks; if you care about legacy
+tokens picking up a new permission you have to add the `can(...)` line
+manually. The Phase-C `manage:ContentAsCode` regression came from exactly
+this drift.
+
+## What custom roles can't grant
+
+Anything that's CASL-checked has a corresponding scope in `scopes.ts`, so
+`buildAbilityFromScopes` covers it. The gaps are routes that **don't**
+go through CASL:
+
+- **SCIM endpoints** (`/api/v1/scim/v2/*`). They use the `isScimAuthenticated`
+  middleware which only accepts the legacy SA scope `scim:manage`. There's
+  no `manage:Scim` scope in the custom-role vocabulary.
+- **Service-account creation/management** (`/api/v1/service-accounts/*`).
+  Controllers use `assertRegisteredAccount(req.account)`, which rejects any
+  SA-bearer principal. Even an "admin" custom role can't escalate by minting
+  more SAs from a SA token — by design.
+- **Personal-access-token creation as the SA.** Same `assertRegisteredAccount`
+  gate. The `manage:PersonalAccessToken` scope exists in the vocabulary but
+  the route blocks SA principals before CASL runs.
+- **Session-only routes** (e.g., `PATCH /api/v1/org`). Some org-mutation
+  routes don't include `allowApiKeyAuthentication` middleware, so bearer
+  auth returns 401 regardless of CASL. `manage:Organization` scope exists
+  but doesn't help over a bearer token.
+- **`impersonate:User`.** The scope exists in `ORGANIZATION_MANAGEMENT`,
+  but the impersonation route is admin-only and gated outside the
+  custom-role flow.
+- **Instance-level operations** (license, instance config). Not in
+  `scopes.ts`; admin-only via session.
+
+## Project vs organization assignment of custom roles
+
+A custom role can include any subset of scopes from `scopes.ts`. What
+actually takes effect at runtime depends on **where the role is assigned**:
+
+- **`organization_memberships.role_uuid`** — `buildAbilityFromScopes` is
+  called with `{ organizationUuid }` context. Org-management scopes
+  (`manage:OrganizationMemberProfile`, `manage:InviteLink`, etc.) take
+  effect; project-only scopes still compile but only match subjects whose
+  conditions include the org uuid.
+- **`project_memberships.role_uuid`** — context is `{ projectUuid }`.
+  Project-scoped subjects match; org-management scopes silently no-op
+  because their target subjects (`OrganizationMemberProfile` etc.) don't
+  carry a `projectUuid`.
+
+This is a known UX trap: the role builder shows all scopes regardless of
+intended assignment level. An admin who toggles `manage:OrganizationMemberProfile`
+on a project-only role gets nothing — no error, just no effect. There's no
+filter or warning today; intent is preserved by convention only.
+
+## Code references
+
+- `packages/backend/src/models/UserModel.ts::generateUserAbilityBuilder` —
+  the merge point. Routes humans / SAs / PATs into the right ability builder.
+- `packages/common/src/authorization/scopeAbilityBuilder.ts` —
+  `buildAbilityFromScopes` for any custom-role-driven path.
+- `packages/common/src/authorization/projectMemberAbility.ts` &
+  `organizationMemberAbility.ts` — system role definitions.
+- `packages/common/src/authorization/serviceAccountAbility.ts` — legacy SA
+  scope handlers + the new `SYSTEM_*` aliases that delegate to the org-member
+  builders.

--- a/docs/service-accounts.md
+++ b/docs/service-accounts.md
@@ -1,0 +1,273 @@
+# Service accounts
+
+A service account (SA) is a non-human principal — a long-lived bearer token
+that authenticates as its own dedicated user record and acts on the
+organization's behalf. Use one for CI deploys, dashboards-as-code uploads,
+SCIM provisioning, scheduled scripts, etc.
+
+For the broader authentication picture (sessions, PATs, SCIM, embed) see
+[`authentication-and-roles.md`](./authentication-and-roles.md).
+
+## Anatomy
+
+Each SA has three coupled DB rows, all created in a single transaction by
+`ServiceAccountModel.save`:
+
+```
+service_accounts                       users (is_internal=true)
+─────────────────                      ─────────
+service_account_uuid                   user_uuid  ◀──────────┐
+description                            first_name = description
+expires_at                             last_name  = ''                 │
+token_hash (sha256, never the token)   is_active  = false             │
+scopes (text[])                        is_internal = true             │
+service_account_user_uuid ─────────────┘                              │
+                                                                       │
+                                       organization_memberships         │
+                                       ─────────────────────────         │
+                                       user_id     ◀─────────────────┘
+                                       organization_id
+                                       role        (ornamental tier)
+                                       role_uuid   (custom role, optional)
+```
+
+Why three rows:
+
+- The **`users` row** gives the SA a real `userUuid` so all FK-attributed
+  surfaces (`created_by_user_uuid`, audit log, scheduler ownership, ...)
+  resolve to the SA itself rather than a fallback admin. `is_internal=true`
+  filters it out of human-facing listings (`/org/users`, SCIM `/Users`,
+  share/invite pickers, login-by-email).
+- The **`organization_memberships` row** is what the auth middleware joins
+  through to land the SA in the right org with the right role. The custom-role
+  hookup lives here too (`role_uuid`), not on `service_accounts`.
+- The **`service_accounts` row** holds the credential metadata (token hash,
+  expiry, ornamental scope list) and points back at the user via
+  `service_account_user_uuid`.
+
+Token format: `ldsvc_<32 hex>` (32 random bytes, hex-encoded). The cleartext
+token is returned **once** by `POST /api/v1/service-accounts` — only the hash
+is persisted. Lose it and rotation isn't exposed (see *Rotation* below) so
+recovery means delete + recreate.
+
+## Permission shapes
+
+A new SA must specify **exactly one** of `scopes` or `roleUuid`. The model
+rejects both-or-neither with a 400 (`ParameterError`).
+
+### 1. Legacy scope (`scopes: [...]`)
+
+Coarse, pre-defined buckets. Each scope name maps to a hardcoded ability set
+in `packages/common/src/authorization/serviceAccountAbility.ts`. The current
+catalog:
+
+| Scope | Shape | Purpose |
+|---|---|---|
+| `org:read` | broad org-level read with some baseline `manage:*` (legacy) | read-only style integrations |
+| `org:edit` | inherits `org:read` + `manage:Space/ScheduledDeliveries/Tags/MetricsTree/PinnedItems/DashboardComments/SemanticViewer/Job/ContentAsCode` | most CI workflows (dashboards-as-code uploads work here — `manage:ContentAsCode` was restored after Phase C) |
+| `org:admin` | inherits `org:edit` + project deploy/update/delete, org admin, group/invite/SCIM admin | full automation principal |
+| `scim:manage` | only `manage:OrganizationMemberProfile` + `manage:Group` (no chart/dashboard surfaces at all) | dedicated to SCIM IdP integrations |
+| `system:viewer` | delegates to `applyOrganizationMemberStaticAbilities.viewer` — same CASL as a human viewer | preferred for new viewer SAs |
+| `system:interactive_viewer` | delegates to `interactive_viewer` | |
+| `system:editor` | delegates to `editor` | |
+| `system:developer` | delegates to `developer` | preview-project deploys, content-as-code, virtual views, custom SQL/fields, etc. |
+| `system:admin` | delegates to `admin` | |
+
+The `system:*` aliases are the path the create UI uses today — they keep the
+SA's ability set in lockstep with the corresponding human role with no
+parallel mapping to drift. The four legacy `org:*`/`scim:manage` scopes are
+preserved on the wire for back-compat with already-minted tokens but not
+surfaced in the UI for new SAs.
+
+### 2. Custom role (`roleUuid: "..."`)
+
+For everything more granular. The role is a row in `roles` with an arbitrary
+subset of scopes from `scopes.ts` (e.g., `view:Project`, `manage:Dashboard`,
+`manage:DeployProject`, `manage:OrganizationMemberProfile`). At create time
+the role is validated to belong to the SA's organization (cross-org
+assignments are rejected with 400). At runtime, `buildAbilityFromScopes` is
+called against the role's scope list — exactly the same path human users go
+through when they have a custom role assigned.
+
+Why this exists: the legacy `system:*` aliases are coarse — there are five
+buckets total. A custom role lets you build something like "CLI deployer
+that can `manage:DeployProject` + `manage:ContentAsCode` and *nothing else*".
+
+## Ability resolution at request time
+
+Auth middleware (`authenticateServiceAccount` in
+`packages/backend/src/ee/authentication/`) loads the SA's `users` row,
+overrides `is_active=true` on the resulting `SessionUser` (defence against
+"account deactivated" rejections downstream), and lets the request proceed.
+
+`UserModel.generateUserAbilityBuilder` then routes any `is_internal` user
+through the SA branch:
+
+```
+is_internal user:
+  ├─ has organization_memberships.role_uuid?
+  │   → buildAbilityFromScopes(custom role's scopes)        # custom-role path
+  └─ else (legacy scope SA)
+      → applyServiceAccountAbilities(service_accounts.scopes)  # legacy path
+```
+
+The custom-role path takes precedence whenever `role_uuid` is set. The
+`customRoles.enabled` flag (`CUSTOM_ROLES_ENABLED` env var) is **not**
+consulted on the SA path — it's a feature/UI gate that controls whether the
+role builder shows up in settings, not a runtime ability gate. If a SA's
+membership row points at a custom role, that role drives runtime CASL
+regardless of how the flag is set; otherwise toggling the flag would
+silently break every CI workflow keyed off a role-driven token.
+
+## Lifecycle
+
+### Creation
+
+`POST /api/v1/service-accounts`. Admin-authenticated. Body:
+
+```json
+{
+  "description": "CI deploy bot",
+  "expiresAt": "2026-12-31T00:00:00Z",
+  "scopes": ["system:developer"]      // OR "roleUuid": "<uuid>"
+}
+```
+
+Response includes the cleartext `token` once — copy it before closing the
+modal. Subsequent reads of the SA never include the token.
+
+### Authentication
+
+`Authorization: Bearer ldsvc_…`. The middleware:
+
+1. Hashes the token, looks up `service_accounts.token_hash`.
+2. Rejects if expired (`expires_at < now()`) or if the row has been deleted.
+3. Updates `last_used_at` for telemetry.
+4. Loads the linked `users` row → builds `SessionUser` from it.
+
+Rejected tokens always return 401, never leak whether the token existed or
+just expired.
+
+### Listing / inspection
+
+`GET /api/v1/service-accounts` returns every SA in the org **except**
+SCIM-only ones (filtered by `scopes <@ ['org:read','org:edit','org:admin','system:*']`).
+Each row includes the `roleUuid` (when set) so the admin UI can resolve
+the role name. Tokens are never returned here.
+
+### Deletion
+
+`DELETE /api/v1/service-accounts/{uuid}` is **tombstone semantics**:
+
+- The `service_accounts` row is removed → the token authenticates as 401.
+- The dedicated `users` row is **kept** so historical FKs
+  (`created_by_user_uuid` on charts, dashboards, schedulers, audit log) keep
+  resolving and the UI continues to render "Created by <description>" on past
+  content.
+- Cascade in the other direction (deleting the user row → drops the SA) is
+  enforced at the FK level so an orphaned SA can never exist.
+
+### Rotation
+
+There is **no** rotate endpoint exposed for the `/api/v1/service-accounts`
+route. Only SCIM tokens can rotate (via `PATCH
+/api/v1/scim/access-tokens/{uuid}/rotate`). To rotate a regular SA today:
+delete it and create a new one with the same description / scope shape, then
+update consumers. This is intentional — explicit re-create surfaces the
+permission shape to whoever's doing the rotation.
+
+### Expiration
+
+`expiresAt` is opt-in: pass `null` to mint a non-expiring token (allowed but
+discouraged), or any future ISO timestamp. Once past, the next auth attempt
+returns 401 — there's no "renew" surface; mint a new one.
+
+## Attribution
+
+The SA's `users` row is its own identity for any FK-attributed surface:
+
+- Spaces/dashboards/charts created via SA: `created_by_user_uuid` points at
+  the SA's user uuid, not at the admin who minted the token.
+- `GET /api/v1/user` with an SA token returns the SA's identity (firstName =
+  description, etc.), not a spoofed admin.
+- Audit log rows tie the action to the SA's user uuid; companion fields can
+  surface the original SA uuid for human-readable attribution in admin UIs.
+
+Pre-Phase-C this was different — the auth middleware spoofed the seeded
+admin. The Phase C cutover (already merged on `main`) introduced the
+dedicated user record. If you're chasing an attribution discrepancy in older
+content, that's likely the seam: the FKs were rewritten when the SA's user
+was provisioned by the backfill migration, but content created before the
+migration may still point at the original admin.
+
+## Internal-user filtering
+
+The SA's `users` row has `is_internal=true`. Every human-facing listing
+must filter it out — there are integration tests pinning these:
+
+- `/api/v1/org/users` (admin org member list, including search)
+- `/api/v1/scim/v2/Users` (SCIM IdP feed)
+- Share / invite pickers
+- Login-by-email lookups
+
+If you add a new query that joins `users` and surfaces results to humans,
+add `WHERE users.is_internal = false`. The integration tests in
+`packages/api-tests/tests/serviceAccounts.test.ts` will catch leaks at the
+known endpoints; new endpoints need their own coverage.
+
+## Common gotchas
+
+- **Don't reuse description as a uniqueness signal.** Two SAs with the same
+  description are valid — the SA user records are independent.
+- **`scim:manage` SAs are not general-purpose.** Their CASL only covers
+  `OrganizationMemberProfile` + `Group`. Hitting any chart/dashboard endpoint
+  returns 403 even though the token is otherwise valid (the auth middleware
+  still resolves it).
+- **Custom role assigned after creation.** There's no API to *change* an
+  existing SA's `roleUuid` post-create. To repurpose an SA, delete + recreate.
+  Updating the custom *role* itself (adding/removing scopes) does flow into
+  every assigned SA's CASL on the next request — there's no caching.
+- **Custom role deletion is blocked when assigned.** The
+  `organization_memberships.role_uuid` FK has `ON DELETE RESTRICT`. The API
+  returns 400 with a clear error rather than orphaning rows.
+- **Broad scopes do not respect space membership.** The plain `manage:Space`,
+  `manage:Dashboard`, `manage:SavedChart` scopes (no `@public` / `@assigned`
+  / `@space` modifier) compile to `{ organizationUuid }` only — no
+  `access: { $elemMatch }` filter. An SA with these scopes can edit content
+  in **private spaces** even if no human is a member of those spaces. Same
+  shape as the legacy `org:edit` / `org:admin` SAs (where the equivalent
+  `access` blocks in `applyServiceAccountAbilities` are commented out).
+  Use the `@*` modifiers for narrower, membership-aware permissions.
+
+## Maintenance notes
+
+- **`org:*` legacy SA scope drift.** The hand-coded handlers in
+  `applyServiceAccountAbilities` for `ORG_READ` / `ORG_EDIT` / `ORG_ADMIN`
+  are loose copies of the corresponding `applyOrganizationMemberStaticAbilities`
+  builders, with the SA-specific quirks (commented-out `access` blocks,
+  etc.). There's **no parity test** today, so adding a permission to a
+  human role does not automatically extend it to legacy `org:*` SA tokens.
+  The `manage:ContentAsCode` Phase-C regression came from exactly this
+  drift; the fix added it back to ORG_EDIT manually. A parity test mirroring
+  `roleToScopeParity.test.ts` would catch the next one before it lands.
+- **`system:*` SA scopes do not drift.** They delegate to
+  `applyOrganizationMemberStaticAbilities[role]` directly, so any change
+  to a human role's CASL flows through automatically. New SA tokens should
+  prefer `system:*` over the legacy `org:*` scopes for this reason.
+- **Long-term direction**: deprecate the legacy `org:*` SA scopes once
+  outstanding tokens are migrated to `system:*` equivalents. Then the
+  hand-coded `applyServiceAccountAbilities` handlers for `ORG_*` can be
+  deleted and `*MemberAbility.ts` becomes the single source of truth for
+  every principal.
+
+## Code references
+
+| Area | File |
+|---|---|
+| Token mint, validation, save transaction | `packages/backend/src/ee/models/ServiceAccountModel.ts` |
+| Service / controller | `packages/backend/src/ee/services/ServiceAccountService/`, `packages/backend/src/ee/controllers/serviceAccountsController.ts` |
+| Auth middleware | `packages/backend/src/ee/authentication/middlewares.ts` (`authenticateServiceAccount`, `isScimAuthenticated`) |
+| CASL — legacy + system aliases | `packages/common/src/authorization/serviceAccountAbility.ts` |
+| Scope vocabulary | `packages/common/src/authorization/scopes.ts` |
+| Frontend modal | `packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx` |
+| API tests | `packages/api-tests/tests/serviceAccounts.test.ts` |

--- a/packages/api-tests/tests/serviceAccounts.test.ts
+++ b/packages/api-tests/tests/serviceAccounts.test.ts
@@ -3,7 +3,11 @@ import {
     SEED_ORG_1_ADMIN,
     SEED_PROJECT,
     ServiceAccountScope,
+    type ChartAsCode,
 } from '@lightdash/common';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import * as nodePath from 'path';
 import { ApiClient, Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
 
@@ -42,6 +46,11 @@ const bearerClient = (token: string) => {
             }),
         post: <T = unknown>(path: string, body?: unknown) =>
             client.post<T>(path, body, {
+                headers: authHeader,
+                failOnStatusCode: false,
+            }),
+        put: <T = unknown>(path: string, body?: unknown) =>
+            client.put<T>(path, body, {
                 headers: authHeader,
                 failOnStatusCode: false,
             }),
@@ -688,5 +697,414 @@ describe('Service Account content attribution', () => {
         const access = detailResp.body.results.access ?? [];
         const accessUuids = access.map((a) => a.userUuid);
         expect(accessUuids).not.toContain(SEED_ORG_1_ADMIN.user_uuid);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Custom-role path. A service account can be created with a `roleUuid`
+// pointing at an org-level custom role; CASL is then derived from the role's
+// scope list via `buildAbilityFromScopes` (NOT the legacy
+// `applyServiceAccountAbilities` mapping). The two paths are mutually
+// exclusive — `scopes` and `roleUuid` cannot both be set.
+// ---------------------------------------------------------------------------
+
+const rolesUrl = `/api/v2/orgs/${SEED_ORG_1.organization_uuid}/roles`;
+
+type CreatedRole = { roleUuid: string; name: string };
+
+const createCustomRole = async (
+    admin: ApiClient,
+    name: string,
+    scopes: string[],
+): Promise<CreatedRole> => {
+    const resp = await admin.post<Body<CreatedRole>>(rolesUrl, {
+        name,
+        description: `api-test ${name}`,
+        scopes,
+    });
+    expect(resp.status).toBeGreaterThanOrEqual(200);
+    expect(resp.status).toBeLessThan(300);
+    return resp.body.results;
+};
+
+describe('Service Account custom-role path', () => {
+    let admin: ApiClient;
+    const createdRoleUuids: string[] = [];
+
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    afterAll(async () => {
+        for (const roleUuid of createdRoleUuids) {
+            // eslint-disable-next-line no-await-in-loop
+            await admin.delete(`${rolesUrl}/${roleUuid}`, {
+                failOnStatusCode: false,
+            });
+        }
+    });
+
+    it('Should create a SA bound to a custom role and respect that role’s scopes', async () => {
+        const role = await createCustomRole(admin, `cust-role ${Date.now()}`, [
+            'view:Project',
+        ]);
+        createdRoleUuids.push(role.roleUuid);
+
+        const createResp = await admin.post<
+            Body<{
+                uuid: string;
+                token: string;
+                roleUuid: string | null;
+                scopes: string[];
+            }>
+        >(`${apiUrl}/service-accounts`, {
+            description: `custom-role SA ${Date.now()}`,
+            expiresAt: inOneHour(),
+            roleUuid: role.roleUuid,
+        });
+        expect(createResp.status).toBe(201);
+        // The API echoes the roleUuid back; legacy `scopes` is empty for a
+        // role-driven SA. Anything else here would mean the controller is
+        // dropping/translating the field unexpectedly.
+        expect(createResp.body.results.roleUuid).toBe(role.roleUuid);
+        expect(createResp.body.results.scopes).toEqual([]);
+
+        const sa = bearerClient(createResp.body.results.token);
+
+        // view:Project allowed → /org/projects must succeed.
+        const projects = await sa.get(`${apiUrl}/org/projects`);
+        expect(projects.status).toBe(200);
+
+        // manage:OrganizationMemberProfile not in role → must be denied.
+        const orgUsers = await sa.get(`${apiUrl}/org/users`);
+        expect(orgUsers.status).toBe(403);
+
+        // manage:SavedChart not in role → modifying a chart must be denied.
+        // We resolve a real chart uuid from the seed project to keep this
+        // robust across reset-db cycles.
+        const chartsResp = await admin.get<Body<Array<{ uuid: string }>>>(
+            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/charts`,
+        );
+        const someChartUuid = chartsResp.body.results[0]?.uuid;
+        if (!someChartUuid) throw new Error('No charts found in seed project');
+        const patchChart = await sa.patch(`${apiUrl}/saved/${someChartUuid}`, {
+            name: 'should-not-apply',
+        });
+        expect(patchChart.status).toBe(403);
+    });
+
+    it('Should reject creation with both `scopes` and `roleUuid` set', async () => {
+        const role = await createCustomRole(admin, `mutex-both ${Date.now()}`, [
+            'view:Project',
+        ]);
+        createdRoleUuids.push(role.roleUuid);
+
+        const resp = await admin.post(
+            `${apiUrl}/service-accounts`,
+            {
+                description: 'should-not-create',
+                expiresAt: inOneHour(),
+                scopes: [ServiceAccountScope.ORG_READ],
+                roleUuid: role.roleUuid,
+            },
+            { failOnStatusCode: false },
+        );
+        expect(resp.status).toBe(400);
+    });
+
+    it('Should reject creation with neither `scopes` nor `roleUuid`', async () => {
+        const resp = await admin.post(
+            `${apiUrl}/service-accounts`,
+            {
+                description: 'should-not-create',
+                expiresAt: inOneHour(),
+            },
+            { failOnStatusCode: false },
+        );
+        expect(resp.status).toBe(400);
+    });
+
+    it('Should reject a roleUuid that does not exist in this org', async () => {
+        const resp = await admin.post(
+            `${apiUrl}/service-accounts`,
+            {
+                description: 'should-not-create',
+                expiresAt: inOneHour(),
+                // Random uuid that won't match any role.
+                roleUuid: '00000000-0000-0000-0000-000000000000',
+            },
+            { failOnStatusCode: false },
+        );
+        expect(resp.status).toBe(400);
+    });
+
+    it('Should not break legacy `scopes`-only service accounts', async () => {
+        // Smoke test for back-compat: a `scopes` SA must still authenticate
+        // and the runtime ability must come from `applyServiceAccountAbilities`
+        // (the legacy hardcoded mapping), independent of any custom role.
+        const { token } = await createServiceAccountToken(admin, [
+            ServiceAccountScope.ORG_EDIT,
+        ]);
+        const sa = bearerClient(token);
+
+        const projects = await sa.get(`${apiUrl}/org/projects`);
+        expect(projects.status).toBe(200);
+
+        // ORG_EDIT grants `manage:Space` (legacy mapping)
+        const space = await sa.post<Body<{ uuid: string }>>(
+            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
+            { name: `legacy-edit-${Date.now()}` },
+        );
+        expect(space.status).toBe(200);
+        if (space.body.results?.uuid) {
+            await admin.delete(
+                `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces/${space.body.results.uuid}`,
+                { failOnStatusCode: false },
+            );
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// CLI deploy/upload surface via a custom role. The legacy `org:edit` scope
+// does NOT grant `manage:DeployProject` or `manage:ContentAsCode`, so an SA
+// that needs to run `lightdash deploy` / `lightdash upload` would historically
+// have to use `org:admin`. The custom-role path lets operators grant exactly
+// those abilities — and nothing else — to a CI service account.
+// ---------------------------------------------------------------------------
+
+describe('Service Account custom-role: CLI deploy/upload', () => {
+    let admin: ApiClient;
+    const projectUuid = SEED_PROJECT.project_uuid;
+    const createdRoleUuids: string[] = [];
+
+    let chartAsCodeFixture: ChartAsCode;
+
+    beforeAll(async () => {
+        admin = await login();
+        chartAsCodeFixture = yaml.load(
+            fs.readFileSync(
+                nodePath.resolve(__dirname, '../fixtures/chartAsCode.yml'),
+                'utf8',
+            ),
+        ) as ChartAsCode;
+    });
+
+    afterAll(async () => {
+        for (const roleUuid of createdRoleUuids) {
+            // eslint-disable-next-line no-await-in-loop
+            await admin.delete(`${rolesUrl}/${roleUuid}`, {
+                failOnStatusCode: false,
+            });
+        }
+    });
+
+    it('legacy ORG_EDIT can upload content-as-code (back-compat for `lightdash upload`)', async () => {
+        // Pre-Phase-C the auth middleware spoofed the admin user so an
+        // `org:edit` SA implicitly had `manage:ContentAsCode`. The cutover
+        // to a dedicated SA identity dropped that and broke the existing
+        // CI workflow; `applyServiceAccountAbilities` now grants it
+        // explicitly to ORG_EDIT so `lightdash upload` keeps working.
+        // Deploy (`PUT /explores` → `manage:DeployProject`) is intentionally
+        // still admin-only — that workflow is heavier and needs explicit
+        // opt-in via either ORG_ADMIN or a custom role.
+        const { token } = await createServiceAccountToken(admin, [
+            ServiceAccountScope.ORG_EDIT,
+        ]);
+        const sa = bearerClient(token);
+
+        const cac = await sa.post(
+            `${apiUrl}/projects/${projectUuid}/charts/${chartAsCodeFixture.slug}/code`,
+            chartAsCodeFixture,
+        );
+        expect(cac.status).toBe(200);
+
+        const deploy = await sa.put(
+            `${apiUrl}/projects/${projectUuid}/explores`,
+            [],
+        );
+        expect(deploy.status).toBe(403);
+    });
+
+    // The `system:*` SA scopes delegate to the same
+    // `applyOrganizationMemberStaticAbilities` builders that human users go
+    // through, so the SA's CASL must match the user-with-this-role shape.
+    // We exercise a representative slice — admin / developer / editor /
+    // viewer — and pin: who can deploy, who can upload CAC, who can
+    // create spaces.
+    it('system:admin grants the same shape as a human admin (deploy + CAC + space)', async () => {
+        const { token } = await createServiceAccountToken(admin, [
+            ServiceAccountScope.SYSTEM_ADMIN,
+        ]);
+        const sa = bearerClient(token);
+        // PUT /explores with `[]` lands at body validation downstream of
+        // CASL, so a non-401/403 status is what proves the role passed
+        // the deploy permission check. Sending real explores would corrupt
+        // the seeded project's catalog.
+        const deployStatus = (
+            await sa.put(`${apiUrl}/projects/${projectUuid}/explores`, [])
+        ).status;
+        expect([401, 403]).not.toContain(deployStatus);
+        expect(
+            (
+                await sa.post(
+                    `${apiUrl}/projects/${projectUuid}/charts/${chartAsCodeFixture.slug}/code`,
+                    chartAsCodeFixture,
+                )
+            ).status,
+        ).toBe(200);
+        const space = await sa.post<Body<{ uuid: string }>>(
+            `${apiUrl}/projects/${projectUuid}/spaces`,
+            { name: `system-admin-${Date.now()}` },
+        );
+        expect(space.status).toBe(200);
+        if (space.body.results?.uuid) {
+            await admin.delete(
+                `${apiUrl}/projects/${projectUuid}/spaces/${space.body.results.uuid}`,
+                { failOnStatusCode: false },
+            );
+        }
+    });
+
+    it('system:developer grants CAC + spaces but NOT deploy on a non-preview project', async () => {
+        const { token } = await createServiceAccountToken(admin, [
+            ServiceAccountScope.SYSTEM_DEVELOPER,
+        ]);
+        const sa = bearerClient(token);
+        // Developer's `manage:DeployProject` is conditional on preview
+        // projects the SA itself created — the seeded Jaffle Shop is type
+        // DEFAULT so deploy is denied (mirrors human-developer behavior).
+        expect(
+            (await sa.put(`${apiUrl}/projects/${projectUuid}/explores`, []))
+                .status,
+        ).toBe(403);
+        expect(
+            (
+                await sa.post(
+                    `${apiUrl}/projects/${projectUuid}/charts/${chartAsCodeFixture.slug}/code`,
+                    chartAsCodeFixture,
+                )
+            ).status,
+        ).toBe(200);
+        const space = await sa.post<Body<{ uuid: string }>>(
+            `${apiUrl}/projects/${projectUuid}/spaces`,
+            { name: `system-developer-${Date.now()}` },
+        );
+        expect(space.status).toBe(200);
+        if (space.body.results?.uuid) {
+            await admin.delete(
+                `${apiUrl}/projects/${projectUuid}/spaces/${space.body.results.uuid}`,
+                { failOnStatusCode: false },
+            );
+        }
+    });
+
+    it('system:editor cannot deploy or upload CAC, but can manage spaces', async () => {
+        const { token } = await createServiceAccountToken(admin, [
+            ServiceAccountScope.SYSTEM_EDITOR,
+        ]);
+        const sa = bearerClient(token);
+        expect(
+            (await sa.put(`${apiUrl}/projects/${projectUuid}/explores`, []))
+                .status,
+        ).toBe(403);
+        expect(
+            (
+                await sa.post(
+                    `${apiUrl}/projects/${projectUuid}/charts/${chartAsCodeFixture.slug}/code`,
+                    chartAsCodeFixture,
+                )
+            ).status,
+        ).toBe(403);
+        const space = await sa.post<Body<{ uuid: string }>>(
+            `${apiUrl}/projects/${projectUuid}/spaces`,
+            { name: `system-editor-${Date.now()}` },
+        );
+        expect(space.status).toBe(200);
+        if (space.body.results?.uuid) {
+            await admin.delete(
+                `${apiUrl}/projects/${projectUuid}/spaces/${space.body.results.uuid}`,
+                { failOnStatusCode: false },
+            );
+        }
+    });
+
+    it('system:viewer cannot deploy, upload, or create spaces', async () => {
+        const { token } = await createServiceAccountToken(admin, [
+            ServiceAccountScope.SYSTEM_VIEWER,
+        ]);
+        const sa = bearerClient(token);
+        expect(
+            (await sa.put(`${apiUrl}/projects/${projectUuid}/explores`, []))
+                .status,
+        ).toBe(403);
+        expect(
+            (
+                await sa.post(
+                    `${apiUrl}/projects/${projectUuid}/charts/${chartAsCodeFixture.slug}/code`,
+                    chartAsCodeFixture,
+                )
+            ).status,
+        ).toBe(403);
+        expect(
+            (
+                await sa.post(`${apiUrl}/projects/${projectUuid}/spaces`, {
+                    name: `system-viewer-${Date.now()}`,
+                })
+            ).status,
+        ).toBe(403);
+    });
+
+    it('a custom role with `manage:DeployProject` + `manage:ContentAsCode` lets the SA deploy and upload', async () => {
+        const role = await createCustomRole(
+            admin,
+            `cli-deployer ${Date.now()}`,
+            [
+                'view:Project',
+                'manage:DeployProject',
+                'manage:ContentAsCode',
+                'manage:Space',
+                'manage:Dashboard',
+                'manage:SavedChart',
+            ],
+        );
+        createdRoleUuids.push(role.roleUuid);
+
+        const createResp = await admin.post<Body<{ token: string }>>(
+            `${apiUrl}/service-accounts`,
+            {
+                description: `cli-deployer SA ${Date.now()}`,
+                expiresAt: inOneHour(),
+                roleUuid: role.roleUuid,
+            },
+        );
+        expect(createResp.status).toBe(201);
+        const sa = bearerClient(createResp.body.results.token);
+
+        // PUT /explores → manage:DeployProject (the deploy command).
+        // Body validation happens after CASL; not-401/403 is what proves
+        // the role passed the deploy permission check.
+        const deploy = await sa.put(
+            `${apiUrl}/projects/${projectUuid}/explores`,
+            [],
+        );
+        expect([401, 403]).not.toContain(deploy.status);
+
+        // POST /charts/<slug>/code → manage:ContentAsCode (the upload command)
+        const cac = await sa.post(
+            `${apiUrl}/projects/${projectUuid}/charts/${chartAsCodeFixture.slug}/code`,
+            chartAsCodeFixture,
+        );
+        expect(cac.status).toBe(200);
+
+        // Negative: the role doesn't grant `delete:Project` or org-member
+        // management; those must still be denied.
+        const deleteProject = await sa.delete(
+            `${apiUrl}/org/projects/${projectUuid}`,
+        );
+        expect(deleteProject.status).toBe(403);
+
+        const orgUsers = await sa.get(`${apiUrl}/org/users`);
+        expect(orgUsers.status).toBe(403);
     });
 });

--- a/packages/backend/src/ee/authentication/middleware.mock.ts
+++ b/packages/backend/src/ee/authentication/middleware.mock.ts
@@ -21,6 +21,7 @@ export const mockServiceAccount: ServiceAccount = {
     rotatedAt: null,
     scopes: [ServiceAccountScope.SCIM_MANAGE],
     userUuid: 'sa-user-uuid',
+    roleUuid: null,
 };
 
 const mockSaSessionUser = {

--- a/packages/backend/src/ee/authentication/serviceAccount.mock.ts
+++ b/packages/backend/src/ee/authentication/serviceAccount.mock.ts
@@ -23,6 +23,7 @@ export const mockServiceAccount: ServiceAccount = {
     rotatedAt: null,
     scopes: [ServiceAccountScope.ORG_ADMIN],
     userUuid: 'sa-dedicated-user-uuid',
+    roleUuid: null,
 };
 
 export const mockExpiredServiceAccount: ServiceAccount = {

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -2,6 +2,7 @@ import {
     AuthTokenPrefix,
     CreateServiceAccount,
     OrganizationMemberRole,
+    ParameterError,
     ServiceAccount,
     ServiceAccountScope,
     ServiceAccountWithToken,
@@ -10,12 +11,18 @@ import {
 } from '@lightdash/common';
 import * as crypto from 'crypto';
 import { Knex } from 'knex';
+import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
+import { RolesTableName } from '../../database/entities/roles';
 import { DbUser } from '../../database/entities/users';
 import { deprecatedHash, hash } from '../../utils/hash';
 import {
     DbServiceAccounts,
     ServiceAccountsTableName,
 } from '../database/entities/serviceAccounts';
+
+type DbServiceAccountWithRole = DbServiceAccounts & {
+    role_uuid: string | null;
+};
 
 export class ServiceAccountModel {
     private readonly database: Knex;
@@ -25,7 +32,7 @@ export class ServiceAccountModel {
     }
 
     static mapDbObjectToServiceAccount(
-        data: DbServiceAccounts,
+        data: DbServiceAccountWithRole,
     ): ServiceAccount {
         if (!data.service_account_user_uuid) {
             // Backfill migration populates this for every existing row, and
@@ -48,7 +55,31 @@ export class ServiceAccountModel {
             createdByUserUuid: data.created_by_user_uuid,
             scopes: data.scopes as ServiceAccountScope[],
             userUuid: data.service_account_user_uuid,
+            roleUuid: data.role_uuid ?? null,
         };
+    }
+
+    /**
+     * Returns the SELECT shape used by all read paths. Joins
+     * `organization_memberships` to surface the SA's optional org-level
+     * custom role assignment alongside the service_accounts columns.
+     */
+    private serviceAccountSelectQuery() {
+        return this.database(ServiceAccountsTableName)
+            .leftJoin(
+                'users',
+                'users.user_uuid',
+                `${ServiceAccountsTableName}.service_account_user_uuid`,
+            )
+            .leftJoin(
+                OrganizationMembershipsTableName,
+                `${OrganizationMembershipsTableName}.user_id`,
+                'users.user_id',
+            )
+            .select<DbServiceAccountWithRole[]>(
+                `${ServiceAccountsTableName}.*`,
+                `${OrganizationMembershipsTableName}.role_uuid`,
+            );
     }
 
     static generateToken(prefix: string = ''): string {
@@ -84,6 +115,25 @@ export class ServiceAccountModel {
     static getRoleForScopes(
         scopes: ServiceAccountScope[],
     ): OrganizationMemberRole {
+        // Prefer explicit `system:*` scopes — they map 1:1 to the org role
+        // tier and let admin-UI listings show "Admin/Developer/..." rather
+        // than collapsing everything onto the legacy three-bucket scheme.
+        if (scopes.includes(ServiceAccountScope.SYSTEM_ADMIN)) {
+            return OrganizationMemberRole.ADMIN;
+        }
+        if (scopes.includes(ServiceAccountScope.SYSTEM_DEVELOPER)) {
+            return OrganizationMemberRole.DEVELOPER;
+        }
+        if (scopes.includes(ServiceAccountScope.SYSTEM_EDITOR)) {
+            return OrganizationMemberRole.EDITOR;
+        }
+        if (scopes.includes(ServiceAccountScope.SYSTEM_INTERACTIVE_VIEWER)) {
+            return OrganizationMemberRole.INTERACTIVE_VIEWER;
+        }
+        if (scopes.includes(ServiceAccountScope.SYSTEM_VIEWER)) {
+            return OrganizationMemberRole.VIEWER;
+        }
+        // Legacy coarse scopes
         if (scopes.includes(ServiceAccountScope.ORG_ADMIN)) {
             return OrganizationMemberRole.ADMIN;
         }
@@ -101,10 +151,46 @@ export class ServiceAccountModel {
         data: CreateServiceAccount,
         token: string,
     ): Promise<ServiceAccountWithToken> {
+        // Permission shape: exactly one of `scopes` (legacy preset) or
+        // `roleUuid` (custom org role) must drive runtime CASL. Sending both
+        // is rejected so we always have one source of truth.
+        const hasScopes = !!data.scopes && data.scopes.length > 0;
+        const hasRoleUuid = !!data.roleUuid;
+        if (hasScopes && hasRoleUuid) {
+            throw new ParameterError(
+                'Specify either scopes or roleUuid, not both',
+            );
+        }
+        if (!hasScopes && !hasRoleUuid) {
+            throw new ParameterError(
+                'A service account must have either scopes or a roleUuid',
+            );
+        }
+
         const tokenHash = await hash(token);
-        const role = ServiceAccountModel.getRoleForScopes(data.scopes);
+        const scopes = data.scopes ?? [];
+        // Ornamental org-membership role: only consulted by admin-UI listings.
+        // For custom-role-driven SAs, default to MEMBER (least privilege at
+        // the FK level); for legacy-scope SAs, derive from the broadest scope.
+        const role = hasRoleUuid
+            ? OrganizationMemberRole.MEMBER
+            : ServiceAccountModel.getRoleForScopes(scopes);
 
         return this.database.transaction(async (trx) => {
+            // If a custom role was provided, validate it belongs to the SA's
+            // organization (defence against cross-org role assignment).
+            if (data.roleUuid) {
+                const [roleRow] = await trx(RolesTableName)
+                    .where('role_uuid', data.roleUuid)
+                    .andWhere('organization_uuid', data.organizationUuid)
+                    .select('role_uuid');
+                if (!roleRow) {
+                    throw new ParameterError(
+                        `Role ${data.roleUuid} not found in this organization`,
+                    );
+                }
+            }
+
             // Dedicated user row for this service account. Marked
             // `is_internal = true` so listings/login/SCIM filter it out;
             // `is_active = false` defends-in-depth against any login path.
@@ -139,10 +225,11 @@ export class ServiceAccountModel {
                 );
             }
 
-            await trx('organization_memberships').insert({
+            await trx(OrganizationMembershipsTableName).insert({
                 user_id: saUser.user_id,
                 organization_id: org.organization_id,
                 role,
+                role_uuid: data.roleUuid ?? null,
             });
 
             const [row] = await trx(ServiceAccountsTableName)
@@ -152,7 +239,7 @@ export class ServiceAccountModel {
                     expires_at: data.expiresAt,
                     description: data.description,
                     token_hash: tokenHash,
-                    scopes: data.scopes,
+                    scopes,
                     service_account_user_uuid: saUser.user_uuid,
                 })
                 .returning('*');
@@ -162,7 +249,10 @@ export class ServiceAccountModel {
                 );
             }
             return {
-                ...ServiceAccountModel.mapDbObjectToServiceAccount(row),
+                ...ServiceAccountModel.mapDbObjectToServiceAccount({
+                    ...row,
+                    role_uuid: data.roleUuid ?? null,
+                }),
                 token,
             };
         });
@@ -202,15 +292,18 @@ export class ServiceAccountModel {
         const token = ServiceAccountModel.generateToken(prefix);
         const tokenHash = await hash(token);
 
-        const [row] = await this.database(ServiceAccountsTableName)
+        await this.database(ServiceAccountsTableName)
             .update({
                 rotated_at: new Date(),
                 rotated_by_user_uuid: rotatedByUserUuid,
                 expires_at: expiresAt,
                 token_hash: tokenHash,
             })
-            .where('service_account_uuid', serviceAccountUuid)
-            .returning('*');
+            .where('service_account_uuid', serviceAccountUuid);
+        const [row] = await this.serviceAccountSelectQuery().where(
+            `${ServiceAccountsTableName}.service_account_uuid`,
+            serviceAccountUuid,
+        );
         return {
             ...ServiceAccountModel.mapDbObjectToServiceAccount(row),
             token,
@@ -221,12 +314,15 @@ export class ServiceAccountModel {
         organizationUuid: string,
         scopes?: ServiceAccountScope[],
     ): Promise<ServiceAccount[]> {
-        const query = this.database('service_accounts')
-            .select('*')
-            .where('organization_uuid', organizationUuid);
+        const query = this.serviceAccountSelectQuery().where(
+            `${ServiceAccountsTableName}.organization_uuid`,
+            organizationUuid,
+        );
         if (scopes) {
             // scopes <@ ? returns true only if the database's scopes array is a full subset of elements from the provided scopes array
-            void query.whereRaw('scopes <@ ?', [scopes]);
+            void query.whereRaw(`${ServiceAccountsTableName}.scopes <@ ?`, [
+                scopes,
+            ]);
         }
         const rows = await query;
         return rows.map(ServiceAccountModel.mapDbObjectToServiceAccount);
@@ -235,18 +331,21 @@ export class ServiceAccountModel {
     async getTokenbyUuid(
         serviceAccountUuid: string,
     ): Promise<ServiceAccount | undefined> {
-        const [row] = await this.database('service_accounts')
-            .select('*')
-            .where('service_account_uuid', serviceAccountUuid);
+        const [row] = await this.serviceAccountSelectQuery().where(
+            `${ServiceAccountsTableName}.service_account_uuid`,
+            serviceAccountUuid,
+        );
         return row && ServiceAccountModel.mapDbObjectToServiceAccount(row);
     }
 
     async getByToken(token: string): Promise<ServiceAccount> {
         const hashedToken = await hash(token);
-        const [row] = await this.database('service_accounts')
-            .select('*')
-            .where('token_hash', hashedToken)
-            .orWhere('token_hash', deprecatedHash(token)); // Adding old sha256 hash for backwards compatibility
+        const [row] = await this.serviceAccountSelectQuery()
+            .where(`${ServiceAccountsTableName}.token_hash`, hashedToken)
+            .orWhere(
+                `${ServiceAccountsTableName}.token_hash`,
+                deprecatedHash(token),
+            ); // Adding old sha256 hash for backwards compatibility
         const mappedRow = ServiceAccountModel.mapDbObjectToServiceAccount(row);
         return mappedRow;
     }

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -87,6 +87,7 @@ export class ServiceAccountService extends BaseService {
                     expiresAt: tokenDetails.expiresAt,
                     description: tokenDetails.description,
                     scopes: tokenDetails.scopes,
+                    roleUuid: tokenDetails.roleUuid,
                 },
                 prefix,
             });
@@ -99,7 +100,10 @@ export class ServiceAccountService extends BaseService {
             });
             return token;
         } catch (error) {
-            if (error instanceof ForbiddenError) {
+            if (
+                error instanceof ForbiddenError ||
+                error instanceof ParameterError
+            ) {
                 throw error;
             }
             this.logger.error(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -197,7 +197,17 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ServiceAccountScope: {
         dataType: 'refEnum',
-        enums: ['scim:manage', 'org:admin', 'org:edit', 'org:read'],
+        enums: [
+            'scim:manage',
+            'org:admin',
+            'org:edit',
+            'org:read',
+            'system:admin',
+            'system:developer',
+            'system:editor',
+            'system:interactive_viewer',
+            'system:viewer',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ServiceAccount: {
@@ -205,6 +215,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                roleUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 userUuid: { dataType: 'string', required: true },
                 scopes: {
                     dataType: 'array',
@@ -252,7 +270,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ServiceAccount.expiresAt-or-description-or-scopes_': {
+    'Pick_ServiceAccount.expiresAt-or-description_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -266,11 +284,6 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 description: { dataType: 'string', required: true },
-                scopes: {
-                    dataType: 'array',
-                    array: { dataType: 'refEnum', ref: 'ServiceAccountScope' },
-                    required: true,
-                },
             },
             validators: {},
         },
@@ -279,7 +292,29 @@ const models: TsoaRoute.Models = {
     ApiCreateServiceAccountRequest: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_ServiceAccount.expiresAt-or-description-or-scopes_',
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Pick_ServiceAccount.expiresAt-or-description_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        roleUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
+                        scopes: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refEnum',
+                                ref: 'ServiceAccountScope',
+                            },
+                        },
+                    },
+                },
+            ],
             validators: {},
         },
     },
@@ -997,25 +1032,6 @@ const models: TsoaRoute.Models = {
             },
         },
         additionalProperties: true,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ServiceAccount.expiresAt-or-description_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                expiresAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'datetime' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                description: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCreateScimServiceAccountRequest: {
@@ -9142,11 +9158,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9161,11 +9177,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9180,11 +9196,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9215,29 +9231,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                chartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 searchRank:
                                                                                                     {
                                                                                                         dataType:
@@ -9261,11 +9254,28 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
                                                                                                     },
                                                                                                 tableName:
                                                                                                     {
@@ -9278,6 +9288,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9393,11 +9409,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9473,29 +9489,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    chartUsage:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     searchRank:
                                                                                                         {
                                                                                                             dataType:
@@ -9519,11 +9512,28 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
                                                                                                         },
                                                                                                     tableName:
                                                                                                         {
@@ -9536,6 +9546,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9567,11 +9583,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9586,11 +9602,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -21465,7 +21481,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21475,7 +21491,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21485,7 +21501,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21498,7 +21514,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21909,7 +21925,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21919,7 +21935,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21929,7 +21945,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21942,7 +21958,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -58,11 +58,25 @@
                 "type": "object"
             },
             "ServiceAccountScope": {
-                "enum": ["scim:manage", "org:admin", "org:edit", "org:read"],
+                "enum": [
+                    "scim:manage",
+                    "org:admin",
+                    "org:edit",
+                    "org:read",
+                    "system:admin",
+                    "system:developer",
+                    "system:editor",
+                    "system:interactive_viewer",
+                    "system:viewer"
+                ],
                 "type": "string"
             },
             "ServiceAccount": {
                 "properties": {
+                    "roleUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "userUuid": {
                         "type": "string"
                     },
@@ -106,6 +120,7 @@
                     }
                 },
                 "required": [
+                    "roleUuid",
                     "userUuid",
                     "scopes",
                     "rotatedAt",
@@ -119,7 +134,7 @@
                 ],
                 "type": "object"
             },
-            "Pick_ServiceAccount.expiresAt-or-description-or-scopes_": {
+            "Pick_ServiceAccount.expiresAt-or-description_": {
                 "properties": {
                     "expiresAt": {
                         "type": "string",
@@ -128,20 +143,33 @@
                     },
                     "description": {
                         "type": "string"
-                    },
-                    "scopes": {
-                        "items": {
-                            "$ref": "#/components/schemas/ServiceAccountScope"
-                        },
-                        "type": "array"
                     }
                 },
-                "required": ["expiresAt", "description", "scopes"],
+                "required": ["expiresAt", "description"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ApiCreateServiceAccountRequest": {
-                "$ref": "#/components/schemas/Pick_ServiceAccount.expiresAt-or-description-or-scopes_"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_ServiceAccount.expiresAt-or-description_"
+                    },
+                    {
+                        "properties": {
+                            "roleUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "scopes": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ServiceAccountScope"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
             },
             "ScimSchemaType.LIST_RESPONSE": {
                 "enum": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
@@ -1004,21 +1032,6 @@
                 ],
                 "type": "object",
                 "additionalProperties": true
-            },
-            "Pick_ServiceAccount.expiresAt-or-description_": {
-                "properties": {
-                    "expiresAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "nullable": true
-                    },
-                    "description": {
-                        "type": "string"
-                    }
-                },
-                "required": ["expiresAt", "description"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ApiCreateScimServiceAccountRequest": {
                 "$ref": "#/components/schemas/Pick_ServiceAccount.expiresAt-or-description_"
@@ -10594,36 +10607,20 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "error",
-                                                            "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10631,14 +10628,17 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
+                                                                        "fieldType": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10687,8 +10687,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10732,18 +10732,15 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
-                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10751,14 +10748,17 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
+                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10786,8 +10786,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -22879,22 +22879,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -23249,22 +23249,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -31732,7 +31732,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2879.0",
+        "version": "0.2884.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -3,6 +3,7 @@ import {
     ActivateUser,
     AlreadyExistsError,
     applyServiceAccountAbilities,
+    buildAbilityFromScopes,
     CreateUserArgs,
     CreateUserWithRole,
     ForbiddenError,
@@ -625,12 +626,57 @@ export class UserModel {
         );
 
         // Service accounts get a dedicated `users` row marked `is_internal`.
-        // Their runtime authorization comes from `applyServiceAccountAbilities`
-        // (driven by the SA's scopes), not the role/project ability builder
-        // — so this branch covers both live SA requests and worker
-        // re-hydration (schedulers, async queries) without a scope→role
-        // regression. v2 will unify this onto the standard role-based path.
+        // Two permission shapes coexist:
+        //  1. Custom org role (preferred): `organization_memberships.role_uuid`
+        //     points at a custom role; CASL composes from its `scoped_roles`
+        //     via the standard `buildAbilityFromScopes` path. UI scope-toggling
+        //     drives runtime behavior end-to-end.
+        //  2. Legacy scopes (back-compat): `service_accounts.scopes` drives
+        //     CASL via `applyServiceAccountAbilities`. SAs created before
+        //     custom-role support keep working unchanged.
         if (user.is_internal) {
+            // Custom-role path: if the SA's user has a role_uuid set, build
+            // CASL from that role's scopes. Reuses the same loader the human
+            // path uses below. The `customRoles.enabled` flag is intentionally
+            // NOT consulted here — it's a feature/UI gate (does the role
+            // builder appear in settings?), not a runtime ability gate. Once
+            // a role exists in the DB and is bound to the SA's
+            // organization_membership, the runtime must respect it. If we
+            // silently neutered role-driven SAs whenever an admin toggled
+            // the flag off, every CI workflow on those tokens would 403
+            // overnight.
+            if (user.role_uuid) {
+                const customRoleScopes = await this.customRoleScopes([
+                    user.role_uuid,
+                ]);
+                const scopes = customRoleScopes[user.role_uuid];
+                if (scopes) {
+                    const builder = new AbilityBuilder<MemberAbility>(Ability);
+                    buildAbilityFromScopes(
+                        {
+                            organizationUuid: user.organization_uuid as string,
+                            userUuid: user.user_uuid,
+                            scopes,
+                            isEnterprise:
+                                this.lightdashConfig.license.licenseKey !==
+                                undefined,
+                            organizationRole: user.role,
+                            permissionsConfig: {
+                                pat: this.lightdashConfig.auth.pat,
+                            },
+                        },
+                        builder,
+                    );
+                    return {
+                        abilityBuilder: builder,
+                        lightdashUser,
+                    };
+                }
+            }
+
+            // Legacy scopes path: SA pre-dates custom-role support, or the
+            // role lookup didn't resolve. Fall back to the scope-derived
+            // ability set.
             const serviceAccount = await this.findServiceAccountByUserUuid(
                 user.user_uuid,
             );
@@ -639,6 +685,7 @@ export class UserModel {
                 applyServiceAccountAbilities({
                     scopes: serviceAccount.scopes,
                     organizationUuid: serviceAccount.organizationUuid,
+                    userUuid: user.user_uuid,
                     builder,
                 });
                 return {

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -1,0 +1,201 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import { OrganizationMemberRole } from '../types/organizationMemberProfile';
+import { getUserAbilityBuilder } from './index';
+import applyOrganizationMemberAbilities from './organizationMemberAbility';
+import { type MemberAbility } from './types';
+
+const ORG_UUID = 'test-org-uuid';
+const USER_UUID = 'test-user-uuid';
+const CUSTOM_ROLE_UUID = '11111111-1111-4111-a111-111111111111';
+
+const PERMISSIONS_CONFIG = {
+    pat: { enabled: false, allowedOrgRoles: [] },
+};
+
+const buildExpected = (role: OrganizationMemberRole) => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    applyOrganizationMemberAbilities({
+        role,
+        member: { organizationUuid: ORG_UUID, userUuid: USER_UUID },
+        builder,
+        permissionsConfig: PERMISSIONS_CONFIG,
+    });
+    return builder.build().rules;
+};
+
+const ruleSetEqual = (a: unknown[], b: unknown[]) => {
+    expect(a.length).toBe(b.length);
+    expect(JSON.stringify(a.slice().sort())).toBe(
+        JSON.stringify(b.slice().sort()),
+    );
+};
+
+describe('getUserAbilityBuilder — org-level role resolution', () => {
+    describe('Backwards compatibility with system roles', () => {
+        it.each([
+            OrganizationMemberRole.MEMBER,
+            OrganizationMemberRole.VIEWER,
+            OrganizationMemberRole.INTERACTIVE_VIEWER,
+            OrganizationMemberRole.EDITOR,
+            OrganizationMemberRole.DEVELOPER,
+            OrganizationMemberRole.ADMIN,
+        ])(
+            '%s user without roleUuid uses the system role path (unchanged)',
+            (role) => {
+                const builder = getUserAbilityBuilder({
+                    user: {
+                        role,
+                        organizationUuid: ORG_UUID,
+                        userUuid: USER_UUID,
+                        roleUuid: undefined,
+                    },
+                    projectProfiles: [],
+                    permissionsConfig: PERMISSIONS_CONFIG,
+                });
+                ruleSetEqual(builder.build().rules, buildExpected(role));
+            },
+        );
+    });
+
+    describe('Custom-roles feature flag', () => {
+        it('falls through to the system role path when customRolesEnabled=false (even if roleUuid is set)', () => {
+            const builder = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.ADMIN,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: CUSTOM_ROLE_UUID,
+                },
+                projectProfiles: [],
+                permissionsConfig: PERMISSIONS_CONFIG,
+                customRoleScopes: { [CUSTOM_ROLE_UUID]: ['view:Dashboard'] },
+                customRolesEnabled: false, // gate off
+            });
+            ruleSetEqual(
+                builder.build().rules,
+                buildExpected(OrganizationMemberRole.ADMIN),
+            );
+        });
+
+        it('falls through to the system role path when customRolesEnabled=true but the role has no scopes loaded', () => {
+            const builder = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.ADMIN,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: CUSTOM_ROLE_UUID,
+                },
+                projectProfiles: [],
+                permissionsConfig: PERMISSIONS_CONFIG,
+                customRoleScopes: {}, // no scopes for this role
+                customRolesEnabled: true,
+            });
+            ruleSetEqual(
+                builder.build().rules,
+                buildExpected(OrganizationMemberRole.ADMIN),
+            );
+        });
+    });
+
+    describe('Org-level custom role active', () => {
+        it('uses the scope-derived path when roleUuid + customRolesEnabled + scopes are all present', () => {
+            // A custom role granting only view:Dashboard. Admin's normal
+            // abilities should NOT appear (e.g. manage:InviteLink).
+            const builder = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.ADMIN, // ignored — custom role wins
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: CUSTOM_ROLE_UUID,
+                },
+                projectProfiles: [],
+                permissionsConfig: PERMISSIONS_CONFIG,
+                customRoleScopes: { [CUSTOM_ROLE_UUID]: ['view:Dashboard'] },
+                customRolesEnabled: true,
+            });
+            const ability = builder.build();
+            // Custom role grants what the scope says
+            expect(
+                ability.rules.find((r) => r.subject === 'Dashboard'),
+            ).toBeDefined();
+            // Admin abilities are NOT present
+            expect(
+                ability.rules.find((r) => r.subject === 'InviteLink'),
+            ).toBeUndefined();
+            expect(
+                ability.rules.find((r) => r.subject === 'Organization'),
+            ).toBeUndefined();
+        });
+
+        it('different custom roles produce different abilities (smoke)', () => {
+            const READ_ONLY_UUID = '22222222-2222-4222-a222-222222222222';
+            const EDIT_UUID = '33333333-3333-4333-a333-333333333333';
+
+            const readOnlyBuilder = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: READ_ONLY_UUID,
+                },
+                projectProfiles: [],
+                permissionsConfig: PERMISSIONS_CONFIG,
+                customRoleScopes: {
+                    [READ_ONLY_UUID]: ['view:Dashboard'],
+                    [EDIT_UUID]: ['view:Dashboard', 'manage:Dashboard'],
+                },
+                customRolesEnabled: true,
+            });
+
+            const editBuilder = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: EDIT_UUID,
+                },
+                projectProfiles: [],
+                permissionsConfig: PERMISSIONS_CONFIG,
+                customRoleScopes: {
+                    [READ_ONLY_UUID]: ['view:Dashboard'],
+                    [EDIT_UUID]: ['view:Dashboard', 'manage:Dashboard'],
+                },
+                customRolesEnabled: true,
+            });
+
+            const readOnlyRules = readOnlyBuilder.build().rules;
+            const editRules = editBuilder.build().rules;
+            // Edit role has manage rules; readOnly does not
+            expect(editRules.some((r) => r.action === 'manage')).toBe(true);
+            expect(readOnlyRules.some((r) => r.action === 'manage')).toBe(
+                false,
+            );
+        });
+    });
+
+    describe('Project profile resolution still works alongside org-level custom roles', () => {
+        it('combines org system role with project-level system role', () => {
+            const PROJECT_UUID = 'test-project-uuid';
+            const builder = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: undefined,
+                },
+                projectProfiles: [
+                    {
+                        projectUuid: PROJECT_UUID,
+                        role: 'admin' as never, // ProjectMemberRole.ADMIN
+                        userUuid: USER_UUID,
+                        roleUuid: undefined,
+                    },
+                ],
+                permissionsConfig: PERMISSIONS_CONFIG,
+            });
+            const { rules } = builder.build();
+            // Org member abilities (minimal) plus project admin abilities
+            expect(rules.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -37,16 +37,39 @@ export const getUserAbilityBuilder = ({
 }: UserAbilityBuilderArgs) => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     if (user.role && user.organizationUuid) {
-        // TODO custom roles at organization level are not supported yet
-        applyOrganizationMemberAbilities({
-            role: user.role,
-            member: {
-                organizationUuid: user.organizationUuid,
-                userUuid: user.userUuid,
-            },
-            builder,
-            permissionsConfig,
-        });
+        // Org-level custom role: if the user's organization_memberships row
+        // points at a role_uuid AND custom roles are enabled AND we have the
+        // role's scopes, build CASL from those scopes (same path as
+        // project-level custom roles below). Falls back to the system role
+        // path otherwise.
+        const orgCustomRoleScopes =
+            customRolesEnabled && user.roleUuid
+                ? customRoleScopes?.[user.roleUuid]
+                : undefined;
+
+        if (orgCustomRoleScopes) {
+            buildAbilityFromScopes(
+                {
+                    organizationUuid: user.organizationUuid,
+                    userUuid: user.userUuid,
+                    scopes: orgCustomRoleScopes,
+                    isEnterprise,
+                    organizationRole: user.role,
+                    permissionsConfig,
+                },
+                builder,
+            );
+        } else {
+            applyOrganizationMemberAbilities({
+                role: user.role,
+                member: {
+                    organizationUuid: user.organizationUuid,
+                    userUuid: user.userUuid,
+                },
+                builder,
+                permissionsConfig,
+            });
+        }
 
         projectProfiles.forEach((projectProfile) => {
             if (projectProfile.roleUuid && customRolesEnabled) {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -20,7 +20,7 @@ const applyOrganizationMemberDynamicAbilities = ({
     }
 };
 
-const applyOrganizationMemberStaticAbilities: Record<
+export const applyOrganizationMemberStaticAbilities: Record<
     OrganizationMemberRole,
     (
         member: OrganizationMemberAbilitiesArgs['member'],

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -1,11 +1,19 @@
 import { type AbilityBuilder } from '@casl/ability';
 import { ServiceAccountScope } from '../ee/serviceAccounts/types';
+import { OrganizationMemberRole } from '../types/organizationMemberProfile';
 import { ProjectType } from '../types/projects';
+import { applyOrganizationMemberStaticAbilities } from './organizationMemberAbility';
 import { type MemberAbility } from './types';
 
 type ServiceAccountAbilitiesArgs = {
     organizationUuid: string;
     builder: Pick<AbilityBuilder<MemberAbility>, 'can'>;
+    // Dedicated user uuid for the service account. Required so that
+    // `*@self`-style ability conditions (e.g. `manage:DeployProject@self`,
+    // `delete:Project@self`) resolve to the SA's own row rather than
+    // matching nothing. Older legacy-scope handlers that don't reference
+    // userUuid keep working unchanged.
+    userUuid: string;
 };
 
 const applyServiceAccountStaticAbilities: Record<
@@ -173,10 +181,12 @@ const applyServiceAccountStaticAbilities: Record<
     },
     [ServiceAccountScope.ORG_EDIT]: ({
         organizationUuid,
+        userUuid,
         builder: { can },
     }) => {
         applyServiceAccountStaticAbilities[ServiceAccountScope.ORG_READ]({
             organizationUuid,
+            userUuid,
             builder: { can },
         });
         can('manage', 'Space', {
@@ -205,13 +215,23 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'MetricsTree', {
             organizationUuid,
         });
+        // CLI-driven content-as-code upload (`lightdash upload`) runs as an
+        // SA with `org:edit`. Pre-Phase-C the auth middleware spoofed the
+        // admin user so the call was implicitly allowed; the cutover to a
+        // dedicated SA identity dropped that side-effect, so we restore it
+        // here explicitly to preserve the existing CI workflow.
+        can('manage', 'ContentAsCode', {
+            organizationUuid,
+        });
     },
     [ServiceAccountScope.ORG_ADMIN]: ({
         organizationUuid,
+        userUuid,
         builder: { can },
     }) => {
         applyServiceAccountStaticAbilities[ServiceAccountScope.ORG_EDIT]({
             organizationUuid,
+            userUuid,
             builder: { can },
         });
         can('manage', 'PreAggregation', {
@@ -344,10 +364,62 @@ const applyServiceAccountStaticAbilities: Record<
             organizationUuid,
         });
     },
+    // System-role aliases. Each one delegates to the matching org-member
+    // ability builder so the SA's CASL is exactly the user-with-this-role
+    // shape — no parallel scope mapping to drift out of sync.
+    [ServiceAccountScope.SYSTEM_ADMIN]: ({
+        organizationUuid,
+        userUuid,
+        builder: { can },
+    }) => {
+        applyOrganizationMemberStaticAbilities[OrganizationMemberRole.ADMIN](
+            { organizationUuid, userUuid },
+            { can },
+        );
+    },
+    [ServiceAccountScope.SYSTEM_DEVELOPER]: ({
+        organizationUuid,
+        userUuid,
+        builder: { can },
+    }) => {
+        applyOrganizationMemberStaticAbilities[
+            OrganizationMemberRole.DEVELOPER
+        ]({ organizationUuid, userUuid }, { can });
+    },
+    [ServiceAccountScope.SYSTEM_EDITOR]: ({
+        organizationUuid,
+        userUuid,
+        builder: { can },
+    }) => {
+        applyOrganizationMemberStaticAbilities[OrganizationMemberRole.EDITOR](
+            { organizationUuid, userUuid },
+            { can },
+        );
+    },
+    [ServiceAccountScope.SYSTEM_INTERACTIVE_VIEWER]: ({
+        organizationUuid,
+        userUuid,
+        builder: { can },
+    }) => {
+        applyOrganizationMemberStaticAbilities[
+            OrganizationMemberRole.INTERACTIVE_VIEWER
+        ]({ organizationUuid, userUuid }, { can });
+    },
+    [ServiceAccountScope.SYSTEM_VIEWER]: ({
+        organizationUuid,
+        userUuid,
+        builder: { can },
+    }) => {
+        applyOrganizationMemberStaticAbilities[OrganizationMemberRole.VIEWER](
+            { organizationUuid, userUuid },
+            { can },
+        );
+    },
 };
 
 export const applyServiceAccountAbilities = ({
     organizationUuid,
+    userUuid,
     builder,
     scopes,
 }: ServiceAccountAbilitiesArgs & {
@@ -356,6 +428,7 @@ export const applyServiceAccountAbilities = ({
     scopes.forEach((scope) => {
         applyServiceAccountStaticAbilities[scope]({
             organizationUuid,
+            userUuid,
             builder,
         });
     });

--- a/packages/common/src/ee/serviceAccounts/types.ts
+++ b/packages/common/src/ee/serviceAccounts/types.ts
@@ -1,8 +1,22 @@
 export enum ServiceAccountScope {
     SCIM_MANAGE = 'scim:manage',
+    // Legacy coarse-grained SA scopes — kept on the wire for back-compat
+    // with tokens minted before system-role aliases existed. New tokens use
+    // the `SYSTEM_*` aliases below, which give the SA exactly the same CASL
+    // grants as a human user with that organization role.
     ORG_ADMIN = 'org:admin',
     ORG_EDIT = 'org:edit',
     ORG_READ = 'org:read',
+    // System-role aliases. Each one delegates to the matching
+    // `applyOrganizationMemberStaticAbilities` block so the SA's runtime
+    // ability set is identical to a user assigned that org role. Member is
+    // intentionally not exposed — it grants near-zero abilities and isn't
+    // a useful SA shape.
+    SYSTEM_ADMIN = 'system:admin',
+    SYSTEM_DEVELOPER = 'system:developer',
+    SYSTEM_EDITOR = 'system:editor',
+    SYSTEM_INTERACTIVE_VIEWER = 'system:interactive_viewer',
+    SYSTEM_VIEWER = 'system:viewer',
 }
 
 export type ServiceAccount = {
@@ -20,6 +34,11 @@ export type ServiceAccount = {
     // service account itself (not a fallback admin) on `created_by_user_uuid`
     // / `updated_by_user_uuid` and audit logs.
     userUuid: string;
+    // Optional org-level custom role assignment. When set, runtime CASL is
+    // composed from the role's `scoped_roles` via `buildAbilityFromScopes`,
+    // overriding the legacy `scopes` array. Null for SAs created via the
+    // legacy scopes-only path (kept for back-compat).
+    roleUuid: string | null;
 };
 
 export type ServiceAccountWithToken = ServiceAccount & {
@@ -28,8 +47,13 @@ export type ServiceAccountWithToken = ServiceAccount & {
 
 export type ApiCreateServiceAccountRequest = Pick<
     ServiceAccount,
-    'expiresAt' | 'description' | 'scopes'
->;
+    'expiresAt' | 'description'
+> & {
+    // One of `scopes` (legacy preset) or `roleUuid` (custom org role) must be
+    // provided. Sending both is rejected at the service layer.
+    scopes?: ServiceAccountScope[];
+    roleUuid?: string | null;
+};
 
 export type ApiCreateServiceAccountResponse = {
     token: string;
@@ -38,5 +62,8 @@ export type ApiCreateServiceAccountResponse = {
 
 export type CreateServiceAccount = Pick<
     ServiceAccount,
-    'organizationUuid' | 'expiresAt' | 'description' | 'scopes'
->;
+    'organizationUuid' | 'expiresAt' | 'description'
+> & {
+    scopes?: ServiceAccountScope[];
+    roleUuid?: string | null;
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -51,6 +51,7 @@ export {
 export * from './authorization/jwtAbility';
 export * from './authorization/parseAccount';
 export * from './authorization/roleToScopeMapping';
+export * from './authorization/scopeAbilityBuilder';
 export * from './authorization/scopes';
 export * from './authorization/serviceAccountAbility';
 export * from './authorization/space/spaceAccessResolver';

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
@@ -1,9 +1,9 @@
 import { ServiceAccountScope } from '@lightdash/common';
 import {
     ActionIcon,
+    Anchor,
     Button,
     CopyButton,
-    MultiSelect,
     Select,
     Stack,
     TextInput,
@@ -12,53 +12,46 @@ import {
 import { useForm } from '@mantine/form';
 import { IconCheck, IconCopy, IconKey } from '@tabler/icons-react';
 import { addDays } from 'date-fns';
-import { type FC } from 'react';
+import { useMemo, type FC } from 'react';
+import { Link } from 'react-router';
 import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
+import { useCustomRoles } from '../customRoles/useCustomRoles';
 
-const AVAILABLE_SCOPES = Object.values(ServiceAccountScope)
-    .filter((scope) => !scope.startsWith('scim:'))
-    .reduce<{ group: string; items: string[] }[]>((acc, scope) => {
-        const group = scope.split(':')[0];
-        const existingGroup = acc.find((g) => g.group === group);
-        if (existingGroup) {
-            existingGroup.items.push(scope);
-        } else {
-            acc.push({ group, items: [scope] });
-        }
-        return acc;
-    }, []);
+// Organization system roles surfaced as SA permission shapes. The SA inherits
+// the exact same CASL grants as a user assigned this org role at the
+// `applyOrganizationMemberStaticAbilities` level. `member` is intentionally
+// omitted — it grants near-zero abilities and isn't a useful SA shape. SCIM
+// tokens are minted via the dedicated SCIM token UI in org settings.
+//
+// The `scope:` prefix is just an internal tag for the dropdown's value
+// space — it tells `handleOnSubmit` to translate to a `scopes: [...]`
+// payload (vs `role:<uuid>` → `roleUuid` payload). It is NOT the literal
+// "legacy" `org:*` scopes — those are kept accepted on the wire for
+// back-compat but aren't surfaced in this dropdown.
+const SYSTEM_ROLE_OPTIONS: { value: string; label: string }[] = [
+    { value: `scope:${ServiceAccountScope.SYSTEM_VIEWER}`, label: 'Viewer' },
+    {
+        value: `scope:${ServiceAccountScope.SYSTEM_INTERACTIVE_VIEWER}`,
+        label: 'Interactive viewer',
+    },
+    { value: `scope:${ServiceAccountScope.SYSTEM_EDITOR}`, label: 'Editor' },
+    {
+        value: `scope:${ServiceAccountScope.SYSTEM_DEVELOPER}`,
+        label: 'Developer',
+    },
+    { value: `scope:${ServiceAccountScope.SYSTEM_ADMIN}`, label: 'Admin' },
+];
 
 const expireOptions = [
-    {
-        label: 'No expiration',
-        value: '',
-    },
-    {
-        label: '7 days',
-        value: '7',
-    },
-    {
-        label: '30 days',
-        value: '30',
-    },
-    {
-        label: '60 days',
-        value: '60',
-    },
-    {
-        label: '90 days',
-        value: '90',
-    },
-    {
-        label: '6 months',
-        value: '180',
-    },
-    {
-        label: '1 year',
-        value: '365',
-    },
+    { label: 'No expiration', value: '' },
+    { label: '7 days', value: '7' },
+    { label: '30 days', value: '30' },
+    { label: '60 days', value: '60' },
+    { label: '90 days', value: '90' },
+    { label: '6 months', value: '180' },
+    { label: '1 year', value: '365' },
 ];
 
 type Props = {
@@ -76,11 +69,47 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
     isWorking,
     token,
 }) => {
+    const { listRoles } = useCustomRoles();
+
+    // Each option's `value` is either `scope:<service-account-scope>` (e.g.
+    // `scope:system:admin`) or `role:<roleUuid>`. The handleOnSubmit
+    // translator splits the prefix off on the first `:` and routes to
+    // either `scopes` or `roleUuid` on the create payload. Mantine v8
+    // grouped data expects `{ group, items: [...] }`, not a flat
+    // `group:` per item.
+    //
+    // Custom roles are sorted alphabetically (case-insensitive) so the
+    // dropdown order is stable as the operator adds/edits roles. The
+    // system-role group keeps its hand-curated order (Viewer → Admin) so
+    // permission tiers read top-to-bottom.
+    const roleOptions = useMemo(() => {
+        const customRoleOptions = (listRoles.data ?? [])
+            .map((role) => ({
+                value: `role:${role.roleUuid}`,
+                label: role.name,
+            }))
+            .sort((a, b) =>
+                a.label.localeCompare(b.label, undefined, {
+                    sensitivity: 'base',
+                }),
+            );
+        const groups: {
+            group: string;
+            items: { value: string; label: string }[];
+        }[] = [
+            { group: 'Organization system roles', items: SYSTEM_ROLE_OPTIONS },
+        ];
+        if (customRoleOptions.length > 0) {
+            groups.push({ group: 'Custom roles', items: customRoleOptions });
+        }
+        return groups;
+    }, [listRoles.data]);
+
     const form = useForm({
         initialValues: {
             description: '',
             expiresAt: '',
-            scopes: [] as ServiceAccountScope[],
+            roleSelection: '',
         },
         transformValues: (values) => {
             return {
@@ -90,12 +119,8 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
             };
         },
         validate: {
-            scopes: (value) => {
-                if (value.length === 0) {
-                    return 'At least one scope is required';
-                }
-                return null;
-            },
+            roleSelection: (value) =>
+                value === '' ? 'Please select a permission set' : null,
         },
     });
 
@@ -104,12 +129,31 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
         onClose();
     };
 
-    const handleOnSubmit = form.onSubmit(({ expiresAt, ...values }) => {
-        onSave({
-            ...values,
-            expiresAt: expiresAt ? addDays(new Date(), expiresAt) : expiresAt,
-        });
-    });
+    const handleOnSubmit = form.onSubmit(
+        ({ expiresAt, roleSelection, description }) => {
+            // Translate the unified role selection into the API shape:
+            //   scope:<service-account-scope> → { scopes: [<scope>] }
+            //   role:<uuid>                   → { roleUuid: <uuid> }
+            // We split on the FIRST `:` only — service-account scope names
+            // themselves contain a `:` (e.g. `system:admin`) so a naive
+            // `split(':')` would drop the suffix and ship `scopes: ['system']`.
+            const sepIdx = roleSelection.indexOf(':');
+            const kind = roleSelection.slice(0, sepIdx) as 'scope' | 'role';
+            const value = roleSelection.slice(sepIdx + 1);
+            const payload =
+                kind === 'scope'
+                    ? { scopes: [value as ServiceAccountScope] }
+                    : { roleUuid: value };
+
+            onSave({
+                description,
+                expiresAt: expiresAt
+                    ? addDays(new Date(), expiresAt)
+                    : expiresAt,
+                ...payload,
+            });
+        },
+    );
 
     return (
         <MantineModal
@@ -153,15 +197,29 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
                             disabled={isWorking}
                             {...form.getInputProps('expiresAt')}
                         />
-                        <MultiSelect
-                            label="Scopes"
-                            placeholder="Select scopes"
-                            data={AVAILABLE_SCOPES}
+                        <Select
+                            label="Role"
+                            description={
+                                <>
+                                    Pick a system role or a custom role you've
+                                    created in{' '}
+                                    <Anchor
+                                        component={Link}
+                                        to="/generalSettings/customRoles"
+                                        size="xs"
+                                    >
+                                        custom roles
+                                    </Anchor>
+                                    .
+                                </>
+                            }
+                            placeholder="Select a permission set"
+                            data={roleOptions}
                             required
                             searchable
-                            maxDropdownHeight={140}
-                            disabled={isWorking}
-                            {...form.getInputProps('scopes')}
+                            maxDropdownHeight={220}
+                            disabled={isWorking || listRoles.isLoading}
+                            {...form.getInputProps('roleSelection')}
                         />
                     </Stack>
                 </form>

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -1,6 +1,8 @@
 import {
     formatDate,
     formatTimestamp,
+    ServiceAccountScope,
+    type RoleWithScopes,
     type ServiceAccount,
 } from '@lightdash/common';
 import {
@@ -21,22 +23,44 @@ import {
     IconKey,
     IconTrash,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
+import { useCustomRoles } from '../customRoles/useCustomRoles';
 import { ServiceAccountPermissionsModal } from './ServiceAccountPermissionsModal';
 import { ServiceAccountsDeleteModal } from './ServiceAccountsDeleteModal';
 import { isServiceAccountStale, STALE_THRESHOLD_DAYS } from './staleness';
+
+// Display labels for the SA scope vocabulary. Both the new system-role
+// aliases and the legacy `org:*` shorthands map to a single human-readable
+// role name (per the codebase convention that "role" is the named bundle
+// the SA is bound to; "scope" is an individual permission inside it).
+const SCOPE_LABEL: Partial<Record<ServiceAccountScope, string>> = {
+    [ServiceAccountScope.SYSTEM_ADMIN]: 'Admin',
+    [ServiceAccountScope.SYSTEM_DEVELOPER]: 'Developer',
+    [ServiceAccountScope.SYSTEM_EDITOR]: 'Editor',
+    [ServiceAccountScope.SYSTEM_INTERACTIVE_VIEWER]: 'Interactive viewer',
+    [ServiceAccountScope.SYSTEM_VIEWER]: 'Viewer',
+    [ServiceAccountScope.ORG_ADMIN]: 'Admin',
+    [ServiceAccountScope.ORG_EDIT]: 'Editor',
+    [ServiceAccountScope.ORG_READ]: 'Viewer',
+    [ServiceAccountScope.SCIM_MANAGE]: 'SCIM',
+};
 
 const TableRow: FC<{
     onClickDelete: (serviceAccount: ServiceAccount) => void;
     onClickInfo: (serviceAccount: ServiceAccount) => void;
     serviceAccount: ServiceAccount;
-}> = ({ onClickDelete, onClickInfo, serviceAccount }) => {
-    const { description, scopes, lastUsedAt, rotatedAt, expiresAt } =
+    rolesByUuid: Map<string, RoleWithScopes>;
+}> = ({ onClickDelete, onClickInfo, serviceAccount, rolesByUuid }) => {
+    const { description, scopes, roleUuid, lastUsedAt, rotatedAt, expiresAt } =
         serviceAccount;
     const stale = isServiceAccountStale(serviceAccount);
 
+    // Role-driven SAs render the role name as a single badge; scope-driven
+    // SAs render their scope list. The two paths are mutually exclusive
+    // (validated server-side) so we don't show both.
+    const role = roleUuid ? rolesByUuid.get(roleUuid) : undefined;
     const scopeBadges = scopes.map((scope) => (
         <Badge
             key={scope}
@@ -47,7 +71,7 @@ const TableRow: FC<{
             px="xxs"
         >
             <Text fz="xs" fw={400} color="ldGray.8">
-                {scope}
+                {SCOPE_LABEL[scope] ?? scope}
             </Text>
         </Badge>
     ));
@@ -77,14 +101,26 @@ const TableRow: FC<{
                 </Group>
             </td>
             <td style={{ whiteSpace: 'nowrap' }}>
-                {scopes.length > 2 ? (
+                {roleUuid ? (
+                    <Badge
+                        variant="filled"
+                        color="indigo.1"
+                        radius="xs"
+                        sx={{ textTransform: 'none' }}
+                        px="xxs"
+                    >
+                        <Text fz="xs" fw={500} color="indigo.9">
+                            {role?.name ?? 'Custom role'}
+                        </Text>
+                    </Badge>
+                ) : scopes.length > 2 ? (
                     <HoverCard offset={-20}>
                         <HoverCard.Target>
-                            <Group>{`${scopes.length} scopes`}</Group>
+                            <Group>{`${scopes.length} permissions`}</Group>
                         </HoverCard.Target>
                         <HoverCard.Dropdown>
                             <Stack>
-                                <Text fw="700">Selected Scopes</Text>
+                                <Text fw="700">Permissions</Text>
                                 {scopeBadges}
                             </Stack>
                         </HoverCard.Dropdown>
@@ -176,6 +212,16 @@ export const ServiceAccountsTable: FC<TableProps> = ({
         { open: openPermissions, close: closePermissions },
     ] = useDisclosure(false);
 
+    const { listRoles } = useCustomRoles();
+    // Map roleUuid → role so each row can resolve the badge label without a
+    // per-row request. `listRoles` is already used by the create modal so the
+    // query is cached.
+    const rolesByUuid = useMemo(() => {
+        const map = new Map<string, RoleWithScopes>();
+        (listRoles.data ?? []).forEach((r) => map.set(r.roleUuid, r));
+        return map;
+    }, [listRoles.data]);
+
     const [serviceAccountToDelete, setServiceAccountToDelete] = useState<
         ServiceAccount | undefined
     >();
@@ -216,7 +262,7 @@ export const ServiceAccountsTable: FC<TableProps> = ({
                     <tr>
                         <th>Description</th>
                         <th style={{ whiteSpace: 'nowrap', width: '1%' }}>
-                            Scopes
+                            Role
                         </th>
                         <th style={{ whiteSpace: 'nowrap', width: '1%' }}>
                             Expires at
@@ -234,6 +280,7 @@ export const ServiceAccountsTable: FC<TableProps> = ({
                             serviceAccount={serviceAccount}
                             onClickDelete={handleOpenModal}
                             onClickInfo={handleOpenPermissions}
+                            rolesByUuid={rolesByUuid}
                         />
                     ))}
                 </tbody>

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
@@ -1,7 +1,7 @@
 import { type RoleWithScopes } from '@lightdash/common';
 import { Group, Stack } from '@mantine-8/core';
 import { IconIdBadge2 } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { EmptyState } from '../../../components/common/EmptyState';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -36,11 +36,24 @@ export const CustomRoles = () => {
         void navigate(`/generalSettings/customRoles/${result.roleUuid}`);
     };
 
+    // Sort roles alphabetically (case-insensitive) so the table stays
+    // stable as new roles get added — the API returns insertion order
+    // by default which gets noisy with many roles.
+    const sortedRoles = useMemo(
+        () =>
+            (listRoles.data ?? []).slice().sort((a, b) =>
+                a.name.localeCompare(b.name, undefined, {
+                    sensitivity: 'base',
+                }),
+            ),
+        [listRoles.data],
+    );
+
     if (listRoles.isLoading) {
         return <PageSpinner />;
     }
 
-    const hasRoles = (listRoles?.data?.length ?? 0) > 0;
+    const hasRoles = sortedRoles.length > 0;
 
     return (
         <Stack mb="lg" gap="md">
@@ -64,7 +77,7 @@ export const CustomRoles = () => {
             {hasRoles ? (
                 <>
                     <CustomRolesTable
-                        roles={listRoles?.data ?? []}
+                        roles={sortedRoles}
                         onDelete={handleDeleteRole}
                         onEdit={handleEditRole}
                         isDeleting={deleteRole.isLoading}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7429/implement-org-custom-roles-for-service-account-users
Closes: https://linear.app/lightdash/issue/PROD-7408/switch-service-account-role-to-use-user-role-permissions
Closes: https://linear.app/lightdash/issue/PROD-7432/service-account-custom-scope-ui
Closes: https://linear.app/lightdash/issue/PROD-7412/add-custom-scopes-to-service-accounts

### Description:

Introduces built-in "legacy" custom roles for service accounts that mirror the existing `applyServiceAccountAbilities` CASL output, enabling service accounts to be driven by the custom-roles system without changing their effective permissions.

**Legacy role insertion migration** adds three system-owned custom roles (`org:read`, `org:edit`, `org:admin`) with deterministic UUIDs to the `roles` table, and populates their corresponding `scoped_roles` entries from the `SERVICE_ACCOUNT_LEGACY_ROLE_SCOPES` constant. The migration is idempotent via `ON CONFLICT` upserts.

**Backfill migration** walks all existing service accounts and sets `organization_memberships.role_uuid` to the matching legacy role UUID based on the broadest org-scope present. SCIM-only service accounts are left with `role_uuid = NULL` and continue resolving CASL via the scope-derived path.

**New service accounts** created after this change have `role_uuid` assigned immediately in `ServiceAccountModel.save()` via `getLegacyRoleUuidForScopes`.

**`getUserAbilityBuilder`** now checks for an org-level `role_uuid` on the user. When `customRolesEnabled` is true and scopes are loaded for that role, CASL is composed from those scopes instead of the system role enum. Falls back to the existing system role path when the flag is off or no scopes are found.

**New scopes** added to support parity with the legacy SA ability rules:
- `view:Dashboard@inherits`, `view:Dashboard@all`
- `view:SavedChart@inherits`, `view:SavedChart@all`
- `view:Space@inherits`, `view:Space@all`
- `manage:Space@inherits`
- `view:Job@all`, `view:JobStatus@all`

**Parity test** (`serviceAccountRoleParity.test.ts`) verifies that for each of `org:read`, `org:edit`, and `org:admin`, the scope-set-derived CASL rules are semantically equivalent to what `applyServiceAccountAbilities` produces today, accounting for CASL's `manage` subsumption semantics.

**`getUserAbilityBuilder` unit tests** (`getUserAbilityBuilder.test.ts`) cover backwards compatibility for all system roles, feature-flag fallback behavior, and correct activation of org-level custom roles.

test-frontend test-cli