### PR TITLE
fix: throw better errors on Athena client failures

### DIFF
--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
@@ -1,6 +1,8 @@
 import {
     AthenaAuthenticationType,
     CreateAthenaCredentials,
+    WarehouseConnectionError,
+    WarehouseQueryError,
     WarehouseTypes,
 } from '@lightdash/common';
 
@@ -118,6 +120,186 @@ describe('AthenaWarehouseClient', () => {
             expect(mockAthenaClient).toHaveBeenCalledWith({
                 region: 'us-east-1',
                 credentials: 'sts-credentials',
+            });
+        });
+    });
+
+    describe('error translation', () => {
+        // Synthesizes an error with the shape produced by the AWS SDK:
+        // an Error subclass whose `name` is the AWS error code, with optional
+        // $metadata.httpStatusCode (set by the SDK on every ServiceException).
+        const makeAwsError = (
+            name: string,
+            message: string,
+            httpStatusCode?: number,
+        ): Error => {
+            const err = new Error(message) as Error & {
+                $metadata?: { httpStatusCode?: number };
+            };
+            err.name = name;
+            if (httpStatusCode !== undefined) {
+                err.$metadata = { httpStatusCode };
+            }
+            return err;
+        };
+
+        const setMockSendToReject = (error: Error) => {
+            mockAthenaClient.mockImplementation(() => ({
+                send: jest.fn().mockRejectedValue(error),
+            }));
+        };
+
+        test('translates UnrecognizedClientException into WarehouseConnectionError with hint', async () => {
+            setMockSendToReject(
+                makeAwsError(
+                    'UnrecognizedClientException',
+                    'The security token included in the request is invalid.',
+                ),
+            );
+            const client = new AthenaWarehouseClient(baseCredentials);
+
+            await expect(client.test()).rejects.toBeInstanceOf(
+                WarehouseConnectionError,
+            );
+            await expect(client.test()).rejects.toMatchObject({
+                message: expect.stringContaining(
+                    '[UnrecognizedClientException]',
+                ),
+            });
+            await expect(client.test()).rejects.toMatchObject({
+                message: expect.stringContaining(
+                    'AWS rejected the access key ID',
+                ),
+            });
+        });
+
+        test('translates InvalidSignatureException into WarehouseConnectionError', async () => {
+            setMockSendToReject(
+                makeAwsError(
+                    'InvalidSignatureException',
+                    'Signature does not match.',
+                ),
+            );
+            const client = new AthenaWarehouseClient(baseCredentials);
+
+            await expect(client.test()).rejects.toBeInstanceOf(
+                WarehouseConnectionError,
+            );
+            await expect(client.test()).rejects.toMatchObject({
+                message: expect.stringContaining('secret access key'),
+            });
+        });
+
+        test('translates ExpiredTokenException into WarehouseConnectionError', async () => {
+            setMockSendToReject(
+                makeAwsError(
+                    'ExpiredTokenException',
+                    'The security token has expired.',
+                ),
+            );
+            const client = new AthenaWarehouseClient(baseCredentials);
+
+            await expect(client.test()).rejects.toBeInstanceOf(
+                WarehouseConnectionError,
+            );
+            await expect(client.test()).rejects.toMatchObject({
+                message: expect.stringContaining('expired'),
+            });
+        });
+
+        test('translates CredentialsProviderError into WarehouseConnectionError', async () => {
+            setMockSendToReject(
+                makeAwsError(
+                    'CredentialsProviderError',
+                    'Could not load credentials from any providers',
+                ),
+            );
+            const client = new AthenaWarehouseClient(baseCredentials);
+
+            await expect(client.test()).rejects.toBeInstanceOf(
+                WarehouseConnectionError,
+            );
+            await expect(client.test()).rejects.toMatchObject({
+                message: expect.stringContaining('IAM Role'),
+            });
+        });
+
+        test('keeps non-auth errors as WarehouseQueryError from streamQuery', async () => {
+            setMockSendToReject(
+                makeAwsError(
+                    'InvalidRequestException',
+                    'Workgroup primary not found',
+                ),
+            );
+            const client = new AthenaWarehouseClient(baseCredentials);
+
+            await expect(client.test()).rejects.toBeInstanceOf(
+                WarehouseQueryError,
+            );
+            await expect(client.test()).rejects.toMatchObject({
+                message: expect.stringContaining('[InvalidRequestException]'),
+            });
+        });
+
+        test('falls back to httpStatusCode=401 when error name is unfamiliar', async () => {
+            // Some AWS error variants don't show up in our known-name set but
+            // are still authentication failures (e.g. credential-provider chain
+            // wrapping). HTTP 401 alone should be enough to classify as a
+            // connection error.
+            setMockSendToReject(
+                makeAwsError('SomeFutureAwsAuthError', 'unauthenticated', 401),
+            );
+            const client = new AthenaWarehouseClient(baseCredentials);
+
+            await expect(client.test()).rejects.toBeInstanceOf(
+                WarehouseConnectionError,
+            );
+            await expect(client.test()).rejects.toMatchObject({
+                message: expect.stringContaining(
+                    '[SomeFutureAwsAuthError 401]',
+                ),
+            });
+        });
+
+        test('does NOT promote httpStatusCode=403 to a connection error (could be IAM gap)', async () => {
+            // AccessDeniedException is 403 but represents an IAM permission
+            // gap during a query — it should remain WarehouseQueryError when
+            // streamQuery is the caller. The catalog/tables/fields paths
+            // explicitly opt into 'connection' default elsewhere.
+            setMockSendToReject(
+                makeAwsError(
+                    'AccessDeniedException',
+                    'You are not authorized to perform: athena:GetQueryResults',
+                    403,
+                ),
+            );
+            const client = new AthenaWarehouseClient(baseCredentials);
+
+            await expect(client.test()).rejects.toBeInstanceOf(
+                WarehouseQueryError,
+            );
+            await expect(client.test()).rejects.toMatchObject({
+                message: expect.stringContaining('[AccessDeniedException 403]'),
+            });
+        });
+
+        test('catalog/tables/fields default to WarehouseConnectionError', async () => {
+            setMockSendToReject(
+                makeAwsError(
+                    'AccessDeniedException',
+                    'You are not authorized to perform: athena:ListTableMetadata',
+                ),
+            );
+            const client = new AthenaWarehouseClient(baseCredentials);
+
+            await expect(client.getAllTables()).rejects.toBeInstanceOf(
+                WarehouseConnectionError,
+            );
+            await expect(client.getAllTables()).rejects.toMatchObject({
+                message: expect.stringContaining('[AccessDeniedException]'),
+            });
+            await expect(client.getAllTables()).rejects.toMatchObject({
+                message: expect.stringContaining('Failed to list tables'),
             });
         });
     });

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -87,6 +87,98 @@ const convertDataTypeToDimensionType = (
 // Force lowercase for column names
 const normalizeColumnName = (columnName: string) => columnName.toLowerCase();
 
+const AWS_AUTH_ERROR_NAMES = new Set([
+    'UnrecognizedClientException',
+    'InvalidClientTokenId',
+    'InvalidSignatureException',
+    'SignatureDoesNotMatch',
+    'ExpiredToken',
+    'ExpiredTokenException',
+    'CredentialsProviderError',
+    'CredentialsError',
+    'MissingAuthenticationToken',
+    'MissingAuthenticationTokenException',
+]);
+
+const getAuthErrorHint = (awsErrorName: string): string => {
+    switch (awsErrorName) {
+        case 'UnrecognizedClientException':
+        case 'InvalidClientTokenId':
+            return 'AWS rejected the access key ID. Check the access key in your project settings is correct and the IAM user is enabled.';
+        case 'InvalidSignatureException':
+        case 'SignatureDoesNotMatch':
+            return 'AWS rejected the request signature. Check the secret access key matches the access key ID, and that your system clock is in sync.';
+        case 'ExpiredToken':
+        case 'ExpiredTokenException':
+            return 'AWS credentials have expired. If you are using temporary or assume-role credentials, generate new ones.';
+        case 'CredentialsProviderError':
+        case 'CredentialsError':
+        case 'MissingAuthenticationToken':
+        case 'MissingAuthenticationTokenException':
+            return 'No AWS credentials could be loaded. If using IAM Role authentication, make sure the host has an attached role with Athena access.';
+        default:
+            return '';
+    }
+};
+
+// Translates a raw error from the AWS SDK (or anywhere else thrown out of an
+// Athena client.send call) into a Lightdash error. Auth/credential failures
+// are surfaced as WarehouseConnectionError so the UI categorizes them as a
+// project-config problem rather than a query problem.
+const translateAthenaError = (
+    error: unknown,
+    options: {
+        contextPrefix?: string;
+        defaultErrorClass?: 'connection' | 'query';
+    } = {},
+): Error => {
+    const err = error as {
+        name?: string;
+        message?: string;
+        $metadata?: { httpStatusCode?: number };
+    };
+    const awsErrorName =
+        typeof err?.name === 'string' &&
+        err.name !== 'Error' &&
+        !err.name.startsWith('Warehouse')
+            ? err.name
+            : undefined;
+    const httpStatusCode =
+        typeof err?.$metadata?.httpStatusCode === 'number'
+            ? err.$metadata.httpStatusCode
+            : undefined;
+
+    const baseMessage = getErrorMessage(error);
+    const hint = awsErrorName ? getAuthErrorHint(awsErrorName) : '';
+
+    // e.g. "[UnrecognizedClientException 403]" or "[403]" if name is missing.
+    const tag = [awsErrorName, httpStatusCode]
+        .filter((p) => p !== undefined && p !== '')
+        .join(' ');
+
+    const messageParts = [
+        options.contextPrefix,
+        tag.length > 0 ? `[${tag}]` : null,
+        baseMessage,
+        hint,
+    ].filter((p): p is string => typeof p === 'string' && p.length > 0);
+    const fullMessage = messageParts.join(' ');
+
+    // Auth signal precedence: known AWS error name first; otherwise fall back
+    // to HTTP 401 which is unambiguously an authentication failure. We do
+    // *not* fall back on 403 — it also covers IAM permission gaps (e.g.
+    // missing athena:ListTableMetadata), which are query-time problems and
+    // belong in WarehouseQueryError unless the caller asks otherwise.
+    const isAuthError =
+        (awsErrorName !== undefined &&
+            AWS_AUTH_ERROR_NAMES.has(awsErrorName)) ||
+        httpStatusCode === 401;
+    if (isAuthError || options.defaultErrorClass === 'connection') {
+        return new WarehouseConnectionError(fullMessage);
+    }
+    return new WarehouseQueryError(fullMessage);
+};
+
 export class AthenaSqlBuilder extends WarehouseBaseSqlBuilder {
     readonly type = WarehouseTypes.ATHENA;
 
@@ -436,11 +528,10 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
                     if (error.name === 'MetadataException') {
                         return undefined;
                     }
-                    throw new WarehouseConnectionError(
-                        `Failed to fetch table metadata for '${database}.${schema}.${table}'. ${getErrorMessage(
-                            e,
-                        )}`,
-                    );
+                    throw translateAthenaError(e, {
+                        contextPrefix: `Failed to fetch table metadata for '${database}.${schema}.${table}'.`,
+                        defaultErrorClass: 'connection',
+                    });
                 }
             },
         );
