### PR TITLE
feat(managed-agent): add action category and previous-version metadata helpers

### DIFF
--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -80,6 +80,32 @@ export type ManagedAgentAction = {
     createdAt: Date;
 };
 
+export type ManagedAgentActionCategory = 'undo' | 'dismiss';
+
+const REVERSIBLE_ACTION_TYPES: ReadonlySet<ManagedAgentActionType> = new Set([
+    ManagedAgentActionType.SOFT_DELETED,
+    ManagedAgentActionType.CREATED_CONTENT,
+    ManagedAgentActionType.FIXED_BROKEN,
+]);
+
+export const getManagedAgentActionCategory = (
+    actionType: ManagedAgentActionType,
+): ManagedAgentActionCategory =>
+    REVERSIBLE_ACTION_TYPES.has(actionType) ? 'undo' : 'dismiss';
+
+export type FixedBrokenActionMetadata = {
+    previousVersionUuid: string;
+};
+
+export const getFixedBrokenMetadata = (
+    metadata: Record<string, unknown>,
+): FixedBrokenActionMetadata | null => {
+    const { previousVersionUuid } = metadata;
+    return typeof previousVersionUuid === 'string'
+        ? { previousVersionUuid }
+        : null;
+};
+
 export type UpdateManagedAgentSettings = {
     enabled?: boolean;
     schedule?: ManagedAgentScheduleOption;


### PR DESCRIPTION
## Summary

Foundation PR for the revert-actions work. Adds two helpers to `@lightdash/common` for the Autopilot (managed agent) feature:

1. `getManagedAgentActionCategory(actionType)` → `'undo' | 'dismiss'` — single source of truth for which action types are real reversals (mutate world state) vs log-only dismissals.
2. `getFixedBrokenMetadata(metadata)` → typed accessor for the `{ previousVersionUuid }` shape stored on `FIXED_BROKEN` actions, returns `null` for legacy actions that predate revert support.

## Why

Today `reverseAction` switch-cases over action types and conflates two semantically different operations: undoing a state change (e.g. restoring a soft-deleted chart) vs dismissing a log entry (e.g. dismissing a "stale" flag). The next PRs in this stack split that conceptual model and need a shared helper to derive category, plus a typed reader for the metadata field used to revert chart fixes.

This PR is pure additions — no callers change, no behavior changes. Sets up the next two PRs.

## Categories

| Action type | Category |
|---|---|
| `SOFT_DELETED` | undo |
| `CREATED_CONTENT` | undo |
| `FIXED_BROKEN` | undo |
| `FLAGGED_STALE` | dismiss |
| `FLAGGED_BROKEN` | dismiss |
| `FLAGGED_SLOW` | dismiss |
| `INSIGHT` | dismiss |

## Regression analysis

| Group | Effect |
|---|---|
| All users | Pure additions to `@lightdash/common` exports. Nothing imports them yet. |

## Test plan

- [ ] CI build of `@lightdash/common` succeeds
- [ ] No-op runtime: PR doesn't change any behavior, only exposes new symbols
