### PR TITLE
feat(observability): codify wide-event logging convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,67 @@ The canonical source of truth for field types is `packages/common/src/types/fiel
     -   Import from `@lightdash/common`: `import { assertUnreachable } from '@lightdash/common';`
     -   This provides compile-time safety when new union members are added
 
+## Logging — Prefer Wide Events
+
+When adding logging to a unit of work (a request, job, scheduler task, or operation), prefer a **wide events** approach: accumulate context as the work flows through, then emit **one structured event at the end** with as many fields as you can muster — rather than scattering many thin log lines throughout the code path.
+
+**Why**: high-cardinality dimensions (user ID, org ID, project UUID, route, latency, DB time, cache hits, build SHA, feature flags, region, error info, upstream timings, etc.) preserved on a single event let us answer arbitrary questions at query time without pre-building dashboards. Aggregated metrics throw away per-request context the moment they're rolled up; wide events keep it.
+
+**How to apply in this codebase**: Lightdash uses Winston via `import Logger from './logging/logger';` with a structured-context object as the second argument — this IS the wide-event payload.
+
+-   ✅ **Good** — accumulate context, emit one fat event:
+
+    ```typescript
+    const event: Record<string, unknown> = {
+        requestId,
+        userUuid: user.userUuid,
+        organizationUuid: user.organizationUuid,
+        projectUuid,
+        route: '/api/v1/...',
+    };
+    try {
+        const t0 = Date.now();
+        const explore = await this.getExplore(...);
+        event.exploreLoadMs = Date.now() - t0;
+        event.exploreName = explore.name;
+
+        const t1 = Date.now();
+        const rows = await warehouseClient.runQuery(...);
+        event.warehouseQueryMs = Date.now() - t1;
+        event.rowCount = rows.length;
+        event.cacheHit = false;
+
+        event.outcome = 'success';
+    } catch (e) {
+        event.outcome = 'error';
+        event.errorName = e.name;
+        event.errorMessage = e.message;
+        throw e;
+    } finally {
+        event.totalMs = Date.now() - tStart;
+        Logger.info('runQuery', event);
+    }
+    ```
+
+-   ❌ **Avoid** — scattered, low-context lines that lose correlation:
+
+    ```typescript
+    Logger.info('Loading explore');
+    Logger.info('Running warehouse query');
+    Logger.info(`Got ${rows.length} rows`);
+    Logger.info('Done');
+    ```
+
+**Guidelines**:
+
+-   **One event per unit of work.** A request handler, a scheduler task, a CLI command — each gets one wide event at completion, not many along the way.
+-   **Pass the event object down** the call chain (or use a request-scoped context) so deeper code can attach fields without a fresh `Logger.info` call. Winston child loggers (`Logger.child({ ... })`) are also fine for cross-cutting context.
+-   **Always include the outcome** (`success` / `error` / `aborted`) and **a duration field** so the same event drives both error analysis and latency analysis.
+-   **High-cardinality fields are the point** — include UUIDs, route, build SHA, feature-flag values. Don't pre-aggregate.
+-   **Never log secrets or PII** — see `sensitiveCredentialsFieldNames` in `packages/common/src/types/projects.ts`. Field names like `password`, `token`, `keyfileContents`, raw user emails, etc. must never appear in event payloads.
+-   **Errors still get `Logger.error`**, but with the same accumulated wide context — don't throw away the event when something fails, attach the error fields and emit it.
+-   **Existing thin logs are fine** — don't refactor them as a side quest. This guidance shapes new code.
+
 ## Security Best Practices
 
 ### Installing Dependencies — Always Use `sfw`

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -286,6 +286,13 @@ export function getIntervalSyntax(
 export class MetricQueryBuilder {
     private compilationErrors: string[] = [];
 
+    private caseSensitiveFilters: Array<{
+        fieldId: string;
+        ruleCaseSensitive: boolean | null;
+        fieldCaseSensitive: boolean | null;
+        finalSqlContainsUpper: boolean;
+    }> = [];
+
     private readonly baseMetricIdByPopMetricId: Record<string, string> = {};
 
     private popComparisonConfigs: Array<{
@@ -1477,14 +1484,12 @@ export class MetricQueryBuilder {
             ),
         );
 
-        Logger.info('query.case_sensitive_applied', {
-            exploreName: explore.name,
+        this.caseSensitiveFilters.push({
+            fieldId: getItemId(field),
             ruleCaseSensitive:
                 filterRuleWithParamReplacedValues.caseSensitive ?? null,
             fieldCaseSensitive:
                 'caseSensitive' in field ? (field.caseSensitive ?? null) : null,
-            exploreCaseSensitive: this.args.explore.caseSensitive ?? null,
-            fieldId: getItemId(field),
             finalSqlContainsUpper: /UPPER\s*\(/i.test(renderedFilterSql),
         });
 
@@ -3897,6 +3902,7 @@ export class MetricQueryBuilder {
     }
 
     public compileQuery(): CompiledQuery {
+        const start = Date.now();
         const { explore, compiledMetricQuery } = this.args;
         const fields = getFieldsFromMetricQuery(compiledMetricQuery, explore);
 
@@ -4444,6 +4450,31 @@ export class MetricQueryBuilder {
                 parameterReferences.has(key),
             ),
         );
+
+        Logger.info('query.compile', {
+            exploreName: explore.name,
+            exploreCaseSensitive: this.args.explore.caseSensitive ?? null,
+            adapterType: this.args.warehouseSqlBuilder.getAdapterType(),
+            timezone: this.args.timezone,
+            dataTimezone: this.args.dataTimezone ?? null,
+            useTimezoneAwareDateTrunc:
+                this.args.useTimezoneAwareDateTrunc ?? false,
+            dimensionCount: compiledMetricQuery.dimensions.length,
+            metricCount: compiledMetricQuery.metrics.length,
+            tableCalculationCount: compiledMetricQuery.tableCalculations.length,
+            popComparisonCount: this.popComparisonConfigs.length,
+            hasPivotConfiguration: this.args.pivotConfiguration !== undefined,
+            continueOnError: this.args.continueOnError ?? false,
+            warningCount: warnings.length,
+            compilationErrorCount: this.compilationErrors.length,
+            parameterReferenceCount: parameterReferences.size,
+            missingParameterReferenceCount: missingParameterReferences.size,
+            renderedSqlBytes: replacedSql.length,
+            caseSensitiveFilterCount: this.caseSensitiveFilters.length,
+            caseSensitiveFilters: this.caseSensitiveFilters,
+            durationMs: Date.now() - start,
+            outcome: 'success',
+        });
 
         return {
             query: replacedSql,


### PR DESCRIPTION
## Summary

- Adds a **Logging — Prefer Wide Events** section to `CLAUDE.md` describing the accumulator-emit-once-per-unit-of-work pattern, with a concrete `Logger.info('msg', context)` example and guardrails (always include outcome + duration, never log secrets/PII, don't refactor existing thin logs).
- Migrates the recently added `query.case_sensitive_applied` log in `MetricQueryBuilder` from one-event-per-filter-rule to one wide `query.compile` event per `compileQuery()` invocation. The new event carries ~19 fields covering query shape, warehouse context, output characteristics, parameter coverage, and the per-rule filter array nested inline.

## Why

Recent observability work (`expressWinstonMiddleware`, audit logs, `pre-aggregate audit`, `case_sensitive resolution events`) has been organically converging on the wide-event pattern — one fat structured record per unit of work, with high-cardinality dimensions preserved so query-time questions don't need pre-built dashboards. This PR writes the convention down so future code can reach for it deliberately, and migrates the most recent log as the first reference example.

The volume change per query:
- 0 filters: was 0 events → now 1 event (slight increase)
- 1 filter: was 1 event → now 1 event (same)
- N filters (N>1): was N events → now 1 event (decrease as N grows)

The single fat event makes questions like *"queries on postgres where any rule overrode the explore's `caseSensitive=true` with `caseSensitive=false` and produced UPPER() SQL"* a single filter on a single event type, not a JOIN across emissions keyed only by emission time.

## Test plan

- [x] Verified end-to-end via PAT + JSON file logging with `LIGHTDASH_LOG_OUTPUTS=console,file LIGHTDASH_LOG_FILE_FORMAT=json`:
  - 1-filter query → exactly 1 `query.compile` event, 0 `query.case_sensitive_applied` events; payload has all 19 fields plus auto-attached `sentryTraceId`, `level`, `timestamp`.
  - 2-filter query → exactly 1 `query.compile` event with `caseSensitiveFilterCount=2` and a 2-element `caseSensitiveFilters` array; per-rule `finalSqlContainsUpper` correctly reflects `UPPER()` wrapping per rule (true for the `caseSensitive:false` rule, false for the `caseSensitive:true` rule).
- [ ] Reviewer: confirm the field set on `query.compile` is what observability needs at query time, or suggest additions/removals before this becomes a precedent for future migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)