### PR TITLE
feat(managed-agent): make fix-broken chart actions reversible

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1391,6 +1391,7 @@ export type ManagedAgentActionReversedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         actionType: string;
+        actionCategory: 'undo' | 'dismiss';
         targetType: string;
         sessionId: string;
         actionAgeMs: number;

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -2,10 +2,13 @@ import { subject } from '@casl/ability';
 import {
     FeatureFlags,
     ForbiddenError,
+    getFixedBrokenMetadata,
+    getManagedAgentActionCategory,
     getManagedAgentScheduleCron,
     ManagedAgentActionType,
     ManagedAgentTargetType,
     NotFoundError,
+    ParameterError,
     ProjectType,
     ServiceAccountScope,
     type ChartConfig,
@@ -517,11 +520,14 @@ export class ManagedAgentService extends BaseService {
                     );
                 }
                 break;
+            case ManagedAgentActionType.FIXED_BROKEN:
+                await this.restorePreviousChartVersion(action);
+                break;
             case ManagedAgentActionType.FLAGGED_STALE:
             case ManagedAgentActionType.FLAGGED_BROKEN:
+            case ManagedAgentActionType.FLAGGED_SLOW:
             case ManagedAgentActionType.INSIGHT:
-            case ManagedAgentActionType.FIXED_BROKEN:
-                // These are log-only entries — marking as reversed dismisses them
+                // Log-only entries — marking as reversed dismisses them
                 break;
             default:
                 break;
@@ -541,6 +547,9 @@ export class ManagedAgentService extends BaseService {
                 organizationId: organizationUuid,
                 projectId: projectUuid,
                 actionType: action.actionType,
+                actionCategory: getManagedAgentActionCategory(
+                    action.actionType,
+                ),
                 targetType: action.targetType,
                 sessionId: action.sessionId,
                 actionAgeMs: Date.now() - new Date(action.createdAt).getTime(),
@@ -548,6 +557,29 @@ export class ManagedAgentService extends BaseService {
         });
 
         return reversed;
+    }
+
+    private async restorePreviousChartVersion(
+        action: ManagedAgentAction,
+    ): Promise<void> {
+        if (action.targetType !== ManagedAgentTargetType.CHART) {
+            return;
+        }
+        const metadata = getFixedBrokenMetadata(action.metadata);
+        if (!metadata) {
+            throw new ParameterError(
+                'This fix was recorded before revert support — restore manually via the chart version history.',
+            );
+        }
+        const previousChart = await this.savedChartModel.get(
+            action.targetUuid,
+            metadata.previousVersionUuid,
+        );
+        await this.savedChartModel.createVersion(
+            action.targetUuid,
+            previousChart,
+            undefined, // user — version creation doesn't require one
+        );
     }
 
     // --- Heartbeat ---
@@ -1052,6 +1084,15 @@ chartConfig:
             chartUuid,
         );
 
+        const previousVersion =
+            await this.savedChartModel.getLatestVersionSummary(chartUuid);
+        if (!previousVersion) {
+            throw new Error(
+                `Cannot fix chart ${chartUuid}: no existing version found`,
+            );
+        }
+        const previousVersionUuid = previousVersion.versionUuid;
+
         // Create a new version with the fixed config
         await this.savedChartModel.createVersion(
             chartUuid,
@@ -1080,7 +1121,7 @@ chartConfig:
             targetUuid: chartUuid,
             targetName: chartName,
             description,
-            metadata: {},
+            metadata: { previousVersionUuid },
         });
 
         return JSON.stringify({


### PR DESCRIPTION
Closes PROD-7453

## Summary

Makes Autopilot's `FIXED_BROKEN` actions reversible. Stacks on top of #22740.

Before this PR, when a user clicked "Revert" on a chart-fix action, the agent's switch-case fell through to the "log-only" branch and only flipped `reversedAt` — the chart kept the agent's version. Workaround was to manually use the chart history dropdown.

## How it works

Two coordinated changes in `ManagedAgentService`:

**Write path (`handleFixBrokenChart`):**
- Before `createVersion` is called, fetch the chart's current latest version via `savedChartModel.getLatestVersionSummary(chartUuid)`.
- Store its UUID in the action metadata as `{ previousVersionUuid }`.

**Read path (`reverseAction` → `restorePreviousChartVersion`):**
- Read `previousVersionUuid` via the typed `getFixedBrokenMetadata` helper from common.
- Fetch the prior chart payload via `savedChartModel.get(chartUuid, previousVersionUuid)`.
- Apply it as a new version via `createVersion` — preserves history rather than rewriting.

## Why store the UUID instead of computing from DB

Initial intuition was "use the existing `rollbackToVersionAtTimestamp` API with `action.createdAt - 1ms`." That's racy: `createVersion` runs *before* `createAction`, so `action.createdAt` lands *after* the agent's version's `created_at` — the rollback target is the agent's own version. Computing from session+user+chart in DB is fragile too. Capturing the version UUID at write time is one extra field, deterministic, and survives subsequent edits.

## Behavioral changes

1. **Legacy `FIXED_BROKEN` actions throw a clear error on revert** instead of silently no-oping. Existing actions in the DB don't have `previousVersionUuid`. `restorePreviousChartVersion` throws a `ParameterError` with a message pointing the user to the chart's version history.
2. **`FLAGGED_SLOW` is now an explicit dismiss case** instead of falling through to the default branch. Same behavior, more obvious intent.
3. **Analytics `managed_agent.action_reversed` event gets a new `actionCategory` property** (`'undo' | 'dismiss'`) so we can distinguish real reversals from dismissals.

## Out of scope

- Warning the user if there are newer human-authored versions between the agent fix and now (worth its own UX design).
- Re-flagging the chart as broken after a successful revert (`validateProject` will rediscover on next run).
- Diff visualization between fixed and pre-fix versions (separate Slack feedback item, not in PROD-7453's scope).

## Regression analysis

| Group | Effect |
|---|---|
| Users with newly-created `FIXED_BROKEN` actions | Revert button now actually restores the previous version (previously a silent no-op). |
| Users with legacy `FIXED_BROKEN` actions | Revert now throws a typed error with a clear "use chart history" message instead of silently succeeding. |
| Users with other action types | No change. |
| Users without Autopilot enabled | No change. |
| Service accounts / cross-project | No change — per-project authorization unchanged. |

The legacy-action error path is acceptable because the prior behavior was actively misleading.

## Test plan

- [ ] Trigger a real `FIXED_BROKEN` action; verify `metadata.previousVersionUuid` is populated in the DB
- [ ] Click "Revert" → chart's latest version reverts to the pre-fix payload (new version with old content)
- [ ] Manually clear `metadata` on an action and click "Revert" → toast shows "predates revert support" error
- [ ] Reverse a `SOFT_DELETED` action → still restores content
- [ ] Reverse a `CREATED_CONTENT` action → still soft-deletes the agent-created chart
- [ ] PostHog: confirm new `actionCategory` property appears on `managed_agent.action_reversed` events
