### PR TITLE
fix(managed-agent): rename action labels to deleted/fixed

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -570,7 +570,7 @@ export class ManagedAgentService extends BaseService {
             if (counts.flagged_broken)
                 summaryParts.push(`*${counts.flagged_broken}* flagged broken`);
             if (counts.soft_deleted)
-                summaryParts.push(`*${counts.soft_deleted}* cleaned up`);
+                summaryParts.push(`*${counts.soft_deleted}* deleted`);
             if (counts.insight)
                 summaryParts.push(
                     `*${counts.insight}* insight${counts.insight > 1 ? 's' : ''}`,

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -229,7 +229,7 @@ const ACTION_CONFIG: Record<
             'Marked as unused. Future Autopilot runs will review flagged items and clean them up.',
     },
     soft_deleted: {
-        label: 'Cleaned up',
+        label: 'Deleted',
         dotColor: 'var(--mantine-color-red-5)',
     },
     flagged_broken: {
@@ -245,7 +245,7 @@ const ACTION_CONFIG: Record<
             'Marked as slow. Future Autopilot runs will review flagged items and try to optimize them.',
     },
     fixed_broken: {
-        label: 'Auto-fixed',
+        label: 'Fixed',
         dotColor: 'var(--mantine-color-teal-5)',
     },
     created_content: {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -150,7 +150,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
         if (counts.created_content)
             parts.push(`${counts.created_content} created`);
         if (counts.flagged_stale) parts.push(`${counts.flagged_stale} flagged`);
-        if (counts.soft_deleted) parts.push(`${counts.soft_deleted} cleaned`);
+        if (counts.soft_deleted) parts.push(`${counts.soft_deleted} deleted`);
         return parts.join(', ');
     }, [actions]);
 


### PR DESCRIPTION
Closes:

### Description:
Renames action labels in the Managed Agent / Autopilot UI to use clearer, more concise terminology:

- `"Cleaned up"` / `"cleaned up"` / `"cleaned"` → `"Deleted"` / `"deleted"`
- `"Auto-fixed"` → `"Fixed"`