### PR TITLE
feat(ai-agents): preserve pending prompt across agent switches

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -7,7 +7,7 @@ import {
     useCombobox,
 } from '@mantine-8/core';
 import { IconCheck, IconCirclePlus, IconSelector } from '@tabler/icons-react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { getAgentOptions, type Agent } from './AgentSelectorUtils';
@@ -24,6 +24,7 @@ export const AgentSelector = ({
     projectUuid,
 }: Props) => {
     const navigate = useNavigate();
+    const { search } = useLocation();
     const combobox = useCombobox({
         onDropdownClose: () => combobox.resetSelectedOption(),
     });
@@ -36,9 +37,15 @@ export const AgentSelector = ({
                 viewTransition: true,
             });
         } else {
-            void navigate(`/projects/${projectUuid}/ai-agents/${value}`, {
-                viewTransition: true,
-            });
+            void navigate(
+                {
+                    pathname: `/projects/${projectUuid}/ai-agents/${value}/threads`,
+                    search,
+                },
+                {
+                    viewTransition: true,
+                },
+            );
         }
         combobox.closeDropdown();
     };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -11,7 +11,7 @@ import {
     Textarea,
 } from '@mantine-8/core';
 import { IconArrowUp, IconBrain } from '@tabler/icons-react';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { ModelSelector } from '../../../../../components/common/ModelSelector/ModelSelector';
@@ -33,6 +33,8 @@ interface AgentChatInputProps {
     onModelChange?: (modelId: string) => void;
     extendedThinking?: boolean;
     onExtendedThinkingChange?: (enabled: boolean) => void;
+    defaultValue?: string;
+    onValueChange?: (value: string) => void;
 }
 
 export const AgentChatInput = ({
@@ -49,13 +51,22 @@ export const AgentChatInput = ({
     onModelChange,
     extendedThinking = false,
     onExtendedThinkingChange,
+    defaultValue,
+    onValueChange,
 }: AgentChatInputProps) => {
     // this is a workaround to prevent the enter key from being pressed when
     // the user is composing a character
     // see https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent for more details
     const [isComposing, setIsComposing] = useState(false);
     const inputRef = useRef<HTMLTextAreaElement>(null);
-    const [value, setValue] = useState('');
+    const [value, setValueState] = useState(defaultValue ?? '');
+    const setValue = useCallback(
+        (next: string) => {
+            setValueState(next);
+            onValueChange?.(next);
+        },
+        [onValueChange],
+    );
     const navigate = useNavigate();
 
     const hasValue = value.trim().length > 0;
@@ -92,7 +103,7 @@ export const AgentChatInput = ({
         return () => {
             elem.removeEventListener('keydown', handleKeyDown);
         };
-    }, [onSubmit, disabled, loading, value, isComposing]);
+    }, [onSubmit, disabled, loading, value, isComposing, setValue]);
 
     useLayoutEffect(() => {
         if (!inputRef.current) return;

--- a/packages/frontend/src/ee/features/aiCopilot/components/PendingPromptContext/PendingPromptContext.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PendingPromptContext/PendingPromptContext.tsx
@@ -1,0 +1,48 @@
+import {
+    createContext,
+    useContext,
+    useMemo,
+    useState,
+    type FC,
+    type ReactNode,
+} from 'react';
+
+/**
+ * Holds an in-progress new-thread prompt above `AgentPage` so it survives
+ * the page remount triggered by switching agents.
+ */
+
+type PendingPromptContextValue = {
+    pendingPrompt: string;
+    setPendingPrompt: (prompt: string) => void;
+};
+
+const PendingPromptContext = createContext<PendingPromptContextValue | null>(
+    null,
+);
+
+export const PendingPromptProvider: FC<{ children: ReactNode }> = ({
+    children,
+}) => {
+    const [pendingPrompt, setPendingPrompt] = useState('');
+    const value = useMemo(
+        () => ({ pendingPrompt, setPendingPrompt }),
+        [pendingPrompt],
+    );
+    return (
+        <PendingPromptContext.Provider value={value}>
+            {children}
+        </PendingPromptContext.Provider>
+    );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const usePendingPrompt = (): PendingPromptContextValue => {
+    const ctx = useContext(PendingPromptContext);
+    if (!ctx) {
+        throw new Error(
+            'usePendingPrompt must be used within a PendingPromptProvider',
+        );
+    }
+    return ctx;
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -25,6 +25,7 @@ import { useSavedQuery } from '../../../hooks/useSavedQuery';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
 import { DefaultAgentButton } from '../../features/aiCopilot/components/DefaultAgentButton/DefaultAgentButton';
+import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { PinnedContextCard } from '../../features/aiCopilot/components/PinnedContextCard/PinnedContextCard';
 import { SuggestedQuestions } from '../../features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions';
 import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
@@ -128,8 +129,11 @@ const AiAgentNewThreadPage: FC = () => {
     );
     const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
 
+    const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
+
     const onSubmit = useCallback(
         (prompt: string) => {
+            setPendingPrompt('');
             void createAgentThread({
                 prompt,
                 context: contextInput.length > 0 ? contextInput : undefined,
@@ -147,6 +151,7 @@ const AiAgentNewThreadPage: FC = () => {
             });
         },
         [
+            setPendingPrompt,
             createAgentThread,
             contextInput,
             previewItems,
@@ -278,6 +283,8 @@ const AiAgentNewThreadPage: FC = () => {
                                 ? setExtendedThinking
                                 : undefined
                         }
+                        defaultValue={pendingPrompt}
+                        onValueChange={setPendingPrompt}
                     />
                 </Stack>
             </Stack>

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentsRootLayout.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentsRootLayout.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 import { Outlet } from 'react-router';
 import NavBar from '../../../components/NavBar';
 import { MobileNavBar } from '../../../MobileRoutes';
+import { PendingPromptProvider } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { store } from '../../features/aiCopilot/store';
 import { AiAgentThreadStreamAbortControllerContextProvider } from '../../features/aiCopilot/streaming/AiAgentThreadStreamAbortControllerContextProvider';
 
@@ -13,7 +14,9 @@ export const AiAgentsRootLayout = () => {
             {isMobile ? <MobileNavBar /> : <NavBar />}
             <Provider store={store}>
                 <AiAgentThreadStreamAbortControllerContextProvider>
-                    <Outlet />
+                    <PendingPromptProvider>
+                        <Outlet />
+                    </PendingPromptProvider>
                 </AiAgentThreadStreamAbortControllerContextProvider>
             </Provider>
         </>


### PR DESCRIPTION
<!-- reference the related issue e.g. #150 -->

### Description:

Keep pending prompt + pinned conversation context while using agent switcher

![CleanShot 2026-05-06 at 11.21.51.gif](https://app.graphite.com/user-attachments/assets/0673e5f8-64b5-43c1-bc6e-d51fd4c97de4.gif)



<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->