### PR TITLE
chore: migrate `DashboardComments` to config-based flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -336,6 +336,9 @@ export const lightdashConfigMock: LightdashConfig = {
         enabled: false,
         retentionDays: 30,
     },
+    dashboardComments: {
+        enabled: true,
+    },
     preAggregates: {
         enabled: false,
         parquetEnabled: false,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -894,21 +894,15 @@ describe('feature flag env-var allowlists', () => {
         expect(config.disabledFeatureFlags.has('killed-flag')).toBe(true);
     });
 
-    test('legacy DISABLE_DASHBOARD_COMMENTS=true translates to disabledFeatureFlags', () => {
-        // Backward-compat for self-hosters who set the legacy env var before
-        // the unified LIGHTDASH_DISABLE_FEATURE_FLAGS pattern was introduced.
-        process.env.DISABLE_DASHBOARD_COMMENTS = 'true';
-        const config = parseConfig();
-        expect(
-            config.disabledFeatureFlags.has('dashboard-comments-enabled'),
-        ).toBe(true);
-    });
-
-    test('legacy DISABLE_DASHBOARD_COMMENTS unset leaves the flag out of disabledFeatureFlags', () => {
+    test('dashboardComments.enabled defaults to true when DISABLE_DASHBOARD_COMMENTS is unset', () => {
         delete process.env.DISABLE_DASHBOARD_COMMENTS;
         const config = parseConfig();
-        expect(
-            config.disabledFeatureFlags.has('dashboard-comments-enabled'),
-        ).toBe(false);
+        expect(config.dashboardComments.enabled).toBe(true);
+    });
+
+    test('DISABLE_DASHBOARD_COMMENTS=true disables dashboardComments', () => {
+        process.env.DISABLE_DASHBOARD_COMMENTS = 'true';
+        const config = parseConfig();
+        expect(config.dashboardComments.enabled).toBe(false);
     });
 });

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1245,6 +1245,9 @@ export type LightdashConfig = {
         enabled: boolean;
         retentionDays: number;
     };
+    dashboardComments: {
+        enabled: boolean;
+    };
     preAggregates: {
         enabled: boolean;
         parquetEnabled: boolean;
@@ -1585,7 +1588,6 @@ const LEGACY_DISABLE_ENV_VARS: ReadonlyArray<
     readonly [envVar: string, flagId: string]
 > = [
     // Add per migration; truthy env value disables the flag.
-    ['DISABLE_DASHBOARD_COMMENTS', 'dashboard-comments-enabled'],
 ];
 
 export const parseConfig = (): LightdashConfig => {
@@ -2290,6 +2292,9 @@ export const parseConfig = (): LightdashConfig => {
             enabled:
                 process.env.FUNNEL_BUILDER_ENABLED === 'true' ||
                 lightdashMode === LightdashMode.PR,
+        },
+        dashboardComments: {
+            enabled: process.env.DISABLE_DASHBOARD_COMMENTS !== 'true',
         },
         softDelete: {
             enabled: process.env.SOFT_DELETE_ENABLED === 'true',

--- a/packages/backend/src/services/CommentService/CommentService.test.ts
+++ b/packages/backend/src/services/CommentService/CommentService.test.ts
@@ -7,9 +7,9 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { CommentModel } from '../../models/CommentModel/CommentModel';
 import type { DashboardModel } from '../../models/DashboardModel/DashboardModel';
-import type { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import type { NotificationsModel } from '../../models/NotificationsModel/NotificationsModel';
 import type { UserModel } from '../../models/UserModel';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -126,10 +126,6 @@ const userModel = {
     })),
 };
 
-const featureFlagModel = {
-    get: jest.fn(async () => ({ enabled: true })),
-};
-
 const spacePermissionService = {
     can: jest.fn(async () => true),
 };
@@ -141,13 +137,13 @@ describe('CommentService', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         service = new CommentService({
+            lightdashConfig: lightdashConfigMock,
             analytics: analyticsMock,
             dashboardModel: dashboardModel as unknown as DashboardModel,
             commentModel: commentModel as unknown as CommentModel,
             notificationsModel:
                 notificationsModel as unknown as NotificationsModel,
             userModel: userModel as unknown as UserModel,
-            featureFlagModel: featureFlagModel as unknown as FeatureFlagModel,
             spacePermissionService:
                 spacePermissionService as unknown as SpacePermissionService,
         });

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -2,32 +2,32 @@ import { subject } from '@casl/ability';
 import {
     Comment,
     DashboardDAO,
-    FeatureFlags,
     ForbiddenError,
-    LightdashUser,
     SessionUser,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
+import { LightdashConfig } from '../../config/parseConfig';
 import { CommentModel } from '../../models/CommentModel/CommentModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
-import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { NotificationsModel } from '../../models/NotificationsModel/NotificationsModel';
 import { UserModel } from '../../models/UserModel';
 import { BaseService } from '../BaseService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 
 type CommentServiceArguments = {
+    lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
     dashboardModel: DashboardModel;
     commentModel: CommentModel;
     notificationsModel: NotificationsModel;
     userModel: UserModel;
-    featureFlagModel: FeatureFlagModel;
     spacePermissionService: SpacePermissionService;
 };
 
 export class CommentService extends BaseService {
+    lightdashConfig: LightdashConfig;
+
     analytics: LightdashAnalytics;
 
     dashboardModel: DashboardModel;
@@ -38,26 +38,24 @@ export class CommentService extends BaseService {
 
     userModel: UserModel;
 
-    featureFlagModel: FeatureFlagModel;
-
     spacePermissionService: SpacePermissionService;
 
     constructor({
+        lightdashConfig,
         analytics,
         dashboardModel,
         commentModel,
         notificationsModel,
         userModel,
-        featureFlagModel,
         spacePermissionService,
     }: CommentServiceArguments) {
         super();
+        this.lightdashConfig = lightdashConfig;
         this.analytics = analytics;
         this.dashboardModel = dashboardModel;
         this.commentModel = commentModel;
         this.notificationsModel = notificationsModel;
         this.userModel = userModel;
-        this.featureFlagModel = featureFlagModel;
         this.spacePermissionService = spacePermissionService;
     }
 
@@ -78,17 +76,8 @@ export class CommentService extends BaseService {
         }
     }
 
-    private async isFeatureEnabled(
-        user: Pick<
-            LightdashUser,
-            'userUuid' | 'organizationUuid' | 'organizationName'
-        >,
-    ) {
-        const featureFlag = await this.featureFlagModel.get({
-            user,
-            featureFlagId: FeatureFlags.DashboardComments,
-        });
-        if (!featureFlag.enabled)
+    private throwIfDisabled() {
+        if (!this.lightdashConfig.dashboardComments.enabled)
             throw new ForbiddenError('Feature not enabled');
     }
 
@@ -153,7 +142,7 @@ export class CommentService extends BaseService {
         replyTo: string | null,
         mentions: string[],
     ): Promise<string> {
-        await this.isFeatureEnabled(user);
+        this.throwIfDisabled();
 
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
@@ -218,7 +207,7 @@ export class CommentService extends BaseService {
         dashboardUuidOrSlug: string,
         options?: { projectUuid?: string },
     ): Promise<Record<string, Comment[]>> {
-        await this.isFeatureEnabled(user);
+        this.throwIfDisabled();
 
         const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
@@ -268,7 +257,7 @@ export class CommentService extends BaseService {
         dashboardUuid: string,
         commentId: string,
     ): Promise<void> {
-        await this.isFeatureEnabled(user);
+        this.throwIfDisabled();
 
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
@@ -314,7 +303,7 @@ export class CommentService extends BaseService {
         dashboardUuid: string,
         commentId: string,
     ): Promise<void> {
-        await this.isFeatureEnabled(user);
+        this.throwIfDisabled();
 
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -131,6 +131,9 @@ export const BaseResponse: HealthState = {
         enabled: false,
         retentionDays: 30,
     },
+    dashboardComments: {
+        enabled: true,
+    },
     preAggregates: {
         enabled: false,
     },

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -232,6 +232,9 @@ export class HealthService extends BaseService {
                 enabled: this.lightdashConfig.softDelete.enabled,
                 retentionDays: this.lightdashConfig.softDelete.retentionDays,
             },
+            dashboardComments: {
+                enabled: this.lightdashConfig.dashboardComments.enabled,
+            },
             preAggregates: {
                 enabled: this.lightdashConfig.preAggregates.enabled,
             },

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -313,12 +313,12 @@ export class ServiceRepository
             'commentService',
             () =>
                 new CommentService({
+                    lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
                     dashboardModel: this.models.getDashboardModel(),
                     commentModel: this.models.getCommentModel(),
                     notificationsModel: this.models.getNotificationsModel(),
                     userModel: this.models.getUserModel(),
-                    featureFlagModel: this.models.getFeatureFlagModel(),
                     spacePermissionService: this.getSpacePermissionService(),
                 }),
         );

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -506,6 +506,9 @@ export type HealthState = {
         enabled: boolean;
         retentionDays: number;
     };
+    dashboardComments: {
+        enabled: boolean;
+    };
     preAggregates: {
         enabled: boolean;
     };

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -16,11 +16,6 @@ export enum FeatureFlags {
     EnableTimezoneSupport = 'enable-timezone-support',
 
     /**
-     * Enable dashboard comments
-     */
-    DashboardComments = 'dashboard-comments-enabled',
-
-    /**
      * Enable scheduler task that replaces custom metrics after project compile
      */
     ReplaceCustomMetricsOnCompile = 'replace-custom-metrics-on-compile',

--- a/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
+++ b/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
@@ -1,10 +1,11 @@
-import { FeatureFlags } from '@lightdash/common';
 import { type UserWithAbility } from '../../../hooks/user/useUser';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../providers/App/useApp';
 
 export const useDashboardCommentsCheck = (
     user: UserWithAbility | undefined,
 ) => {
+    const { health } = useApp();
+
     const canViewDashboardComments = !!user?.ability?.can(
         'view',
         'DashboardComments',
@@ -15,13 +16,9 @@ export const useDashboardCommentsCheck = (
         'DashboardComments',
     );
 
-    const { data: dashboardCommentsFeatureFlag } = useServerFeatureFlag(
-        FeatureFlags.DashboardComments,
-    );
-
-    // We want to keep this flag enabled by default, so users on self-hosting can use this feature
+    // Default-on; opt out via DISABLE_DASHBOARD_COMMENTS=true on the backend.
     const isDashboardCommentsEnabled =
-        dashboardCommentsFeatureFlag?.enabled ?? true;
+        health.data?.dashboardComments.enabled ?? true;
 
     return {
         canViewDashboardComments:

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -131,6 +131,9 @@ export default function mockHealthResponse(
             enabled: false,
             retentionDays: 30,
         },
+        dashboardComments: {
+            enabled: true,
+        },
         preAggregates: {
             enabled: false,
         },


### PR DESCRIPTION
<!-- reference the related issue e.g. #150 -->

### Description:

Migrates the dashboard comments feature flag from the dynamic `FeatureFlagModel` / `LIGHTDASH_DISABLE_FEATURE_FLAGS` system to a static server-side config field (`dashboardComments.enabled`), controlled by the existing `DISABLE_DASHBOARD_COMMENTS` environment variable.

Previously, the `DISABLE_DASHBOARD_COMMENTS` env var was translated into a disabled feature flag entry and checked at runtime via `FeatureFlagModel.get()` on every comment operation. Now, the value is parsed once at startup into `lightdashConfig.dashboardComments.enabled` and exposed through the health endpoint, removing the need for `FeatureFlagModel` in `CommentService` entirely.

On the frontend, `useDashboardCommentsCheck` no longer calls `useServerFeatureFlag` and instead reads `health.data?.dashboardComments.enabled` directly, keeping the default-on behaviour for self-hosters who have not set the env var.

The `DashboardComments` entry has been removed from the `FeatureFlags` enum as it is no longer backed by the feature flag infrastructure.