### PR TITLE
fix(skills): clarify disabled suggested dashboard filters

### DIFF
--- a/skills/developing-in-lightdash/resources/dashboard-best-practices.md
+++ b/skills/developing-in-lightdash/resources/dashboard-best-practices.md
@@ -245,6 +245,7 @@ filters:
         fieldId: orders_region
         tableName: orders
       values: []                # No default = show all regions
+      disabled: true            # Important: This keeps the filter available on the dashboard without applying it until a value is provided
 ```
 
 **When to use default values:**


### PR DESCRIPTION
## Summary
- Document that suggested dashboard filters should be authored with `values: []` and `disabled: true`
- Preserve the example for filters that should start active on load

## Testing
- Not run (not requested)