@@ -498,11 +589,10 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
                 nextToken = response.NextToken;
             } while (nextToken);
         } catch (e: unknown) {
-            throw new WarehouseConnectionError(
-                `Failed to list tables in '${this.credentials.database}.${
-                    this.credentials.schema
-                }'. ${getErrorMessage(e)}`,
-            );
+            throw translateAthenaError(e, {
+                contextPrefix: `Failed to list tables in '${this.credentials.database}.${this.credentials.schema}'.`,
+                defaultErrorClass: 'connection',
+            });
         }
 
         return tables;
@@ -547,15 +637,14 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
 
             return result;
         } catch (e: unknown) {
-            throw new WarehouseConnectionError(
-                `Failed to get fields for table '${db}.${sch}.${tableName}'. ${getErrorMessage(
-                    e,
-                )}`,
-            );
+            throw translateAthenaError(e, {
+                contextPrefix: `Failed to get fields for table '${db}.${sch}.${tableName}'.`,
+                defaultErrorClass: 'connection',
+            });
         }
     }
 
     parseError(error: Error): Error {
-        return new WarehouseQueryError(getErrorMessage(error));
+        return translateAthenaError(error);
     }
 }


### PR DESCRIPTION
### Description:
Athena auth/credential failures now return a classified, actionable error instead of a generic WarehouseQueryError wrapping the bare AWS message.

  - All four AWS SDK catch sites (streamQuery, getCatalog, getAllTables, getFields) route through a new translateAthenaError helper.
  - Known auth errors (UnrecognizedClientException, InvalidSignatureException, ExpiredTokenException, CredentialsProviderError, etc.) become WarehouseConnectionError — matching what
  Snowflake/BigQuery/Databricks already do for connection-time failures.
  - Messages now include the AWS error code, HTTP status, and a one-line hint:
  [UnrecognizedClientException 400] The security token included in the request is invalid. AWS rejected the access key ID. Check the access key in your project settings is correct and the IAM user
  is enabled.

  On fragility

  Branching on error.name is the standard pattern across our warehouse clients. Three safeguards:

  1. error.name is part of AWS SDK v3's documented error contract; SDK version is pinned.
  2. HTTP 401 fallback catches future auth-error names we haven't catalogued. We deliberately don't fall back on 403 (also covers IAM permission gaps, which are query-time issues).
  3. If both signals miss, behavior degrades to the previous baseline — we never lose information, only fail to upgrade the classification.
