### PR TITLE
fix(table-calc): only show SQL deprecation callout in SQL mode

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -305,7 +305,7 @@ const TableCalculationModal: FC<Props> = ({
 
     const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
     const showSqlDeprecationCallout =
-        cannotAuthorCustomSql === true && editMode !== EditMode.TEMPLATE;
+        cannotAuthorCustomSql === true && editMode === EditMode.SQL;
     const canConvertExistingSqlToFormula =
         isExistingSqlCalc &&
         isFormulaSupported &&


### PR DESCRIPTION
### Description

The "Editors won't be able to create new SQL table calculations" deprecation callout was showing in formula mode too — it gated on `editMode !== EditMode.TEMPLATE`, so anyone with the `cannotAuthorCustomSql` permission saw the warning even when authoring a formula calc, where it's irrelevant noise.

Tightened the condition to `editMode === EditMode.SQL`. The callout now only renders when the user is actually in SQL mode — i.e. creating a new SQL calc (after switching from the default formula mode) or editing an existing SQL calc.

### Who's affected

- **Users with `cannotAuthorCustomSql === true`** in formula mode → no longer see the deprecation callout. This is the intended fix.
- **Users in SQL mode (new or edit)** → behavior unchanged. Callout, "Convert to formula" button, and "Try formulas now" button all still gate correctly off the same SQL-mode condition.
- **Users in template mode** → unchanged (still suppressed, as before).
- **Users without `cannotAuthorCustomSql`** → unchanged (callout never showed for them).