### PR TITLE
feat(timezone): align pivot CSV temporal format with non-pivot CSV

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -5,12 +5,12 @@ import {
     ApiSqlQueryResults,
     DashboardFilters,
     DateGranularity,
-    DimensionType,
     DownloadFileType,
     ExportCsvDashboardPayload,
     ForbiddenError,
     formatItemValue,
     formatRows,
+    formatTemporalCellForSpreadsheet,
     friendlyName,
     getErrorMessage,
     getItemLabel,
@@ -18,8 +18,6 @@ import {
     getItemMap,
     isDashboardChartTileType,
     isDashboardSqlChartTile,
-    isDimension,
-    isField,
     ItemsMap,
     MetricQuery,
     MissingConfigError,
@@ -249,24 +247,12 @@ export class CsvService extends BaseService {
                 return data;
             }
 
-            const itemIsField = isField(item);
-            if (itemIsField && item.type === DimensionType.TIMESTAMP) {
-                const m = timezone
-                    ? moment.utc(data).tz(timezone)
-                    : moment(data);
-                return m.format('YYYY-MM-DD HH:mm:ss.SSS');
-            }
-            if (itemIsField && item.type === DimensionType.DATE) {
-                // Only TZ format dates that have timestamps as base dimensions
-                const m =
-                    timezone &&
-                    isDimension(item) &&
-                    item.timeIntervalBaseDimensionType ===
-                        DimensionType.TIMESTAMP
-                        ? moment.utc(data).tz(timezone)
-                        : moment(data);
-                return m.format('YYYY-MM-DD');
-            }
+            const spreadsheetTemporal = formatTemporalCellForSpreadsheet(
+                item,
+                data,
+                timezone,
+            );
+            if (spreadsheetTemporal !== undefined) return spreadsheetTemporal;
 
             // Return raw value and let csv-stringify handle the rest
             if (onlyRaw) return data;

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -241,6 +241,9 @@ export class PivotTableService extends BaseService {
             undefined,
             timezone,
         );
+
+        // Pivot CSV uses the same wall-clock temporal format as non-pivot
+        // CSV so spreadsheet apps auto-detect dates. See GLITCH-406.
         const csvResults = pivotResultsAsCsv({
             pivotConfig,
             rows: formattedRows,
@@ -250,6 +253,8 @@ export class PivotTableService extends BaseService {
             onlyRaw,
             maxColumnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
             pivotDetails,
+            timezone,
+            formatTemporalsForSpreadsheet: true,
         });
 
         const csvContent = await new Promise<string>((resolve, reject) => {

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -23,6 +23,7 @@ import { TimeFrames } from '../types/timeFrames';
 import { getArrayValue, getObjectValue } from '../utils/accessors';
 import {
     formatItemValue,
+    formatTemporalCellForSpreadsheet,
     isShiftableForTzExport,
     toIsoWithProjectOffset,
 } from '../utils/formatting';
@@ -1585,6 +1586,9 @@ type PivotResultsParams = {
     // is the warehouse instant shifted into the project tz with an explicit
     // offset suffix. No-op for other modes / fields.
     timezone?: string;
+    // When true, shiftable temporal cells (header + body, both modes) emit
+    // the wall-clock format spreadsheet apps auto-detect as a date.
+    formatTemporalsForSpreadsheet?: boolean;
 };
 
 export const pivotResultsAsData = ({
@@ -1598,6 +1602,7 @@ export const pivotResultsAsData = ({
     undefinedCharacter = '',
     pivotDetails,
     timezone,
+    formatTemporalsForSpreadsheet = false,
 }: PivotResultsParams): PivotResultsData => {
     const getFieldLabel = (fieldId: string) => {
         const customLabel = customLabels?.[fieldId];
@@ -1626,16 +1631,22 @@ export const pivotResultsAsData = ({
           });
 
     const formatField = onlyRaw ? 'raw' : 'formatted';
-    // For onlyRaw + timezone, re-encode TIMESTAMP / DATE-base-TS values
-    // into the project tz with an explicit offset suffix. No-op for other
-    // modes / fields, so non-onlyRaw and non-tz callers are byte-identical.
     const pickValue = (
         cellValue: ResultValue | undefined,
         fieldId: string,
     ): string => {
+        const item = itemMap[fieldId];
+        if (formatTemporalsForSpreadsheet) {
+            const spreadsheetTemporal = formatTemporalCellForSpreadsheet(
+                item,
+                cellValue?.raw,
+                timezone,
+            );
+            if (spreadsheetTemporal !== undefined) return spreadsheetTemporal;
+        }
         const base = (cellValue?.[formatField] as string) ?? '';
         if (!onlyRaw || !timezone) return base;
-        if (!isShiftableForTzExport(itemMap[fieldId])) return base;
+        if (!isShiftableForTzExport(item)) return base;
         const shifted = toIsoWithProjectOffset(cellValue?.raw, timezone);
         return shifted ?? base;
     };

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -19,6 +19,7 @@ import {
     formatDate,
     formatItemValue,
     formatNumberValue,
+    formatTemporalCellForSpreadsheet,
     formatTimestamp,
     formatValueWithExpression,
     getCustomFormatFromLegacy,
@@ -2058,6 +2059,97 @@ describe('Formatting', () => {
                     'Asia/Karachi',
                 ),
             ).toBe('2024-01-15T07:00:00.000+05:00');
+        });
+    });
+
+    describe('formatTemporalCellForSpreadsheet', () => {
+        const tz = 'Pacific/Pago_Pago'; // UTC-11
+        const tsField = {
+            ...dimension,
+            type: DimensionType.TIMESTAMP,
+            name: 'event_timestamp',
+        };
+        const dateBaseTsField = {
+            ...dimension,
+            type: DimensionType.DATE,
+            name: 'event_timestamp_day',
+            timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+        };
+        const calendarDateField = {
+            ...dimension,
+            type: DimensionType.DATE,
+            name: 'order_date',
+        };
+
+        test('TIMESTAMP shifts into project tz with millis', () => {
+            expect(
+                formatTemporalCellForSpreadsheet(
+                    tsField,
+                    '2024-01-15T18:00:00.000Z',
+                    tz,
+                ),
+            ).toBe('2024-01-15 07:00:00.000');
+        });
+
+        test('TIMESTAMP without timezone formats wall-clock as-is', () => {
+            expect(
+                formatTemporalCellForSpreadsheet(
+                    tsField,
+                    '2024-01-15T18:00:00.000Z',
+                    undefined,
+                ),
+            ).toBe('2024-01-15 18:00:00.000');
+        });
+
+        test('DATE-base-TS shifts into project tz', () => {
+            expect(
+                formatTemporalCellForSpreadsheet(
+                    dateBaseTsField,
+                    '2024-01-15T11:00:00.000Z',
+                    tz,
+                ),
+            ).toBe('2024-01-15');
+        });
+
+        test('calendar DATE is not shifted even when tz is set', () => {
+            expect(
+                formatTemporalCellForSpreadsheet(
+                    calendarDateField,
+                    '2024-01-15',
+                    tz,
+                ),
+            ).toBe('2024-01-15');
+        });
+
+        test('returns undefined for non-temporal fields', () => {
+            expect(
+                formatTemporalCellForSpreadsheet(dimension, 'foo', tz),
+            ).toBeUndefined();
+            expect(
+                formatTemporalCellForSpreadsheet(metric, 42, tz),
+            ).toBeUndefined();
+        });
+
+        test('returns undefined for null / empty raw values', () => {
+            expect(
+                formatTemporalCellForSpreadsheet(tsField, null, tz),
+            ).toBeUndefined();
+            expect(
+                formatTemporalCellForSpreadsheet(tsField, undefined, tz),
+            ).toBeUndefined();
+            expect(
+                formatTemporalCellForSpreadsheet(tsField, '', tz),
+            ).toBeUndefined();
+        });
+
+        test('accepts Date input', () => {
+            expect(
+                formatTemporalCellForSpreadsheet(
+                    tsField,
+                    new Date('2024-01-15T18:00:00.000Z'),
+                    tz,
+                ),
+            ).toBe('2024-01-15 07:00:00.000');
         });
     });
 });

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -231,6 +231,33 @@ export const isShiftableForTzExport = (item: Item | undefined): boolean => {
     );
 };
 
+// Renders a temporal cell as the wall-clock string Excel and Google Sheets
+// auto-detect as a date. TIMESTAMP → `YYYY-MM-DD HH:mm:ss.SSS`, DATE →
+// `YYYY-MM-DD`. Shifts into the project tz when the item is timezone-
+// shiftable (TIMESTAMP / DATE-base-TS) and a timezone is supplied; calendar
+// DATEs are formatted as-is. Returns undefined for non-temporal fields or
+// unparseable values so callers can fall through to their existing
+// formatting path.
+export const formatTemporalCellForSpreadsheet = (
+    item: Item | undefined,
+    rawValue: unknown,
+    timezone: string | undefined,
+): string | undefined => {
+    if (!isField(item)) return undefined;
+    const isTimestamp = item.type === DimensionType.TIMESTAMP;
+    const isDate = item.type === DimensionType.DATE;
+    if (!isTimestamp && !isDate) return undefined;
+    if (rawValue === null || rawValue === undefined || rawValue === '') {
+        return undefined;
+    }
+    const shouldShift = !!timezone && isShiftableForTzExport(item);
+    const m = shouldShift
+        ? moment.utc(rawValue as MomentInput).tz(timezone!)
+        : moment(rawValue as MomentInput);
+    if (!m.isValid()) return undefined;
+    return m.format(isTimestamp ? 'YYYY-MM-DD HH:mm:ss.SSS' : 'YYYY-MM-DD');
+};
+
 export function getLocalTimeDisplay(
     value: MomentInput,
     showTimezone: boolean = true,


### PR DESCRIPTION
Pivot CSV temporal cells now emit the same spreadsheet-friendly wall-clock format as non-pivot CSV (`YYYY-MM-DD HH:mm:ss.SSS` for TIMESTAMP, `YYYY-MM-DD` for DATE), in headers and body, in both formatted and raw modes. Spreadsheet apps now auto-detect them as dates instead of treating them as text. Project-tz shift stays gated on `enable-timezone-support`; non-pivot CSV is byte-identical to before.

A new helper `formatTemporalCellForSpreadsheet` is the single source of truth for the format. `CsvService.convertRowToCsv` is refactored onto it (no behaviour change), and `pivotResultsAsCsv` / `pivotResultsAsData` get an opt-in `formatTemporalsForSpreadsheet` flag that the CSV pivot path passes; gsheets / Excel callers don't pass it and are untouched.

## Before / after

Setup: project tz `Pacific/Pago_Pago` (UTC-11), `enable-timezone-support` on, same metric query in every case (dims `category`, `event_timestamp` (TIMESTAMP), `event_timestamp_day` (DATE), metric `count`).

<details>
<summary><strong>Pivot CSV — formatted (before)</strong></summary>

```csv
,"Event timestamp day","2023-12-31","2024-01-14","2024-01-15","2024-01-16","2024-01-31","2024-03-09","2024-11-02"
"Category","Event timestamp","Count","Count","Count","Count","Count","Count","Count"
"year_boundary","2023-12-31, 13:00:00:000 (-11:00)","1",,,,,,
"tokyo_midnight","2024-01-14, 04:00:00:000 (-11:00)",,"1",,,,,
"utc_midnight","2024-01-14, 13:00:00:000 (-11:00)",,"1",,,,,
"early_utc","2024-01-14, 15:00:00:000 (-11:00)",,"1",,,,,
"mid_utc","2024-01-15, 07:00:00:000 (-11:00)",,,"1",,,,
"month_boundary","2024-01-31, 04:00:00:000 (-11:00)",,,,,"1",,
```
</details>

<details>
<summary><strong>Pivot CSV — raw (before)</strong></summary>

```csv
,"Event timestamp day","2023-12-31T11:00:00Z","2024-01-14T11:00:00Z","2024-01-15T11:00:00Z","2024-01-16T11:00:00Z","2024-01-31T11:00:00Z","2024-03-09T11:00:00Z","2024-11-02T11:00:00Z"
"Category","Event timestamp","Count","Count","Count","Count","Count","Count","Count"
"year_boundary","2024-01-01T00:00:00Z","1",,,,,,
"tokyo_midnight","2024-01-14T15:00:00Z",,"1",,,,,
"utc_midnight","2024-01-15T00:00:00Z",,"1",,,,,
"early_utc","2024-01-15T02:00:00Z",,"1",,,,,
"mid_utc","2024-01-15T18:00:00Z",,,"1",,,,
"month_boundary","2024-01-31T15:00:00Z",,,,,"1",,
```
</details>

<details open>
<summary><strong>Pivot CSV — formatted &amp; raw (after, byte-identical)</strong></summary>

```csv
,"Event timestamp day","2023-12-31","2024-01-14","2024-01-15","2024-01-16","2024-01-31","2024-03-09","2024-11-02"
"Category","Event timestamp","Count","Count","Count","Count","Count","Count","Count"
"year_boundary","2023-12-31 13:00:00.000","1",,,,,,
"tokyo_midnight","2024-01-14 04:00:00.000",,"1",,,,,
"utc_midnight","2024-01-14 13:00:00.000",,"1",,,,,
"early_utc","2024-01-14 15:00:00.000",,"1",,,,,
"mid_utc","2024-01-15 07:00:00.000",,,"1",,,,
"month_boundary","2024-01-31 04:00:00.000",,,,,"1",,
```
</details>

<details>
<summary><strong>Non-pivot CSV — formatted &amp; raw (before == after, byte-identical)</strong></summary>

```csv
﻿Category,Event timestamp,Event timestamp day,Count
"year_boundary","2023-12-31 13:00:00.000","2023-12-31","1"
"tokyo_midnight","2024-01-14 04:00:00.000","2024-01-14","1"
"utc_midnight","2024-01-14 13:00:00.000","2024-01-14","1"
"early_utc","2024-01-14 15:00:00.000","2024-01-14","1"
"mid_utc","2024-01-15 07:00:00.000","2024-01-15","1"
"month_boundary","2024-01-31 04:00:00.000","2024-01-31","1"
```
</details>

Pivot csv's now use the same format for dates as non-pivot, dates can be digested natively in gsheets 
<img width="414" height="474" alt="CleanShot 2026-05-06 at 13 20 52" src="https://github.com/user-attachments/assets/62ec75a0-1047-45ae-956d-7e5a5fe5b445" />

**BEFORE - as text and incorrect formatting when compared to non-pivot**
<img width="655" height="452" alt="CleanShot 2026-05-06 at 13 23 30" src="https://github.com/user-attachments/assets/decca50e-0cdb-40ea-9c17-fc1ce71d0c5f" />


Pivot's `(category, event_timestamp)` pairs after the change equal non-pivot's. Excel and gsheets paths exercised with both flag on and flag off — outputs unchanged on those paths (the new flag is opt-in, only the CSV pivot path passes it).

Closes: https://linear.app/lightdash/issue/GLITCH-406/align-pivot-csv-temporal-format-with-non-pivot-csv-excelsheets