### PR TITLE
feat: required parameters & decouple parameters from dimensions

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/customers.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/customers.yml
@@ -11,6 +11,23 @@ models:
             options_from_dimension:
               dimension: "first_name"
               model: "customers"
+          required_tenant:
+            label: "Tenant (required, no dimension reference)"
+            description: "Demo of a required parameter that has no underlying dimension reference. It is always shown in the Customers explore and the query is blocked until a value is selected."
+            required: true
+            options:
+              - "acme"
+              - "globex"
+              - "stark-industries"
+          required_region_with_default:
+            label: "Region (required with default)"
+            description: "Demo of a required parameter that has a default — always shown but does not block the query."
+            required: true
+            default: "EMEA"
+            options:
+              - "AMER"
+              - "EMEA"
+              - "APAC"
         primary_key: customer_id
         spotlight:
           categories: ["experimental"]

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -159,6 +159,7 @@ import {
     UserAccessControls,
     UserAttributeValueMap,
     UserWarehouseCredentials,
+    validateParameterConfiguration,
     VizColumn,
     WarehouseClient,
     WarehouseConnectionError,
@@ -7754,6 +7755,16 @@ export class ProjectService extends BaseService {
         ) {
             throw new ForbiddenError(
                 `User does not have permission to update project parameters`,
+            );
+        }
+
+        const validation = validateParameterConfiguration(
+            parameters,
+            'project',
+        );
+        if (!validation.isValid) {
+            throw new ParameterError(
+                validation.error ?? 'Invalid project parameter configuration',
             );
         }
 

--- a/packages/common/src/compiler/parameters.test.ts
+++ b/packages/common/src/compiler/parameters.test.ts
@@ -1,4 +1,6 @@
+import { type Table } from '../types/explore';
 import {
+    getAvailableParametersFromTables,
     getParameterReferences,
     validateParameterConfiguration,
     validateParameterNames,
@@ -370,5 +372,155 @@ describe('validateParameterConfiguration', () => {
         });
         expect(result.isValid).toBe(true);
         expect(result.error).toBeNull();
+    });
+
+    it('should pass for model-level parameter with required: true', () => {
+        const result = validateParameterConfiguration(
+            {
+                tenant: {
+                    label: 'Tenant',
+                    options: ['acme', 'globex'],
+                    required: true,
+                },
+            },
+            'model',
+        );
+        expect(result.isValid).toBe(true);
+        expect(result.error).toBeNull();
+    });
+
+    it('should pass for model-level parameter with required: false', () => {
+        const result = validateParameterConfiguration(
+            {
+                tenant: {
+                    label: 'Tenant',
+                    options: ['acme', 'globex'],
+                    required: false,
+                },
+            },
+            'model',
+        );
+        expect(result.isValid).toBe(true);
+        expect(result.error).toBeNull();
+    });
+
+    it('should still enforce options/options_from_dimension/allow_custom_values when required is set', () => {
+        const result = validateParameterConfiguration(
+            {
+                tenant: {
+                    label: 'Tenant',
+                    required: true,
+                },
+            },
+            'model',
+        );
+        expect(result.isValid).toBe(false);
+        expect(result.error).not.toBeNull();
+    });
+
+    it('should reject project-level parameter with required: true', () => {
+        const result = validateParameterConfiguration(
+            {
+                tenant: {
+                    label: 'Tenant',
+                    options: ['acme', 'globex'],
+                    required: true,
+                },
+            },
+            'project',
+        );
+        expect(result.isValid).toBe(false);
+        expect(result.error).toContain('tenant');
+        expect(result.error).toContain('model-level');
+    });
+
+    it('should pass for project-level parameter without required', () => {
+        const result = validateParameterConfiguration(
+            {
+                tenant: {
+                    label: 'Tenant',
+                    options: ['acme', 'globex'],
+                },
+            },
+            'project',
+        );
+        expect(result.isValid).toBe(true);
+        expect(result.error).toBeNull();
+    });
+
+    it('should pass for project-level parameter with required: false', () => {
+        const result = validateParameterConfiguration(
+            {
+                tenant: {
+                    label: 'Tenant',
+                    options: ['acme', 'globex'],
+                    required: false,
+                },
+            },
+            'project',
+        );
+        expect(result.isValid).toBe(true);
+        expect(result.error).toBeNull();
+    });
+});
+
+describe('getAvailableParametersFromTables', () => {
+    const buildTable = (
+        name: string,
+        params: Record<
+            string,
+            { label: string; required?: boolean; options?: string[] }
+        >,
+    ): Table =>
+        ({
+            name,
+            originalName: name,
+            label: name,
+            database: 'db',
+            schema: 'public',
+            sqlTable: `"${name}"`,
+            dimensions: {},
+            metrics: {},
+            lineageGraph: {},
+            parameters: params,
+        }) as unknown as Table;
+
+    const tables = [
+        buildTable('customers', {
+            customer_name: { label: 'Customer name', options: ['a'] },
+            required_tenant: {
+                label: 'Tenant',
+                required: true,
+                options: ['acme'],
+            },
+        }),
+        buildTable('orders', {
+            currency: { label: 'Currency', options: ['usd'] },
+        }),
+    ];
+
+    it('preserves `required` on all tables when no baseTable is provided', () => {
+        const result = getAvailableParametersFromTables(tables);
+        expect(result['customers.required_tenant'].required).toBe(true);
+        expect(result['customers.customer_name'].required).toBeUndefined();
+    });
+
+    it('preserves `required` on the base table when baseTable is provided', () => {
+        const result = getAvailableParametersFromTables(tables, 'customers');
+        expect(result['customers.required_tenant'].required).toBe(true);
+    });
+
+    it('strips `required` from non-base tables when baseTable is provided', () => {
+        const result = getAvailableParametersFromTables(tables, 'orders');
+        expect(result['customers.required_tenant'].required).toBe(false);
+        expect(result['customers.customer_name'].required).toBe(false);
+        // Base-table params keep their original (un-set) required flag
+        expect(result['orders.currency'].required).toBeUndefined();
+    });
+
+    it('keeps non-required params from joined tables available for SQL references', () => {
+        const result = getAvailableParametersFromTables(tables, 'orders');
+        expect(result['customers.customer_name']).toBeDefined();
+        expect(result['customers.customer_name'].label).toBe('Customer name');
     });
 });

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -133,15 +133,21 @@ export const getAvailableParameterNames = (
     );
 
 /**
- * Get all available parameter names for a project and explore
- * @param exploreParameters - The explore parameters
- * @param includedTables - The included tables
- * @returns An array of available parameter names
+ * Get all available parameter names for a project and explore.
+ *
+ * When `baseTable` is provided, parameters defined on tables other than the
+ * base are still returned (so they can be referenced in SQL/liquid), but their
+ * `required` flag is dropped. Required only applies to the explore's base
+ * table — joined tables become required only if their params actually appear
+ * in the compiled SQL (handled separately via `parameterReferences`).
  */
 export const getAvailableParametersFromTables = (
     includedTables: (Table | CompiledTable)[],
+    baseTable?: string,
 ): Record<string, LightdashProjectParameter> =>
     includedTables.reduce((acc, table) => {
+        const tableName = table.originalName ?? table.name;
+        const isBaseTable = baseTable !== undefined && tableName === baseTable;
         const tableParameters = Object.keys(table.parameters || {}).reduce<
             Record<string, LightdashProjectParameter>
         >((acc2, p) => {
@@ -150,8 +156,6 @@ export const getAvailableParametersFromTables = (
                 return acc2;
             }
 
-            // Use the original table name for parameters if available, otherwise use the current name
-            const tableName = table.originalName ?? table.name;
             const parameterKey = `${tableName}.${p}`;
 
             return {
@@ -159,6 +163,9 @@ export const getAvailableParametersFromTables = (
                 [parameterKey]: {
                     ...parameter,
                     type: parameter.type || 'string',
+                    ...(baseTable !== undefined && !isBaseTable
+                        ? { required: false }
+                        : {}),
                 },
             };
         }, {});
@@ -219,14 +226,33 @@ const getParametersSchemaAndValidator = ():
     return cached;
 };
 
+export type ParameterScope = 'project' | 'model';
+
 /**
  * Validate parameter configuration using AJV against the JSON schema.
+ *
+ * `scope` defaults to 'model' for backwards compatibility. When 'project' is
+ * passed, fields that are only valid at model level (currently `required`) are
+ * rejected with a clear error.
  */
 export const validateParameterConfiguration = (
     parameters: Record<string, LightdashProjectParameter> | undefined,
+    scope: ParameterScope = 'model',
 ): { isValid: boolean; error: string | null } => {
     if (!parameters || Object.keys(parameters).length === 0) {
         return { isValid: true, error: null };
+    }
+
+    if (scope === 'project') {
+        const projectLevelRequired = Object.entries(parameters)
+            .filter(([, def]) => def?.required === true)
+            .map(([name]) => name);
+        if (projectLevelRequired.length > 0) {
+            return {
+                isValid: false,
+                error: `\`required: true\` is only supported on model-level parameters. Move these parameters under a model's \`config.meta.parameters\` to require them: ${projectLevelRequired.join(', ')}`,
+            };
+        }
     }
 
     const schemaAndValidator = getParametersSchemaAndValidator();

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -995,6 +995,10 @@
                                     "description": "Whether users can input custom values beyond predefined options",
                                     "type": "boolean"
                                 },
+                                "required": {
+                                    "description": "When true, the parameter is always shown in the explore and a value (or default) must be set before the query can run",
+                                    "type": "boolean"
+                                },
                                 "options_from_dimension": {
                                     "description": "Get parameter options from a dimension in a model",
                                     "type": "object",

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -21,6 +21,7 @@ export type LightdashProjectParameter = {
     default?: ParameterValue;
     multiple?: boolean; // the parameter input will be a multi select
     allow_custom_values?: boolean; // allows users to input custom values beyond predefined options
+    required?: boolean; // when true, the parameter is always shown in the explore and a value (or default) must be set before the query can run
     options?: string[] | number[]; // hardcoded options - kept separate as they're always homogeneous arrays
     options_from_dimension?: {
         // options will be populated from dimension values

--- a/packages/frontend/src/components/Explorer/ParametersCard/ParametersCard.tsx
+++ b/packages/frontend/src/components/Explorer/ParametersCard/ParametersCard.tsx
@@ -40,8 +40,10 @@ const ParametersCard = memo(
 
         const filteredParameterDefinitions = useMemo(() => {
             return Object.fromEntries(
-                Object.entries(parameterDefinitions).filter(([key]) =>
-                    parameterReferences?.includes(key),
+                Object.entries(parameterDefinitions).filter(
+                    ([key, def]) =>
+                        def.required === true ||
+                        parameterReferences?.includes(key),
                 ),
             );
         }, [parameterDefinitions, parameterReferences]);

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -175,6 +175,7 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
             return explore
                 ? getAvailableParametersFromTables(
                       Object.values(explore.tables),
+                      explore.baseTable,
                   )
                 : {};
         }, [explore]);
@@ -185,6 +186,14 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                 ...(exploreParameterDefinitions ?? {}),
             };
         }, [projectParameters, exploreParameterDefinitions]);
+
+        const hasRequiredParameter = useMemo(
+            () =>
+                Object.values(parameterDefinitions).some(
+                    (def) => def.required === true,
+                ),
+            [parameterDefinitions],
+        );
 
         useEffect(() => {
             dispatch(
@@ -230,11 +239,12 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                         ))}
 
                     {!!tableName &&
-                        parameterReferencesFromRedux &&
-                        parameterReferencesFromRedux?.length > 0 && (
+                        ((parameterReferencesFromRedux &&
+                            parameterReferencesFromRedux.length > 0) ||
+                            hasRequiredParameter) && (
                             <ParametersCard
                                 parameterReferences={
-                                    parameterReferencesFromRedux
+                                    parameterReferencesFromRedux ?? undefined
                                 }
                             />
                         )}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
@@ -23,8 +23,9 @@ const EmbedDashboardParameters: FC = () => {
 
     const referencedParameters = useMemo(() => {
         return Object.fromEntries(
-            Object.entries(parameterDefinitions).filter(([key]) =>
-                parameterReferences.has(key),
+            Object.entries(parameterDefinitions).filter(
+                ([key, def]) =>
+                    def.required === true || parameterReferences.has(key),
             ),
         );
     }, [parameterDefinitions, parameterReferences]);

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -553,8 +553,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             .flatMap((tile) => tileParameterReferences[tile.uuid] ?? []);
 
         return Object.fromEntries(
-            Object.entries(parameters).filter(([key]) =>
-                activeParamKeys.includes(key),
+            Object.entries(parameters).filter(
+                ([key, def]) =>
+                    def.required === true || activeParamKeys.includes(key),
             ),
         );
     }, [dashboardTiles, parameters, tileParameterReferences, isActiveTile]);

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -122,7 +122,10 @@ export const useDashboardChartReadyQuery = (
     useEffect(() => {
         if (explore) {
             addParameterDefinitions(
-                getAvailableParametersFromTables(Object.values(explore.tables)),
+                getAvailableParametersFromTables(
+                    Object.values(explore.tables),
+                    explore.baseTable,
+                ),
             );
         }
     }, [explore, addParameterDefinitions]);

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -107,13 +107,21 @@ export const useExplorerQueryManager = () => {
     const missingRequiredParameters = useMemo(() => {
         if (parameterReferences === null) return null;
 
-        // Missing required parameters are the ones that are not set and don't have a default value
-        const missing = parameterReferences.filter(
+        // Two ways a parameter is "required" for query execution:
+        //   1. It is referenced in the compiled SQL — without a value the SQL substitution will fail
+        //   2. It has `required: true` in its definition — the user has marked it mandatory regardless of whether it appears in current SQL (e.g. liquid-only usage)
+        const requiredKeys = Object.keys(parameterDefinitions ?? {}).filter(
+            (key) => parameterDefinitions?.[key]?.required === true,
+        );
+        const keysToCheck = Array.from(
+            new Set([...parameterReferences, ...requiredKeys]),
+        );
+
+        return keysToCheck.filter(
             (parameter) =>
                 !parameters?.[parameter] &&
                 !parameterDefinitions?.[parameter]?.default,
         );
-        return missing;
     }, [parameterReferences, parameters, parameterDefinitions]);
 
     // Dispatch functions for query UUID history

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -180,8 +180,9 @@ const Dashboard: FC = () => {
 
     const referencedParameters = useMemo(() => {
         return Object.fromEntries(
-            Object.entries(parameterDefinitions).filter(([key]) =>
-                parameterReferences.has(key),
+            Object.entries(parameterDefinitions).filter(
+                ([key, def]) =>
+                    def.required === true || parameterReferences.has(key),
             ),
         );
     }, [parameterDefinitions, parameterReferences]);

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -225,10 +225,29 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 
     const addParameterDefinitions = useCallback(
         (parameters: ParameterDefinitions) => {
-            setParameterDefinitions((prev) => ({
-                ...prev,
-                ...parameters,
-            }));
+            setParameterDefinitions((prev) => {
+                const merged: ParameterDefinitions = { ...prev };
+                for (const [key, def] of Object.entries(parameters)) {
+                    const existing = merged[key];
+                    // OR-merge `required` so that if any contributing tile says
+                    // a parameter is required (because it's on that tile's base
+                    // table), the dashboard treats it as required regardless of
+                    // load order or other tiles where the same param sits on a
+                    // joined table.
+                    merged[key] = existing
+                        ? {
+                              ...existing,
+                              ...def,
+                              required:
+                                  existing.required === true ||
+                                  def.required === true
+                                      ? true
+                                      : def.required,
+                          }
+                        : def;
+                }
+                return merged;
+            });
         },
         [],
     );
@@ -492,11 +511,18 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     }, [projectParameters, addParameterDefinitions]);
 
     const missingRequiredParameters = useMemo(() => {
-        // If no parameter references, return empty array
-        if (!dashboardParameterReferences.size) return [];
+        // Parameters can become required for the dashboard in two ways:
+        //   1. A chart on the dashboard references the parameter in its SQL
+        //   2. The parameter has `required: true` in its definition
+        const requiredKeys = Object.keys(parameterDefinitions).filter(
+            (key) => parameterDefinitions[key]?.required === true,
+        );
+        const keysToCheck = Array.from(
+            new Set([...dashboardParameterReferences, ...requiredKeys]),
+        );
+        if (keysToCheck.length === 0) return [];
 
-        // Missing required parameters are the ones that are not set and don't have a default value
-        return Array.from(dashboardParameterReferences).filter(
+        return keysToCheck.filter(
             (parameterName) =>
                 !parameters[parameterName] &&
                 !parameterDefinitions[parameterName]?.default,


### PR DESCRIPTION
[PROD-7476](https://linear.app/lightdash/issue/PROD-7476/required-parameters-and-decouple-parameters-from-dimensions)

## Summary

- Adds `required: true` for **model-level** parameters and lets parameters surface in the explore and dashboard without needing a dimension that references them.
- Required parameters always show on their model's base explore (and on dashboards containing a chart from that explore) and block query execution until a value is set or a default is provided.
- Required is rejected for **project-level** parameters (validation runs in `replaceProjectParameters`).
- Required is **scoped to the explore's base table** — joined-table required params surface only when their SQL is actually referenced. Multi-tile dashboards OR-merge `required` so any tile that considers a parameter required wins, regardless of load order.
- Demo example added under `examples/full-jaffle-shop-demo/dbt/models/customers.yml` (`required_tenant`, `required_region_with_default`).

## Motivating use case

A user is parameterising the `sql_from` clause of a model — e.g. `sql_from: ${TABLE_PREFIX}_events_${ld.parameters.region}` — so the explore points at a different physical table per parameter value. The parameter is `required: true` with a default, so the explore is always queryable but the user can switch tables by changing the parameter.

Before this change, the parameter only appeared in the explore/dashboard UI if a dimension that referenced it was added to the results table — which is awkward when the parameter drives `sql_from` and has no natural dimension to expose. With this change the required parameter shows up in the explore and on dashboards without any dimension being selected, while still being blocked-on or default-resolved at run time.

## Changed surfaces

- **Type/schema**: `LightdashProjectParameter.required?: boolean`, JSON schema (`lightdash-dbt-2.0.json`)
- **Validation**: `validateParameterConfiguration(parameters, scope: 'project' | 'model')` — rejects `required: true` at project scope; wired into `ProjectService.replaceProjectParameters`
- **Compiler helper**: `getAvailableParametersFromTables(tables, baseTable?)` — strips `required` from non-base tables when `baseTable` is provided
- **Frontend explore**: `ParametersCard` filter, `useExplorerQueryManager` missing-required computation, render condition in `Explorer/index.tsx`
- **Frontend dashboard**: `Dashboard.tsx` filter, `DashboardProvider` (OR-merge in `addParameterDefinitions` + `missingRequiredParameters`), per-tab filter in `dashboardTabs/index.tsx`, embed dashboard parameters

## Test plan
- [x] Unit tests for parameter validation and `getAvailableParametersFromTables` (45 tests passing)
- [x] Manual: customers explore shows both required params with no fields selected
- [x] Manual: orders explore (which joins customers) does **not** show customers' required params
- [x] Manual: events explore (no customers relation) shows no Parameters card
- [x] Manual: required + default ("EMEA") doesn't block query
- [x] Manual: required without default red-outlines the input and blocks "Run query"
- [x] Manual: dashboard with customers chart shows both required params in the filter bar
- [x] Manual: API rejects project-level `required: true` with a clear `ParameterError`
- [x] Frontend + common typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)