### PR TITLE
feat(authorization): gate custom SQL table calculations behind a new scope

### DIFF
--- a/packages/backend/src/database/migrations/20260511094034_grant_custom_sql_table_calculations_to_custom_sql_roles.ts
+++ b/packages/backend/src/database/migrations/20260511094034_grant_custom_sql_table_calculations_to_custom_sql_roles.ts
@@ -1,0 +1,55 @@
+import { Knex } from 'knex';
+
+const ScopedRolesTableName = 'scoped_roles';
+const CUSTOM_SQL_SCOPE = 'manage:CustomSql';
+const CUSTOM_SQL_TC_SCOPE = 'manage:CustomSqlTableCalculations';
+
+/**
+ * Backfill the new `manage:CustomSqlTableCalculations` scope into every custom
+ * role that already has `manage:CustomSql`. Without this, custom roles that
+ * unlocked SQL chart authoring would silently lose SQL table calculation
+ * authoring once the gate flips on.
+ *
+ * Wrapped in try/catch because this is a backfill: failing it would block all
+ * later migrations, and the worst case (some roles miss the new scope) is
+ * recoverable by re-running the SQL manually.
+ */
+export async function up(knex: Knex): Promise<void> {
+    try {
+        await knex.raw(
+            `
+            INSERT INTO ?? (role_uuid, scope_name, granted_by)
+            SELECT role_uuid, ?, granted_by
+            FROM ??
+            WHERE scope_name = ?
+            ON CONFLICT DO NOTHING
+            `,
+            [
+                ScopedRolesTableName,
+                CUSTOM_SQL_TC_SCOPE,
+                ScopedRolesTableName,
+                CUSTOM_SQL_SCOPE,
+            ],
+        );
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260511094034] Failed to backfill ${CUSTOM_SQL_TC_SCOPE} for roles with ${CUSTOM_SQL_SCOPE}. Affected custom roles will need to grant ${CUSTOM_SQL_TC_SCOPE} manually.`,
+            error,
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    try {
+        await knex(ScopedRolesTableName)
+            .where('scope_name', CUSTOM_SQL_TC_SCOPE)
+            .delete();
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260511094034] Failed to remove ${CUSTOM_SQL_TC_SCOPE} rows during rollback.`,
+            error,
+        );
+    }
+}

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -549,6 +549,7 @@ export class SavedChartService
                 metrics: oldChartMetrics,
                 dimensions: oldChartDimensions,
                 customDimensions: oldCustomDimensions,
+                tableCalculations: oldTableCalculations,
             },
         } = await this.savedChartModel.get(savedChartUuid);
 
