### PR TITLE
feat(ai-agents): add runSavedChart tool

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -151,6 +151,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     openIdIdentityModel: models.getOpenIdIdentityModel(),
                     spaceService: repository.getSpaceService(),
                     projectModel: models.getProjectModel(),
+                    savedChartService: repository.getSavedChartService(),
                     aiOrganizationSettingsService:
                         repository.getAiOrganizationSettingsService(),
                     shareService: repository.getShareService(),

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -111,6 +111,7 @@ import { BaseService } from '../../../services/BaseService';
 import { CatalogService } from '../../../services/CatalogService/CatalogService';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
+import { SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
 import { ShareService } from '../../../services/ShareService/ShareService';
 import { SpaceService } from '../../../services/SpaceService/SpaceService';
 import {
@@ -141,6 +142,7 @@ import {
     GetDashboardChartsFn,
     GetExploreFn,
     GetPromptFn,
+    GetSavedChartFn,
     ListExploresFn,
     RunAsyncQueryFn,
     SearchFieldValuesFn,
@@ -192,6 +194,7 @@ type AiAgentServiceDependencies = {
     userModel: UserModel;
     spaceService: SpaceService;
     projectModel: ProjectModel;
+    savedChartService: SavedChartService;
     aiOrganizationSettingsService: AiOrganizationSettingsService;
     shareService: ShareService;
     prometheusMetrics?: PrometheusMetrics;
@@ -262,6 +265,8 @@ export class AiAgentService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
+    private readonly savedChartService: SavedChartService;
+
     private readonly prometheusMetrics?: PrometheusMetrics;
 
     private readonly aiOrganizationSettingsService: AiOrganizationSettingsService;
@@ -289,6 +294,7 @@ export class AiAgentService extends BaseService {
         this.userModel = dependencies.userModel;
         this.spaceService = dependencies.spaceService;
         this.projectModel = dependencies.projectModel;
+        this.savedChartService = dependencies.savedChartService;
         this.prometheusMetrics = dependencies.prometheusMetrics;
         this.aiOrganizationSettingsService =
             dependencies.aiOrganizationSettingsService;
@@ -2847,6 +2853,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             return webOrSlackPrompt;
         };
 
+        const getSavedChart: GetSavedChartFn = (chartUuid) =>
+            this.savedChartService.get(chartUuid, fromSession(user), {
+                projectUuid,
+            });
+
         const runAsyncQuery: RunAsyncQueryFn = (metricQuery) =>
             wrapSentryTransaction(
                 'AiAgent.runAsyncQuery',
@@ -3084,6 +3095,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             updateProgress,
             getPrompt,
             runAsyncQuery,
+            getSavedChart,
             sendFile,
             storeToolCall,
             storeToolResults,
@@ -3160,6 +3172,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             updateProgress,
             getPrompt,
             runAsyncQuery,
+            getSavedChart,
             sendFile,
             storeToolCall,
             storeToolResults,
@@ -3210,6 +3223,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             findFields,
             findExplores,
             runAsyncQuery,
+            getSavedChart,
             getPrompt,
             sendFile,
             storeToolCall,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -19,6 +19,7 @@ import { getGetDashboardCharts } from '../tools/getDashboardCharts';
 import { getImproveContext } from '../tools/improveContext';
 import { getProposeChange } from '../tools/proposeChange';
 import { getRunQuery } from '../tools/runQuery';
+import { getRunSavedChart } from '../tools/runSavedChart';
 import { getSearchFieldValues } from '../tools/searchFieldValues';
 import type {
     AiAgentArgs,
@@ -115,6 +116,14 @@ const getAgentTools = (
         enableSelfImprovement: args.enableSelfImprovement,
     });
 
+    const runSavedChart = getRunSavedChart({
+        updateProgress: dependencies.updateProgress,
+        runAsyncQuery: dependencies.runAsyncQuery,
+        getSavedChart: dependencies.getSavedChart,
+        maxLimit: args.maxQueryLimit,
+        enableDataAccess: args.enableDataAccess,
+    });
+
     const generateDashboard = getGenerateDashboardV2({
         getPrompt: dependencies.getPrompt,
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
@@ -137,6 +146,7 @@ const getAgentTools = (
         findExplores,
         findFields,
         runQuery,
+        runSavedChart,
         generateDashboard,
         ...(args.canManageAgent ? { improveContext } : {}),
         ...(args.enableSelfImprovement && args.canManageAgent

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -372,6 +372,7 @@ ${EXPLORE_SELECTION_AMBIGUITY_CHECKER}
     - Format results as a markdown list with descriptive link titles: e.g. [Dashboard Name](url) and [Chart Name](url). Never output bare URLs.
     - If no results found, offer to create a new chart based on available data
     - Do NOT call "findExplores" or "findFields" when searching for dashboards or charts
+    - **Inspecting an existing saved chart's data**: when the user pinned a chart (you'll see Chart "..." (chartUuid: ...) listed in the prompt context) or you discovered one via findContent / findCharts and want to see its actual rows, call "runSavedChart" with the chartUuid. Prefer this over building a fresh "runQuery" — the chart's saved metric query, filters, sorts, and custom metrics are applied automatically. Only build a new "runQuery" if you need a different shape than what the saved chart provides.
 
   3.5. **Field Value Search:**
     - Use "searchFieldValues" tool when users need to find specific values within dimension fields

--- a/packages/backend/src/ee/services/ai/tools/runSavedChart.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSavedChart.ts
@@ -1,0 +1,151 @@
+import {
+    getValidAiQueryLimit,
+    toolRunSavedChartArgsSchema,
+    toolRunSavedChartOutputSchema,
+    type AiMetricQueryWithFilters,
+    type MetricQuery,
+} from '@lightdash/common';
+import { tool } from 'ai';
+import { NO_RESULTS_RETRY_PROMPT } from '../prompts/noResultsRetry';
+import type {
+    GetSavedChartFn,
+    RunAsyncQueryFn,
+    UpdateProgressFn,
+} from '../types/aiAgentDependencies';
+import { convertQueryResultsToCsv } from '../utils/convertQueryResultsToCsv';
+import { serializeData } from '../utils/serializeData';
+import { toModelOutput } from '../utils/toModelOutput';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+
+type Dependencies = {
+    updateProgress: UpdateProgressFn;
+    runAsyncQuery: RunAsyncQueryFn;
+    getSavedChart: GetSavedChartFn;
+    maxLimit: number;
+    enableDataAccess: boolean;
+};
+
+/**
+ * Builds a structural summary the LLM can read to understand what the saved
+ * chart is querying. When `includeFullSpec` is false (data access disabled
+ * mode), only field IDs are surfaced — filter values and sort/limit details
+ * are omitted to keep filter values out of the LLM context.
+ */
+const buildHeader = (
+    chartUuid: string,
+    name: string,
+    metricQuery: MetricQuery,
+    { includeFullSpec }: { includeFullSpec: boolean },
+) => {
+    const lines = [
+        `Chart: "${name}" (chartUuid: ${chartUuid})`,
+        `Explore: ${metricQuery.exploreName}`,
+        `Dimensions: ${metricQuery.dimensions.join(', ') || '(none)'}`,
+        `Metrics: ${metricQuery.metrics.join(', ') || '(none)'}`,
+    ];
+
+    if (includeFullSpec) {
+        lines.push(`Filters: ${JSON.stringify(metricQuery.filters)}`);
+        if (metricQuery.sorts.length > 0) {
+            lines.push(`Sorts: ${JSON.stringify(metricQuery.sorts)}`);
+        }
+        lines.push(`Limit: ${metricQuery.limit}`);
+        if (
+            metricQuery.tableCalculations &&
+            metricQuery.tableCalculations.length > 0
+        ) {
+            lines.push(
+                `Table calculations: ${metricQuery.tableCalculations
+                    .map((c) => c.name)
+                    .join(', ')}`,
+            );
+        }
+        if (
+            metricQuery.additionalMetrics &&
+            metricQuery.additionalMetrics.length > 0
+        ) {
+            lines.push(
+                `Custom metrics: ${metricQuery.additionalMetrics
+                    .map((m) => `${m.table}_${m.name}`)
+                    .join(', ')}`,
+            );
+        }
+        if (
+            metricQuery.customDimensions &&
+            metricQuery.customDimensions.length > 0
+        ) {
+            lines.push(
+                `Custom dimensions: ${metricQuery.customDimensions
+                    .map((d) => d.id)
+                    .join(', ')}`,
+            );
+        }
+    }
+
+    lines.push('', '');
+    return lines.join('\n');
+};
+
+export const getRunSavedChart = ({
+    updateProgress,
+    runAsyncQuery,
+    getSavedChart,
+    maxLimit,
+    enableDataAccess,
+}: Dependencies) =>
+    tool({
+        description: toolRunSavedChartArgsSchema.description,
+        inputSchema: toolRunSavedChartArgsSchema,
+        outputSchema: toolRunSavedChartOutputSchema,
+        execute: async ({ chartUuid }) => {
+            try {
+                await updateProgress('Running saved chart...');
+
+                const savedChart = await getSavedChart(chartUuid);
+                const { metricQuery, name } = savedChart;
+
+                if (!enableDataAccess) {
+                    return {
+                        result: `${buildHeader(chartUuid, name, metricQuery, {
+                            includeFullSpec: false,
+                        })}Data access is disabled for this agent. Reason about the chart from its structure above; do not assume specific row values.`,
+                        metadata: { status: 'success' },
+                    };
+                }
+
+                const aiMetricQuery: AiMetricQueryWithFilters = {
+                    exploreName: metricQuery.exploreName,
+                    dimensions: metricQuery.dimensions,
+                    metrics: metricQuery.metrics,
+                    sorts: metricQuery.sorts,
+                    limit: getValidAiQueryLimit(metricQuery.limit, maxLimit),
+                    tableCalculations: metricQuery.tableCalculations,
+                    additionalMetrics: metricQuery.additionalMetrics ?? [],
+                    filters: metricQuery.filters,
+                };
+
+                const queryResults = await runAsyncQuery(aiMetricQuery);
+
+                if (queryResults.rows.length === 0) {
+                    return {
+                        result: NO_RESULTS_RETRY_PROMPT,
+                        metadata: { status: 'success' },
+                    };
+                }
+
+                const csv = convertQueryResultsToCsv(queryResults);
+                return {
+                    result: `${buildHeader(chartUuid, name, metricQuery, {
+                        includeFullSpec: true,
+                    })}${serializeData(csv, 'csv')}`,
+                    metadata: { status: 'success' },
+                };
+            } catch (e) {
+                return {
+                    result: toolErrorHandler(e, 'Error running saved chart.'),
+                    metadata: { status: 'error' },
+                };
+            }
+        },
+        toModelOutput: ({ output }) => toModelOutput(output),
+    });

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -11,6 +11,7 @@ import {
     GetExploreCompilerFn,
     GetExploreFn,
     GetPromptFn,
+    GetSavedChartFn,
     ListExploresFn,
     RunAsyncQueryFn,
     SearchFieldValuesFn,
@@ -65,6 +66,7 @@ export type AiAgentDependencies = {
     getExplore: GetExploreFn;
     getExploreCompiler: GetExploreCompilerFn;
     runAsyncQuery: RunAsyncQueryFn;
+    getSavedChart: GetSavedChartFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
     updatePrompt: UpdatePromptFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -15,6 +15,7 @@ import {
     Filters,
     ItemsMap,
     KnexPaginateArgs,
+    SavedChart,
     SlackPrompt,
     ToolFindContentArgs,
     ToolFindFieldsArgs,
@@ -103,6 +104,8 @@ export type RunAsyncQueryFn = (
     cacheMetadata: CacheMetadata;
     fields: ItemsMap;
 }>;
+
+export type GetSavedChartFn = (chartUuid: string) => Promise<SavedChart>;
 
 export type SendFileFn = (args: PostSlackFile) => Promise<void>;
 

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -10,6 +10,7 @@ import {
     toolImproveContextArgsSchema,
     toolProposeChangeArgsSchema,
     toolRunQueryArgsSchema,
+    toolRunSavedChartArgsSchema,
     toolSearchFieldValuesArgsSchema,
     toolTableVizArgsSchema,
     toolTimeSeriesArgsSchema,
@@ -36,6 +37,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     generateTimeSeriesVizConfig: 'time_series_chart',
     generateBarVizConfig: 'vertical_bar_chart',
     runQuery: 'query_result',
+    runSavedChart: 'run_saved_chart',
     generateDashboard: 'generate_dashboard',
     improveContext: 'improve_context',
     proposeChange: 'propose_change',
@@ -58,6 +60,7 @@ const TOOL_SCHEMAS = {
     improveContext: toolImproveContextArgsSchema,
     proposeChange: toolProposeChangeArgsSchema,
     runQuery: toolRunQueryArgsSchema,
+    runSavedChart: toolRunSavedChartArgsSchema,
 } satisfies Record<ToolName, z.ZodSchema>;
 
 const getToolInfo = (toolName: string) => {

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -11,6 +11,7 @@ export * from './toolImproveContextArgs';
 export * from './toolProposeChangeArgs';
 export * from './toolRunMetricQueryArgs';
 export * from './toolRunQueryArgs';
+export * from './toolRunSavedChartArgs';
 export * from './toolRunSqlArgs';
 export * from './toolSearchFieldValuesArgs';
 export * from './toolTableVizArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunSavedChartArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunSavedChartArgs.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { baseOutputMetadataSchema } from '../outputMetadata';
+import { createToolSchema } from '../toolSchemaBuilder';
+
+const TOOL_RUN_SAVED_CHART_DESCRIPTION = `
+Run an existing saved chart by its UUID and return the rows it produces.
+
+When to use this tool:
+- The user has pinned a chart (you'll see it listed in the prompt context as
+  "Chart \\"...\\" (chartUuid: ...)") and you need to inspect its data to answer
+  their question.
+- You discovered a relevant chart via findContent / findCharts and want to read
+  its results without rebuilding the query from scratch.
+
+Prefer this over runQuery when a saved chart already exists for the data the
+user is asking about. The chart's saved metric query, filters, sorts, and
+custom metrics are applied automatically.
+`;
+
+export const toolRunSavedChartArgsSchema = createToolSchema({
+    description: TOOL_RUN_SAVED_CHART_DESCRIPTION,
+})
+    .extend({
+        chartUuid: z
+            .string()
+            .describe(
+                'UUID of the saved chart to execute. Use the chartUuid from the prompt context or from a prior findContent / findCharts result.',
+            ),
+    })
+    .build();
+
+export type ToolRunSavedChartArgs = z.infer<typeof toolRunSavedChartArgsSchema>;
+
+export const toolRunSavedChartOutputSchema = z.object({
+    result: z.string(),
+    metadata: baseOutputMetadataSchema,
+});
+
+export type ToolRunSavedChartOutput = z.infer<
+    typeof toolRunSavedChartOutputSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -24,6 +24,7 @@ export const ToolNameSchema = z.enum([
     'improveContext',
     'proposeChange',
     'runQuery',
+    'runSavedChart',
 ]);
 
 export type ToolName = z.infer<typeof ToolNameSchema>;
@@ -48,6 +49,7 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     getDashboardCharts: 'Looking up dashboard charts',
     improveContext: 'Improving context',
     runQuery: 'Generating visualization',
+    runSavedChart: 'Running saved chart',
 });
 
 // after-tool-call messages
@@ -66,6 +68,7 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         getDashboardCharts: 'Found dashboard charts',
         improveContext: 'Improved context',
         runQuery: 'Generated visualization',
+        runSavedChart: 'Ran saved chart',
     });
 
 export const AVAILABLE_VISUALIZATION_TYPES = VisualizationTools;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -142,6 +142,7 @@ export const ToolCallDescription: FC<{
             );
         case 'improveContext':
         case 'proposeChange':
+        case 'runSavedChart':
             return <> </>;
         default:
             return assertUnreachable(toolName, `Unknown tool name ${toolName}`);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -31,6 +31,7 @@ export const getToolIcon = (toolName: ToolName) => {
             improveContext: IconSchool,
             proposeChange: IconPencil,
             runQuery: IconTable,
+            runSavedChart: IconChartHistogram,
         };
 
     return iconMap[toolName];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: ZAP-46<!-- reference the related issue e.g. #150 -->

### Description:

This PR introduces a new tool that allows agents to query saved chart information. This is the final task to complete the work of adding "ask from here" from charts and dashboards into agent conversations.