### PR TITLE
feat(managed-agent): label reverse button as undo or dismiss

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -2,6 +2,7 @@ import {
     type ApiError,
     type ContentVerificationInfo,
     type Dashboard,
+    getManagedAgentActionCategory,
     ManagedAgentScheduleOption,
     type Project,
     type SavedChart,
@@ -257,6 +258,16 @@ const ACTION_CONFIG: Record<
         label: 'Insight',
         dotColor: 'var(--mantine-color-violet-5)',
     },
+};
+
+const revertActionLabel = (
+    category: ReturnType<typeof getManagedAgentActionCategory>,
+    isReversed: boolean,
+): string => {
+    if (category === 'undo') {
+        return isReversed ? 'Already undone' : 'Undo action';
+    }
+    return isReversed ? 'Already dismissed' : 'Dismiss';
 };
 
 const TARGET_ICON: Record<
@@ -571,15 +582,26 @@ const DetailSidebar: FC<{
     onClose: () => void;
 }> = ({ action, onClose }) => {
     const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
     const config = ACTION_CONFIG[action.actionType];
     const isReversed = !!action.reversedAt;
     const isProjectTarget = action.targetType === 'project';
+    const category = getManagedAgentActionCategory(action.actionType);
 
-    const revertMutation = useMutation({
+    const revertMutation = useMutation<unknown, ApiError>({
         mutationFn: () => reverseAction(action.projectUuid, action.actionUuid),
         onSuccess: () => {
             void queryClient.invalidateQueries({
                 queryKey: ['managed-agent-actions', action.projectUuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title:
+                    category === 'undo'
+                        ? 'Could not undo action'
+                        : 'Could not dismiss action',
+                apiError: error,
             });
         },
     });
@@ -691,9 +713,7 @@ const DetailSidebar: FC<{
                                     onClick={() => revertMutation.mutate()}
                                     color={isReversed ? undefined : 'red'}
                                 >
-                                    {isReversed
-                                        ? 'Already reverted'
-                                        : 'Revert action'}
+                                    {revertActionLabel(category, isReversed)}
                                 </Menu.Item>
                             </Menu.Dropdown>
                         </Menu>

--- a/packages/frontend/src/ee/features/managedAgent/types.ts
+++ b/packages/frontend/src/ee/features/managedAgent/types.ts
@@ -1,16 +1,14 @@
+import {
+    type ManagedAgentActionType,
+    type ManagedAgentTargetType,
+} from '@lightdash/common';
+
 export type ManagedAgentAction = {
     actionUuid: string;
     projectUuid: string;
     sessionId: string;
-    actionType:
-        | 'flagged_stale'
-        | 'soft_deleted'
-        | 'flagged_broken'
-        | 'flagged_slow'
-        | 'fixed_broken'
-        | 'created_content'
-        | 'insight';
-    targetType: 'chart' | 'dashboard' | 'space' | 'project';
+    actionType: ManagedAgentActionType;
+    targetType: ManagedAgentTargetType;
     targetUuid: string;
     targetName: string;
     description: string;


### PR DESCRIPTION
## Summary

Updates the activity-page revert button to reflect the new undo-vs-dismiss conceptual split, and surfaces backend errors via a toast. Stacks on top of #22741.

## Changes

**Button label derived from action category:**

| Category | Idle label | Reversed label |
|---|---|---|
| undo (`SOFT_DELETED`, `CREATED_CONTENT`, `FIXED_BROKEN`) | "Undo action" | "Already undone" |
| dismiss (flags, insight) | "Dismiss" | "Already dismissed" |

Single source of truth: `getManagedAgentActionCategory` from `@lightdash/common` (added in #22740).

**Error toast on revert failure:**

The `useMutation` had no `onError` handler — backend errors (e.g. the new "previous version missing" `ParameterError` from #22741) were silent. Added an `onError` that calls `showToastApiError` with a category-aware title.

**Type cleanup:**

The frontend's local `ManagedAgentAction` type used bare string literals for `actionType` / `targetType`. Switched to the `ManagedAgentActionType` and `ManagedAgentTargetType` enums from `@lightdash/common` — same JSON values (string enums), better types, no more parallel union to maintain.

## Regression analysis

| Group | Effect |
|---|---|
| Autopilot users | Button labels change. Functionally identical. |
| Users hitting a backend error on revert (incl. legacy `FIXED_BROKEN` actions) | Now see a toast instead of a silent failure. |
| Disabled / no-flag users | Not affected. |

## Test plan

- [ ] Open action sidebar for a `SOFT_DELETED` action → menu shows "Undo action"; after clicking, "Already undone"
- [ ] Same for `CREATED_CONTENT` and `FIXED_BROKEN`
- [ ] Open sidebar for a `FLAGGED_*` / `INSIGHT` → menu shows "Dismiss"; after clicking, "Already dismissed"
- [ ] Trigger a backend error on revert → toast appears with the backend error message