@@ -601,6 +602,36 @@ export class SavedChartService
         ) {
             throw new ForbiddenError(
                 'User cannot save queries with modified custom SQL dimensions',
+            );
+        }
+
+        const oldSqlTcsByName = new Map(
+            (oldTableCalculations ?? [])
+                .filter(isSqlTableCalculation)
+                .map((tc) => [tc.name, tc]),
+        );
+        const hasModifiedSqlTableCalculation = (
+            data.metricQuery.tableCalculations ?? []
+        )
+            .filter(isSqlTableCalculation)
+            .some((tc) => {
+                const saved = oldSqlTcsByName.get(tc.name);
+                return !saved || saved.sql !== tc.sql;
+            });
+
+        if (
+            hasModifiedSqlTableCalculation &&
+            auditedAbility.cannot(
+                'manage',
+                subject('CustomSqlTableCalculations', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { savedChartUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'User cannot save queries with new or modified SQL table calculations',
             );
         }
 

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -277,6 +277,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'CustomFields', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'CustomSqlTableCalculations', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'SqlRunner', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -239,6 +239,9 @@ export const projectMemberAbilities: Record<
         can('manage', 'CustomFields', {
             projectUuid: member.projectUuid,
         });
+        can('manage', 'CustomSqlTableCalculations', {
+            projectUuid: member.projectUuid,
+        });
         can('manage', 'SqlRunner', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.testUtils.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.testUtils.ts
@@ -206,6 +206,11 @@ export const createStandardTestCases = () => [
         subject: 'CustomFields' as const,
         resource: { projectUuid: 'test-project-uuid' },
     },
+    {
+        action: 'manage' as const,
+        subject: 'CustomSqlTableCalculations' as const,
+        resource: { projectUuid: 'test-project-uuid' },
+    },
 
     // Admin-only permissions
     {

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -105,6 +105,7 @@ const BASE_ROLE_SCOPES = {
         'delete:VirtualView',
         'manage:CustomSql',
         'manage:CustomFields',
+        'manage:CustomSqlTableCalculations',
         'manage:SqlRunner',
         'manage:Validation',
         'manage:CompileProject',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -572,6 +572,13 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:CustomSqlTableCalculations',
+        description: 'Create and edit SQL table calculations',
+        isEnterprise: false,
+        group: ScopeGroup.DATA,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'create:VirtualView',
         description: 'Create virtual views',
         isEnterprise: false,

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -246,6 +246,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'CustomFields', {
             organizationUuid,
         });
+        can('manage', 'CustomSqlTableCalculations', {
+            organizationUuid,
+        });
         can('manage', 'SqlRunner', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -30,6 +30,7 @@ export type CaslSubjectNames =
     | 'ContentVerification'
     | 'CustomFields'
     | 'CustomSql'
+    | 'CustomSqlTableCalculations'
     | 'DataApp'
     | 'Dashboard'
     | 'DeployProject'

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -50,6 +50,7 @@ type Props = {
     focusOnRender?: boolean;
     onCmdEnter?: () => void;
     onAiApplied?: () => void;
+    readOnly?: boolean;
     // Structured state for the SQL→formula conversion flow. When set,
     // the AI slot renders the conversion preview body instead of the
     // free-prompt AI input — the slot itself is the same <AiSlot> React
@@ -82,6 +83,7 @@ export const SqlForm: FC<Props> = ({
     focusOnRender = false,
     onCmdEnter,
     onAiApplied,
+    readOnly = false,
     conversionState,
 }) => {
     const theme = useMantineTheme();
@@ -200,12 +202,13 @@ export const SqlForm: FC<Props> = ({
                     }}
                     style={{ zIndex: 0 }}
                     onLoad={handleEditorLoad}
-                    enableLiveAutocompletion
-                    enableBasicAutocompletion
+                    enableLiveAutocompletion={!readOnly}
+                    enableBasicAutocompletion={!readOnly}
                     showPrintMargin={false}
                     isFullScreen={isFullScreen}
                     wrapEnabled={isSoftWrapEnabled}
                     gutterBackgroundColor={theme.colors.ldGray[1]}
+                    readOnly={readOnly}
                     {...form.getInputProps('sql')}
                 />
                 <SqlEditorActions
@@ -216,7 +219,7 @@ export const SqlForm: FC<Props> = ({
             </ScrollArea>
 
             <Box style={{ flexShrink: 0 }}>
-                {!isAmbientAiEnabled ? (
+                {readOnly && !conversionState ? null : !isAmbientAiEnabled ? (
                     <Alert
                         radius={0}
                         icon={<MantineIcon icon={IconSparkles} />}

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -18,9 +18,12 @@ import {
     Anchor,
     Box,
     Button,
+    CopyButton,
+    Divider,
     Group,
     HoverCard,
     Loader,
+    Popover,
     Stack,
     Text,
     TextInput,
@@ -30,11 +33,12 @@ import { useForm } from '@mantine/form';
 import {
     IconAlertTriangle,
     IconCalculator,
-    IconHelpCircle,
+    IconCheck,
+    IconCopy,
+    IconLock,
     IconMaximize,
     IconMinimize,
     IconSparkles,
-    IconSpeakerphone,
     IconWand,
 } from '@tabler/icons-react';
 import {
@@ -50,7 +54,6 @@ import {
 import { useParams } from 'react-router';
 import { useToggle } from 'react-use';
 import { type ValueOf } from 'type-fest';
-import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import {
@@ -65,7 +68,7 @@ import useToaster from '../../../hooks/toaster/useToaster';
 import { useConvertSqlToFormula } from '../../../hooks/useConvertSqlToFormula';
 import { useExplore } from '../../../hooks/useExplore';
 import { useProject } from '../../../hooks/useProject';
-import { useCannotAuthorCustomSql } from '../../../hooks/user/useCannotAuthorCustomSql';
+import { useCannotAuthorCustomSqlTableCalculations } from '../../../hooks/user/useCannotAuthorCustomSqlTableCalculations';
 import { getUniqueTableCalculationName } from '../utils';
 import { FormatRow } from './FormatRow/FormatRow';
 import { FormulaForm, type FormulaFormHandle } from './FormulaForm/FormulaForm';
@@ -127,6 +130,28 @@ const TableCalculationModal: FC<Props> = ({
         );
 
     const isAmbientAiEnabled = health?.ai?.isAmbientAiEnabled === true;
+    const isCustomRolesEnabled = health?.isCustomRolesEnabled === true;
+    const requestContext = useMemo(() => {
+        const tcLabel =
+            tableCalculation?.displayName || 'this SQL table calculation';
+        const chartUrl =
+            typeof window !== 'undefined'
+                ? window.location.href.replace(/\/edit\/?$/, '')
+                : '';
+        return { tcLabel, chartUrl };
+    }, [tableCalculation?.displayName]);
+    const accessRequestMessage = useMemo(
+        () =>
+            isCustomRolesEnabled
+                ? `Hi! Could you grant me 'Manage custom SQL table calculations' via a custom role? I need it to edit '${requestContext.tcLabel}' on this chart: ${requestContext.chartUrl}`
+                : `Hi! Could you grant me SQL access for table calculations? I need to edit '${requestContext.tcLabel}' on this chart: ${requestContext.chartUrl}`,
+        [requestContext, isCustomRolesEnabled],
+    );
+    const changeRequestMessage = useMemo(
+        () =>
+            `Hi! Could you update the SQL of '${requestContext.tcLabel}' on this chart? ${requestContext.chartUrl}`,
+        [requestContext],
+    );
 
     const isNewCalculation = !tableCalculation;
     const hasTemplate = tableCalculation
@@ -303,26 +328,13 @@ const TableCalculationModal: FC<Props> = ({
     const isExistingSqlCalc =
         !!tableCalculation && isSqlTableCalculation(tableCalculation);
 
-    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
-    const showSqlDeprecationCallout =
-        cannotAuthorCustomSql === true && editMode === EditMode.SQL;
-    const canConvertExistingSqlToFormula =
+    const cannotAuthorSqlTcs =
+        useCannotAuthorCustomSqlTableCalculations(projectUuid) === true;
+    const showConvertToFormulaButton =
         isExistingSqlCalc &&
         isFormulaSupported &&
         isAmbientAiEnabled &&
         editMode === EditMode.SQL;
-    const showConvertToFormulaButton =
-        canConvertExistingSqlToFormula && !showSqlDeprecationCallout;
-    const showConvertInCallout =
-        showSqlDeprecationCallout && canConvertExistingSqlToFormula;
-    const showTryFormulasInCallout =
-        showSqlDeprecationCallout &&
-        editMode === EditMode.SQL &&
-        isNewCalculation &&
-        isFormulaSupported;
-    const handleTryFormulasClick = useCallback(() => {
-        setEditMode(EditMode.FORMULA);
-    }, []);
 
     const showConversionPreview =
         editMode === EditMode.SQL &&
@@ -500,7 +512,9 @@ const TableCalculationModal: FC<Props> = ({
         [form],
     );
 
-    const canSwitchEditMode = isNewCalculation && isFormulaSupported;
+    const sqlReadOnly = cannotAuthorSqlTcs && editMode === EditMode.SQL;
+    const canSwitchEditMode =
+        isNewCalculation && isFormulaSupported && !cannotAuthorSqlTcs;
     const editorLabel = editMode === EditMode.FORMULA ? 'Formula' : 'SQL';
     const switchEditModeLabel =
         editMode === EditMode.FORMULA
@@ -545,7 +559,8 @@ const TableCalculationModal: FC<Props> = ({
                     disabled={
                         (editMode === EditMode.SQL &&
                             form.values.sql.length === 0) ||
-                        isFormulaInvalid
+                        isFormulaInvalid ||
+                        sqlReadOnly
                     }
                 >
                     {saveButtonLabel}
@@ -567,95 +582,6 @@ const TableCalculationModal: FC<Props> = ({
             }}
         >
             <Stack gap="xs">
-                {showSqlDeprecationCallout && (
-                    <Callout
-                        variant="warning"
-                        title={
-                            <Group gap={6} wrap="nowrap" align="center">
-                                <Text
-                                    fw={700}
-                                    size="sm"
-                                    c="light-dark(var(--mantine-color-ldDark-9), var(--mantine-color-yellow-1))"
-                                    inherit
-                                >
-                                    Coming soon: Editors won't be able to create
-                                    new SQL table calculations
-                                </Text>
-                                <Tooltip
-                                    label="Existing SQL calculations stay editable — just convert them to formula first. They're easier to read and reuse that way."
-                                    multiline
-                                    w={280}
-                                    withArrow
-                                    position="top"
-                                >
-                                    <Box style={{ display: 'flex' }}>
-                                        <MantineIcon
-                                            icon={IconHelpCircle}
-                                            color="light-dark(var(--mantine-color-ldDark-7), var(--mantine-color-yellow-3))"
-                                            size="sm"
-                                        />
-                                    </Box>
-                                </Tooltip>
-                            </Group>
-                        }
-                        fz="sm"
-                        icon={<MantineIcon icon={IconSpeakerphone} size="lg" />}
-                        bd="1px solid light-dark(var(--mantine-color-yellow-3), var(--mantine-color-yellow-9))"
-                        bg="light-dark(var(--mantine-color-yellow-0), var(--mantine-color-dark-7))"
-                        p="xs"
-                    >
-                        <Stack gap="xs">
-                            <Text
-                                size="xs"
-                                c="light-dark(var(--mantine-color-ldDark-9), var(--mantine-color-yellow-1))"
-                            >
-                                We're moving custom SQL behind a new permission.
-                                Use formulas instead — no SQL required,
-                                validated as you type, and they work in any
-                                warehouse.
-                            </Text>
-                            <Group gap="xs" mt={4} justify="flex-end">
-                                {showConvertInCallout &&
-                                    !showConversionPreview && (
-                                        <Button
-                                            size="compact-xs"
-                                            variant="default"
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconWand}
-                                                    size="sm"
-                                                />
-                                            }
-                                            loading={isConvertingSql}
-                                            onClick={handleConvertClick}
-                                        >
-                                            Convert to formula
-                                        </Button>
-                                    )}
-                                {showTryFormulasInCallout && (
-                                    <Button
-                                        size="compact-xs"
-                                        variant="default"
-                                        onClick={handleTryFormulasClick}
-                                    >
-                                        Try formulas now
-                                    </Button>
-                                )}
-                                <Anchor
-                                    size="xs"
-                                    c="light-dark(var(--mantine-color-ldDark-9), var(--mantine-color-yellow-1))"
-                                    fw={500}
-                                    href="https://docs.lightdash.com/guides/formula-table-calculations"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    underline="always"
-                                >
-                                    Learn more
-                                </Anchor>
-                            </Group>
-                        </Stack>
-                    </Callout>
-                )}
                 <Stack gap={2}>
                     <Group className={classes.inputModeHeader}>
                         <Group gap={6} wrap="nowrap">
@@ -742,7 +668,7 @@ const TableCalculationModal: FC<Props> = ({
                                 <Button
                                     variant="light"
                                     color="indigo"
-                                    size="xs"
+                                    size="compact-xs"
                                     leftSection={
                                         <MantineIcon
                                             icon={IconWand}
@@ -800,7 +726,182 @@ const TableCalculationModal: FC<Props> = ({
                                 isFullScreen={isExpanded}
                             />
                         ) : (
-                            <Box className={classes.sqlEditorBorder}>
+                            <Box
+                                className={classes.sqlEditorBorder}
+                                pos="relative"
+                            >
+                                {sqlReadOnly && !showConversionPreview && (
+                                    <Box
+                                        pos="absolute"
+                                        top={8}
+                                        right={8}
+                                        style={{ zIndex: 5 }}
+                                    >
+                                        <Popover
+                                            position="bottom-end"
+                                            withArrow
+                                            shadow="md"
+                                            width={300}
+                                        >
+                                            <Popover.Target>
+                                                <Button
+                                                    variant="default"
+                                                    size="compact-xs"
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconLock}
+                                                            size="sm"
+                                                        />
+                                                    }
+                                                >
+                                                    View only
+                                                </Button>
+                                            </Popover.Target>
+                                            <Popover.Dropdown>
+                                                <Stack gap="xs">
+                                                    <Text size="xs" fw={600}>
+                                                        You don't have
+                                                        permission to edit SQL
+                                                        here.
+                                                    </Text>
+                                                    <Text size="xs" c="dimmed">
+                                                        Use formulas instead —
+                                                        no SQL required,
+                                                        validated as you type,
+                                                        and they work in any
+                                                        warehouse.
+                                                    </Text>
+                                                    {showConvertToFormulaButton && (
+                                                        <Button
+                                                            size="compact-xs"
+                                                            variant="light"
+                                                            color="indigo"
+                                                            leftSection={
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconWand
+                                                                    }
+                                                                    size="sm"
+                                                                />
+                                                            }
+                                                            onClick={
+                                                                handleConvertClick
+                                                            }
+                                                            loading={
+                                                                isConvertingSql
+                                                            }
+                                                            disabled={
+                                                                !form.values
+                                                                    .sql ||
+                                                                form.values.sql.trim()
+                                                                    .length ===
+                                                                    0
+                                                            }
+                                                            fullWidth
+                                                        >
+                                                            Convert to formula
+                                                        </Button>
+                                                    )}
+                                                    <Divider
+                                                        my={2}
+                                                        label="or"
+                                                        labelPosition="center"
+                                                    />
+                                                    <Text size="xs" c="dimmed">
+                                                        Ask an admin or
+                                                        developer
+                                                        {isCustomRolesEnabled ? (
+                                                            <>
+                                                                {' '}
+                                                                to grant{' '}
+                                                                <Text
+                                                                    component="span"
+                                                                    fw={600}
+                                                                    inherit
+                                                                >
+                                                                    Manage
+                                                                    custom SQL
+                                                                    table
+                                                                    calculations
+                                                                </Text>{' '}
+                                                                via a custom
+                                                                role.
+                                                            </>
+                                                        ) : (
+                                                            ' for SQL access.'
+                                                        )}
+                                                    </Text>
+                                                    <CopyButton
+                                                        value={
+                                                            accessRequestMessage
+                                                        }
+                                                        timeout={2000}
+                                                    >
+                                                        {({ copied, copy }) => (
+                                                            <Button
+                                                                size="compact-xs"
+                                                                variant="default"
+                                                                color={
+                                                                    copied
+                                                                        ? 'teal'
+                                                                        : undefined
+                                                                }
+                                                                leftSection={
+                                                                    <MantineIcon
+                                                                        icon={
+                                                                            copied
+                                                                                ? IconCheck
+                                                                                : IconCopy
+                                                                        }
+                                                                        size="sm"
+                                                                    />
+                                                                }
+                                                                onClick={copy}
+                                                            >
+                                                                {copied
+                                                                    ? 'Copied!'
+                                                                    : 'Copy access request'}
+                                                            </Button>
+                                                        )}
+                                                    </CopyButton>
+                                                    <CopyButton
+                                                        value={
+                                                            changeRequestMessage
+                                                        }
+                                                        timeout={2000}
+                                                    >
+                                                        {({ copied, copy }) => (
+                                                            <Button
+                                                                size="compact-xs"
+                                                                variant="default"
+                                                                color={
+                                                                    copied
+                                                                        ? 'teal'
+                                                                        : undefined
+                                                                }
+                                                                leftSection={
+                                                                    <MantineIcon
+                                                                        icon={
+                                                                            copied
+                                                                                ? IconCheck
+                                                                                : IconCopy
+                                                                        }
+                                                                        size="sm"
+                                                                    />
+                                                                }
+                                                                onClick={copy}
+                                                            >
+                                                                {copied
+                                                                    ? 'Copied!'
+                                                                    : 'Copy SQL change request'}
+                                                            </Button>
+                                                        )}
+                                                    </CopyButton>
+                                                </Stack>
+                                            </Popover.Dropdown>
+                                        </Popover>
+                                    </Box>
+                                )}
                                 <Suspense
                                     fallback={
                                         <Box
@@ -819,6 +920,7 @@ const TableCalculationModal: FC<Props> = ({
                                         focusOnRender={true}
                                         onCmdEnter={handleConfirm}
                                         onAiApplied={handleSqlAiApplied}
+                                        readOnly={sqlReadOnly}
                                         conversionState={
                                             showConversionPreview
                                                 ? {

--- a/packages/frontend/src/hooks/user/useCannotAuthorCustomSqlTableCalculations.ts
+++ b/packages/frontend/src/hooks/user/useCannotAuthorCustomSqlTableCalculations.ts
@@ -1,0 +1,16 @@
+import { subject } from '@casl/ability';
+import useApp from '../../providers/App/useApp';
+
+export const useCannotAuthorCustomSqlTableCalculations = (
+    projectUuid: string | undefined,
+) => {
+    const { user } = useApp();
+
+    return user.data?.ability.cannot(
+        'manage',
+        subject('CustomSqlTableCalculations', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+};


### PR DESCRIPTION
Closes: [ZAP-361](https://linear.app/lightdash/issue/ZAP-361)

Closes: [ZAP-362](https://linear.app/lightdash/issue/ZAP-362)

## Summary

Adds the new `manage:CustomSqlTableCalculations` CASL scope, gates SQL table-calculation authoring on it, and ships the migration UX for editors who lose access. Bundles the gate (ZAP-361) and the migration UX (ZAP-362) so the activation lands as a single deploy with the recovery paths in place from day one.

The pre-activation announcement callout shipped in #22692. **No feature flag** — the deploy IS the activation. Merge → release → editors are gated.

## ⚠️ Before merge

- [ ] **Rebase from main** and **regenerate the migration timestamp**. The file is named `20260505143000_grant_custom_sql_table_calculations_to_custom_sql_roles.ts` — if a newer migration lands on main first, this one ends up out-of-order. Rename to a timestamp later than the latest migration on main before merging.

## What changes

### Common (CASL structural)

- `types.ts` — add `CustomSqlTableCalculations` to `CaslSubjectNames`
- `scopes.ts` — define `manage:CustomSqlTableCalculations` (DATA group, non-enterprise)
- `projectMemberAbility.ts` — grant to developer (admin inherits)
- `organizationMemberAbility.ts` — grant to org developer (admin inherits)
- `roleToScopeMapping.ts` — `BASE_ROLE_SCOPES.developer` includes the new scope (admin inherits via `ROLE_HIERARCHY`)
- `serviceAccountAbility.ts` — service account retains the scope (CI/CD pipelines unaffected)
- `roleToScopeMapping.testUtils.ts` — parity test case

### Backend

- `SavedChartService.createVersion` — on save, compare incoming SQL TCs against the existing chart's. If any are added or have modified SQL, require `manage:CustomSqlTableCalculations`. Throws `ForbiddenError` otherwise. Mirrors the existing `CustomFields` pattern for SQL custom dimensions.
- New migration `20260505143000_grant_custom_sql_table_calculations_to_custom_sql_roles.ts` — backfills the new scope into every custom role that already has `manage:CustomSql`, so custom roles don't silently lose access on activation. Mirrors prior precedent at `20260417111420_grant_custom_fields_to_custom_sql_roles.ts`.

### Frontend

- New hook `useCannotAuthorCustomSqlTableCalculations` — checks the new scope.
- `SqlForm` accepts a `readOnly` prop — editor is read-only, autocomplete disabled, AI input slot hidden (the conversion-preview slot still renders so the convert flow keeps working).
- `TableCalculationModal`:
    - Removes the pre-activation announcement callout — the deploy of this PR ends the announcement period.
    - **New TC + editor without scope** → can't switch to SQL mode (`canSwitchEditMode = false`); modal stays in formula
    - **Existing SQL TC + editor without scope** → SQL editor read-only, save button disabled
    - **`Convert to formula`** **button** stays in the modal header above the editor for everyone (admin/dev/editor) — consistent placement
    - **`View only`** **lock badge** appears in the SQL editor's top-right corner only for gated editors. Clicking it opens a popover with:
        - Lead: _"You don't have permission to edit SQL here."_
        - Formula argument: _"Use formulas instead — no SQL required, validated as you type, and they work in any warehouse."_ (the strong argument from the original announcement)
        - **Convert to formula** CTA inside the popover — primary action
        - "or" divider
        - Conditional ask-for-help text — mentions `Manage custom SQL table calculations` only when `isCustomRolesEnabled`, generic _"for SQL access"_ otherwise
        - **Copy access request** — copies a templated message asking for the permission grant
        - **Copy SQL change request** — copies a templated message asking an admin/dev to make a one-off SQL change on the user's behalf
        - Both copy buttons use Mantine's `CopyButton` with proper `Copied!` feedback
        - Templated messages include the **TC's display name** + the **chart URL** (e.g., _"Hi! ... I need it to edit 'Fun Number Mix' on this chart:_ [_https://localhost:3000/projects/.../saved/](https://localhost:3000/projects/.../saved/)..."_)

## Visibility / regression analysis

| User | Behavior change |
| --- | --- |
| Admin / Developer | None — keep `manage:CustomSqlTableCalculations`, edit SQL TCs as before |
| Editor (and below) on built-in roles | **Lose default SQL TC authoring**. Existing SQL TCs render read-only with Convert + View-only badge; new TCs lock to formula or template mode |
| Editor with custom role granting `manage:CustomSqlTableCalculations` | None — keep authoring SQL TCs |
| Service account | None — `ORG_ADMIN` retains the scope (CI/CD chart deploys unaffected) |
| Custom roles that had `manage:CustomSql` | Backfilled with `manage:CustomSqlTableCalculations` via migration — no silent regressions |
| Cross-project content (charts referenced via promotion, content-as-code) | Unaffected — the gate is on `createVersion`, not on view |

## Automated test plan

- [x] `pnpm -F common build` — clean
- [x] `pnpm -F frontend typecheck` — clean
- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F frontend lint` — 0 warnings, 0 errors
- [x] `pnpm -F backend lint` — clean
- [x] Role parity tests — 10 passed (admin/developer/editor/interactive_viewer/viewer × oss + enterprise)
- [x] SavedChartService existing tests — pass

## Manual test plan

### Setup

- **Editor:** `demo2@lightdash.com` / `demo_password!`
- **Admin:** `demo@lightdash.com` / `demo_password!`
- Run `pnpm -F backend migrate` and restart the backend after pulling.

### Editor — gate active

#### Existing SQL TC

- [ ] Open a chart with a SQL TC (e.g. `tc & custom dim` chart's "Fun Number Mix") → column menu → Edit calculation. Modal opens. SQL is **read-only**, Save button **disabled**, `Convert to formula` button in modal header, `View only` lock badge in SQL editor's top-right corner.
- [ ] Try to type in the SQL editor — nothing happens (read-only).
- [ ] Click `Convert to formula` (header) → AI conversion preview shows. Apply / Discard / Try again work.
- [ ] Apply conversion → editor flips to Formula mode, save button enables, can save the converted formula.
- [ ] Click `View only` badge → popover opens with: _"You don't have permission to edit SQL here."_ + formula benefits + `Convert to formula` button + "or" divider + ask-admin text + `Copy access request` + `Copy SQL change request`.
- [ ] Click `Convert to formula` inside popover → behaves same as header convert.
- [ ] Click `Copy access request` → button shows `Copied!`, clipboard contains the templated access request including the TC display name and chart URL.
- [ ] Click `Copy SQL change request` → button shows `Copied!`, clipboard contains the change-request template.

#### Existing formula TC

- [ ] Edit any existing formula TC. Opens in Formula mode, fully editable, save works. No `View only` badge, no Convert button.

#### New TC

- [ ] Click `+ Table calculation`. Modal opens in Formula mode. **No** "Use SQL instead" anchor in the header. No badge. No callout.
- [ ] Try to switch to SQL → impossible (anchor hidden).
- [ ] Author a formula and save → works normally.

#### Backend safety net

- [ ] Direct API call as editor with PAT, posting a chart save with a new SQL TC payload → **403 ForbiddenError** _"User cannot save queries with modified SQL table calculations"_.

### Admin — no behavior change

- [ ] Edit existing SQL TC. Modal opens, SQL **editable**, Save **enabled**, `Convert to formula` button in header. **No** `View only` badge. **No** popover.
- [ ] Edit existing formula TC — unchanged.
- [ ] Create new TC. Default formula mode, "Use SQL instead" anchor visible, can switch to SQL freely, save works.
- [ ] Save a chart with a brand new SQL TC → success.

### Custom role grant

- [ ] As admin, Settings → Custom Roles → create a role with `manage:CustomSqlTableCalculations` (plus the usual editor scopes).
- [ ] Apply the custom role to `demo2@lightdash.com`.
- [ ] Login as demo2, open existing SQL TC → behaves like admin: editor **editable**, save works, no `View only` badge.
- [ ] Revoke the custom role → editor returns to gated state.

### Conditional copy in popover

- [ ] When `isCustomRolesEnabled === true`: popover ask-text mentions `Manage custom SQL table calculations`; access-request message references the scope by name.
- [ ] When `isCustomRolesEnabled === false`: popover ask-text says _"for SQL access"_; access-request message uses generic phrasing.

### Migration backfill

- [ ] Run against dev DB:

    Counts should match — every role that had `manage:CustomSql` also has `manage:CustomSqlTableCalculations`.

### Edge cases

- [ ] Dark mode: popover, badge, buttons, read-only editor all legible.
- [ ] Existing dashboards with SQL-TC charts viewable as editor (gate is on save, not view).
- [ ] Promoting a chart with SQL TCs from one project to another — unaffected (gate is on `createVersion`, service accounts retain the scope).

🔗 [ZAP-361 — the gate](https://linear.app/lightdash/issue/ZAP-361/gate-custom-sql-table-calculations-behind-a-new-manage-custom-sql)
🔗 [ZAP-362 — migration UX](https://linear.app/lightdash/issue/ZAP-362/formula-onboarding-sqlformula-migration-ux-for-editors-gated-out-of)


<img width="361" height="74" alt="image" src="https://github.com/user-attachments/assets/19d2103f-117f-424c-88be-9538a4ae3626" />

<img width="766" height="466" alt="image" src="https://github.com/user-attachments/assets/860ed2f1-aae7-447a-a39d-7dee76b5476b" />

