### PR TITLE
[codex] Fix dashboard date zoom URL hydration

### DIFF
--- a/packages/e2e/cypress/e2e/app/dateZoomEditMode.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dateZoomEditMode.cy.ts
@@ -1,0 +1,176 @@
+import { SEED_PROJECT } from '@lightdash/common';
+
+const apiUrl = '/api/v1';
+
+const createBigNumberChart = (
+    fieldX: string,
+    fieldY: string,
+): Cypress.Chainable<string> =>
+    cy
+        .request({
+            url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/saved`,
+            method: 'POST',
+            body: {
+                name: `Big number ${fieldX} x ${fieldY}`,
+                description: '',
+                tableName: 'payments',
+                metricQuery: {
+                    dimensions: [fieldX],
+                    metrics: [fieldY],
+                    filters: {},
+                    sorts: [
+                        {
+                            fieldId: fieldX,
+                            descending: true,
+                        },
+                    ],
+                    limit: 500,
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    customDimensions: [],
+                },
+                chartConfig: {
+                    type: 'big_number',
+                    config: {
+                        label: 'Date zoom revenue',
+                    },
+                },
+                tableConfig: {
+                    columnOrder: [fieldX, fieldY],
+                },
+                pivotConfig: {
+                    columns: [],
+                },
+            },
+        })
+        .then((response) => {
+            expect(response.status).to.eq(200);
+            return response.body.results.uuid;
+        });
+
+const createDashboardWithChart = (
+    name: string,
+    chartUuid: string,
+): Cypress.Chainable<string> =>
+    cy
+        .request({
+            url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`,
+            method: 'POST',
+            body: {
+                name,
+                description: '',
+                tiles: [],
+                tabs: [],
+            },
+        })
+        .then((response) => {
+            expect(response.status).to.eq(201);
+
+            const dashboardUuid = response.body.results.uuid;
+            return cy
+                .request({
+                    url: `${apiUrl}/dashboards/${dashboardUuid}`,
+                    method: 'PATCH',
+                    body: {
+                        tiles: [
+                            {
+                                uuid: chartUuid,
+                                type: 'saved_chart',
+                                properties: {
+                                    belongsToDashboard: false,
+                                    savedChartUuid: chartUuid,
+                                    chartName: name,
+                                },
+                                h: 9,
+                                w: 15,
+                                x: 0,
+                                y: 0,
+                                tabUuid: null,
+                            },
+                        ],
+                        filters: {
+                            dimensions: [],
+                            metrics: [],
+                            tableCalculations: [],
+                        },
+                        tabs: [],
+                        name,
+                    },
+                })
+                .then((patchResponse) => {
+                    expect(patchResponse.status).to.eq(200);
+                    return dashboardUuid;
+                });
+        });
+
+describe('Date zoom edit mode', () => {
+    beforeEach(() => {
+        cy.login();
+    });
+
+    it('preserves URL date zoom on initial load and when entering edit mode', () => {
+        createBigNumberChart(
+            'orders_order_date_month',
+            'payments_total_revenue',
+        ).then((chartUuid) => {
+            createDashboardWithChart(
+                'date zoom edit mode big number',
+                chartUuid,
+            ).then((dashboardUuid) => {
+                let requestCountBeforeEdit = 0;
+
+                cy.intercept(
+                    'POST',
+                    `/api/v2/projects/${SEED_PROJECT.project_uuid}/query/dashboard-chart`,
+                ).as('dashboardChartQuery');
+
+                cy.visit(
+                    `/projects/${SEED_PROJECT.project_uuid}/dashboards/${dashboardUuid}/view?dateZoom=day`,
+                );
+
+                cy.contains('date zoom edit mode big number');
+                cy.wait('@dashboardChartQuery', { timeout: 60000 }).then(
+                    ({ request }) => {
+                        expect(request.body.chartUuid).to.eq(chartUuid);
+                        expect(request.body.dateZoom).to.deep.eq({
+                            granularity: 'Day',
+                        });
+                    },
+                );
+
+                cy.get('@dashboardChartQuery.all').then((interceptions) => {
+                    requestCountBeforeEdit = interceptions.length;
+                });
+
+                cy.findByLabelText('Edit dashboard').click();
+                cy.url().should('include', '/edit');
+                cy.findByRole('button', { name: 'Save changes' }).should(
+                    'be.visible',
+                );
+
+                cy.wait(10000);
+                cy.get('@dashboardChartQuery.all').should((interceptions) => {
+                    const requestsAfterEdit = interceptions
+                        .slice(requestCountBeforeEdit)
+                        .filter(
+                            ({ request }) =>
+                                request.body.chartUuid === chartUuid,
+                        );
+                    const emptyDateZoomRequests = requestsAfterEdit.filter(
+                        ({ request }) =>
+                            JSON.stringify(request.body.dateZoom) === '{}',
+                    );
+
+                    expect(
+                        emptyDateZoomRequests,
+                        JSON.stringify(
+                            requestsAfterEdit.map(({ request }) => ({
+                                dateZoom: request.body.dateZoom,
+                            })),
+                        ),
+                    ).to.have.length(0);
+                });
+            });
+        });
+    });
+});

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -153,10 +153,6 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
     );
     const { track } = useTracking();
 
