### PR TITLE
fix(service-accounts): reject SCIM-only tokens on non-SCIM endpoints

### DIFF
--- a/packages/api-tests/tests/serviceAccounts.test.ts
+++ b/packages/api-tests/tests/serviceAccounts.test.ts
@@ -589,16 +589,10 @@ describe('Service Account scope matrix', () => {
             expect(resp.status).toBe(200);
         });
 
-        it('GET /org/projects: SCIM_MANAGE currently allows it (auth succeeds, no scope filter at controller)', async () => {
-            // SCIM_MANAGE only adds 'manage' on OrganizationMemberProfile and
-            // Group in serviceAccountAbility.ts, but `/org/projects` does not
-            // gate on those subjects, so the SA request authenticates and
-            // the controller returns the project list. Captured as current
-            // behavior; any future tightening (e.g. scope-by-subject filter)
-            // will surface here.
+        it('rejects GET /org/projects (SCIM-only tokens are restricted to /scim/* endpoints)', async () => {
             const sa = bearerClient(scimToken);
             const resp = await sa.get(`${apiUrl}/org/projects`);
-            expect(resp.status).toBe(200);
+            expect(resp.status).toBe(401);
         });
     });
 });

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -2,6 +2,7 @@ import {
     AuthorizationError,
     getErrorMessage,
     ScimError,
+    ServiceAccountScope,
 } from '@lightdash/common';
 import { RequestHandler } from 'express';
 import { fromServiceAccount } from '../../auth/account/account';
@@ -163,6 +164,23 @@ export const authenticateServiceAccount: RequestHandler = async (
                 'Invalid service account token. Authentication failed.',
             );
         }
+
+        // SCIM-only tokens are only valid for `/scim/v2/*` endpoints, which
+        // use `isScimAuthenticated`. Reject them here so they can't reach the
+        // regular API surface.
+        const isScimOnly =
+            serviceAccount.scopes.length === 1 &&
+            serviceAccount.scopes[0] === ServiceAccountScope.SCIM_MANAGE;
+        if (isScimOnly) {
+            logServiceAccountAuthFailure(
+                req,
+                'SCIM-only token used outside /scim/* endpoints',
+            );
+            throw new AuthorizationError(
+                'Invalid service account token. Authentication failed.',
+            );
+        }
+
         req.serviceAccount = serviceAccount;
 
         // Load the SA's dedicated `users` row. Abilities are derived from the


### PR DESCRIPTION
## Summary

A service-account token whose only scope is `SCIM_MANAGE` was accepted by `authenticateServiceAccount` and reached the regular API (~241 endpoints). Responses were filtered to empty by CASL, but the endpoints still authenticated — exposing surface to any handler that leaks before the ability check.

Reject SCIM-only tokens in the middleware right after the SA loads. The `/scim/v2/*` endpoints continue to work via `isScimAuthenticated`. Mixed-scope tokens (e.g. `SCIM_MANAGE + ORG_READ`) are unaffected.

Flips the captured-broken test for `GET /org/projects` from 200 to 401, and keeps the SCIM-endpoint test as a guardrail.

Refs [PROD-7414](https://linear.app/lightdash/issue/PROD-7414/bug-permission-correctness).

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [ ] `cd packages/api-tests && pnpm test serviceAccounts` (SCIM-only `/org/projects` → 401, SCIM `/scim/v2/Users` → 200, all other SA tests pass)