### PR TITLE
feat(timezone): shift TIMESTAMP cells in Google Sheets exports

### DIFF
--- a/docs/timezone-handling.md
+++ b/docs/timezone-handling.md
@@ -186,6 +186,7 @@ The resolved timezone rides on the API response (`resolvedTimezone` on `ApiExecu
 - Chart tooltips (`tooltipFormatter`) use the same pair via `resolveAxisTimezone` so headers and hover values agree with the axis
 - CSV exports — including pivot CSVs — run through the backend formatter, so downloads match the Explorer view
 - Excel exports use a wall-clock-as-UTC `Date` builder (`toExcelWallClockDate` in `packages/common/src/utils/formatting.ts`) so date cells stay real dates with project-TZ wall-clock and keep their `numFmt`
+- Google Sheets exports re-encode TIMESTAMP and TIMESTAMP-base DATE intervals as ISO 8601 with an explicit project-TZ offset (`toIsoWithProjectOffset` in `packages/common/src/utils/formatting.ts`); cells stay as text either way (Sheets doesn't auto-detect ISO-Z as datetime), the suffix just communicates the zone honestly
 - The chart card shows a resolved-timezone badge so users can see which zone they're looking at
 
 ```mermaid
@@ -309,7 +310,6 @@ The only remaining hole is NTZ-style columns storing non-UTC data on warehouses 
 | Gap                                                              | Description                                                                                                                                                                                                                                                                           | Impact                                                                                                                                            |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **BigQuery/Athena: no session timezone**                         | These warehouses have no session-timezone plumbing, so the data-timezone setting is inert. NTZ-style columns (BigQuery `DATETIME`, Athena bare `TIMESTAMP`) can't be rebased from their stored zone to UTC                                                                           | Data timezone setting has no effect (UI field is hidden); NTZ columns holding non-UTC data can't be normalized                                    |
-| **Google Sheets pivot deliveries render TIMESTAMP/DATE cells in UTC** | Gsheet pivot deliveries call `pivotResultsAsCsv({ onlyRaw: true })`, which reads `value.raw` and skips the timezone-formatted output from `formatRows`. Pivot column headers built via `formatItemValue` also omit the timezone args. Kept raw so columns preserve their native types in Google Sheets | Gsheet pivot output renders timestamps in UTC even with `EnableTimezoneSupport` on, so it disagrees with the Explorer view when the project TZ is non-UTC |
 
 ---
 

--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -16,6 +16,7 @@ import {
     MissingConfigError,
     NotFoundError,
     TableCalculation,
+    toIsoWithProjectOffset,
     UnexpectedGoogleSheetsError,
 } from '@lightdash/common';
 import { google, sheets_v4 } from 'googleapis';
@@ -301,6 +302,7 @@ export class GoogleDriveClient {
     static formatCell(
         value: AnyType,
         item?: Field | TableCalculation | CustomDimension | Metric,
+        timezone?: string,
     ) {
         // We don't want to use formatItemValue directly because the format for some types on Gsheets
         // is different to what we use to present the data in the UI (eg: timestamps, currencies)
@@ -324,6 +326,12 @@ export class GoogleDriveClient {
                 // For very large BigInt values, convert to string to preserve precision
                 formattedValue = value.toString();
             }
+        } else if (isField(item) && item.type === DimensionType.TIMESTAMP) {
+            // Shift the wall-clock into the project tz with an explicit
+            // offset so cells communicate the zone honestly. Falls through
+            // to the existing passthrough when timezone is unset / UTC.
+            const shifted = toIsoWithProjectOffset(value, timezone);
+            formattedValue = shifted ?? value;
         } else if (isField(item) && item.type === DimensionType.DATE) {
             const timeInterval = isDimension(item)
                 ? item.timeInterval
@@ -373,6 +381,7 @@ export class GoogleDriveClient {
         columnOrder: string[] = [],
         customLabels: Record<string, string> = {},
         hiddenFields: string[] = [],
+        timezone?: string,
     ) {
         if (!this.isEnabled) {
             throw new MissingConfigError('Google Drive is not enabled');
@@ -398,7 +407,7 @@ export class GoogleDriveClient {
                 const item = itemMap[fieldId];
                 // Google sheet doesn't like arrays as values, so we need to convert them to strings
                 const value = row[fieldId];
-                return GoogleDriveClient.formatCell(value, item);
+                return GoogleDriveClient.formatCell(value, item, timezone);
             }),
         );
 

--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -11,6 +11,7 @@ import {
     GoogleSheetsTransientError,
     isDimension,
     isField,
+    isShiftableForTzExport,
     ItemsMap,
     Metric,
     MissingConfigError,
@@ -336,7 +337,13 @@ export class GoogleDriveClient {
             const timeInterval = isDimension(item)
                 ? item.timeInterval
                 : undefined;
-            formattedValue = formatDate(value, timeInterval);
+            // TIMESTAMP-base DATE intervals carry a real instant; shift them
+            // alongside TIMESTAMP fields so non-pivot and pivot exports agree.
+            // Calendar DATEs (no TIMESTAMP base) keep wall-clock formatting.
+            const shifted = isShiftableForTzExport(item)
+                ? toIsoWithProjectOffset(value, timezone)
+                : undefined;
+            formattedValue = shifted ?? formatDate(value, timeInterval);
         } else if (
             // Return the string representation of the Object Wrappers for Primitive Types
             typeof value === 'object' &&

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2228,6 +2228,7 @@ export default class SchedulerTask {
                     maxColumnLimit:
                         this.lightdashConfig.pivotTable.maxColumnLimit,
                     pivotDetails,
+                    timezone: displayTimezone ?? undefined,
                 });
 
                 await this.googleDriveClient.appendCsvToSheet(
@@ -2246,6 +2247,7 @@ export default class SchedulerTask {
                     payload.columnOrder,
                     payload.customLabels,
                     payload.hiddenFields,
+                    displayTimezone ?? undefined,
                 );
             }
 
@@ -2896,6 +2898,7 @@ export default class SchedulerTask {
                         maxColumnLimit:
                             this.lightdashConfig.pivotTable.maxColumnLimit,
                         pivotDetails,
+                        timezone: displayTimezone ?? undefined,
                     });
                     await this.googleDriveClient.appendCsvToSheet(
                         refreshToken,
@@ -2914,6 +2917,7 @@ export default class SchedulerTask {
                         chart.tableConfig.columnOrder,
                         customLabels,
                         getHiddenTableFields(chart.chartConfig),
+                        displayTimezone ?? undefined,
                     );
                 }
             } else if (dashboardUuid) {
@@ -3057,6 +3061,7 @@ export default class SchedulerTask {
                                     this.lightdashConfig.pivotTable
                                         .maxColumnLimit,
                                 pivotDetails,
+                                timezone: displayTimezone ?? undefined,
                             });
 
                             await this.googleDriveClient.appendCsvToSheet(
@@ -3076,6 +3081,7 @@ export default class SchedulerTask {
                                 chart.tableConfig.columnOrder,
                                 customLabels,
                                 getHiddenTableFields(chart.chartConfig),
+                                displayTimezone ?? undefined,
                             );
                         }
                     }, Promise.resolve())

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -21,7 +21,11 @@ import {
 import { type ResultRow, type ResultValue } from '../types/results';
 import { TimeFrames } from '../types/timeFrames';
 import { getArrayValue, getObjectValue } from '../utils/accessors';
-import { formatItemValue } from '../utils/formatting';
+import {
+    formatItemValue,
+    isShiftableForTzExport,
+    toIsoWithProjectOffset,
+} from '../utils/formatting';
 
 type FieldFunction = (fieldId: string) => ItemsMap[string] | undefined;
 
@@ -1577,6 +1581,10 @@ type PivotResultsParams = {
     onlyRaw: boolean;
     maxColumnLimit: number;
     undefinedCharacter?: string;
+    // When set + onlyRaw + the cell's field is TIMESTAMP, the emitted value
+    // is the warehouse instant shifted into the project tz with an explicit
+    // offset suffix. No-op for other modes / fields.
+    timezone?: string;
 };
 
 export const pivotResultsAsData = ({
@@ -1589,6 +1597,7 @@ export const pivotResultsAsData = ({
     maxColumnLimit,
     undefinedCharacter = '',
     pivotDetails,
+    timezone,
 }: PivotResultsParams): PivotResultsData => {
     const getFieldLabel = (fieldId: string) => {
         const customLabel = customLabels?.[fieldId];
@@ -1617,11 +1626,24 @@ export const pivotResultsAsData = ({
           });
 
     const formatField = onlyRaw ? 'raw' : 'formatted';
+    // For onlyRaw + timezone, re-encode TIMESTAMP / DATE-base-TS values
+    // into the project tz with an explicit offset suffix. No-op for other
+    // modes / fields, so non-onlyRaw and non-tz callers are byte-identical.
+    const pickValue = (
+        cellValue: ResultValue | undefined,
+        fieldId: string,
+    ): string => {
+        const base = (cellValue?.[formatField] as string) ?? '';
+        if (!onlyRaw || !timezone) return base;
+        if (!isShiftableForTzExport(itemMap[fieldId])) return base;
+        const shifted = toIsoWithProjectOffset(cellValue?.raw, timezone);
+        return shifted ?? base;
+    };
     const headers = pivotedResults.headerValues.reduce<string[][]>(
         (acc, row, i) => {
             const values = row.map((header) =>
                 'value' in header
-                    ? (header.value[formatField] as string)
+                    ? pickValue(header.value, header.fieldId)
                     : getFieldLabel(header.fieldId),
             );
             const fields = pivotedResults.titleFields[i];
@@ -1654,8 +1676,7 @@ export const pivotResultsAsData = ({
         const cells: PivotResultsDataCell[] = fieldIds.map((fieldId) => ({
             raw: row[fieldId]?.value?.raw ?? '',
             formatted:
-                (row[fieldId]?.value?.[formatField] as string) ||
-                undefinedCharacter,
+                pickValue(row[fieldId]?.value, fieldId) || undefinedCharacter,
             fieldId,
         }));
         return [...noIndexPrefix, ...cells];

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -23,6 +23,7 @@ import {
     formatValueWithExpression,
     getCustomFormatFromLegacy,
     isMomentInput,
+    toIsoWithProjectOffset,
 } from './formatting';
 import {
     additionalMetric,
@@ -1990,6 +1991,73 @@ describe('Formatting', () => {
                     ),
                 );
             });
+        });
+    });
+
+    describe('toIsoWithProjectOffset', () => {
+        const tz = 'Pacific/Pago_Pago'; // UTC-11, no DST
+
+        test('returns undefined when timezone is unset', () => {
+            expect(
+                toIsoWithProjectOffset('2024-01-15T02:00:00.000Z', undefined),
+            ).toBeUndefined();
+        });
+
+        test('returns undefined when timezone is UTC (no-op short-circuit)', () => {
+            expect(
+                toIsoWithProjectOffset('2024-01-15T02:00:00.000Z', 'UTC'),
+            ).toBeUndefined();
+        });
+
+        test('shifts a UTC ISO string into project offset', () => {
+            expect(toIsoWithProjectOffset('2024-01-15T02:00:00.000Z', tz)).toBe(
+                '2024-01-14T15:00:00.000-11:00',
+            );
+        });
+
+        test('always emits millis even when source had none', () => {
+            expect(toIsoWithProjectOffset('2024-01-15T02:00:00Z', tz)).toBe(
+                '2024-01-14T15:00:00.000-11:00',
+            );
+        });
+
+        test('accepts Date input', () => {
+            expect(
+                toIsoWithProjectOffset(
+                    new Date('2024-01-15T02:00:00.000Z'),
+                    tz,
+                ),
+            ).toBe('2024-01-14T15:00:00.000-11:00');
+        });
+
+        test('accepts numeric epoch ms', () => {
+            const epoch = Date.UTC(2024, 0, 15, 2, 0, 0, 0);
+            expect(toIsoWithProjectOffset(epoch, tz)).toBe(
+                '2024-01-14T15:00:00.000-11:00',
+            );
+        });
+
+        test('returns undefined for null/undefined/non-instant inputs', () => {
+            expect(toIsoWithProjectOffset(null, tz)).toBeUndefined();
+            expect(toIsoWithProjectOffset(undefined, tz)).toBeUndefined();
+            expect(toIsoWithProjectOffset({}, tz)).toBeUndefined();
+            expect(toIsoWithProjectOffset(['a'], tz)).toBeUndefined();
+        });
+
+        test('returns undefined for unparseable strings', () => {
+            expect(
+                toIsoWithProjectOffset('not-a-timestamp', tz),
+            ).toBeUndefined();
+        });
+
+        test('honors positive-offset zones (DST-aware via moment-timezone)', () => {
+            // Asia/Karachi is UTC+5 year-round, so 02:00 UTC -> 07:00 +05:00
+            expect(
+                toIsoWithProjectOffset(
+                    '2024-01-15T02:00:00.000Z',
+                    'Asia/Karachi',
+                ),
+            ).toBe('2024-01-15T07:00:00.000+05:00');
         });
     });
 });

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -197,6 +197,40 @@ export function toExcelWallClockDate(
     return moment.tz(value, timezone).utc(true).toDate();
 }
 
+// Re-encode a UTC instant as ISO 8601 in the project tz with an explicit
+// offset suffix (e.g. `2024-01-14T15:00:00.000-11:00`). Returns undefined
+// when there's nothing to shift; callers fall through to passthrough so
+// flag-off / UTC output stays bit-identical.
+export const toIsoWithProjectOffset = (
+    rawValue: unknown,
+    timezone: string | undefined,
+): string | undefined => {
+    if (!timezone || timezone === 'UTC') return undefined;
+    if (
+        typeof rawValue !== 'string' &&
+        typeof rawValue !== 'number' &&
+        !(rawValue instanceof Date)
+    ) {
+        return undefined;
+    }
+    const m = moment.utc(rawValue);
+    if (!m.isValid()) return undefined;
+    return m.tz(timezone).toISOString(true);
+};
+
+// TIMESTAMP fields and TIMESTAMP-base DATE intervals (DATE_TRUNC round-trip)
+// carry a real instant — both shift into the project tz for export.
+// Calendar DATEs (no time component) stay put.
+export const isShiftableForTzExport = (item: Item | undefined): boolean => {
+    if (!isField(item)) return false;
+    if (item.type === DimensionType.TIMESTAMP) return true;
+    return (
+        item.type === DimensionType.DATE &&
+        isDimension(item) &&
+        item.timeIntervalBaseDimensionType === DimensionType.TIMESTAMP
+    );
+};
+
 export function getLocalTimeDisplay(
     value: MomentInput,
     showTimezone: boolean = true,


### PR DESCRIPTION
## Summary

Non-pivot and pivot Google Sheets deliveries now re-encode TIMESTAMP and TIMESTAMP-base DATE cells into the project timezone with an explicit ISO offset suffix (e.g. `2024-01-14T15:00:00.000-11:00`). Flag-off output is byte-identical.

- `formatCell` adds a TIMESTAMP branch using the new `toIsoWithProjectOffset` helper
- `appendToSheet` threads `timezone` through to `formatCell`
- `pivotResultsAsData` shifts TIMESTAMP / DATE-base-TS cells when called with `timezone` + `onlyRaw`; non-gsheets callers pass nothing and stay byte-identical
- The three `SchedulerTask` gsheet sites pass `displayTimezone ?? undefined`

DATE-base intervals stay calendar-only (no shift), other cell types untouched.

### Tests with TZ set to UTC -11:00
**Before**
Non pivot
<img width="1027" height="153" alt="before_non_pivot" src="https://github.com/user-attachments/assets/7b527bf3-bdb5-457f-9252-0c5e2a01ca4c" />
Pivot
<img width="892" height="153" alt="before_pivot" src="https://github.com/user-attachments/assets/7a6bd893-2c3f-4b7b-8217-2746b2ff9925" />

**After**
Non pivot
<img width="1068" height="130" alt="after-non-pivot" src="https://github.com/user-attachments/assets/071b32e5-3b45-4c42-b0b7-4f0ebad8533d" />
Pivot
<img width="1241" height="152" alt="after_pivot" src="https://github.com/user-attachments/assets/2d13f4ed-0784-45a5-aa8c-0523d6ad41e2" />
<img width="881" height="109" alt="pivot_headers" src="https://github.com/user-attachments/assets/57ff2bac-ebdc-4a05-81ec-d985a30a0e0a" />



Closes: GLITCH-407
Relates to: GLITCH-395