### PR TITLE
feat(managed-agent): group activity log by run

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -48,10 +48,7 @@
         light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
     border-radius: var(--mantine-radius-md);
     overflow: hidden;
-    background-color: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-dark-7)
-    );
+    background-color: transparent;
     animation: tableIn 400ms var(--ease-out-quart) both;
     animation-delay: 100ms;
 }
@@ -65,6 +62,8 @@
 
 .table {
     border-collapse: collapse;
+    table-layout: fixed;
+    width: 100%;
 }
 
 .table thead th {
@@ -73,10 +72,7 @@
     text-transform: uppercase;
     letter-spacing: 0.4px;
     color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-2));
-    background-color: light-dark(
-        var(--mantine-color-gray-0),
-        var(--mantine-color-dark-6)
-    );
+    background-color: transparent;
     padding: 7px 12px;
     border-bottom: 1px solid
         light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
@@ -84,6 +80,10 @@
 
 /* Row — staggered entrance + smooth hover */
 .row {
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
     transition: background-color 120ms var(--ease-out-quart);
     animation: rowIn 300ms var(--ease-out-quart) both;
     cursor: pointer;
@@ -149,13 +149,6 @@
 
 .row:last-child td {
     border-bottom: none;
-}
-
-.timestamp {
-    color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-2));
-    white-space: nowrap;
-    font-size: 12px;
-    font-family: var(--mantine-font-family-monospace);
 }
 
 /* Heartbeat status */
@@ -245,11 +238,17 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
-.rowSelected {
+.rowSelected,
+.rowSelected:hover {
     background-color: light-dark(
-        var(--mantine-color-blue-0),
+        var(--mantine-color-gray-1),
         var(--mantine-color-dark-5)
     );
+}
+
+.rowSelected td:first-child {
+    box-shadow: inset 2px 0 0
+        light-dark(var(--mantine-color-gray-5), var(--mantine-color-gray-6));
 }
 
 /* Resize handle */
@@ -461,6 +460,87 @@
     flex-shrink: 0;
 }
 
+/* Run grouping */
+.runHeaderRow {
+    cursor: pointer;
+    user-select: none;
+    background-color: transparent;
+    transition: background-color 120ms var(--ease-out-quart);
+}
+
+.runHeaderRow:hover {
+    background-color: light-dark(
+        var(--mantine-color-gray-1),
+        var(--mantine-color-dark-5)
+    );
+}
+
+.runHeaderRow td {
+    padding: 8px 12px;
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    border-top: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+}
+
+.runChevron {
+    color: var(--mantine-color-dimmed);
+    transition: transform 150ms var(--ease-out-quart);
+    flex-shrink: 0;
+}
+
+.runChevronOpen {
+    color: var(--mantine-color-dimmed);
+    transform: rotate(90deg);
+    transition: transform 150ms var(--ease-out-quart);
+    flex-shrink: 0;
+}
+
+.runCountPill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-4));
+    padding: 1px 6px;
+    border-radius: 6px;
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+}
+
+.showMoreRow {
+    background-color: transparent;
+}
+
+.showMoreRow td {
+    padding: 10px 12px;
+    text-align: center;
+    border-top: 1px dashed
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+}
+
+.showMoreButton {
+    display: inline-block;
+    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-4));
+    font-size: 12px;
+    font-weight: 500;
+    padding: 4px 12px;
+    border-radius: 6px;
+    transition: background-color 120ms var(--ease-out-quart);
+}
+
+.showMoreButton:hover {
+    background-color: light-dark(
+        var(--mantine-color-gray-1),
+        var(--mantine-color-dark-5)
+    );
+}
+
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
     .page,