-    useEffect(() => {
-        if (isEditMode) setDateZoomGranularity(undefined);
-    }, [isEditMode, setDateZoomGranularity]);
-
     // Reset active sub-day granularity when no TIMESTAMP dimensions exist
     // (e.g., saved config or URL param on DATE-only dashboard)
     useEffect(() => {

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -10,7 +10,7 @@ import { captureException } from '@sentry/react';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { type Layout } from 'react-grid-layout';
-import { useBlocker, useNavigate, useParams } from 'react-router';
+import { useBlocker, useLocation, useNavigate, useParams } from 'react-router';
 import { dashboardCSSVars } from '../components/common/Dashboard/dashboard.constants';
 import styles from '../components/common/Dashboard/Dashboard.module.css';
 import DashboardHeader from '../components/common/Dashboard/DashboardHeader';
@@ -31,6 +31,7 @@ import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
+import { useDateZoomGranularitySearch } from '../hooks/useExplorerRoute';
 import useApp from '../providers/App/useApp';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
@@ -40,6 +41,7 @@ import '../styles/react-grid.css';
 
 const Dashboard: FC = () => {
     const navigate = useNavigate();
+    const { search } = useLocation();
     const { projectUuid, dashboardUuid, mode } = useParams<{
         projectUuid: string;
         dashboardUuid: string;
@@ -602,6 +604,13 @@ const Dashboard: FC = () => {
 
         await refreshDashboardVersion();
 
+        const currentParams = new URLSearchParams(search);
+        const dateZoomParam = currentParams.get('dateZoom');
+        const editParams = new URLSearchParams();
+        if (dateZoomParam) {
+            editParams.set('dateZoom', dateZoomParam);
+        }
+
         // Defer the redirect
         void Promise.resolve().then(() => {
             return navigate(
@@ -610,7 +619,7 @@ const Dashboard: FC = () => {
                         dashboardTabs.length > 0
                             ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${activeTab?.uuid}`
                             : `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit`,
-                    search: '',
+                    search: editParams.toString(),
                 },
                 { replace: true },
             );
@@ -621,6 +630,7 @@ const Dashboard: FC = () => {
         resetDashboardFilters,
         refreshDashboardVersion,
         navigate,
+        search,
         activeTab?.uuid,
         dashboardTabs.length,
     ]);
@@ -849,12 +859,14 @@ const DashboardPage: FC = () => {
     }>();
     const { user } = useApp();
     const dashboardCommentsCheck = useDashboardCommentsCheck(user?.data);
+    const dateZoom = useDateZoomGranularitySearch();
 
     return (
         <DashboardProvider
             key={dashboardUuid}
             projectUuid={projectUuid}
             dashboardCommentsCheck={dashboardCommentsCheck}
+            dateZoom={dateZoom}
         >
             <Dashboard />
         </DashboardProvider>


### PR DESCRIPTION
## Summary

- Add a Cypress regression for a time-based big-number dashboard tile loaded with `?dateZoom=day`.
- Hydrate `dateZoom` from the dashboard URL before `DashboardProvider` mounts so initial chart queries include the active granularity.
- Preserve the `dateZoom` URL parameter when entering edit mode and stop edit mode from clearing the active query zoom.

## Root cause

The main dashboard route did not pass the URL `dateZoom` value into `DashboardProvider`. The provider later parsed it in a mount effect, which allowed initial dashboard chart queries to run with an empty `dateZoom` payload. Entering edit mode also dropped the query parameter and the date zoom component cleared active zoom state.

## Validation

- `pnpm -F frontend run linter src/pages/Dashboard.tsx src/features/dateZoom/components/DateZoom.tsx`
- `pnpm -F frontend run formatter src/pages/Dashboard.tsx src/features/dateZoom/components/DateZoom.tsx --check`
- `pnpm -F frontend typecheck`
- `pnpm --filter e2e exec eslint -c .eslintrc.js cypress/e2e/app/dateZoomEditMode.cy.ts`
- `CYPRESS_RETRIES=0 pnpm --filter e2e exec cypress run --spec cypress/e2e/app/dateZoomEditMode.cy.ts --browser chrome --config baseUrl=http://localhost:3010`