### PR TITLE
fix: relabel space menu "Rename" as "Update space"

### DIFF
--- a/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
@@ -94,7 +94,7 @@ export const SpaceBrowserMenu: React.FC<React.PropsWithChildren<Props>> = ({
                     leftSection={<MantineIcon icon={IconEdit} />}
                     onClick={onRename}
                 >
-                    Rename
+                    Update space
                 </Menu.Item>
 
                 {user.data?.ability.can(

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -297,7 +297,9 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                 }}
                                 style={isSqlChart ? { display: 'none' } : {}}
                             >
-                                Rename
+                                {item.type === ResourceViewItemType.SPACE
+                                    ? 'Update space'
+                                    : 'Rename'}
                             </Menu.Item>
 
                             {item.type === ResourceViewItemType.CHART ||


### PR DESCRIPTION
## Summary
- The space context menu's "Rename" item opens a modal that edits both **name** and **color palette (theme)** — the label was misleading.
- Renamed to **"Update space"** in two places:
  - `ResourceActionMenu` (homepage / spaces list / pinned items) — only when `item.type === SPACE`; charts and dashboards keep "Rename".
  - `SpaceBrowserMenu` (space detail page header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)