### PR TITLE
fix: add pivoted/unpivoted CSV and XLSX export option for cartesian charts

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -535,6 +535,7 @@ export class QueryController extends BaseController {
             columnOrder: body.columnOrder,
             hiddenFields: body.hiddenFields,
             pivotConfig: body.pivotConfig,
+            exportPivotedData: body.exportPivotedData,
             attachmentDownloadName: body.attachmentDownloadName,
         });
 
@@ -574,6 +575,7 @@ export class QueryController extends BaseController {
                 columnOrder: body.columnOrder,
                 hiddenFields: body.hiddenFields,
                 pivotConfig: body.pivotConfig,
+                exportPivotedData: body.exportPivotedData,
                 attachmentDownloadName: body.attachmentDownloadName,
             });
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9427,11 +9427,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -9484,11 +9484,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -9525,11 +9525,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10007,11 +10007,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10026,11 +10026,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10045,11 +10045,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10064,11 +10064,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10083,11 +10083,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17848,6 +17848,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                exportPivotedData: { dataType: 'boolean' },
                 asAttachment: { dataType: 'boolean' },
                 limit: {
                     dataType: 'union',
@@ -22065,7 +22066,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22075,7 +22076,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22085,7 +22086,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -22098,7 +22099,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -22509,7 +22510,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22519,7 +22520,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22529,7 +22530,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -22542,7 +22543,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -29395,6 +29396,13 @@ const models: TsoaRoute.Models = {
                                 dataType: 'array',
                                 array: { dataType: 'string' },
                             },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    exportPivotedData: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
                             { dataType: 'undefined' },
                         ],
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10902,8 +10902,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -10952,8 +10952,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -10977,6 +10977,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -18835,6 +18848,9 @@
             },
             "SchedulerCsvOptions": {
                 "properties": {
+                    "exportPivotedData": {
+                        "type": "boolean"
+                    },
                     "asAttachment": {
                         "type": "boolean"
                     },
@@ -23423,22 +23439,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -23793,22 +23809,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -30550,6 +30566,9 @@
                         },
                         "type": "array"
                     },
+                    "exportPivotedData": {
+                        "type": "boolean"
+                    },
                     "attachmentDownloadName": {
                         "type": "string"
                     }
@@ -32322,7 +32341,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2920.0",
+        "version": "0.2924.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -22,6 +22,8 @@ import {
     getColumnOrderFromVizTableConfig,
     getCustomLabelsFromTableConfig,
     getCustomLabelsFromVizTableConfig,
+    getDownloadPivotConfig,
+    getDownloadPivotOptions,
     getErrorMessage,
     getHiddenFieldsFromVizTableConfig,
     getHiddenTableFields,