@@ -472,5 +552,10 @@
 
     .statusDotPulse {
         animation: none;
+    }
+
+    .runChevron,
+    .runChevronOpen {
+        transition: none;
     }
 }

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -30,6 +30,7 @@ import {
     IconBolt,
     IconBrandSlack,
     IconChartBar,
+    IconChevronRight,
     IconCircleCheck,
     IconClock,
     IconDatabase,
@@ -47,7 +48,7 @@ import {
 } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { format, formatDistanceToNowStrict } from 'date-fns';
-import { useCallback, useEffect, type FC, useState } from 'react';
+import { useCallback, useEffect, useMemo, type FC, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
@@ -1108,16 +1109,6 @@ const ActionRow: FC<{
             className={`${classes.row} ${selected ? classes.rowSelected : ''}`}
             onClick={() => onSelect(action)}
         >
-            <Table.Td w={90}>
-                <Tooltip
-                    label={formatAbsoluteTimestamp(action.createdAt)}
-                    withinPortal
-                >
-                    <span className={classes.timestamp}>
-                        {formatTimestamp(action.createdAt)}
-                    </span>
-                </Tooltip>
-            </Table.Td>
             <Table.Td w={100}>
                 {config.tooltip ? (
                     <Tooltip label={config.tooltip} withinPortal>
@@ -1160,6 +1151,115 @@ const ActionRow: FC<{
     );
 };
 
+// --- Run grouping ---
+
+const VISIBLE_RUN_COUNT = 3;
+
+type RunGroup = {
+    sessionId: string;
+    startedAt: string;
+    actions: ManagedAgentAction[];
+    counts: Partial<Record<ManagedAgentAction['actionType'], number>>;
+};
+
+const groupActionsBySession = (actions: ManagedAgentAction[]): RunGroup[] => {
+    const groups = new Map<string, RunGroup>();
+    for (const action of actions) {
+        const existing = groups.get(action.sessionId);
+        if (existing) {
+            existing.actions.push(action);
+            existing.counts[action.actionType] =
+                (existing.counts[action.actionType] ?? 0) + 1;
+            if (action.createdAt < existing.startedAt) {
+                existing.startedAt = action.createdAt;
+            }
+        } else {
+            groups.set(action.sessionId, {
+                sessionId: action.sessionId,
+                startedAt: action.createdAt,
+                actions: [action],
+                counts: { [action.actionType]: 1 },
+            });
+        }
+    }
+    return Array.from(groups.values());
+};
+
+const RunHeaderRow: FC<{
+    run: RunGroup;
+    isOpen: boolean;
+    onToggle: () => void;
+}> = ({ run, isOpen, onToggle }) => {
+    const totalCount = run.actions.length;
+    return (
+        <Table.Tr className={classes.runHeaderRow} onClick={onToggle}>
+            <Table.Td colSpan={3}>
+                <Group justify="space-between" gap="xs" wrap="nowrap">
+                    <Group gap="xs" wrap="nowrap">
+                        <IconChevronRight
+                            size={12}
+                            className={
+                                isOpen
+                                    ? classes.runChevronOpen
+                                    : classes.runChevron
+                            }
+                        />
+                        <Text
+                            fz={11}
+                            fw={600}
+                            tt="uppercase"
+                            c="dimmed"
+                            lts={0.4}
+                        >
+                            Run
+                        </Text>
+                        <Text fz="xs" c="dimmed">
+                            ·
+                        </Text>
+                        <Tooltip
+                            label={formatAbsoluteTimestamp(run.startedAt)}
+                            withinPortal
+                        >
+                            <Text fz="xs" c="dimmed">
+                                {formatTimestamp(run.startedAt)}
+                            </Text>
+                        </Tooltip>
+                    </Group>
+                    <Group gap={6} wrap="nowrap">
+                        {Object.entries(run.counts).map(([type, count]) => {
+                            const cfg =
+                                ACTION_CONFIG[
+                                    type as ManagedAgentAction['actionType']
+                                ];
+                            return (
+                                <Tooltip
+                                    key={type}
+                                    label={cfg.label}
+                                    withinPortal
+                                >
+                                    <span className={classes.runCountPill}>
+                                        <Box
+                                            className={classes.dot}
+                                            style={{
+                                                backgroundColor: cfg.dotColor,
+                                            }}
+                                        />
+                                        {count}
+                                    </span>
+                                </Tooltip>
+                            );
+                        })}
+                        <Text fz={11} c="dimmed">
+                            {totalCount}{' '}
+                            {totalCount === 1 ? 'action' : 'actions'}
+                        </Text>
+                    </Group>
+                </Group>
+            </Table.Td>
+        </Table.Tr>
+    );
+};
+
 // --- Page ---
 
 // ts-unused-exports:disable-next-line
@@ -1172,7 +1272,64 @@ export const ManagedAgentActivityPage: FC = () => {
         useManagedAgentSettings();
     const [selected, setSelected] = useState<ManagedAgentAction | null>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
-    const filtered = actions ?? [];
+    const [userOpenState, setUserOpenState] = useState<Map<string, boolean>>(
+        new Map(),
+    );
+    const [defaultOpenSet, setDefaultOpenSet] = useState<Set<string>>(
+        new Set(),
+    );
+    const [showOlderRuns, setShowOlderRuns] = useState(false);
+    const runs = useMemo(() => groupActionsBySession(actions ?? []), [actions]);
+
+    useEffect(() => {
+        setDefaultOpenSet((prev) => {
+            const next = new Set(prev);
+            runs.slice(0, VISIBLE_RUN_COUNT).forEach((r) =>
+                next.add(r.sessionId),
+            );
+            return next;
+        });
+    }, [runs]);
+
+    const isRunOpen = useCallback(
+        (sessionId: string) => {
+            const userValue = userOpenState.get(sessionId);
+            if (userValue !== undefined) return userValue;
+            return defaultOpenSet.has(sessionId);
+        },
+        [userOpenState, defaultOpenSet],
+    );
+
+    const toggleRun = useCallback(
+        (sessionId: string) => {
+            setUserOpenState((prev) => {
+                const next = new Map(prev);
+                next.set(sessionId, !isRunOpen(sessionId));
+                return next;
+            });
+        },
+        [isRunOpen],
+    );
+
+    const handleSelectAction = useCallback(
+        (action: ManagedAgentAction) => {
+            setSettingsOpen(false);
+            setSelected(action);
+            const runIdx = runs.findIndex(
+                (r) => r.sessionId === action.sessionId,
+            );
+            if (runIdx >= VISIBLE_RUN_COUNT) {
+                setShowOlderRuns(true);
+            }
+            setUserOpenState((prev) => {
+                const next = new Map(prev);
+                next.set(action.sessionId, true);
+                return next;
+            });
+        },
+        [runs],
+    );
+
     const runNowMutation = useMutation<undefined, ApiError>({
         mutationFn: () => runHeartbeat(projectUuid!),
         onSuccess: () => {
@@ -1230,7 +1387,7 @@ export const ManagedAgentActivityPage: FC = () => {
                                 }}
                             />
 
-                            {filtered.length === 0 ? (
+                            {runs.length === 0 ? (
                                 <Box className={classes.empty}>
                                     <Text fw={500} fz="sm" mt="xs">
                                         No activity yet
@@ -1245,28 +1402,92 @@ export const ManagedAgentActivityPage: FC = () => {
                                     <Table className={classes.table}>
                                         <Table.Thead>
                                             <Table.Tr>
-                                                <Table.Th />
-                                                <Table.Th>Action</Table.Th>
-                                                <Table.Th>Name</Table.Th>
+                                                <Table.Th w={140}>
+                                                    Action
+                                                </Table.Th>
+                                                <Table.Th w={260}>
+                                                    Name
+                                                </Table.Th>
                                                 <Table.Th>Message</Table.Th>
                                             </Table.Tr>
                                         </Table.Thead>
-                                        <Table.Tbody>
-                                            {filtered.map((action) => (
-                                                <ActionRow
-                                                    key={action.actionUuid}
-                                                    action={action}
-                                                    selected={
-                                                        selected?.actionUuid ===
-                                                        action.actionUuid
-                                                    }
-                                                    onSelect={(action) => {
-                                                        setSettingsOpen(false);
-                                                        setSelected(action);
-                                                    }}
-                                                />
-                                            ))}
-                                        </Table.Tbody>
+                                        {runs.map((run, idx) => {
+                                            const isOlder =
+                                                idx >= VISIBLE_RUN_COUNT;
+                                            if (isOlder && !showOlderRuns)
+                                                return null;
+                                            const open = isRunOpen(
+                                                run.sessionId,
+                                            );
+                                            return (
+                                                <Table.Tbody
+                                                    key={run.sessionId}
+                                                >
+                                                    <RunHeaderRow
+                                                        run={run}
+                                                        isOpen={open}
+                                                        onToggle={() =>
+                                                            toggleRun(
+                                                                run.sessionId,
+                                                            )
+                                                        }
+                                                    />
+                                                    {open &&
+                                                        run.actions.map(
+                                                            (action) => (
+                                                                <ActionRow
+                                                                    key={
+                                                                        action.actionUuid
+                                                                    }
+                                                                    action={
+                                                                        action
+                                                                    }
+                                                                    selected={
+                                                                        selected?.actionUuid ===
+                                                                        action.actionUuid
+                                                                    }
+                                                                    onSelect={
+                                                                        handleSelectAction
+                                                                    }
+                                                                />
+                                                            ),
+                                                        )}
+                                                </Table.Tbody>
+                                            );
+                                        })}
+                                        {!showOlderRuns &&
+                                            runs.length > VISIBLE_RUN_COUNT && (
+                                                <Table.Tbody>
+                                                    <Table.Tr
+                                                        className={
+                                                            classes.showMoreRow
+                                                        }
+                                                    >
+                                                        <Table.Td colSpan={3}>
+                                                            <UnstyledButton
+                                                                className={
+                                                                    classes.showMoreButton
+                                                                }
+                                                                onClick={() =>
+                                                                    setShowOlderRuns(
+                                                                        true,
+                                                                    )
+                                                                }
+                                                            >
+                                                                Show{' '}
+                                                                {runs.length -
+                                                                    VISIBLE_RUN_COUNT}{' '}
+                                                                older{' '}
+                                                                {runs.length -
+                                                                    VISIBLE_RUN_COUNT ===
+                                                                1
+                                                                    ? 'run'
+                                                                    : 'runs'}
+                                                            </UnstyledButton>
+                                                        </Table.Td>
+                                                    </Table.Tr>
+                                                </Table.Tbody>
+                                            )}
                                     </Table>
                                 </Box>
                             )}


### PR DESCRIPTION
Closes: <!-- reference the related issue -->

### Description

The Autopilot activity log was a flat reverse-chronological list. After a few scheduled runs it became hard to tell where one run ended and the next began. This groups actions by `session_id` (already on the action shape — no backend change) so each Autopilot run renders as a collapsible section with a header.

- Frontend-only. The actions API and types are untouched.
- The first 3 runs render expanded by default; older runs collapse behind a "Show N older runs" affordance.
- Run header shows relative time + per-action-type count pills + total. Clicking the header toggles collapse.
- Clicking an action inside a hidden run auto-expands the run *and* reveals the older bucket so the detail sidebar context isn't orphaned.
- Open/closed state resets on reload (intentional — no localStorage churn).
- Polling: new runs arriving via the 30s refetch don't push previously-opened runs out of their default-open state.
- Visual cleanup along the way: dropped the now-vestigial timestamp column inside groups (run header carries the time), softened the table card so it doesn't clash with the page bg (transparent wrapper, action rows explicit white, headers transparent), neutralised the previously-blue selected-row colour with a small left accent.

### Out of scope (deferred)

- Showing runs that produced 0 actions ("agent ran cleanly"). Needs a small backend addition (last-heartbeat timestamp on the settings response). Easy follow-up; orthogonal to grouping.

### Test plan

- [ ] Land on the activity page with multiple runs — first 3 expanded, older collapsed
- [ ] Click a run header — collapses; click again — expands
- [ ] Click "Show N older runs" — reveals older run headers (collapsed by default)
- [ ] Click an action inside an older (hidden) run — older bucket reveals + the run auto-expands
- [ ] Wait 30s for the polled refetch — open runs stay open, new runs land at the top
- [ ] Toggle dark mode — table colours read correctly in both schemes
- [ ] Run a heartbeat with the Run-now button — UI updates after the polled refetch
