### PR TITLE
feat(managed-agent): animate the home-card pixel grid

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.module.css
@@ -66,20 +66,66 @@
     position: absolute;
     top: 0;
     right: 0;
-    bottom: 0;
     color: light-dark(
         var(--mantine-color-violet-4),
         var(--mantine-color-violet-6)
     );
     pointer-events: none;
-    transition:
-        transform 300ms var(--ease-out-quart),
-        opacity 300ms var(--ease-out-quart);
+    transition: opacity 300ms var(--ease-out-quart);
     opacity: 0.6;
+    animation: pixelDrift 22s ease-in-out infinite;
 }
 
 .card:hover .pixelGrid {
     opacity: 1;
+}
+
+@keyframes pixelDrift {
+    0%,
+    100% {
+        transform: translate(0, 0);
+    }
+    33% {
+        transform: translate(-4px, 2px);
+    }
+    66% {
+        transform: translate(3px, -2px);
+    }
+}
+
+.pixelGrid rect {
+    opacity: var(--rect-opacity, 0.1);
+}
+
+/* Staggered twinkle on overlapping subsets — different cycles + delays
+   give each cell a unique-feeling rhythm without per-cell rules. */
+.pixelGrid rect:nth-child(5n + 1) {
+    animation: twinkle 5s ease-in-out infinite;
+}
+
+.pixelGrid rect:nth-child(7n + 3) {
+    animation: twinkle 6s ease-in-out infinite;
+    animation-delay: 1.4s;
+}
+
+.pixelGrid rect:nth-child(11n + 4) {
+    animation: twinkle 4.5s ease-in-out infinite;
+    animation-delay: 2.7s;
+}
+
+.pixelGrid rect:nth-child(13n + 7) {
+    animation: twinkle 7s ease-in-out infinite;
+    animation-delay: 0.6s;
+}
+
+@keyframes twinkle {
+    0%,
+    100% {
+        opacity: var(--rect-opacity, 0.1);
+    }
+    50% {
+        opacity: calc(var(--rect-opacity, 0.1) * 3.2);
+    }
 }
 
 .card:hover {
@@ -239,5 +285,9 @@
     }
     .pixelGrid {
         transition: none;
+        animation: none;
+    }
+    .pixelGrid rect {
+        animation: none;
     }
 }

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -18,7 +18,13 @@ import {
     IconShieldCheck,
     IconTrendingUp,
 } from '@tabler/icons-react';
-import { type FC, useEffect, useMemo, useState } from 'react';
+import {
+    type CSSProperties,
+    type FC,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
 import { useNavigate } from 'react-router';
 import { BetaBadge } from '../../../components/common/BetaBadge';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
@@ -69,7 +75,7 @@ const PixelGrid: FC = () => {
             6, 7, 2, 9, 5, 0, 4, 8, 1, 6, 3, 7, 9, 2, 5, 0, 8, 4, 1, 6, 3, 7, 9,
             2, 5, 8, 0, 4, 1, 3, 6, 7, 9,
         ];
-        for (let row = 0; row < 12; row++) {
+        for (let row = 0; row < 30; row++) {
             for (let col = 0; col < 28; col++) {
                 const idx = row * 28 + col;
                 const val = seed[idx % seed.length];
@@ -86,13 +92,7 @@ const PixelGrid: FC = () => {
     }, []);
 
     return (
-        <svg
-            className={classes.pixelGrid}
-            width="252"
-            height="100%"
-            viewBox="0 0 252 108"
-            preserveAspectRatio="xMaxYMid slice"
-        >
+        <svg className={classes.pixelGrid} width="252" height="270">
             {cells.map((cell, i) => (
                 <rect
                     key={i}
@@ -102,7 +102,11 @@ const PixelGrid: FC = () => {
                     height="7"
                     rx="1.5"
                     fill="currentColor"
-                    opacity={cell.opacity}
+                    style={
+                        {
+                            '--rect-opacity': cell.opacity,
+                        } as CSSProperties
+                    }
                 />
             ))}
         </svg>


### PR DESCRIPTION
Closes: <!-- reference the related issue -->

### Description

Stacked on #22737. The Autopilot home card has a static SVG pixel grid on the right edge — purely decorative. This makes it feel alive with two CSS-only effects, and fixes a pre-existing rendering issue along the way.

**Per-cell twinkle.** Each rect now exposes its base opacity as a CSS custom property (`--rect-opacity`), and a keyframe animates from `var(--rect-opacity)` to `calc(var(--rect-opacity) * 3.2)` and back. Four overlapping `nth-child` selectors (`5n+1`, `7n+3`, `11n+4`, `13n+7`) with different durations (4.5–7s) and delays put each affected cell on its own cycle, so there's no flat strobe. Cells matching multiple selectors take the last one's animation, which adds extra de-sync for free.

**Whole-grid drift.** The SVG slowly wanders on a 22s cycle (`translate(0,0) → (-4,2) → (3,-2) → (0,0)`) — small enough to be subliminal, big enough to make the card feel like it's breathing.

**Fixed pixel rendering.** Previously the SVG used `preserveAspectRatio="xMaxYMid slice"` with `height="100%"`, which scaled cells up dramatically in tall containers and cropped them aggressively in narrow ones. Switched to fixed dimensions (252×270, no `preserveAspectRatio`) so cells always render at their native 7×7 size and 9px column spacing, regardless of card aspect ratio. Increased row count from 12 to 30 so the pattern reaches further down without empty space below in taller card variants.

Both animations honour `prefers-reduced-motion`. No JS, no per-frame work, no layout thrash — pure compositor properties (opacity + transform).

### Test plan

- [ ] Open the home page with Autopilot enabled — pixel grid twinkles softly *and* slowly drifts
- [ ] Confirm twinkle isn't synchronised across cells (no flat strobe pulse)
- [ ] Confirm cells render at consistent native size regardless of card width/height
- [ ] Toggle dark mode — both effects still subtle
- [ ] Set OS reduced-motion preference — both effects stop, cells stay at base opacity in their resting positions
