### PR TITLE
fix: gate custom-group-bins via DB-backed feature flag

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -37,10 +37,7 @@ import useToaster from '../../../../../hooks/toaster/useToaster';
 import { useFilteredFields } from '../../../../../hooks/useFilters';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { useCannotAuthorCustomSql } from '../../../../../hooks/user/useCannotAuthorCustomSql';
-import {
-    useClientFeatureFlag,
-    useServerFeatureFlag,
-} from '../../../../../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -87,9 +84,10 @@ const TreeSingleNodeActions: FC<Props> = ({
     const isWriteBackCustomBinDimensionsEnabled =
         writeBackCustomBinDimensionsFlag?.enabled ?? false;
 
-    const isCustomGroupBinsEnabled = useClientFeatureFlag(
+    const { data: customGroupBinsFlag } = useServerFeatureFlag(
         FeatureFlags.CustomGroupBins,
     );
+    const isCustomGroupBinsEnabled = customGroupBinsFlag?.enabled ?? false;
 
     const duplicateCustomMetric = (customMetric: AdditionalMetric) => {
         const newDeepCopyItem = JSON.parse(JSON.stringify(customMetric));

--- a/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
+++ b/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
@@ -1,31 +1,11 @@
-import {
-    type ApiError,
-    type CommercialFeatureFlags,
-    type FeatureFlag,
-    type FeatureFlags,
-} from '@lightdash/common';
+import { type ApiError, type FeatureFlag } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
-import { useFeatureFlagEnabled as useFeatureFlagEnabledPosthog } from 'posthog-js/react';
 import { lightdashApi } from '../api';
 
 /**
- * Use Client Feature Flag to get the feature flag from the client directly from posthog.
- *
- * @param featureFlag - The feature flag to get.
- * @returns boolean if the feature flag is enabled.
- */
-export const useClientFeatureFlag = (
-    featureFlag: FeatureFlags | CommercialFeatureFlags,
-) => useFeatureFlagEnabledPosthog(featureFlag) === true;
-
-/**
- * Use Server Feature Flag to get the feature flag from the server.
- * This is useful to:
- * - Get the feature flag from the server (which works well on shared instances)
- * - When implemented, get a mix of Posthog and Environment variables feature flags (not always implemented)
- *
- * @param featureFlagId - The feature flag to get.
- * @returns The feature flag.
+ * Get a feature flag value from the backend, which resolves through the
+ * unified DB-backed flag system (env-var allowlists → DB → optional PostHog
+ * fallback).
  */
 export const useServerFeatureFlag = (featureFlagId: string) => {
     return useQuery<FeatureFlag, ApiError>(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->
 - TreeSingleNodeActions.tsx — swapped useClientFeatureFlag(FeatureFlags.CustomGroupBins) → useServerFeatureFlag(FeatureFlags.CustomGroupBins) with ?.enabled ?? false fallback (matches the WriteBackCustomBinDimensions pattern in the same file).
- useServerOrClientFeatureFlag.ts — deleted useClientFeatureFlag (was the last consumer) plus the now-orphan posthog-js/react import. File now only exports useServerFeatureFlag. The filename is a tiny lie now — it can be renamed in a future cleanup but I'd leave it for this PR's scope.
<!-- Even better add a screenshot / gif / loom -->
