### PR TITLE
fix: return managed agent schedule enum in settings API

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -304,7 +304,7 @@ export const lightdashConfigMock: LightdashConfig = {
     managedAgent: {
         anthropicApiKey: null,
         skillIds: [],
-        schedule: '0 * * * *',
+        schedule: '0 0 * * *',
         sessionTimeoutMs: 300000,
     },
     mcp: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2262,7 +2262,7 @@ export const parseConfig = (): LightdashConfig => {
                 .split(',')
                 .map((skillId) => skillId.trim())
                 .filter(Boolean),
-            schedule: process.env.MANAGED_AGENT_SCHEDULE || '0 * * * *',
+            schedule: process.env.MANAGED_AGENT_SCHEDULE || '0 0 * * *',
             sessionTimeoutMs: parseInt(
                 process.env.MANAGED_AGENT_SESSION_TIMEOUT_MS || '300000',
                 10,

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -35,13 +35,10 @@ export class ManagedAgentModel {
     // --- Settings ---
 
     static mapDbSettings(row: DbManagedAgentSettings): ManagedAgentSettings {
-        const scheduleCron = getManagedAgentScheduleCron(
-            getManagedAgentScheduleOption(row.schedule_cron),
-        );
         return {
             projectUuid: row.project_uuid,
             enabled: row.enabled,
-            scheduleCron,
+            schedule: getManagedAgentScheduleOption(row.schedule_cron),
             enabledByUserUuid: row.enabled_by_user_uuid,
             slackChannelId: row.slack_channel_id,
             toolSettings: row.tool_settings ?? {},

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -1,6 +1,7 @@
 import {
     EE_SCHEDULER_TASKS,
     getErrorMessage,
+    getManagedAgentScheduleCron,
     isSchedulerTaskName,
     SCHEDULER_TASKS,
     SchedulerJobStatus,
@@ -171,7 +172,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     );
                 } finally {
                     const schedule =
-                        settings.scheduleCron ??
+                        getManagedAgentScheduleCron(settings.schedule) ??
                         this.lightdashConfig.managedAgent.schedule;
                     await this.schedulerClient.scheduleManagedAgentHeartbeat(
                         schedule,

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     FeatureFlags,
     ForbiddenError,
+    getManagedAgentScheduleCron,
     ManagedAgentActionType,
     ManagedAgentTargetType,
     NotFoundError,
@@ -334,7 +335,7 @@ export class ManagedAgentService extends BaseService {
 
             // Schedule the first heartbeat job
             const schedule =
-                settings.scheduleCron ??
+                getManagedAgentScheduleCron(settings.schedule) ??
                 this.lightdashConfig.managedAgent.schedule;
             await this.schedulerClient.scheduleManagedAgentHeartbeat(
                 schedule,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1181,7 +1181,10 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
-                scheduleCron: { dataType: 'string', required: true },
+                schedule: {
+                    ref: 'ManagedAgentScheduleOption',
+                    required: true,
+                },
                 enabled: { dataType: 'boolean', required: true },
                 projectUuid: { dataType: 'string', required: true },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1222,8 +1222,8 @@
                         "type": "string",
                         "nullable": true
                     },
-                    "scheduleCron": {
-                        "type": "string"
+                    "schedule": {
+                        "$ref": "#/components/schemas/ManagedAgentScheduleOption"
                     },
                     "enabled": {
                         "type": "boolean"
@@ -1238,7 +1238,7 @@
                     "toolSettings",
                     "slackChannelId",
                     "enabledByUserUuid",
-                    "scheduleCron",
+                    "schedule",
                     "enabled",
                     "projectUuid"
                 ],

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -29,7 +29,7 @@ export const ManagedAgentScheduleCronByOption: Record<
 };
 
 export const getManagedAgentScheduleCron = (
-    schedule: ManagedAgentScheduleOption = ManagedAgentScheduleOption.HOURLY,
+    schedule: ManagedAgentScheduleOption = ManagedAgentScheduleOption.DAILY,
 ) => ManagedAgentScheduleCronByOption[schedule];
 
 export const getManagedAgentScheduleOption = (
@@ -43,7 +43,7 @@ export const getManagedAgentScheduleOption = (
 export type ManagedAgentSettings = {
     projectUuid: string;
     enabled: boolean;
-    scheduleCron: string;
+    schedule: ManagedAgentScheduleOption;
     enabledByUserUuid: string | null;
     slackChannelId: string | null;
     toolSettings: Record<string, boolean>;

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -6,7 +6,6 @@ import {
     type Project,
     type SavedChart,
     type UpdatedByUser,
-    getManagedAgentScheduleOption,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -128,7 +127,7 @@ const CAPABILITY_GROUPS = [
 
 const SetupSection: FC<{
     enabled: boolean;
-    schedule: string;
+    schedule: ManagedAgentScheduleOption;
     settingsOpen: boolean;
     onOpenSettings: () => void;
     onRunNow: () => void;
@@ -141,9 +140,9 @@ const SetupSection: FC<{
     onRunNow,
     isRunNowLoading,
 }) => {
-    const schedule = getManagedAgentScheduleOption(initialSchedule);
     const scheduleLabel =
-        SCHEDULE_OPTIONS.find((o) => o.value === schedule)?.label ?? 'Hourly';
+        SCHEDULE_OPTIONS.find((o) => o.value === initialSchedule)?.label ??
+        'Hourly';
 
     return (
         <Stack gap={0}>
@@ -790,7 +789,7 @@ const DetailSidebar: FC<{
 const SettingsSidebar: FC<{
     projectUuid: string;
     enabled: boolean;
-    schedule: string;
+    schedule: ManagedAgentScheduleOption;
     slackChannelId: string | null;
     toolSettings: Record<string, boolean>;
     isLoading: boolean;
@@ -807,7 +806,6 @@ const SettingsSidebar: FC<{
     const queryClient = useQueryClient();
     const { data: slackInstallation } = useGetSlack();
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
-    const selectedSchedule = getManagedAgentScheduleOption(schedule);
     const [slackNotificationsEnabled, setSlackNotificationsEnabled] =
         useState(!!slackChannelId);
 
@@ -926,7 +924,7 @@ const SettingsSidebar: FC<{
                             </Text>
                             <Select
                                 data={SCHEDULE_OPTIONS}
-                                value={selectedSchedule}
+                                value={schedule}
                                 onChange={handleScheduleChange}
                                 size="sm"
                                 disabled={isLoading || mutation.isLoading}
@@ -1213,7 +1211,10 @@ export const ManagedAgentActivityPage: FC = () => {
                         <Stack gap="lg">
                             <SetupSection
                                 enabled={settings?.enabled ?? false}
-                                schedule={settings?.scheduleCron ?? '0 * * * *'}
+                                schedule={
+                                    settings?.schedule ??
+                                    ManagedAgentScheduleOption.DAILY
+                                }
                                 settingsOpen={settingsOpen}
                                 isRunNowLoading={runNowMutation.isLoading}
                                 onRunNow={() => runNowMutation.mutate()}
@@ -1288,7 +1289,8 @@ export const ManagedAgentActivityPage: FC = () => {
                                     projectUuid={projectUuid!}
                                     enabled={settings?.enabled ?? false}
                                     schedule={
-                                        settings?.scheduleCron ?? '0 * * * *'
+                                        settings?.schedule ??
+                                        ManagedAgentScheduleOption.DAILY
                                     }
                                     slackChannelId={
                                         settings?.slackChannelId ?? null

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -1,8 +1,4 @@
-import {
-    FeatureFlags,
-    ManagedAgentScheduleOption,
-    getManagedAgentScheduleOption,
-} from '@lightdash/common';
+import { FeatureFlags, ManagedAgentScheduleOption } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -43,11 +39,8 @@ const formatRelative = (dateStr: string) => {
     return `${Math.floor(hours / 24)}d ago`;
 };
 
-const formatSchedule = (cron: string) => {
-    return getManagedAgentScheduleOption(cron) ===
-        ManagedAgentScheduleOption.DAILY
-        ? '24h'
-        : '1h';
+const formatSchedule = (schedule: ManagedAgentScheduleOption) => {
+    return schedule === ManagedAgentScheduleOption.DAILY ? '24h' : '1h';
 };
 
 /** Generates a deterministic grid of subtle squares */
@@ -118,7 +111,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
     const isEnabled = settings?.enabled ?? false;
     const actionCount = actions?.length ?? 0;
     const lastActionAt = actions?.[0]?.createdAt ?? null;
-    const schedule = settings?.scheduleCron ?? '0 * * * *';
+    const schedule = settings?.schedule ?? ManagedAgentScheduleOption.DAILY;
 
     // Feature carousel — must be before any early returns (hooks rule)
     const [featureIdx, setFeatureIdx] = useState(0);

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
@@ -59,7 +59,7 @@ export const ManagedAgentSetupModal: FC<{
     onEnabled: () => void;
 }> = ({ projectUuid, opened, onClose, onEnabled }) => {
     const queryClient = useQueryClient();
-    const [schedule, setSchedule] = useState(ManagedAgentScheduleOption.HOURLY);
+    const [schedule, setSchedule] = useState(ManagedAgentScheduleOption.DAILY);
 
     const mutation = useMutation({
         mutationFn: () =>

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
@@ -1,3 +1,4 @@
+import { type ManagedAgentScheduleOption } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../../../../api';
@@ -5,7 +6,7 @@ import { lightdashApi } from '../../../../api';
 type ManagedAgentSettings = {
     projectUuid: string;
     enabled: boolean;
-    scheduleCron: string;
+    schedule: ManagedAgentScheduleOption;
     enabledByUserUuid: string | null;
     slackChannelId: string | null;
     toolSettings: Record<string, boolean>;


### PR DESCRIPTION
## Summary
- Change managed agent settings reads to return `schedule: hourly | daily` instead of `scheduleCron`
- Keep cron expressions internal for persistence and heartbeat scheduling only
- Default managed-agent setup to daily across backend config, model mapping, and frontend defaults

## Testing
- Not run (not requested)