### PR TITLE
feat(managed-agent): show reverted state on activity log + sidebar

### DIFF
--- a/packages/backend/src/ee/database/entities/managedAgent.ts
+++ b/packages/backend/src/ee/database/entities/managedAgent.ts
@@ -81,6 +81,11 @@ export type DbManagedAgentAction = {
     created_at: Date;
 };
 
+export type DbManagedAgentActionWithReverser = DbManagedAgentAction & {
+    reversed_by_first_name: string | null;
+    reversed_by_last_name: string | null;
+};
+
 export type DbManagedAgentActionCreate = Omit<
     DbManagedAgentAction,
     'action_uuid' | 'reversed_at' | 'reversed_by_user_uuid' | 'created_at'

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -12,7 +12,7 @@ import type { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     ManagedAgentActionsTableName,
     ManagedAgentSettingsTableName,
-    type DbManagedAgentAction,
+    type DbManagedAgentActionWithReverser,
     type DbManagedAgentSettings,
 } from '../database/entities/managedAgent';
 
@@ -174,7 +174,23 @@ export class ManagedAgentModel {
 
     // --- Actions ---
 
-    static mapDbAction(row: DbManagedAgentAction): ManagedAgentAction {
+    private actionsQuery() {
+        return this.database(ManagedAgentActionsTableName)
+            .leftJoin(
+                'users as reversed_by',
+                `${ManagedAgentActionsTableName}.reversed_by_user_uuid`,
+                'reversed_by.user_uuid',
+            )
+            .select<DbManagedAgentActionWithReverser[]>([
+                `${ManagedAgentActionsTableName}.*`,
+                'reversed_by.first_name as reversed_by_first_name',
+                'reversed_by.last_name as reversed_by_last_name',
+            ]);
+    }
+
+    static mapDbAction(
+        row: DbManagedAgentActionWithReverser,
+    ): ManagedAgentAction {
         return {
             actionUuid: row.action_uuid,
             projectUuid: row.project_uuid,
@@ -187,6 +203,16 @@ export class ManagedAgentModel {
             metadata: row.metadata,
             reversedAt: row.reversed_at,
             reversedByUserUuid: row.reversed_by_user_uuid,
+            reversedByUser:
+                row.reversed_by_user_uuid &&
+                row.reversed_by_first_name !== null &&
+                row.reversed_by_last_name !== null
+                    ? {
+                          userUuid: row.reversed_by_user_uuid,
+                          firstName: row.reversed_by_first_name,
+                          lastName: row.reversed_by_last_name,
+                      }
+                    : null,
             createdAt: row.created_at,
         };
     }
@@ -206,25 +232,39 @@ export class ManagedAgentModel {
                 metadata: action.metadata,
             })
             .returning('*');
-        return ManagedAgentModel.mapDbAction(row);
+        // New actions have no reverser yet
+        return ManagedAgentModel.mapDbAction({
+            ...row,
+            reversed_by_first_name: null,
+            reversed_by_last_name: null,
+        });
     }
 
     async getActions(
         projectUuid: string,
         filters: ManagedAgentActionFilters = {},
     ): Promise<ManagedAgentAction[]> {
-        let query = this.database(ManagedAgentActionsTableName)
-            .where({ project_uuid: projectUuid })
-            .orderBy('created_at', 'desc');
+        let query = this.actionsQuery()
+            .where(`${ManagedAgentActionsTableName}.project_uuid`, projectUuid)
+            .orderBy(`${ManagedAgentActionsTableName}.created_at`, 'desc');
 
         if (filters.date) {
-            query = query.whereRaw('created_at::date = ?', [filters.date]);
+            query = query.whereRaw(
+                `${ManagedAgentActionsTableName}.created_at::date = ?`,
+                [filters.date],
+            );
         }
         if (filters.actionType) {
-            query = query.where({ action_type: filters.actionType });
+            query = query.where(
+                `${ManagedAgentActionsTableName}.action_type`,
+                filters.actionType,
+            );
         }
         if (filters.sessionId) {
-            query = query.where({ session_id: filters.sessionId });
+            query = query.where(
+                `${ManagedAgentActionsTableName}.session_id`,
+                filters.sessionId,
+            );
         }
 
         const rows = await query;
@@ -235,16 +275,16 @@ export class ManagedAgentModel {
         projectUuid: string,
         limit: number = 50,
     ): Promise<ManagedAgentAction[]> {
-        const rows = await this.database(ManagedAgentActionsTableName)
-            .where({ project_uuid: projectUuid })
-            .orderBy('created_at', 'desc')
+        const rows = await this.actionsQuery()
+            .where(`${ManagedAgentActionsTableName}.project_uuid`, projectUuid)
+            .orderBy(`${ManagedAgentActionsTableName}.created_at`, 'desc')
             .limit(limit);
         return rows.map(ManagedAgentModel.mapDbAction);
     }
 
     async getAction(actionUuid: string): Promise<ManagedAgentAction | null> {
-        const row = await this.database(ManagedAgentActionsTableName)
-            .where({ action_uuid: actionUuid })
+        const row = await this.actionsQuery()
+            .where(`${ManagedAgentActionsTableName}.action_uuid`, actionUuid)
             .first();
         return row ? ManagedAgentModel.mapDbAction(row) : null;
     }
@@ -253,20 +293,23 @@ export class ManagedAgentModel {
         actionUuid: string,
         userUuid: string,
     ): Promise<ManagedAgentAction> {
-        const [row] = await this.database(ManagedAgentActionsTableName)
+        const updated = await this.database(ManagedAgentActionsTableName)
             .where({ action_uuid: actionUuid })
             .whereNull('reversed_at')
             .update({
                 reversed_at: new Date(),
                 reversed_by_user_uuid: userUuid,
-            })
-            .returning('*');
-        if (!row) {
+            });
+        if (updated === 0) {
             throw new Error(
                 `Action ${actionUuid} not found or already reversed`,
             );
         }
-        return ManagedAgentModel.mapDbAction(row);
+        const action = await this.getAction(actionUuid);
+        if (!action) {
+            throw new Error(`Action ${actionUuid} disappeared after reversal`);
+        }
+        return action;
     }
 
     async getUserQuestions(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1248,12 +1248,33 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ManagedAgentActionUser: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                lastName: { dataType: 'string', required: true },
+                firstName: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ManagedAgentAction: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 createdAt: { dataType: 'datetime', required: true },
+                reversedByUser: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ManagedAgentActionUser' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 reversedByUserUuid: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1294,11 +1294,34 @@
                 "type": "object",
                 "description": "Construct a type with a set of properties K of type T"
             },
+            "ManagedAgentActionUser": {
+                "properties": {
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["lastName", "firstName", "userUuid"],
+                "type": "object"
+            },
             "ManagedAgentAction": {
                 "properties": {
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "reversedByUser": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ManagedAgentActionUser"
+                            }
+                        ],
+                        "nullable": true
                     },
                     "reversedByUserUuid": {
                         "type": "string",
@@ -1339,6 +1362,7 @@
                 },
                 "required": [
                     "createdAt",
+                    "reversedByUser",
                     "reversedByUserUuid",
                     "reversedAt",
                     "metadata",
@@ -31708,7 +31732,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2877.0",
+        "version": "0.2879.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -65,6 +65,12 @@ export type ManagedAgentSettings = {
     updatedAt: Date;
 };
 
+export type ManagedAgentActionUser = {
+    userUuid: string;
+    firstName: string;
+    lastName: string;
+};
+
 export type ManagedAgentAction = {
     actionUuid: string;
     projectUuid: string;
@@ -77,6 +83,7 @@ export type ManagedAgentAction = {
     metadata: Record<string, unknown>;
     reversedAt: Date | null;
     reversedByUserUuid: string | null;
+    reversedByUser: ManagedAgentActionUser | null;
     createdAt: Date;
 };
 

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -251,6 +251,18 @@
         light-dark(var(--mantine-color-gray-5), var(--mantine-color-gray-6));
 }
 
+.rowReversed {
+    opacity: 0.55;
+}
+
+.rowReversed .actionPill {
+    text-decoration: line-through;
+    text-decoration-color: light-dark(
+        var(--mantine-color-gray-5),
+        var(--mantine-color-gray-6)
+    );
+}
+
 /* Resize handle */
 .resizeHandle {
     width: 1px;
@@ -277,6 +289,16 @@
 
 .sidebarHeader {
     padding: 12px 16px;
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+}
+
+.reversedBanner {
+    padding: 8px 16px;
+    background-color: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-6)
+    );
     border-bottom: 1px solid
         light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
 }

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -683,6 +683,14 @@ const DetailSidebar: FC<{
             : null;
     const hasProjectDetails = !!targetProject;
 
+    const reversedLabel = action.reversedAt
+        ? `${formatDistanceToNowStrict(new Date(action.reversedAt))} ago${
+              action.reversedByUser
+                  ? ` by ${action.reversedByUser.firstName} ${action.reversedByUser.lastName}`
+                  : ''
+          }`
+        : null;
+
     return (
         <Stack gap={0} h="100%" className={classes.sidebar}>
             {/* Header */}
@@ -757,6 +765,20 @@ const DetailSidebar: FC<{
                     )}
                 </Group>
             </Stack>
+
+            {reversedLabel && (
+                <Group gap={6} className={classes.reversedBanner} wrap="nowrap">
+                    <MantineIcon
+                        icon={IconArrowBackUp}
+                        size="sm"
+                        color="var(--mantine-color-dimmed)"
+                    />
+                    <Text fz="xs" c="dimmed">
+                        {category === 'undo' ? 'Undone' : 'Dismissed'}{' '}
+                        {reversedLabel}
+                    </Text>
+                </Group>
+            )}
 
             {/* Content */}
             <Stack gap="md" p="md" style={{ overflow: 'auto', flex: 1 }}>
@@ -1123,10 +1145,17 @@ const ActionRow: FC<{
 }> = ({ action, selected, onSelect }) => {
     const config = ACTION_CONFIG[action.actionType];
     const TargetIcon = TARGET_ICON[action.targetType];
+    const isReversed = !!action.reversedAt;
 
     return (
         <Table.Tr
-            className={`${classes.row} ${selected ? classes.rowSelected : ''}`}
+            className={[
+                classes.row,
+                selected && classes.rowSelected,
+                isReversed && classes.rowReversed,
+            ]
+                .filter(Boolean)
+                .join(' ')}
             onClick={() => onSelect(action)}
         >
             <Table.Td w={100}>

--- a/packages/frontend/src/ee/features/managedAgent/types.ts
+++ b/packages/frontend/src/ee/features/managedAgent/types.ts
@@ -3,6 +3,12 @@ import {
     type ManagedAgentTargetType,
 } from '@lightdash/common';
 
+export type ManagedAgentActionUser = {
+    userUuid: string;
+    firstName: string;
+    lastName: string;
+};
+
 export type ManagedAgentAction = {
     actionUuid: string;
     projectUuid: string;
@@ -15,5 +21,6 @@ export type ManagedAgentAction = {
     metadata: Record<string, unknown>;
     reversedAt: string | null;
     reversedByUserUuid: string | null;
+    reversedByUser: ManagedAgentActionUser | null;
     createdAt: string;
 };


### PR DESCRIPTION
## Summary

When an Autopilot action is reverted, surface that state visibly on both the activity log row and the action sidebar — instead of the user having to click into the menu to see "Already reverted." Stacks on top of #22742.

## Changes

**Backend — enrich the action API with the reverser user:**

Added `ManagedAgentActionUser` type and a new `reversedByUser: { userUuid, firstName, lastName } | null` field to `ManagedAgentAction`. Implementation:
- `ManagedAgentModel` gains a private `actionsQuery()` helper that LEFT JOINs `users` for the reverser and selects their name fields. All read paths (`getActions`, `getRecentActions`, `getAction`, `reverseAction`) now go through it — single source of truth for the JOIN.
- `mapDbAction` builds the typed nested user object when the JOIN matches, returns `null` when no reverser is set.
- `reverseAction` no longer does the dangling `.returning('*')` (which wouldn't include the JOIN'd columns); it now updates and re-fetches via `getAction` to keep one consistent shape.
- New row type `DbManagedAgentActionWithReverser = DbManagedAgentAction & { reversed_by_first_name, reversed_by_last_name }`.

**Frontend — visual treatment for reverted state:**

| Surface | Before | After |
|---|---|---|
| Activity log row | Looks identical to active rows | Dimmed to opacity 0.55, action label gets strikethrough |
| Sidebar | "Already reverted" only inside the dots menu | Banner near the top: "↩ Undone 3 minutes ago by John Doe" / "↩ Dismissed ..." |

The banner uses the `category` variable (added in #22742) to pick "Undone" vs "Dismissed".

## Why backend instead of two API calls

The frontend could have queried `/users/{uuid}` separately on the client. But:
- That's an extra round-trip per opened sidebar
- Repeats the pattern other entities follow (charts' `createdBy`, dashboards' `updatedBy` are nested user info, not just UUIDs)
- The JOIN cost is negligible (already returning the action row) and keeps the API self-describing

## Regression analysis

| Group | Effect |
|---|---|
| Autopilot users | Reverted actions now visually distinct in both row and sidebar — better signal. No behavior change. |
| Non-Autopilot users | Unaffected. |
| Existing reversed actions | Their `reversed_by_user_uuid` is already set in DB — banner appears for them too on next page load. No data migration needed. |
| Service accounts / cross-project | Auth unchanged. |

The `reverseAction` model method change (`.returning('*')` → update-then-getAction) is a small contract addition: the returned action now includes the JOIN'd reverser fields. Callers that just used the metadata fields are unaffected.

## Test plan

- [ ] Open an action that's been reverted → sidebar shows banner "↩ Undone X ago by [name]"
- [ ] Same action's row in the table is dimmed with strikethrough on the label
- [ ] Open an unreversed action → no banner, row at full opacity
- [ ] Reverse an action → both row and sidebar update on success
- [ ] Inspect the API response body for an action with a reverser → `reversedByUser` is the typed object; `reversedByUserUuid` is also still present