@@ -529,6 +531,8 @@ export default class SchedulerTask {
                     format === SchedulerFormat.XLSX
                         ? DownloadFileType.XLSX
                         : DownloadFileType.CSV;
+                const exportPivotedData =
+                    csvOptions?.exportPivotedData !== false;
 
                 const baseAnalyticsProperties: DownloadCsv['properties'] = {
                     jobId,
@@ -556,6 +560,15 @@ export default class SchedulerTask {
                             userId: account.user.id,
                             properties: baseAnalyticsProperties,
                         });
+                        const chart =
+                            await this.schedulerService.savedChartModel.get(
+                                savedChartUuid,
+                            );
+                        const {
+                            pivotConfig: downloadPivotConfig,
+                            exportPivotedData: effectiveExportPivotedData,
+                        } = getDownloadPivotOptions(chart, exportPivotedData);
+                        const shouldPivotResults = !!downloadPivotConfig;
                         const query =
                             await this.asyncQueryService.executeAsyncSavedChartQuery(
                                 {
@@ -566,13 +579,10 @@ export default class SchedulerTask {
                                     context:
                                         QueryExecutionContext.SCHEDULED_DELIVERY,
                                     limit: getSchedulerCsvLimit(csvOptions),
-                                    pivotResults: pivotResultsFlag.enabled,
+                                    pivotResults:
+                                        pivotResultsFlag.enabled &&
+                                        shouldPivotResults,
                                 },
-                            );
-
-                        const chart =
-                            await this.schedulerService.savedChartModel.get(
-                                savedChartUuid,
                             );
                         const downloadResult =
                             await this.asyncQueryService.downloadSyncQueryResults(
@@ -589,7 +599,9 @@ export default class SchedulerTask {
                                     hiddenFields: getHiddenTableFields(
                                         chart.chartConfig,
                                     ),
-                                    pivotConfig: getPivotConfig(chart),
+                                    pivotConfig: downloadPivotConfig,
+                                    exportPivotedData:
+                                        effectiveExportPivotedData,
                                     columnOrder: chart.tableConfig.columnOrder,
                                     expirationSecondsOverride,
                                 },
@@ -691,6 +703,20 @@ export default class SchedulerTask {
                             async ({ chartUuid, tileUuid }) => {
                                 const chartLimit =
                                     getSchedulerCsvLimit(csvOptions);
+                                const chart =
+                                    await this.schedulerService.savedChartModel.get(
+                                        chartUuid,
+                                    );
+                                const {
+                                    pivotConfig: downloadPivotConfig,
+                                    exportPivotedData:
+                                        effectiveExportPivotedData,
+                                } = getDownloadPivotOptions(
+                                    chart,
+                                    exportPivotedData,
+                                );
+                                const shouldPivotResults =
+                                    !!downloadPivotConfig;
                                 const query =
                                     await this.asyncQueryService.executeAsyncDashboardChartQuery(
                                         {
@@ -707,12 +733,9 @@ export default class SchedulerTask {
                                             parameters: finalParameters,
                                             limit: chartLimit,
                                             pivotResults:
-                                                pivotResultsFlag.enabled,
+                                                pivotResultsFlag.enabled &&
+                                                shouldPivotResults,
                                         },
-                                    );
-                                const chart =
-                                    await this.schedulerService.savedChartModel.get(
-                                        chartUuid,
                                     );
                                 const downloadResult =
                                     await this.asyncQueryService.downloadSyncQueryResults(
@@ -730,7 +753,9 @@ export default class SchedulerTask {
                                             hiddenFields: getHiddenTableFields(
                                                 chart.chartConfig,
                                             ),
-                                            pivotConfig: getPivotConfig(chart),
+                                            pivotConfig: downloadPivotConfig,
+                                            exportPivotedData:
+                                                effectiveExportPivotedData,
                                             columnOrder:
                                                 chart.tableConfig.columnOrder,
                                             expirationSecondsOverride,
@@ -4224,6 +4249,10 @@ export default class SchedulerTask {
         fileUrl: string;
         s3FileUrl?: string;
     }> {
+        const chart =
+            await this.schedulerService.savedChartModel.get(chartUuid);
+        const downloadPivotConfig = getDownloadPivotConfig(chart);
+        const shouldPivotResults = !!downloadPivotConfig;
         const query =
             await this.asyncQueryService.executeAsyncDashboardChartQuery({
                 account,
@@ -4240,10 +4269,8 @@ export default class SchedulerTask {
                     formatted: true,
                     limit: 'table',
                 }),
-                pivotResults: pivotResultsFlag.enabled,
+                pivotResults: pivotResultsFlag.enabled && shouldPivotResults,
             });
-        const chart =
-            await this.schedulerService.savedChartModel.get(chartUuid);
         const downloadResult =
             await this.asyncQueryService.downloadSyncQueryResults(
                 {
@@ -4256,7 +4283,7 @@ export default class SchedulerTask {
                         chart.chartConfig.config,
                     ),
                     hiddenFields: getHiddenTableFields(chart.chartConfig),
-                    pivotConfig: getPivotConfig(chart),
+                    pivotConfig: downloadPivotConfig,
                     columnOrder: chart.tableConfig.columnOrder,
                 },
                 SCHEDULER_POLLING_OPTIONS,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1128,6 +1128,7 @@ export class AsyncQueryService extends ProjectService {
         columnOrder = [],
         hiddenFields = [],
         pivotConfig,
+        exportPivotedData = true,
         attachmentDownloadName,
         expirationSecondsOverride,
     }: DownloadAsyncQueryResultsArgs): Promise<DownloadAsyncQueryResultsInternal> {
@@ -1253,11 +1254,12 @@ export class AsyncQueryService extends ProjectService {
                       ),
                   )
                 : fields;
+        const downloadPivotConfig = exportPivotedData ? pivotConfig : undefined;
 
         switch (type) {
             case DownloadFileType.CSV:
                 // Check if this is a pivot table download
-                if (pivotConfig && queryHistory.metricQuery) {
+                if (downloadPivotConfig && queryHistory.metricQuery) {
                     return this.pivotTableService.downloadAsyncPivotTableCsv({
                         resultsFileName,
                         fields,
@@ -1274,7 +1276,7 @@ export class AsyncQueryService extends ProjectService {
                             customLabels,
                             columnOrder: validColumnOrder,
                             hiddenFields,
-                            pivotConfig,
+                            pivotConfig: downloadPivotConfig,
                             attachmentDownloadName,
                         },
                         organizationUuid,
@@ -1299,7 +1301,7 @@ export class AsyncQueryService extends ProjectService {
                         customLabels,
                         columnOrder: validColumnOrder,
                         hiddenFields,
-                        pivotConfig,
+                        pivotConfig: downloadPivotConfig,
                     },
                     attachmentDownloadName,
                     {
@@ -1316,7 +1318,7 @@ export class AsyncQueryService extends ProjectService {
             case DownloadFileType.XLSX: {
                 // Check if this is a pivot table download
                 const xlsxResult =
-                    pivotConfig && queryHistory.metricQuery
+                    downloadPivotConfig && queryHistory.metricQuery
                         ? await ExcelService.downloadAsyncPivotTableXlsx({
                               resultsFileName,
                               fields,
@@ -1334,7 +1336,7 @@ export class AsyncQueryService extends ProjectService {
                                   customLabels,
                                   columnOrder: validColumnOrder,
                                   hiddenFields,
-                                  pivotConfig,
+                                  pivotConfig: downloadPivotConfig,
                                   attachmentDownloadName,
                               },
                               timezone: displayTimezone ?? undefined,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -51,6 +51,7 @@ export type DownloadAsyncQueryResultsArgs = Omit<
     columnOrder?: string[];
     hiddenFields?: string[];
     pivotConfig?: PivotConfig;
+    exportPivotedData?: boolean;
     attachmentDownloadName?: string;
     expirationSecondsOverride?: number;
 };

--- a/packages/common/src/pivot/pivotConfig.ts
+++ b/packages/common/src/pivot/pivotConfig.ts
@@ -58,3 +58,34 @@ export const getPivotConfig = (
             return undefined;
     }
 };
+
+export const getDownloadPivotConfig = (
+    savedChart: Pick<
+        CreateSavedChartVersion,
+        'chartConfig' | 'pivotConfig' | 'tableConfig'
+    >,
+    exportPivotedData: boolean = true,
+): PivotConfig | undefined => {
+    switch (savedChart.chartConfig.type) {
+        case ChartType.TABLE:
+            return getPivotConfig(savedChart);
+        case ChartType.CARTESIAN:
+            return exportPivotedData ? getPivotConfig(savedChart) : undefined;
+        default:
+            return undefined;
+    }
+};
+
+export const getDownloadPivotOptions = (
+    savedChart: Pick<
+        CreateSavedChartVersion,
+        'chartConfig' | 'pivotConfig' | 'tableConfig'
+    >,
+    exportPivotedData: boolean = true,
+): { pivotConfig: PivotConfig | undefined; exportPivotedData: boolean } => ({
+    pivotConfig: getDownloadPivotConfig(savedChart, exportPivotedData),
+    exportPivotedData:
+        savedChart.chartConfig.type === ChartType.CARTESIAN
+            ? exportPivotedData
+            : true,
+});

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -120,6 +120,7 @@ export type DownloadAsyncQueryResultsRequestParams = {
     columnOrder?: string[];
     hiddenFields?: string[];
     pivotConfig?: PivotConfig;
+    exportPivotedData?: boolean;
     attachmentDownloadName?: string;
 };
 

--- a/packages/common/src/types/downloadFile.ts
+++ b/packages/common/src/types/downloadFile.ts
@@ -26,5 +26,6 @@ export type DownloadOptions = {
     columnOrder?: string[];
     hiddenFields?: string[];
     pivotConfig?: PivotConfig;
+    exportPivotedData?: boolean;
     attachmentDownloadName?: string;
 };

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -16,6 +16,7 @@ export type SchedulerCsvOptions = {
     formatted: boolean;
     limit: 'table' | 'all' | number;
     asAttachment?: boolean;
+    exportPivotedData?: boolean;
 };
 
 export type SchedulerImageOptions = {
@@ -719,6 +720,7 @@ export type DownloadAsyncQueryResultsPayload = TraceTaskBase & {
     columnOrder?: string[];
     hiddenFields?: string[];
     pivotConfig?: PivotConfig;
+    exportPivotedData?: boolean;
     attachmentDownloadName?: string;
     encodedJwt?: string;
 };

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1058,6 +1058,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             chart.spaceUuid,
             ability,
         ]);
+        const downloadPivotConfig = getPivotConfig(chart);
 
         // Use the custom hook for dashboard chart downloads
         const { getDownloadQueryUuid } = useDashboardChartDownload(
@@ -1066,6 +1067,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             projectUuid,
             dashboardUuid,
             dashboardChartReadyQuery.executeQueryResponse.queryUuid,
+            !!downloadPivotConfig,
         );
 
         const closeDataExportModal = useCallback(
@@ -1778,7 +1780,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                         chart.chartConfig.config,
                     )}
                     hiddenFields={getHiddenTableFields(chart.chartConfig)}
-                    pivotConfig={getPivotConfig(chart)}
+                    pivotConfig={downloadPivotConfig}
                 />
                 <ExportImageModal
                     echartRef={echartRef}
@@ -1929,11 +1931,13 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         () => setIsDataExportModalOpen(false),
         [],
     );
+    const downloadPivotConfig = getPivotConfig(chart);
 
     const { getDownloadQueryUuid } = useEmbedDashboardChartDownload(
         tileUuid,
         projectUuid,
         dashboardChartReadyQuery.executeQueryResponse.queryUuid,
+        !!downloadPivotConfig,
     );
 
     const chartKind = useMemo(
@@ -2074,7 +2078,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                         chart.chartConfig.config,
                     )}
                     hiddenFields={getHiddenTableFields(chart.chartConfig)}
-                    pivotConfig={getPivotConfig(chart)}
+                    pivotConfig={downloadPivotConfig}
                 />
             )}
             {canExportImages && (

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -14,9 +14,14 @@ import {
     SegmentedControl,
     Stack,
     Text,
+    Tooltip,
 } from '@mantine-8/core';
 import { notifications } from '@mantine/notifications';
-import { IconInfoCircle, IconTableExport } from '@tabler/icons-react';
+import {
+    IconHelpCircle,
+    IconInfoCircle,
+    IconTableExport,
+} from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
 import { memo, useState, type FC, type ReactNode } from 'react';
 import { pollJobStatus } from '../../features/scheduler/hooks/useScheduler';
@@ -33,6 +38,11 @@ type ExportCsvRenderProps = {
     isExporting: boolean;
 };
 
+const EXPORT_DATA_LAYOUT = {
+    PIVOTED: 'pivoted',
+    UNPIVOTED: 'unpivoted',
+} as const;
+
 enum Values {
     FORMATTED = 'formatted',
     RAW = 'raw',
@@ -44,6 +54,7 @@ export type ExportResultsProps = {
     getDownloadQueryUuid: (
         limit: number | null,
         limitType: Limit,
+        exportPivotedData?: boolean,
     ) => Promise<string>;
     columnOrder?: string[];
     customLabels?: Record<string, string>;
@@ -81,6 +92,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         const [limit, setLimit] = useState<Limit>(Limit.TABLE);
         const [customLimit, setCustomLimit] = useState<number>(1);
         const [format, setFormat] = useState<string>(Values.FORMATTED);
+        const [exportPivotedData, setExportPivotedData] = useState(true);
         const [fileType, setFileType] = useState<DownloadFileType>(
             DownloadFileType.CSV,
         );
@@ -96,6 +108,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
                               ? (totalResults ?? 0)
                               : null,
                         limit,
+                        exportPivotedData,
                     );
 
                     const downloadOptions: DownloadOptions = {
@@ -105,7 +118,10 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         customLabels,
                         hiddenFields,
                         showTableNames,
-                        pivotConfig,
+                        pivotConfig: exportPivotedData
+                            ? pivotConfig
+                            : undefined,
+                        exportPivotedData,
                         attachmentDownloadName: chartName
                             ? `${chartName}_${formatDate(new Date())}`
                             : undefined,
@@ -176,7 +192,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
 
         const csvCellsLimit = health.data?.query?.csvCellsLimit || 100000;
         const maxColumnLimit = health.data?.pivotTable?.maxColumnLimit || 60;
-        const isPivotTable = !!pivotConfig;
+        const isPivotTable = exportPivotedData && !!pivotConfig;
         const isDialog = !!renderDialogActions;
         const showLimitNote =
             isPivotTable ||
@@ -220,6 +236,61 @@ const ExportResults: FC<ExportResultsProps> = memo(
                 )}
             </Stack>
         );
+
+        const layoutSelection = pivotConfig ? (
+            <Stack gap="sm">
+                <Stack gap={4}>
+                    <Group gap={4}>
+                        <Text fw={600} fz="sm">
+                            Layout
+                        </Text>
+                        <Tooltip
+                            withinPortal
+                            maw={300}
+                            multiline
+                            label="Grouped keeps the chart's pivoted columns. Flat exports the raw rows behind the chart."
+                            position="top"
+                        >
+                            <div>
+                                <MantineIcon
+                                    icon={IconHelpCircle}
+                                    size="sm"
+                                    color="gray"
+                                />
+                            </div>
+                        </Tooltip>
+                    </Group>
+                    <Text fz="xs" c="dimmed">
+                        Choose whether to export the chart&apos;s grouped layout
+                        or the underlying flat rows.
+                    </Text>
+                </Stack>
+                <SegmentedControl
+                    size="sm"
+                    fullWidth
+                    value={
+                        exportPivotedData
+                            ? EXPORT_DATA_LAYOUT.PIVOTED
+                            : EXPORT_DATA_LAYOUT.UNPIVOTED
+                    }
+                    onChange={(value) =>
+                        setExportPivotedData(
+                            value === EXPORT_DATA_LAYOUT.PIVOTED,
+                        )
+                    }
+                    data={[
+                        {
+                            label: 'Grouped',
+                            value: EXPORT_DATA_LAYOUT.PIVOTED,
+                        },
+                        {
+                            label: 'Flat',
+                            value: EXPORT_DATA_LAYOUT.UNPIVOTED,
+                        },
+                    ]}
+                />
+            </Stack>
+        ) : null;
 
         return (
             <Stack gap="md" miw="20rem">
@@ -291,6 +362,8 @@ const ExportResults: FC<ExportResultsProps> = memo(
                                 ]}
                             />
                         </Stack>
+
+                        {layoutSelection}
 
                         {!hideLimitSelection &&
                             (forceShowLimitSelection ? (

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -12,6 +12,7 @@ import { memo, useCallback } from 'react';
 import useEchartsCartesianConfig from '../../../hooks/echarts/useEchartsCartesianConfig';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
+import { type Limit } from '../../ExportResults/types';
 import ExportSelector from '../../ExportSelector';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -29,7 +30,7 @@ import {
 export type ChartDownloadMenuProps = {
     getDownloadQueryUuid: (
         limit: number | null,
-        exportPivotedResults: boolean,
+        exportPivotedResults?: boolean,
     ) => Promise<string>;
     projectUuid: string;
     chartName?: string;
@@ -79,10 +80,13 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             },
         });
 
-        // ChartDownloadMenu downloads pivoted results when they are available
         const getChartDownloadQueryUuid = useCallback(
-            (limit: number | null) => {
-                return getDownloadQueryUuid(limit, true);
+            (
+                limit: number | null,
+                _limitType: Limit,
+                exportPivotedData: boolean = true,
+            ) => {
+                return getDownloadQueryUuid(limit, exportPivotedData);
             },
             [getDownloadQueryUuid],
         );

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormSetupTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormSetupTab.tsx
@@ -474,6 +474,55 @@ export const SchedulerFormSetupTab: FC<Props> = ({
                                             </i>
                                         )}
                                     </Stack>
+                                    <Radio.Group
+                                        label={
+                                            <>
+                                                Layout
+                                                <Tooltip
+                                                    withinPortal
+                                                    maw={300}
+                                                    multiline
+                                                    label="Applies to cartesian charts with pivoted dimensions. Grouped keeps the chart's column structure; Flat returns the raw rows from the query."
+                                                    position="top"
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconHelpCircle}
+                                                        size="md"
+                                                        display="inline"
+                                                        color="gray"
+                                                        style={{
+                                                            marginLeft: '4px',
+                                                            marginBottom:
+                                                                '-4px',
+                                                        }}
+                                                    />
+                                                </Tooltip>
+                                            </>
+                                        }
+                                        value={
+                                            form.values.options
+                                                .exportPivotedData
+                                                ? 'pivoted'
+                                                : 'unpivoted'
+                                        }
+                                        onChange={(value) =>
+                                            form.setFieldValue(
+                                                'options.exportPivotedData',
+                                                value === 'pivoted',
+                                            )
+                                        }
+                                    >
+                                        <Stack gap="xxs" pt="xs">
+                                            <Radio
+                                                label="Grouped"
+                                                value="pivoted"
+                                            />
+                                            <Radio
+                                                label="Flat"
+                                                value="unpivoted"
+                                            />
+                                        </Stack>
+                                    </Radio.Group>
                                 </Group>
                             </Collapse>
                         </Stack>

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -33,6 +33,7 @@ export interface SchedulerFormValues {
         customLimit: number;
         withPdf: boolean;
         asAttachment: boolean;
+        exportPivotedData: boolean;
     };
     emailTargets: string[];
     slackTargets: string[];
@@ -68,6 +69,7 @@ export const DEFAULT_VALUES: SchedulerFormValues = {
         customLimit: 1,
         withPdf: false,
         asAttachment: false,
+        exportPivotedData: true,
     },
     emailTargets: [],
     slackTargets: [],
@@ -136,6 +138,7 @@ export const getFormValuesFromScheduler = (
             formOptions.customLimit = options.limit as number;
         }
         formOptions.asAttachment = options.asAttachment || false;
+        formOptions.exportPivotedData = options.exportPivotedData !== false;
     } else if (isSchedulerImageOptions(options)) {
         formOptions.withPdf = options.withPdf || false;
     }
@@ -198,6 +201,7 @@ export const transformFormValues = (
                 (values.emailTargets?.length || 0) > 0
                     ? values.options.asAttachment
                     : false,
+            exportPivotedData: values.options.exportPivotedData,
         } satisfies SchedulerCsvOptions;
     } else if (values.format === SchedulerFormat.IMAGE) {
         options = {

--- a/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadButton.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadButton.tsx
@@ -8,6 +8,7 @@ import { IconDownload } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import ExportResults from '../../../../components/ExportResults';
+import { type Limit } from '../../../../components/ExportResults/types';
 
 type Props = {
     projectUuid: string;
@@ -16,7 +17,11 @@ type Props = {
     columnOrder: string[];
     totalResults: number;
     chartName: string | undefined;
-    getDownloadQueryUuid: (limit: number | null) => Promise<string>;
+    getDownloadQueryUuid: (
+        limit: number | null,
+        limitType?: Limit,
+        exportPivotedData?: boolean,
+    ) => Promise<string>;
 };
 
 const ResultsDownloadButton: FC<Props> = ({

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartDownload.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartDownload.ts
@@ -18,6 +18,7 @@ export const useDashboardChartDownload = (
     projectUuid: string | undefined,
     dashboardUuid: string | undefined,
     originalQueryUuid: string,
+    canExportPivotedData: boolean,
 ) => {
     // Get dashboard filters and sorts for this tile
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
@@ -36,13 +37,25 @@ export const useDashboardChartDownload = (
     );
 
     const getDownloadQueryUuid = useCallback(
-        async (limit: number | null, limitType: Limit): Promise<string> => {
+        async (
+            limit: number | null,
+            limitType: Limit,
+            exportPivotedData: boolean = true,
+        ): Promise<string> => {
             if (!projectUuid || !dashboardUuid) {
                 throw new Error('Missing required parameters');
             }
 
+            const originalQueryIsPivoted =
+                canExportPivotedData && !!useSqlPivotResults?.enabled;
+            const shouldPivotResults =
+                exportPivotedData && originalQueryIsPivoted;
+
             // When limiting to the table, use the original query uuid so we don't execute a new query
-            if (limitType === Limit.TABLE) {
+            if (
+                limitType === Limit.TABLE &&
+                originalQueryIsPivoted === shouldPivotResults
+            ) {
                 return originalQueryUuid;
             }
 
@@ -65,7 +78,7 @@ export const useDashboardChartDownload = (
                         limit,
                         invalidateCache: false,
                         parameters,
-                        pivotResults: useSqlPivotResults?.enabled,
+                        pivotResults: shouldPivotResults,
                     }),
                 });
 
@@ -97,6 +110,7 @@ export const useDashboardChartDownload = (
             dashboardSorts,
             dateZoomGranularity,
             parameters,
+            canExportPivotedData,
             useSqlPivotResults?.enabled,
             originalQueryUuid,
         ],

--- a/packages/frontend/src/hooks/dashboard/useEmbedDashboardChartDownload.ts
+++ b/packages/frontend/src/hooks/dashboard/useEmbedDashboardChartDownload.ts
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     QueryHistoryStatus,
     type ApiExecuteAsyncDashboardChartQueryResults,
 } from '@lightdash/common';
@@ -7,12 +8,14 @@ import { lightdashApi } from '../../api';
 import { Limit } from '../../components/ExportResults/types';
 import { pollForResults } from '../../features/queryRunner/executeQuery';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
+import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
 export const useEmbedDashboardChartDownload = (
     tileUuid: string,
     projectUuid: string | undefined,
     originalQueryUuid: string,
+    canExportPivotedData: boolean,
 ) => {
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
     const chartSort = useDashboardContext((c) => c.chartSort);
@@ -24,15 +27,30 @@ export const useEmbedDashboardChartDownload = (
     const dateZoomGranularity = useDashboardContext(
         (c) => c.dateZoomGranularity,
     );
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
+        FeatureFlags.UseSqlPivotResults,
+    );
 
     const getDownloadQueryUuid = useCallback(
-        async (limit: number | null, limitType: Limit): Promise<string> => {
+        async (
+            limit: number | null,
+            limitType: Limit,
+            exportPivotedData: boolean = true,
+        ): Promise<string> => {
             if (!projectUuid) {
                 throw new Error('Missing required parameters');
             }
 
+            const originalQueryIsPivoted =
+                canExportPivotedData && !!useSqlPivotResults?.enabled;
+            const shouldPivotResults =
+                exportPivotedData && originalQueryIsPivoted;
+
             // When limiting to the table, use the original query uuid
-            if (limitType === Limit.TABLE) {
+            if (
+                limitType === Limit.TABLE &&
+                originalQueryIsPivoted === shouldPivotResults
+            ) {
                 return originalQueryUuid;
             }
 
@@ -51,6 +69,7 @@ export const useEmbedDashboardChartDownload = (
                         limit,
                         invalidateCache: false,
                         parameters,
+                        pivotResults: shouldPivotResults,
                     }),
                 });
 
@@ -79,6 +98,8 @@ export const useEmbedDashboardChartDownload = (
             dashboardSorts,
             dateZoomGranularity,
             parameters,
+            canExportPivotedData,
+            useSqlPivotResults?.enabled,
             originalQueryUuid,
         ],
     );

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -100,6 +100,7 @@ export const scheduleDownloadQuery = async (
             columnOrder: options.columnOrder,
             hiddenFields: options.hiddenFields,
             pivotConfig: options.pivotConfig,
+            exportPivotedData: options.exportPivotedData,
             attachmentDownloadName: options.attachmentDownloadName,
         }),
         version: 'v2',


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/22725

## Summary

Adds an explicit `Pivoted` / `Unpivoted` export option for CSV/XLSX chart exports, while preserving existing pivoted behavior by default.

## What changed

- Added a `Data` export option to CSV/XLSX downloads
- Threaded the selection through the frontend export flow, scheduler form, shared types, and backend download pipeline
- Ensured query execution and file generation use the same export shape
- Updated `getDownloadPivotConfig` so:
  - table charts always stay pivoted if they have a pivot config
  - cartesian charts respect the selected export layout

## Behavior

- Default behavior remains `Pivoted`
- Table charts keep their current pivoted export behavior
- Cartesian charts can now be exported as either:
  - `Pivoted`
  - `Unpivoted`

## Why

Cartesian exports sometimes need stable raw columns for downstream consumers, but table pivots should continue exporting in their pivoted shape.

## Verification

- `pnpm -F common test -- --runTestsByPath packages/common/src/pivot/pivotConfig.test.ts`
- `pnpm -F common typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F backend test -- --runTestsByPath packages/backend/src/scheduler/SchedulerTask.test.ts`