### PR TITLE
fix: re-apply pivot x-axis sort-field protection + regression locks

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -3842,4 +3842,814 @@ SELECT * FROM group_by_query LIMIT 50`);
             );
         });
     });
+
+    describe('Regressions for resolved pivot sort bugs', () => {
+        // These tests lock the SQL shape that fixes a previously-shipped bug.
+        // Each one is anchored to a GitHub issue so a regression has a name.
+
+        test('Two groupBy columns with sort on the second groupBy column produces deterministic column ordering (#16871)', () => {
+            // https://github.com/lightdash/lightdash/issues/16871
+            // Repro: pivot on [payment_method, status], sort by status ASC.
+            // Bug: column headers came out in the wrong order with duplicate
+            // (payment_method, status) tuples appearing under one payment_method.
+            // Expectation: column_index iterates groupByColumns in declared order
+            // with the sort direction applied to the matched field, so each
+            // unique (payment_method, status) pair gets a single deterministic
+            // column_index.
+            const pivotConfiguration = {
+                indexColumn: [
+                    { reference: 'order_date_year', type: VizIndexType.TIME },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'total_revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'payment_method' },
+                    { reference: 'status' },
+                ],
+                sortBy: [
+                    { reference: 'status', direction: SortByDirection.ASC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // column_index ORDER BY follows groupBy order with the sort direction
+            // applied to the matched field (status). The other groupBy field
+            // defaults to ASC, giving us a fully-determined column ordering.
+            expect(replaceWhitespace(result)).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."payment_method" ASC, g."status" ASC) AS "column_index"',
+            );
+
+            // group_by_query GROUPs on both groupBy fields → unique tuples.
+            expect(replaceWhitespace(result)).toContain(
+                'group by "payment_method", "status", "order_date_year"',
+            );
+
+            // No anchor CTEs: dimension sort path, not metric sort.
+            expect(result).not.toContain('column_ranking AS (');
+            expect(result).not.toContain('anchor_column AS (');
+        });
+
+        test('Sort direction on the groupBy field flows through to column_index even with multi-key sort (#17018)', () => {
+            // https://github.com/lightdash/lightdash/issues/17018
+            // Repro: dims=[month_name, month, year], pivot=year,
+            // sort=[year DESC, month ASC]. Results table was right but the
+            // chart series came out in alphabetical year order.
+            // Expectation: when the sort references the groupBy field, the
+            // column_index DENSE_RANK ORDER BY honors that direction so the
+            // chart series order matches the underlying sort.
+            const pivotConfiguration = {
+                indexColumn: [
+                    { reference: 'month_name', type: VizIndexType.CATEGORY },
+                    { reference: 'month', type: VizIndexType.TIME },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'count',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupByColumns: [{ reference: 'year' }],
+                sortBy: [
+                    { reference: 'year', direction: SortByDirection.DESC },
+                    { reference: 'month', direction: SortByDirection.ASC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // Column ordering reflects the sort direction on the pivot field.
+            expect(replaceWhitespace(result)).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."year" DESC) AS "column_index"',
+            );
+
+            // Row ordering uses the index columns in sort order, with month_name
+            // (no explicit sort entry) defaulting to ASC at the end.
+            expect(replaceWhitespace(result)).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."month" ASC, g."month_name" ASC) AS "row_index"',
+            );
+        });
+
+        test('CTE names are quoted when field references contain spaces (#20683)', () => {
+            // https://github.com/lightdash/lightdash/issues/20683
+            // Repro: a metric named "AVERAGE TAX RATE 2" combined with a
+            // pivot + metric sort. The pivot pipeline derives CTE names like
+            // "events_AVERAGE TAX RATE 2_column_anchor" from field references,
+            // and an unquoted CTE name in WITH or in LEFT JOIN broke with
+            // `syntax error at or near "TAX"`.
+            // Expectation: anchor CTE names AND every JOIN target are wrapped
+            // in the warehouse quote char so spaces are tolerated.
+            const fieldWithSpaces = 'events_AVG TAX RATE';
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: fieldWithSpaces,
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    {
+                        reference: fieldWithSpaces,
+                        direction: SortByDirection.DESC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // CTE definitions in the WITH clause must be quoted.
+            expect(result).toContain(`"${fieldWithSpaces}_column_anchor" AS (`);
+            expect(result).toContain(`"${fieldWithSpaces}_row_anchor" AS (`);
+
+            // Every reference of those CTEs (LEFT JOIN, qualified column
+            // accesses) must also be quoted — the original bug was unquoted
+            // names appearing in JOIN clauses, not just CTE definitions.
+            expect(result).toContain(
+                `LEFT JOIN "${fieldWithSpaces}_row_anchor"`,
+            );
+            expect(result).toContain(
+                `LEFT JOIN "${fieldWithSpaces}_column_anchor"`,
+            );
+            expect(result).toContain(
+                `"${fieldWithSpaces}_column_anchor"."${fieldWithSpaces}_column_anchor_value"`,
+            );
+            expect(result).toContain(
+                `"${fieldWithSpaces}_row_anchor"."${fieldWithSpaces}_row_anchor_value"`,
+            );
+
+            // The bare unquoted form must not appear anywhere — that is what
+            // would produce the original `syntax error at or near "TAX"`.
+            expect(result).not.toContain(`${fieldWithSpaces}_column_anchor AS`);
+            expect(result).not.toContain(
+                `LEFT JOIN ${fieldWithSpaces}_row_anchor`,
+            );
+        });
+
+        test('Pivot SQL on Databricks emits self-contained row_ranking + column_ranking CTEs for metric sort (#20681)', () => {
+            // https://github.com/lightdash/lightdash/issues/20681
+            // Repro: pivot chart with metric-based sorting on Databricks where
+            // a dashboard filter caused the base query to return 0 rows.
+            // Spark inlines CTEs and its Window optimizer consumed anchor
+            // value columns out of the pivot_query SELECT list, so the final
+            // CROSS JOIN couldn't resolve them.
+            // Expectation: row_index/col_idx are computed in their OWN CTEs
+            // (row_ranking, column_ranking), each carrying the JOIN to the
+            // anchor CTE in its own scope. pivot_query then just JOINs the
+            // precomputed rankings — no inline DENSE_RANK referencing values
+            // from a sibling CTE that Spark could lose during inlining.
+            const mockDatabricksBuilder = {
+                getFieldQuoteChar: () => '`',
+                getAdapterType: () => SupportedDbtAdapter.DATABRICKS,
+                getStartOfWeek: () => WeekDay.MONDAY,
+                getNullSafeEqualSql: defaultNullSafeEqualSql,
+            } as unknown as WarehouseSqlBuilder;
+
+            const pivotConfiguration = {
+                indexColumn: [
+                    { reference: 'event_tier', type: VizIndexType.CATEGORY },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'count',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupByColumns: [{ reference: 'event' }],
+                sortBy: [
+                    { reference: 'count', direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockDatabricksBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // Both ranking CTEs must exist.
+            expect(result).toContain('row_ranking AS (');
+            expect(result).toContain('column_ranking AS (');
+
+            // row_ranking is self-contained: it owns its JOIN to row_anchor
+            // and produces row_index as a concrete output column.
+            expect(replaceWhitespace(result)).toContain(
+                'row_ranking AS (SELECT DISTINCT g.`event_tier`, DENSE_RANK() OVER (ORDER BY `count_row_anchor`.`count_row_anchor_value` DESC, g.`event_tier` ASC) AS `row_index` FROM group_by_query g LEFT JOIN `count_row_anchor` ON (g.`event_tier` = `count_row_anchor`.`event_tier` OR (g.`event_tier` IS NULL AND `count_row_anchor`.`event_tier` IS NULL)))',
+            );
+
+            // pivot_query just joins precomputed rankings — no inline
+            // DENSE_RANK that would reference anchor cols across the
+            // sibling CTE Spark inlines.
+            const pivotQueryRegex = /pivot_query AS \(([^)]+)\)/;
+            const pivotQueryBody = result.match(pivotQueryRegex)?.[1] ?? '';
+            expect(pivotQueryBody).not.toContain('DENSE_RANK');
+            expect(pivotQueryBody).toContain('rr.`row_index`');
+            expect(pivotQueryBody).toContain('cr.`col_idx`');
+        });
+
+        test('nullsFirst on a value-column sort propagates through anchor CTE and row_index (#19202)', () => {
+            // https://github.com/lightdash/lightdash/issues/19202
+            // Repro: SQL pivot pipeline + sort by a metric with nullsFirst
+            // semantics + a tiebreaker dim with the opposite null treatment.
+            // Bug: the nullsFirst flag on the value-column sort was dropped
+            // somewhere between sortBy and the column anchor SQL.
+            // Expectation: NULLS FIRST/LAST flows into FIRST_VALUE inside the
+            // column anchor CTE, into the column_ranking ORDER BY, and into
+            // the row_index ORDER BY, with each sort entry getting its own
+            // nulls treatment in a multi-key sort.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        nullsFirst: true,
+                    },
+                    {
+                        reference: 'date',
+                        direction: SortByDirection.ASC,
+                        nullsFirst: false,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // FIRST_VALUE inside the column anchor CTE picks the metric value
+            // at the desired column under NULLS FIRST semantics.
+            expect(replaceWhitespace(result)).toContain(
+                'FIRST_VALUE("revenue_sum") OVER (PARTITION BY "category" ORDER BY "revenue_sum" DESC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            );
+
+            // column_ranking ORDER BY echoes the NULLS treatment for the
+            // anchor value, then falls back to the groupBy field as tiebreaker.
+            expect(replaceWhitespace(result)).toContain(
+                'DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC NULLS FIRST, g."category" ASC) AS "col_idx"',
+            );
+
+            // row_index ORDER BY combines BOTH sort entries with their own
+            // NULLS treatment — value column under NULLS FIRST, date under
+            // NULLS LAST. A regression that drops the per-entry nulls flag
+            // would collapse one of these.
+            expect(replaceWhitespace(result)).toContain(
+                'DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" DESC NULLS FIRST, g."date" ASC NULLS LAST) AS "row_index"',
+            );
+        });
+
+        test('Metric sort orders rows by the value at the leftmost (anchor) pivot column, not aggregated across all columns (#19509)', () => {
+            // https://github.com/lightdash/lightdash/issues/19509 / GLITCH-145
+            // Repro: pivoted table with multiple value columns. Users expect
+            // rows ordered by the leftmost column's value (just like before
+            // the SQL pivot rewrite). The bug ordered rows by the row-MAX
+            // across all pivot columns, scrambling the apparent ranking.
+            // Expectation: row_anchor SQL guards the metric value with a
+            // CASE WHEN that picks ONLY the anchor column's value, joined via
+            // CROSS JOIN anchor_column. There is no MAX/MIN/SUM(metric) form
+            // that aggregates across pivot columns.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: 'revenue', direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // Anchor column CTE is what selects the leftmost pivot column.
+            expect(result).toContain('anchor_column AS (');
+            expect(result).toContain('CROSS JOIN anchor_column ac');
+
+            // row_anchor's metric value comes from a CASE WHEN guarded on
+            // anchor_category equality — i.e., from the leftmost column only.
+            expect(replaceWhitespace(result)).toContain(
+                'MAX(CASE WHEN (q."category" = ac."anchor_category" OR (q."category" IS NULL AND ac."anchor_category" IS NULL)) THEN q."revenue_sum" END)',
+            );
+
+            // Negative: the bugged behavior would aggregate the metric across
+            // every pivot column. The collapsed SQL must not contain bare
+            // forms like `MAX(q."revenue_sum")` or `SUM(q."revenue_sum")` —
+            // every reference to q."revenue_sum" must be inside a CASE WHEN
+            // guarded on the anchor column.
+            const collapsed = replaceWhitespace(result);
+            const bareAggregates = [
+                'MAX(q."revenue_sum")',
+                'MIN(q."revenue_sum")',
+                'SUM(q."revenue_sum")',
+                'AVG(q."revenue_sum")',
+            ];
+            bareAggregates.forEach((expr) => {
+                expect(collapsed).not.toContain(expr);
+            });
+        });
+
+        test('Multiple value columns with metric sort produce frame clauses on every column anchor FIRST_VALUE (#18064)', () => {
+            // https://github.com/lightdash/lightdash/issues/18064 / GLITCH-90
+            // Repro: USE_SQL_PIVOT_RESULTS + sort by a value column on
+            // Redshift. Window functions with ORDER BY require explicit frame
+            // clauses; missing frames produced "Aggregate window functions
+            // with an ORDER BY clause require a frame clause".
+            // Expectation: with a multi-key sort across multiple value
+            // columns, EVERY FIRST_VALUE in the pivot SQL has an explicit
+            // ROWS BETWEEN frame clause — not just the first one.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                    {
+                        reference: 'orders',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: 'revenue', direction: SortByDirection.DESC },
+                    { reference: 'orders', direction: SortByDirection.ASC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // Both sort metrics produce a column_anchor CTE.
+            expect(result).toContain('"revenue_column_anchor" AS (');
+            expect(result).toContain('"orders_column_anchor" AS (');
+
+            // Count is the assertion: every FIRST_VALUE must be paired with a
+            // ROWS BETWEEN frame clause. A regression that leaves frames off
+            // a second/third FIRST_VALUE would make this fail on Redshift.
+            const firstValueMatches = result.match(/FIRST_VALUE/g);
+            const rowsBetweenMatches = result.match(
+                /ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING/g,
+            );
+            const firstValueCount = firstValueMatches
+                ? firstValueMatches.length
+                : 0;
+            const rowsBetweenCount = rowsBetweenMatches
+                ? rowsBetweenMatches.length
+                : 0;
+            expect(firstValueCount).toBeGreaterThanOrEqual(2);
+            expect(rowsBetweenCount).toBe(firstValueCount);
+
+            // Spot check: each metric's column anchor SQL contains the full
+            // FIRST_VALUE + frame syntax.
+            expect(replaceWhitespace(result)).toContain(
+                'FIRST_VALUE("revenue_sum") OVER (PARTITION BY "category" ORDER BY "revenue_sum" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            );
+            expect(replaceWhitespace(result)).toContain(
+                'FIRST_VALUE("orders_count") OVER (PARTITION BY "category" ORDER BY "orders_count" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            );
+        });
+
+        test('Multi-groupBy with no sort produces a deterministic column ordering across all groupBy fields (#9767, #11038)', () => {
+            // https://github.com/lightdash/lightdash/issues/9767
+            // https://github.com/lightdash/lightdash/issues/11038
+            // Repro: same query + same data → different column order across
+            // re-renders, leading to inconsistent chart series colors.
+            // Expectation: the column_index DENSE_RANK ORDER BY chains every
+            // groupBy field as a deterministic tiebreaker — no warehouse-row-
+            // order leakage and no alphabetical-only fallback that would tie.
+            const pivotConfiguration = {
+                indexColumn: [
+                    { reference: 'order_date_week', type: VizIndexType.TIME },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'event_count',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'type_of_event' },
+                    { reference: 'region' },
+                ],
+                sortBy: undefined,
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // All groupBy fields appear in the column_index ORDER BY in their
+            // declared order, each with explicit ASC. This is what makes the
+            // pivot column order stable across runs.
+            expect(replaceWhitespace(result)).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."type_of_event" ASC, g."region" ASC) AS "column_index"',
+            );
+
+            // Same invariant for row_index — index columns chain deterministically.
+            expect(result.toLowerCase()).toContain(
+                'dense_rank() over (order by g."order_date_week" asc) as "row_index"',
+            );
+        });
+
+        test('Multi-key groupBy sort follows groupBy declaration order, not sortBy order, with each direction matched by reference (#16871)', () => {
+            // https://github.com/lightdash/lightdash/issues/16871
+            // Repro: groupBy=[payment_method, status], sortBy=[status DESC,
+            // payment_method ASC]. The bug let sortBy order leak into the
+            // column_index ORDER BY, producing alternating-tuple column orders
+            // that re-emerged as duplicate (payment_method, status) tuples
+            // under a single payment_method.
+            // Expectation: column_index ORDER BY iterates groupByColumns in
+            // declared order — payment_method first, status second — and
+            // picks each direction from the matching sortBy entry by
+            // reference. The sortBy listing order is irrelevant.
+            const pivotConfiguration = {
+                indexColumn: [
+                    { reference: 'order_date_year', type: VizIndexType.TIME },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'total_revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'payment_method' },
+                    { reference: 'status' },
+                ],
+                // Deliberately reversed: sortBy lists status first.
+                sortBy: [
+                    { reference: 'status', direction: SortByDirection.DESC },
+                    {
+                        reference: 'payment_method',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // payment_method comes first because groupByColumns lists it
+            // first; status's DESC and payment_method's ASC are picked from
+            // sortBy by reference match. The reverse order would indicate a
+            // regression where sortBy order won.
+            expect(replaceWhitespace(result)).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."payment_method" ASC, g."status" DESC) AS "column_index"',
+            );
+
+            // Negative: the (wrongly) sortBy-ordered shape must not appear.
+            expect(replaceWhitespace(result)).not.toContain(
+                'DENSE_RANK() OVER (ORDER BY g."status" DESC, g."payment_method" ASC) AS "column_index"',
+            );
+        });
+
+        test('total_columns CTE counts via nested DISTINCT subquery, never via COUNT(DISTINCT CONCAT(...)) (#19767)', () => {
+            // https://github.com/lightdash/lightdash/issues/19767 / PROD-2762
+            // Repro: pivot a chart whose groupBy mixes types (e.g. a
+            // TIMESTAMP column AND a STRING column) on Redshift. The bug
+            // emitted `COUNT(DISTINCT CONCAT('col1', "col1", '-', 'col2',
+            // "col2"))` for total_columns, which Redshift refused because
+            // CONCAT across mixed types fails type checking.
+            // Expectation: total_columns is computed via
+            // `SELECT COUNT(*) FROM (SELECT DISTINCT col1, col2 FROM
+            // filtered_rows) AS distinct_groups` — warehouse-agnostic, no
+            // CONCAT, no DISTINCT-CONCAT.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'order_date_year' },
+                    { reference: 'payment_method' },
+                ],
+                sortBy: [{ reference: 'date', direction: SortByDirection.ASC }],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // Subquery-DISTINCT shape — both groupBy refs appear in the
+            // SELECT DISTINCT list inside the inner subquery.
+            expect(replaceWhitespace(result)).toContain(
+                'total_columns AS (SELECT COUNT(*) AS total_columns FROM (SELECT DISTINCT "order_date_year", "payment_method" FROM filtered_rows) AS distinct_groups)',
+            );
+
+            // Negative: the bugged Redshift-incompatible form must not
+            // appear anywhere. CONCAT-based counting was the original bug.
+            expect(result).not.toContain('COUNT(DISTINCT CONCAT(');
+            expect(result).not.toContain('COUNT(DISTINCT concat(');
+        });
+
+        test('Named time-interval index columns sort chronologically via CASE WHEN, not alphabetically (#18245)', () => {
+            // https://github.com/lightdash/lightdash/issues/18245
+            // Repro: x-axis = month_name (or day_of_week_name, quarter_name)
+            // with groupBy and sort ASC. The default string ORDER BY put
+            // April before December alphabetically; users expected
+            // chronological order.
+            // Expectation: PivotQueryBuilder dispatches MONTH_NAME,
+            // DAY_OF_WEEK_NAME, and QUARTER_NAME index columns to
+            // CASE-WHEN ORDER BY expressions that map names to
+            // chronological positions. A regression that drops the special
+            // case falls back to bare alphabetical "name" ASC ordering.
+            const monthNameDimension: CompiledDimension = {
+                type: DimensionType.STRING,
+                name: 'month_name',
+                label: 'Month Name',
+                table: 'orders',
+                tableLabel: 'Orders',
+                fieldType: FieldType.DIMENSION,
+                sql: '${TABLE}.month_name',
+                compiledSql: '"orders".month_name',
+                tablesReferences: ['orders'],
+                timeInterval: TimeFrames.MONTH_NAME,
+                hidden: false,
+            };
+            const dayNameDimension: CompiledDimension = {
+                ...monthNameDimension,
+                name: 'day_name',
+                label: 'Day Name',
+                sql: '${TABLE}.day_name',
+                compiledSql: '"orders".day_name',
+                timeInterval: TimeFrames.DAY_OF_WEEK_NAME,
+            };
+            const quarterNameDimension: CompiledDimension = {
+                ...monthNameDimension,
+                name: 'quarter_name',
+                label: 'Quarter Name',
+                sql: '${TABLE}.quarter_name',
+                compiledSql: '"orders".quarter_name',
+                timeInterval: TimeFrames.QUARTER_NAME,
+            };
+
+            const itemsMap: ItemsMap = {
+                orders_month_name: monthNameDimension,
+                orders_day_name: dayNameDimension,
+                orders_quarter_name: quarterNameDimension,
+            };
+
+            // Each named-time-interval dim is exercised in turn under the
+            // same pivot+groupBy+sort scenario.
+            const cases: Array<{
+                reference: string;
+                marker: string;
+            }> = [
+                {
+                    reference: 'orders_month_name',
+                    marker: '"orders_month_name" = \'January\' THEN 1',
+                },
+                {
+                    reference: 'orders_day_name',
+                    marker: '"orders_day_name" = \'Monday\' THEN',
+                },
+                {
+                    reference: 'orders_quarter_name',
+                    marker: '"orders_quarter_name" = \'Q1\' THEN 1',
+                },
+            ];
+
+            for (const { reference, marker } of cases) {
+                const pivotConfiguration = {
+                    indexColumn: [{ reference, type: VizIndexType.CATEGORY }],
+                    valuesColumns: [
+                        {
+                            reference: 'revenue',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                    groupByColumns: [{ reference: 'category' }],
+                    sortBy: [{ reference, direction: SortByDirection.ASC }],
+                };
+
+                const builder = new PivotQueryBuilder(
+                    baseSql,
+                    pivotConfiguration,
+                    mockWarehouseSqlBuilder,
+                    500,
+                    itemsMap,
+                );
+                const result = builder.toSql();
+
+                // CASE-WHEN mapping for chronological order is present.
+                expect(result).toContain('CASE');
+                expect(result).toContain(marker);
+
+                // Negative: the bare alphabetical "ref" ASC form would mean
+                // the special-case dispatch was bypassed. Only the bare
+                // form (the dim itself, not the table-prefixed compiledSql)
+                // is what would replace the CASE WHEN.
+                expect(replaceWhitespace(result)).not.toContain(
+                    `DENSE_RANK() OVER (ORDER BY g."${reference}" ASC) AS "row_index"`,
+                );
+            }
+        });
+
+        test('Sorted custom bin dimension as pivot index uses the hidden _order column for row_index — not the bin label (#20566)', () => {
+            // https://github.com/lightdash/lightdash/issues/20566
+            // Repro: cartesian chart with x-axis = a custom bin dimension
+            // (e.g. 11 fixed bins on orders.amount), grouped by status,
+            // sort by the bin ASC. Without group by, the chart sorts
+            // correctly; adding a group by routed the chart through the
+            // pivot pipeline, and the bin's hidden `_order` column was
+            // dropped from the pivot CTEs — so bins came out alphabetically
+            // (e.g. 101-113 before 1-11).
+            // Expectation: the pivot SQL select-list and group_by_query
+            // group-by carry the bin's `_order` column through, and
+            // row_index ORDER BY references ONLY the `_order` alias — the
+            // bare bin reference must not leak in alongside it.
+            const binDimension: CustomBinDimension = {
+                id: 'amount_binned_amount',
+                name: 'binned_amount',
+                table: 'orders',
+                type: CustomDimensionType.BIN,
+                dimensionId: 'orders_amount',
+                binType: BinType.FIXED_WIDTH,
+                binWidth: 10,
+            };
+            const itemsMap: ItemsMap = {
+                amount_binned_amount: binDimension,
+            };
+
+            const pivotConfiguration = {
+                indexColumn: [
+                    {
+                        reference: 'amount_binned_amount',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'unique_order_count',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupByColumns: [{ reference: 'status' }],
+                sortBy: [
+                    {
+                        reference: 'amount_binned_amount',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+                500,
+                itemsMap,
+            );
+            const result = builder.toSql();
+
+            // _order column flows through group_by_query so it is available
+            // downstream in row_index ORDER BY.
+            expect(result).toContain('"amount_binned_amount_order"');
+            expect(replaceWhitespace(result)).toContain(
+                'group by "status", "amount_binned_amount", "amount_binned_amount_order"',
+            );
+
+            // row_index orders by the _order alias — the negative assertion
+            // is what locks the regression: the bare bin reference must not
+            // appear in row_index ORDER BY, otherwise alphabetical fallback
+            // could re-creep in.
+            expect(result.toLowerCase()).toContain(
+                'dense_rank() over (order by g."amount_binned_amount_order" asc) as "row_index"',
+            );
+            expect(replaceWhitespace(result)).not.toContain(
+                'DENSE_RANK() OVER (ORDER BY g."amount_binned_amount" ASC) AS "row_index"',
+            );
+        });
+
+        test('column_anchor CTE body contains the FIRST_VALUE PARTITION BY groupBy expression — not row-anchor MAX(CASE WHEN…) (#19509 column-side)', () => {
+            // Companion to the existing #19509 row-anchor test. That test
+            // locks that row_anchor uses MAX(CASE WHEN guarded on
+            // anchor_category equality...). This locks the column-side
+            // anchor's distinct shape: column_anchor uses FIRST_VALUE
+            // PARTITION BY <groupBy> ORDER BY <metric>, with frame clause.
+            // Risk: a refactor that "unifies" anchor CTE generation could
+            // collapse the two CTEs into one shape, silently re-introducing
+            // the wrong-rows ordering #19509 fixed without any of the
+            // existing isolated-line assertions failing — they test that
+            // the substrings exist somewhere, not that they are inside
+            // column_anchor.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: 'revenue', direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+            const collapsed = replaceWhitespace(result);
+
+            // Slice out the column_anchor CTE body so the assertions are
+            // scoped to just that CTE rather than the whole SQL. Nested
+            // parens inside FIRST_VALUE / OVER (...) make a regex slice
+            // brittle, so use named CTE markers as bounds.
+            const colAnchorStart = collapsed.indexOf(
+                '"revenue_column_anchor" AS (',
+            );
+            const rowAnchorStart = collapsed.indexOf(
+                '"revenue_row_anchor" AS (',
+                colAnchorStart,
+            );
+            expect(colAnchorStart).toBeGreaterThanOrEqual(0);
+            expect(rowAnchorStart).toBeGreaterThan(colAnchorStart);
+            const colAnchorBody = collapsed.slice(
+                colAnchorStart,
+                rowAnchorStart,
+            );
+
+            // FIRST_VALUE PARTITION BY <groupBy> ORDER BY <metric>, with the
+            // explicit ROWS BETWEEN frame, lives inside column_anchor.
+            expect(colAnchorBody).toContain(
+                'FIRST_VALUE("revenue_sum") OVER (PARTITION BY "category" ORDER BY "revenue_sum" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            );
+
+            // Negative: column_anchor must NOT carry row-anchor's
+            // MAX(CASE WHEN…) expression — that is the row-side shape.
+            // Mixing them up is the documented regression path.
+            expect(colAnchorBody).not.toContain('MAX(CASE WHEN');
+            expect(colAnchorBody).not.toContain('CROSS JOIN anchor_column');
+        });
+    });
 });

--- a/packages/backend/src/utils/SubtotalsCalculator.test.ts
+++ b/packages/backend/src/utils/SubtotalsCalculator.test.ts
@@ -1,0 +1,178 @@
+import {
+    type Filters,
+    type MetricQuery,
+    type SortField,
+    type TableCalculation,
+} from '@lightdash/common';
+import { SubtotalsCalculator } from './SubtotalsCalculator';
+
+const EMPTY_FILTERS: Filters = {};
+
+const buildMetricQuery = (
+    overrides: Partial<MetricQuery> = {},
+): MetricQuery => ({
+    exploreName: 'events',
+    dimensions: ['events_event_tier', 'events_event_type', 'events_country'],
+    metrics: ['events_total_count'],
+    filters: EMPTY_FILTERS,
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+    ...overrides,
+});
+
+const SORT: SortField = {
+    fieldId: 'events_country',
+    descending: false,
+};
+
+const TC_REFERENCING_DIMENSION: TableCalculation = {
+    name: 'is_high_tier',
+    displayName: 'Is high tier',
+    sql: "CASE WHEN ${events.event_tier} = 'High' THEN 1 ELSE 0 END",
+};
+
+const TC_REFERENCING_METRIC: TableCalculation = {
+    name: 'count_doubled',
+    displayName: 'Count doubled',
+    sql: '${events.total_count} * 2',
+};
+
+describe('SubtotalsCalculator (#14187)', () => {
+    describe('createSubtotalQueryConfig — sort stripping (#14298)', () => {
+        it('drops sorts from the subtotal query even when input metricQuery sorts the removed dimension', () => {
+            // Repro: sorting by the last dimension (which is excluded from subtotal
+            // groups) made the subtotal query reference an unselected column and
+            // crash. Fix: subtotal queries must never carry sorts.
+            const baseMetricQuery = buildMetricQuery({ sorts: [SORT] });
+
+            const result = SubtotalsCalculator.createSubtotalQueryConfig(
+                baseMetricQuery,
+                ['events_event_tier', 'events_event_type'],
+            );
+
+            expect(result.metricQuery.sorts).toEqual([]);
+        });
+
+        it('drops sorts even when input metricQuery has multiple sorts', () => {
+            const baseMetricQuery = buildMetricQuery({
+                sorts: [
+                    SORT,
+                    { fieldId: 'events_event_type', descending: true },
+                ],
+            });
+
+            const result = SubtotalsCalculator.createSubtotalQueryConfig(
+                baseMetricQuery,
+                ['events_event_tier'],
+            );
+
+            expect(result.metricQuery.sorts).toEqual([]);
+        });
+
+        it('includes pivotDimensions in the subtotal dimensions', () => {
+            const baseMetricQuery = buildMetricQuery();
+
+            const result = SubtotalsCalculator.createSubtotalQueryConfig(
+                baseMetricQuery,
+                ['events_event_tier'],
+                ['events_event_type'],
+            );
+
+            expect(result.dimensions).toEqual([
+                'events_event_tier',
+                'events_event_type',
+            ]);
+            expect(result.metricQuery.dimensions).toEqual([
+                'events_event_tier',
+                'events_event_type',
+            ]);
+        });
+    });
+
+    describe('filterTableCalculations — TC referencing unavailable field (#14403)', () => {
+        it('excludes a table calculation referencing a dimension absent from subtotal dimensions', () => {
+            // Repro: a TC like CASE WHEN ${events.event_tier} = 'High' references a
+            // dimension that gets dropped from the subtotal grouping. Before the fix,
+            // the subtotal query was issued with the TC anyway and SQL compilation
+            // failed because the dimension column didn't exist in the SELECT.
+            const baseMetricQuery = buildMetricQuery({
+                tableCalculations: [TC_REFERENCING_DIMENSION],
+            });
+
+            const filtered = SubtotalsCalculator.filterTableCalculations(
+                baseMetricQuery,
+                // event_tier intentionally absent
+                ['events_event_type', 'events_country'],
+            );
+
+            expect(filtered).toEqual([]);
+        });
+
+        it('keeps a table calculation when its referenced dimension is in subtotal dimensions', () => {
+            const baseMetricQuery = buildMetricQuery({
+                tableCalculations: [TC_REFERENCING_DIMENSION],
+            });
+
+            const filtered = SubtotalsCalculator.filterTableCalculations(
+                baseMetricQuery,
+                ['events_event_tier', 'events_event_type'],
+            );
+
+            expect(filtered).toEqual([TC_REFERENCING_DIMENSION]);
+        });
+
+        it('keeps a table calculation referencing a metric (metrics survive subtotal grouping)', () => {
+            const baseMetricQuery = buildMetricQuery({
+                tableCalculations: [TC_REFERENCING_METRIC],
+            });
+
+            const filtered = SubtotalsCalculator.filterTableCalculations(
+                baseMetricQuery,
+                // dimensions list omits any dim — the TC references a metric, not a dim
+                ['events_event_tier'],
+            );
+
+            expect(filtered).toEqual([TC_REFERENCING_METRIC]);
+        });
+
+        it('preserves only the safe TCs when a mix is supplied', () => {
+            const baseMetricQuery = buildMetricQuery({
+                tableCalculations: [
+                    TC_REFERENCING_DIMENSION, // references events_event_tier (dropped)
+                    TC_REFERENCING_METRIC, // references events_total_count (kept)
+                ],
+            });
+
+            const filtered = SubtotalsCalculator.filterTableCalculations(
+                baseMetricQuery,
+                ['events_event_type'],
+            );
+
+            expect(filtered).toEqual([TC_REFERENCING_METRIC]);
+        });
+    });
+
+    describe('createSubtotalQueryConfig — combined invariants', () => {
+        it('returns sorts:[] AND filters TCs with missing field refs in a single call', () => {
+            const baseMetricQuery = buildMetricQuery({
+                sorts: [SORT],
+                tableCalculations: [
+                    TC_REFERENCING_DIMENSION,
+                    TC_REFERENCING_METRIC,
+                ],
+            });
+
+            const result = SubtotalsCalculator.createSubtotalQueryConfig(
+                baseMetricQuery,
+                ['events_event_type'],
+            );
+
+            expect(result.metricQuery.sorts).toEqual([]);
+            expect(result.metricQuery.tableCalculations).toEqual([
+                TC_REFERENCING_METRIC,
+            ]);
+            expect(result.tableCalculations).toEqual([TC_REFERENCING_METRIC]);
+        });
+    });
+});

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -4,6 +4,7 @@ import {
     DimensionType,
     FieldType,
     MetricType,
+    TableCalculationType,
     type ItemsMap,
     type TableCalculation,
 } from '../types/field';
@@ -467,6 +468,12 @@ describe('derivePivotConfigurationFromChart', () => {
                 {
                     reference: 'payments_total_revenue',
                     aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+            expect(result?.indexColumn).toEqual([
+                {
+                    reference: 'payments_payment_method',
+                    type: VizIndexType.CATEGORY,
                 },
             ]);
         });
@@ -1042,6 +1049,259 @@ describe('derivePivotConfigurationFromChart', () => {
             expect(result?.groupByColumns).toEqual([
                 { reference: 'payments_payment_method' },
             ]);
+        });
+    });
+
+    describe('Regressions for resolved pivot bugs', () => {
+        it('preserves metricQuery.metrics order in valuesColumns for table charts with metricsAsRows + multiple dimensions (#19838)', () => {
+            // https://github.com/lightdash/lightdash/issues/19838
+            // Repro: select metrics in a specific order (Profit → Revenue → Sales),
+            // pivot a table chart by a date dimension, enable "metrics as rows".
+            // Bug: the metric rows came out in a different order from the user's
+            // selection — there was no UI affordance to fix it.
+            // Expectation: valuesColumns reflects metricQuery.metrics order
+            // verbatim, not alphabetical or some other implicit ordering.
+            const itemsWithThreeMetrics: ItemsMap = {
+                orders_order_date_day: {
+                    sql: '${TABLE}.order_date_day',
+                    name: 'order_date_day',
+                    type: DimensionType.DATE,
+                    index: 1,
+                    label: 'Order date day',
+                    table: 'orders',
+                    groups: [],
+                    hidden: false,
+                    fieldType: FieldType.DIMENSION,
+                    tableLabel: 'Orders',
+                },
+                orders_status: {
+                    sql: '${TABLE}.status',
+                    name: 'status',
+                    type: DimensionType.STRING,
+                    index: 2,
+                    label: 'Status',
+                    table: 'orders',
+                    groups: [],
+                    hidden: false,
+                    fieldType: FieldType.DIMENSION,
+                    tableLabel: 'Orders',
+                },
+                // Metric names are intentionally NOT in alphabetical order so a
+                // regression that re-sorts them (alphabetical, by label, by SUM
+                // before AVG, etc.) shows up clearly.
+                orders_zzz_profit: {
+                    sql: '${TABLE}.profit',
+                    name: 'zzz_profit',
+                    type: MetricType.SUM,
+                    index: 1,
+                    label: 'Profit',
+                    table: 'orders',
+                    groups: [],
+                    hidden: false,
+                    filters: [],
+                    fieldType: FieldType.METRIC,
+                    tableLabel: 'Orders',
+                },
+                orders_aaa_revenue: {
+                    sql: '${TABLE}.revenue',
+                    name: 'aaa_revenue',
+                    type: MetricType.SUM,
+                    index: 2,
+                    label: 'Revenue',
+                    table: 'orders',
+                    groups: [],
+                    hidden: false,
+                    filters: [],
+                    fieldType: FieldType.METRIC,
+                    tableLabel: 'Orders',
+                },
+                orders_mmm_sales_count: {
+                    sql: '${TABLE}.sales_count',
+                    name: 'mmm_sales_count',
+                    type: MetricType.COUNT,
+                    index: 3,
+                    label: 'Sales count',
+                    table: 'orders',
+                    groups: [],
+                    hidden: false,
+                    filters: [],
+                    fieldType: FieldType.METRIC,
+                    tableLabel: 'Orders',
+                },
+            };
+
+            const metricQuery: MetricQuery = {
+                exploreName: 'orders',
+                dimensions: ['orders_order_date_day', 'orders_status'],
+                // Selection order: Profit, Revenue, Sales count.
+                metrics: [
+                    'orders_zzz_profit',
+                    'orders_aaa_revenue',
+                    'orders_mmm_sales_count',
+                ],
+                filters: {},
+                sorts: [
+                    { fieldId: 'orders_order_date_day', descending: false },
+                ],
+                limit: 500,
+                tableCalculations: [],
+                additionalMetrics: [],
+                metricOverrides: {},
+            };
+
+            const tableChartConfig = {
+                type: ChartType.TABLE,
+                config: {
+                    metricsAsRows: true,
+                },
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: tableChartConfig,
+                pivotConfig: { columns: ['orders_order_date_day'] },
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                metricQuery,
+                itemsWithThreeMetrics,
+            );
+
+            // metricsAsRows must round-trip onto the pivot configuration.
+            expect(result?.metricsAsRows).toBe(true);
+
+            // valuesColumns order is the contract: it must match the order in
+            // metricQuery.metrics. If a future change re-sorts metrics by
+            // label, by name, or by aggregation type, this test will fail.
+            expect(result?.valuesColumns).toEqual([
+                {
+                    reference: 'orders_zzz_profit',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+                {
+                    reference: 'orders_aaa_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+                {
+                    reference: 'orders_mmm_sales_count',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+        });
+
+        it('a sort-only table calculation that is not the xField stays out of indexColumn and valuesColumns', () => {
+            // Locks the invariant that a TC referenced ONLY by a sort entry
+            // (not on any chart axis) is routed exclusively to
+            // sortOnlyColumns. The two pathways that could re-break this:
+            //
+            // 1. getIndexColumn re-introducing a `sortFieldIds.has(tc.name)`
+            //    branch — that would make the TC enter indexColumn alongside
+            //    its sortOnlyColumns entry, so the chart grows a phantom
+            //    series for the sort field.
+            // 2. The sortOnlyColumns filter dropping the indexColumn-aware
+            //    exclusion — that would let an xField TC double up as both
+            //    indexColumn and sortOnlyColumns when sorted by itself.
+            //
+            // The fixture: cartesian chart, x = a non-pivot dim, y = a
+            // metric, plus a TC `y_day` used only for sort.
+            const sortOnlyTc: TableCalculation = {
+                name: 'y_day',
+                displayName: 'Day of year',
+                type: TableCalculationType.NUMBER,
+                sql: 'EXTRACT(DOY FROM ${orders.order_date_day})',
+            };
+
+            const itemsForRepro: ItemsMap = {
+                ...mockItems,
+                orders_unique_order_count: {
+                    sql: 'COUNT(DISTINCT ${TABLE}.order_id)',
+                    name: 'unique_order_count',
+                    type: MetricType.COUNT_DISTINCT,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    label: 'Unique order count',
+                    hidden: false,
+                    index: 0,
+                    filters: [],
+                    groups: [],
+                },
+            };
+
+            const cartesianChartConfig: CartesianChartConfig = {
+                type: ChartType.CARTESIAN,
+                config: {
+                    layout: {
+                        // x-axis: a non-pivot dim. The y-axis carries ONLY the
+                        // metric — the TC is not on the chart.
+                        xField: 'payments_payment_method',
+                        yField: ['orders_unique_order_count'],
+                    },
+                    eChartsConfig: { series: [] },
+                },
+            };
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: cartesianChartConfig,
+                pivotConfig: { columns: ['orders_status'] },
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                metrics: ['orders_unique_order_count'],
+                tableCalculations: [sortOnlyTc],
+                // The TC drives sort order but is not visualized.
+                sorts: [{ fieldId: 'y_day', descending: false }],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                itemsForRepro,
+            );
+
+            expect(result).toBeDefined();
+
+            // valuesColumns must contain exactly the y-axis metric. Anything
+            // else (the TC creeping back in, an additional metric, etc.)
+            // would make the rendered chart double its series count.
+            expect(result?.valuesColumns).toHaveLength(1);
+            expect(result?.valuesColumns).toEqual([
+                {
+                    reference: 'orders_unique_order_count',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+
+            // The TC is preserved as a sort-only column so PivotQueryBuilder
+            // can still emit anchor CTEs that order rows by it.
+            expect(result?.sortOnlyColumns).toEqual([
+                {
+                    reference: 'y_day',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+
+            // sortBy still references the TC — the chart-render layer relies
+            // on the value columns / sortOnlyColumns split, not on dropping
+            // the sort entry.
+            expect(result?.sortBy).toEqual([
+                { reference: 'y_day', direction: SortByDirection.ASC },
+            ]);
+
+            // Hard guarantee: y_day must not appear as an index column
+            // either. If it did, the chart would render it on the x-axis or
+            // along a series dimension.
+            const indexRefs = Array.isArray(result?.indexColumn)
+                ? result!.indexColumn.map((c) => c.reference)
+                : [result?.indexColumn?.reference];
+            expect(indexRefs).not.toContain('y_day');
         });
     });
 });

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -284,6 +284,7 @@ function getCartesianPivotConfiguration(
         const sortOnlyMetrics = metricQuery.sorts
             .filter(
                 (sort) =>
+                    sort.fieldId !== xField &&
                     !valuesRefs.has(sort.fieldId) &&
                     (metricQuery.metrics.includes(sort.fieldId) ||
                         (metricQuery.tableCalculations || []).some(
@@ -294,6 +295,7 @@ function getCartesianPivotConfiguration(
                 reference: sort.fieldId,
                 aggregation: VizAggregationOptions.ANY,
             }));
+
         // Find columns that are not groupBy or value columns (these become index columns)
         // Include sortOnlyMetrics in the valuesColumns passed to getIndexColumn
         // so they aren't incorrectly classified as index columns.

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1583,3 +1583,55 @@ describe('visibleMetricFieldIds in pivotQueryResults', () => {
         expect(result.dataColumnCount).toBe(6);
     });
 });
+
+describe('convertSqlPivotedRowsToPivotData metric ordering (#19838 / #19919)', () => {
+    it('orders metricsAsRows row labels by columnOrder, not valuesColumns first-occurrence', () => {
+        // baseMetricsArray was previously derived via Array.from(new Set(...)),
+        // which preserves valuesColumns first-occurrence order rather than the
+        // user's metric selection sequence (columnOrder). With metricsAsRows: true
+        // this produced metric label rows in the wrong order. Fixed in PR #19910
+        // by sorting by columnOrder.indexOf.
+        //
+        // valuesColumns order in COMPLEX_SQL_PIVOT_DETAILS:
+        //   payments_total_revenue, orders_average_order_size, orders_total_order_amount
+        // columnOrder below intentionally reverses that, so the two derivations diverge.
+        const columnOrder = [
+            'payments_payment_method',
+            'orders_order_date_year',
+            'orders_is_completed',
+            'orders_promo_code',
+            'orders_total_order_amount',
+            'payments_total_revenue',
+            'orders_average_order_size',
+        ];
+
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: COMPLEX_SQL_PIVOTED_ROWS,
+            pivotDetails: COMPLEX_SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: true,
+                columnOrder,
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        // In metricsAsRows mode each indexValues row ends with a metric label.
+        const metricRowOrder = result.indexValues
+            .map((row) => row[row.length - 1])
+            .filter(
+                (entry): entry is { type: 'label'; fieldId: string } =>
+                    entry.type === 'label',
+            )
+            .map((entry) => entry.fieldId);
+
+        expect(metricRowOrder).toEqual([
+            'orders_total_order_amount',
+            'payments_total_revenue',
+            'orders_average_order_size',
+        ]);
+    });
+});

--- a/packages/common/src/pivot/pivotResultsAsCsv.test.ts
+++ b/packages/common/src/pivot/pivotResultsAsCsv.test.ts
@@ -1,4 +1,5 @@
 import type { ItemsMap } from '../types/field';
+import type { ResultRow } from '../types/results';
 import { pivotResultsAsCsv, pivotResultsAsData } from './pivotQueryResults';
 import {
     getFieldMock,
@@ -83,6 +84,70 @@ describe('pivotResultsAsCsv', () => {
 
         const allValues = result.flat();
         expect(allValues).toContain('Page Views');
+    });
+
+    it('returns empty cells for rows missing an expected pivot field instead of throwing (#16866)', () => {
+        // https://github.com/lightdash/lightdash/issues/16866
+        // Repro: a CSV export with a pivoted chart whose result rows are
+        // missing one of the value-column fields used to throw
+        // `Cannot get key 'X' from object` deep inside the pivot pipeline,
+        // crashing scheduled deliveries silently.
+        // Expectation: pivotResultsAsCsv tolerates missing fields by
+        // emitting empty/placeholder cells, so the export still succeeds.
+        // The safe accessor lives in pivotResultsAsData and reads
+        // `row[fieldId]?.value?.raw ?? ''` — locking the empty-string
+        // fallback prevents a regression that re-introduces the throw.
+        const partialRows: ResultRow[] = RESULT_ROWS_2DIM_2METRIC.map(
+            (row, idx) => {
+                if (idx === 1) {
+                    // Strip the devices metric on one row to simulate a
+                    // results-set missing a field that valuesColumns expects.
+                    const { devices, ...rest } = row;
+                    return rest;
+                }
+                return row;
+            },
+        );
+
+        const callPivot = () =>
+            pivotResultsAsCsv({
+                pivotConfig: {
+                    pivotDimensions: ['page'],
+                    metricsAsRows: false,
+                },
+                rows: partialRows,
+                itemMap: buildItemsMap(),
+                metricQuery: {
+                    exploreName: 'test',
+                    ...METRIC_QUERY_2DIM_2METRIC,
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    customDimensions: [],
+                    metricOverrides: {},
+                    dimensionOverrides: {},
+                },
+                customLabels: undefined,
+                onlyRaw: false,
+                maxColumnLimit: 60,
+                pivotDetails: null,
+                undefinedCharacter: '',
+            });
+
+        expect(callPivot).not.toThrow();
+
+        const result = callPivot();
+
+        // The output is still a 2D string array of the same surface shape.
+        expect(Array.isArray(result)).toBe(true);
+        result.forEach((row) => {
+            expect(Array.isArray(row)).toBe(true);
+            row.forEach((cell) => {
+                // No undefined cells leak through — the safe accessor
+                // returns empty string when the source field is missing.
+                expect(typeof cell).toBe('string');
+            });
+        });
     });
 
     it('produces same number of columns as pivotResultsAsData', () => {

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -1,5 +1,335 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { SEED_PROJECT } from '@lightdash/common';
+import {
+    CartesianSeriesType,
+    ChartType,
+    SEED_PROJECT,
+    TableCalculationType,
+} from '@lightdash/common';
+
+type QueryResultRow = Record<
+    string,
+    { value?: { raw?: unknown; formatted?: string } }
+>;
+
+type ReadyQueryResults = {
+    status: 'ready';
+    columns?: Record<string, unknown>;
+    rows: QueryResultRow[];
+    pivotDetails?: {
+        indexColumn?:
+            | { reference: string }
+            | Array<{ reference: string }>
+            | undefined;
+        valuesColumns?: Array<{ referenceField: string }>;
+    } | null;
+};
+
+type PivotConfiguration = {
+    indexColumn?:
+        | { reference: string }
+        | Array<{ reference: string }>
+        | undefined;
+    valuesColumns?: Array<{ reference: string }>;
+    sortOnlyColumns?: Array<{ reference: string }>;
+    sortBy?: Array<{ reference: string }>;
+};
+
+const buildExploreUrl = (chartState: Record<string, unknown>) =>
+    `/projects/${SEED_PROJECT.project_uuid}/tables/orders?create_saved_chart_version=${encodeURIComponent(
+        JSON.stringify(chartState),
+    )}`;
+
+const fieldReference = (fieldId: string) => `\${${fieldId}}`;
+
+const getRequestBody = (body: any) =>
+    typeof body === 'string' ? JSON.parse(body) : body;
+
+const getReferences = (columns?: Array<{ reference: string }>) =>
+    columns?.map((column) => column.reference) ?? [];
+
+const getIndexReferences = (indexColumn: PivotConfiguration['indexColumn']) => {
+    if (!indexColumn) return [];
+    return Array.isArray(indexColumn)
+        ? indexColumn.map((column) => column.reference)
+        : [indexColumn.reference];
+};
+
+const getRawValues = (rows: QueryResultRow[], fieldId: string) =>
+    rows
+        .map((row) => row[fieldId]?.value?.raw)
+        .filter((value) => value !== undefined && value !== null);
+
+const getColumnIds = (results: ReadyQueryResults) => [
+    ...Object.keys(results.columns ?? {}),
+    ...results.rows.flatMap((row) => Object.keys(row)),
+];
+
+const unusedTableCalculationName = 'unused_revenue_label';
+
+const waitForReadyPivotResults = (
+    assertResults: (results: ReadyQueryResults) => void,
+) => {
+    cy.wait('@pivotQueryResults', { timeout: 60000 }).then((interception) => {
+        const results = interception.response?.body?.results;
+
+        if (results?.error) {
+            throw new Error(`Query failed: ${results.error}`);
+        }
+
+        if (results?.status !== 'ready') {
+            waitForReadyPivotResults(assertResults);
+            return;
+        }
+
+        assertResults(results);
+    });
+};
+
+const runPivotChart = (
+    chartState: Record<string, unknown>,
+    assertPivotConfiguration: (pivotConfiguration: PivotConfiguration) => void,
+    assertResults: (results: ReadyQueryResults) => void,
+) => {
+    // Only alias requests that carry a pivotConfiguration. The
+    // useSqlPivotResults feature flag resolves async, so an auto-fetch
+    // can fire before the flag lands and produce a metric-query POST
+    // without pivotConfiguration — which would race the Run-query click
+    // and make cy.wait pick up the wrong request.
+    cy.intercept('POST', '**/api/v2/projects/*/query/metric-query', (req) => {
+        const body = getRequestBody(req.body);
+        if (body?.pivotConfiguration !== undefined) {
+            req.alias = 'runPivotQuery';
+        }
+    });
+    cy.intercept('GET', '**/api/v2/projects/*/query/*').as('pivotQueryResults');
+
+    cy.visit(buildExploreUrl(chartState));
+    cy.get('button').contains('Run query').click();
+
+    cy.wait('@runPivotQuery', { timeout: 60000 }).then((interception) => {
+        const body = getRequestBody(interception.request.body);
+        expect(body.pivotConfiguration).to.not.equal(undefined);
+        assertPivotConfiguration(body.pivotConfiguration);
+    });
+
+    waitForReadyPivotResults(assertResults);
+
+    cy.get('[data-testid="visualization"]').as('chartArea');
+    cy.get('@chartArea').findByText('Loading chart').should('not.exist');
+    cy.get('@chartArea')
+        .find('.echarts-for-react canvas, .echarts-for-react svg')
+        .should('exist');
+};
+
+const hiddenMetricSortChartState = {
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['customers_customer_id', 'orders_is_completed'],
+        metrics: ['orders_total_order_amount', 'orders_unique_order_count'],
+        filters: {},
+        sorts: [{ fieldId: 'orders_total_order_amount', descending: true }],
+        limit: 500,
+        tableCalculations: [
+            {
+                name: unusedTableCalculationName,
+                displayName: 'Unused revenue label',
+                type: TableCalculationType.NUMBER,
+                sql: fieldReference('orders.total_order_amount'),
+            },
+        ],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_is_completed'] },
+    tableConfig: {
+        columnOrder: [
+            'customers_customer_id',
+            'orders_is_completed',
+            'orders_total_order_amount',
+            'orders_unique_order_count',
+            unusedTableCalculationName,
+        ],
+    },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customers_customer_id',
+                yField: ['orders_unique_order_count'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customers_customer_id' },
+                            yRef: { field: 'orders_unique_order_count' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+};
+
+const sortOnlyTableCalculationChartState = {
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['customers_customer_id', 'orders_is_completed'],
+        metrics: ['orders_total_order_amount'],
+        filters: {},
+        sorts: [{ fieldId: 'revenue_rank', descending: false }],
+        limit: 500,
+        tableCalculations: [
+            {
+                name: 'revenue_rank',
+                displayName: 'Revenue rank',
+                type: TableCalculationType.NUMBER,
+                sql: `rank() over (order by ${fieldReference(
+                    'orders.total_order_amount',
+                )} desc)`,
+            },
+        ],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_is_completed'] },
+    tableConfig: {
+        columnOrder: [
+            'customers_customer_id',
+            'orders_is_completed',
+            'orders_total_order_amount',
+            'revenue_rank',
+        ],
+    },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customers_customer_id',
+                yField: ['orders_total_order_amount'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customers_customer_id' },
+                            yRef: { field: 'orders_total_order_amount' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+};
+
+const xAxisTableCalculationChartState = {
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: [
+            'customers_first_name',
+            'customers_last_name',
+            'orders_order_date_week',
+        ],
+        metrics: ['orders_total_order_amount'],
+        filters: {},
+        sorts: [{ fieldId: 'customer_label', descending: false }],
+        limit: 500,
+        tableCalculations: [
+            {
+                name: 'customer_label',
+                displayName: 'Customer label',
+                type: TableCalculationType.STRING,
+                sql: `concat(${fieldReference(
+                    'customers.first_name',
+                )}, ' ', ${fieldReference('customers.last_name')})`,
+            },
+        ],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_order_date_week'] },
+    tableConfig: {
+        columnOrder: [
+            'customers_first_name',
+            'customers_last_name',
+            'orders_order_date_week',
+            'orders_total_order_amount',
+            'customer_label',
+        ],
+    },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'customer_label',
+                yField: ['orders_total_order_amount'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.BAR,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'customer_label' },
+                            yRef: { field: 'orders_total_order_amount' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+};
+
+const xAxisMetricChartState = {
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['orders_is_completed'],
+        metrics: ['orders_unique_order_count', 'orders_total_order_amount'],
+        filters: {},
+        sorts: [{ fieldId: 'orders_unique_order_count', descending: true }],
+        limit: 500,
+        tableCalculations: [],
+        additionalMetrics: [],
+        metricOverrides: {},
+    },
+    pivotConfig: { columns: ['orders_is_completed'] },
+    tableConfig: {
+        columnOrder: [
+            'orders_is_completed',
+            'orders_unique_order_count',
+            'orders_total_order_amount',
+        ],
+    },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: 'orders_unique_order_count',
+                yField: ['orders_total_order_amount'],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        type: CartesianSeriesType.SCATTER,
+                        yAxisIndex: 0,
+                        encode: {
+                            xRef: { field: 'orders_unique_order_count' },
+                            yRef: { field: 'orders_total_order_amount' },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+};
 
 describe('Pivot Tables', () => {
     beforeEach(() => {
@@ -45,6 +375,121 @@ describe('Pivot Tables', () => {
 
         cy.get('@chartArea').findByText('Loading chart').should('not.exist');
         cy.get('@chartArea').contains('Is completed'); // Check that the chart updated successfully with the pivot table(containing 'is completed' column)
+    });
+
+    it('Can render a pivoted cartesian chart sorted by a metric that is not displayed', () => {
+        runPivotChart(
+            hiddenMetricSortChartState,
+            (pivotConfiguration) => {
+                expect(getReferences(pivotConfiguration.valuesColumns)).to.eql([
+                    'orders_unique_order_count',
+                ]);
+                expect(
+                    getIndexReferences(pivotConfiguration.indexColumn),
+                ).not.to.include(unusedTableCalculationName);
+                expect(
+                    getReferences(pivotConfiguration.valuesColumns),
+                ).not.to.include(unusedTableCalculationName);
+                expect(
+                    getReferences(pivotConfiguration.sortOnlyColumns),
+                ).to.include('orders_total_order_amount');
+                expect(
+                    getReferences(pivotConfiguration.sortOnlyColumns),
+                ).not.to.include(unusedTableCalculationName);
+                expect(getReferences(pivotConfiguration.sortBy)).to.include(
+                    'orders_total_order_amount',
+                );
+                expect(getReferences(pivotConfiguration.sortBy)).not.to.include(
+                    unusedTableCalculationName,
+                );
+            },
+            (results) => {
+                expect(
+                    getRawValues(results.rows, 'customers_customer_id').length,
+                ).to.be.greaterThan(1);
+                expect(
+                    getColumnIds(results).some((columnId) =>
+                        columnId.includes('orders_total_order_amount'),
+                    ),
+                ).to.equal(false);
+            },
+        );
+    });
+
+    it('Can render a pivoted cartesian chart sorted by a table calculation that is not displayed', () => {
+        runPivotChart(
+            sortOnlyTableCalculationChartState,
+            (pivotConfiguration) => {
+                expect(getReferences(pivotConfiguration.valuesColumns)).to.eql([
+                    'orders_total_order_amount',
+                ]);
+                expect(
+                    getReferences(pivotConfiguration.sortOnlyColumns),
+                ).to.include('revenue_rank');
+                expect(getReferences(pivotConfiguration.sortBy)).to.include(
+                    'revenue_rank',
+                );
+            },
+            (results) => {
+                expect(
+                    getRawValues(results.rows, 'customers_customer_id').length,
+                ).to.be.greaterThan(1);
+                expect(
+                    results.pivotDetails?.valuesColumns?.map(
+                        (column) => column.referenceField,
+                    ) ?? [],
+                ).not.to.include('revenue_rank');
+            },
+        );
+    });
+
+    it('Can render a pivoted cartesian chart with an x-axis table calculation sorted by itself', () => {
+        runPivotChart(
+            xAxisTableCalculationChartState,
+            (pivotConfiguration) => {
+                expect(
+                    getIndexReferences(pivotConfiguration.indexColumn),
+                ).to.include('customer_label');
+                expect(
+                    getReferences(pivotConfiguration.sortOnlyColumns),
+                ).not.to.include('customer_label');
+                expect(getReferences(pivotConfiguration.sortBy)).to.include(
+                    'customer_label',
+                );
+            },
+            (results) => {
+                const customerLabels = getRawValues(
+                    results.rows,
+                    'customer_label',
+                );
+
+                expect(customerLabels.length).to.be.greaterThan(1);
+                expect(new Set(customerLabels).size).to.be.greaterThan(1);
+            },
+        );
+    });
+
+    it('Can render a pivoted scatter chart with an x-axis metric sorted by itself', () => {
+        runPivotChart(
+            xAxisMetricChartState,
+            (pivotConfiguration) => {
+                expect(
+                    getIndexReferences(pivotConfiguration.indexColumn),
+                ).to.include('orders_unique_order_count');
+                expect(
+                    getReferences(pivotConfiguration.sortOnlyColumns),
+                ).not.to.include('orders_unique_order_count');
+                expect(getReferences(pivotConfiguration.sortBy)).to.include(
+                    'orders_unique_order_count',
+                );
+            },
+            (results) => {
+                expect(
+                    getRawValues(results.rows, 'orders_unique_order_count')
+                        .length,
+                ).to.be.greaterThan(0);
+            },
+        );
     });
 
     // todo: remove

--- a/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.test.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.test.tsx
@@ -1,0 +1,80 @@
+import { type RawResultRow } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { ChartDataTable } from './ChartDataTable';
+
+describe('ChartDataTable — pivoted column sort affordance (#12560)', () => {
+    const columnNames = ['indexCol', 'pivotedCol'];
+    const rows: RawResultRow[] = [];
+
+    it('fires onTHClick for a column present in thSortConfig', async () => {
+        const onTHClick = vi.fn();
+        renderWithProviders(
+            <ChartDataTable
+                columnNames={columnNames}
+                rows={rows}
+                thSortConfig={{ indexCol: { direction: undefined } }}
+                onTHClick={onTHClick}
+            />,
+        );
+
+        await userEvent.click(screen.getByText('indexCol'));
+        expect(onTHClick).toHaveBeenCalledWith('indexCol');
+    });
+
+    it('does not fire onTHClick for a column missing from thSortConfig (pivoted/group column)', async () => {
+        // The bug: users could sort by pivoted columns even though it makes no sense.
+        // Fix in PR #12569 made ContentPanel exclude pivoted columns from thSortConfig
+        // and ChartDataTable only attaches onClick when sortConfig exists. Locking the
+        // header layer pins the contract that downstream consumers (SQL runner, viz)
+        // rely on.
+        const onTHClick = vi.fn();
+        renderWithProviders(
+            <ChartDataTable
+                columnNames={columnNames}
+                rows={rows}
+                thSortConfig={{ indexCol: { direction: undefined } }}
+                onTHClick={onTHClick}
+            />,
+        );
+
+        await userEvent.click(screen.getByText('pivotedCol'));
+        expect(onTHClick).not.toHaveBeenCalled();
+    });
+
+    it('renders the "cannot sort" tooltip label for pivoted columns when hovered', async () => {
+        renderWithProviders(
+            <ChartDataTable
+                columnNames={columnNames}
+                rows={rows}
+                thSortConfig={{ indexCol: { direction: undefined } }}
+                onTHClick={vi.fn()}
+            />,
+        );
+
+        await userEvent.hover(screen.getByText('pivotedCol'));
+
+        expect(
+            await screen.findByText('You cannot sort by a group column'),
+        ).toBeInTheDocument();
+    });
+
+    it('omits the cursor:pointer affordance on pivoted column headers', () => {
+        renderWithProviders(
+            <ChartDataTable
+                columnNames={columnNames}
+                rows={rows}
+                thSortConfig={{ indexCol: { direction: undefined } }}
+                onTHClick={vi.fn()}
+            />,
+        );
+
+        const sortableHeaderTh = screen.getByText('indexCol').closest('th');
+        const pivotedHeaderTh = screen.getByText('pivotedCol').closest('th');
+
+        expect(sortableHeaderTh).toHaveStyle({ cursor: 'pointer' });
+        expect(pivotedHeaderTh).not.toHaveStyle({ cursor: 'pointer' });
+    });
+});

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -572,6 +572,102 @@ describe('mergeExistingAndExpectedSeries', () => {
             ['a', 'b', 'c'],
         );
     });
+
+    test('backend-driven series order from columnIndex DENSE_RANK overrides a saved-chart series order that disagrees (PROD-2927 / #20435)', () => {
+        // Repro: a chart was saved with pivot category order [c, a]. New
+        // results introduced category "b" and the backend re-ordered them
+        // by DENSE_RANK columnIndex into [a, b, c]. Before #20435 the merge
+        // preserved the saved [c, a] order and appended "b" at the end ->
+        // [c, a, b], so users had to manually re-order series after every
+        // run.
+        // Expectation: when sortedByPivot is true, the merged output
+        // matches expectedSeriesMap key order verbatim — backend wins over
+        // a stale saved-chart order, not just over a missing one. This
+        // strengthens the "insert in sorted position" test which only
+        // covered an existing series order that was a prefix of the
+        // backend order ([a, c] vs [a, b, c]).
+        const defaultProps = {
+            label: undefined,
+            type: CartesianSeriesType.BAR,
+            areaStyle: undefined,
+            stack: undefined,
+            showSymbol: undefined,
+            smooth: undefined,
+            yAxisIndex: 0,
+        };
+
+        // Existing series order is REVERSED relative to the new backend
+        // order — [c, a] vs backend's [a, b, c]. This is the case the
+        // existing #20435 test does not cover.
+        const existingSeries: Series[] = [
+            {
+                ...defaultProps,
+                encode: {
+                    xRef: { field: 'date' },
+                    yRef: {
+                        field: 'metric',
+                        pivotValues: [{ field: 'version', value: 'c' }],
+                    },
+                },
+            },
+            {
+                ...defaultProps,
+                encode: {
+                    xRef: { field: 'date' },
+                    yRef: {
+                        field: 'metric',
+                        pivotValues: [{ field: 'version', value: 'a' }],
+                    },
+                },
+            },
+        ];
+
+        const expectedSeriesMap: Record<string, Series> = {
+            'date|metric.version.a': {
+                ...defaultProps,
+                encode: {
+                    xRef: { field: 'date' },
+                    yRef: {
+                        field: 'metric',
+                        pivotValues: [{ field: 'version', value: 'a' }],
+                    },
+                },
+            },
+            'date|metric.version.b': {
+                ...defaultProps,
+                encode: {
+                    xRef: { field: 'date' },
+                    yRef: {
+                        field: 'metric',
+                        pivotValues: [{ field: 'version', value: 'b' }],
+                    },
+                },
+            },
+            'date|metric.version.c': {
+                ...defaultProps,
+                encode: {
+                    xRef: { field: 'date' },
+                    yRef: {
+                        field: 'metric',
+                        pivotValues: [{ field: 'version', value: 'c' }],
+                    },
+                },
+            },
+        };
+
+        const result = mergeExistingAndExpectedSeries({
+            expectedSeriesMap,
+            existingSeries,
+            sortedByPivot: true,
+        });
+
+        // Backend order wins — exact equality, not just inclusion. A
+        // regression that re-introduces saved-chart order would either
+        // produce [c, a, b] or [c, a, ...] here.
+        expect(result.map((s) => s.encode.yRef.pivotValues?.[0].value)).toEqual(
+            ['a', 'b', 'c'],
+        );
+    });
 });
 
 describe('getSeriesGroupedByField', () => {

--- a/packages/frontend/src/hooks/plottedData/getPlottedData.test.ts
+++ b/packages/frontend/src/hooks/plottedData/getPlottedData.test.ts
@@ -82,4 +82,81 @@ describe('usePlottedData', () => {
             EXPECTED_PIVOT_RESULTS_WITH_SAME_FIELD_PIVOTED_AND_NON_PIVOTED,
         );
     });
+
+    it('drops a table calculation that is not in keysToPivot or keysToNotPivot from the pivoted output (#19252)', () => {
+        // https://github.com/lightdash/lightdash/issues/19252
+        // Repro: stacked bar chart with xField, a metric yField, a groupBy
+        // dimension, AND a table calculation that is NOT used as a y-axis
+        // value. Stacking computed wrong totals because the TC field leaked
+        // into the pivoted row map and ECharts treated it as another stack
+        // member. Removing the TC, or making it the yField, made stacking
+        // work — pinning the regression at "TC not in yField must be
+        // excluded from the pivoted result row".
+        // Expectation: getPivotedData strips fields that are neither in
+        // keysToPivot (yField) nor in keysToNotPivot (xField/dimensions),
+        // so the TC never appears in result.rows or rowKeyMap. A regression
+        // that re-introduces the TC into the row map would break stacking.
+        const tcFieldId = 'tc_running_total';
+        const rowsWithTc: typeof RESULTS_FOR_SIMPLE_PIVOT = [
+            {
+                dim1: { value: { raw: 1, formatted: '1' } },
+                dim2: { value: { raw: true, formatted: 'yes' } },
+                dim3: { value: { raw: 'value1', formatted: 'value1' } },
+                metric1: { value: { raw: 10, formatted: '10' } },
+                [tcFieldId]: { value: { raw: 100, formatted: '100' } },
+            },
+            {
+                dim1: { value: { raw: 1, formatted: '1' } },
+                dim2: { value: { raw: false, formatted: 'false' } },
+                dim3: { value: { raw: 'value2', formatted: 'value2' } },
+                metric1: { value: { raw: 20, formatted: '20' } },
+                [tcFieldId]: { value: { raw: 200, formatted: '200' } },
+            },
+            {
+                dim1: { value: { raw: 3, formatted: '1' } },
+                dim2: { value: { raw: true, formatted: 'yes' } },
+                dim3: { value: { raw: 'value1', formatted: 'value1' } },
+                metric1: { value: { raw: 30, formatted: '30' } },
+                [tcFieldId]: { value: { raw: 300, formatted: '300' } },
+            },
+        ];
+
+        const result = getPivotedData(
+            rowsWithTc,
+            // pivot on dim2
+            ['dim2'],
+            // yFields: only metric1 — TC is intentionally excluded
+            ['metric1'],
+            // nonPivoted dimensions: only dim1 — TC is intentionally
+            // excluded here too. This is the exact scenario from #19252.
+            ['dim1'],
+        );
+
+        // The TC field is neither pivoted nor preserved as an index col;
+        // it must be silently dropped so stacking treats only the yField
+        // as a stack member.
+        result.rows.forEach((row) => {
+            Object.keys(row).forEach((key) => {
+                expect(key).not.toContain(tcFieldId);
+            });
+        });
+
+        // rowKeyMap also has no entry for the TC — neither bare nor as a
+        // PivotReference.field — guarding the second pathway by which the
+        // TC could leak back into stack groupings.
+        Object.entries(result.rowKeyMap).forEach(([hashedKey, value]) => {
+            expect(hashedKey).not.toContain(tcFieldId);
+            if (typeof value !== 'string') {
+                expect(value.field).not.toBe(tcFieldId);
+            }
+        });
+
+        // Sanity: the metric IS pivoted (the bug only matters when the
+        // pivot pipeline is active).
+        const pivotedKeys = Object.keys(result.rowKeyMap).filter(
+            (k) => k !== 'dim1',
+        );
+        expect(pivotedKeys.length).toBeGreaterThan(0);
+        pivotedKeys.forEach((k) => expect(k).toContain('metric1'));
+    });
 });

--- a/packages/frontend/src/hooks/useExplorerQuery.test.tsx
+++ b/packages/frontend/src/hooks/useExplorerQuery.test.tsx
@@ -5,6 +5,12 @@ import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createExplorerStore } from '../features/explorer/store';
 import { useExplorerQuery } from './useExplorerQuery';
+import { useExplorerQueryManager } from './useExplorerQueryManager';
+import {
+    executeQueryAndWaitForResults,
+    useCancelQuery,
+} from './useQueryResults';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
 
 // Mock the hooks that depend on external APIs
 vi.mock('./useExplore', () => ({
@@ -35,6 +41,58 @@ vi.mock('../providers/Explorer/useQueryExecutor', () => ({
     ]),
 }));
 
+vi.mock('./useExplorerQueryManager', () => ({
+    useExplorerQueryManager: vi.fn(),
+}));
+
+vi.mock('./useQueryResults', () => ({
+    executeQueryAndWaitForResults: vi.fn(),
+    useCancelQuery: vi.fn(() => ({ mutate: vi.fn() })),
+}));
+
+type ManagerMock = ReturnType<typeof useExplorerQueryManager>;
+
+const buildManagerMock = (overrides: Partial<ManagerMock> = {}): ManagerMock =>
+    ({
+        query: { isFetched: false, isFetching: false },
+        queryResults: {
+            queryUuid: null,
+            totalResults: 0,
+            isFetchingFirstPage: false,
+            isFetchingAllPages: false,
+            error: null,
+        },
+        unpivotedQuery: { isFetched: false, isFetching: false },
+        unpivotedQueryResults: {
+            queryUuid: null,
+            totalResults: 0,
+            isFetchingFirstPage: false,
+            isFetchingAllPages: false,
+            error: null,
+        },
+        isLoading: false,
+        activeFields: new Set<string>(),
+        missingRequiredParameters: null,
+        validQueryArgs: null,
+        tableName: '',
+        projectUuid: 'p',
+        explore: null,
+        computedMetricQuery: {
+            exploreName: '',
+            dimensions: [],
+            metrics: [],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+            customDimensions: [],
+        },
+        parameters: {},
+        runQuery: vi.fn(),
+        ...overrides,
+    }) as unknown as ManagerMock;
+
 const createWrapper = () => {
     const queryClient = new QueryClient({
         defaultOptions: {
@@ -56,6 +114,16 @@ const createWrapper = () => {
 describe('useExplorerQuery', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.mocked(useExplorerQueryManager).mockReturnValue(buildManagerMock());
+        vi.mocked(executeQueryAndWaitForResults).mockResolvedValue({
+            queryUuid: 'download-uuid',
+        } as never);
+        vi.mocked(useCancelQuery).mockReturnValue({
+            mutate: vi.fn(),
+        } as never);
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: { enabled: false },
+        } as never);
     });
 
     it('should return query state and actions', () => {
@@ -95,5 +163,141 @@ describe('useExplorerQuery', () => {
         });
 
         expect(result.current.validQueryArgs).toBeNull();
+    });
+
+    describe('getDownloadQueryUuid pivotConfiguration leak (#19117)', () => {
+        // https://github.com/lightdash/lightdash/issues/19117 / PR #19115
+        // Repro: with USE_SQL_PIVOT_RESULTS enabled and a chart that has a
+        // pivotConfiguration in validQueryArgs, calling Download CSV with
+        // exportPivotedResults=false used to spread pivotConfiguration into
+        // the download query — producing CSVs with empty columns where
+        // pivoted dimensions used to be.
+        // Expectation: when exportPivotedResults is false, the download
+        // query payload must explicitly set pivotConfiguration to undefined
+        // (and pivotResults to false), regardless of what validQueryArgs
+        // carries. The fix is a 6-line ternary; trivial to revert via
+        // refactor that re-enables `...validQueryArgs` spread without the
+        // override.
+        const pivotConfiguration = {
+            indexColumn: { reference: 'date', type: 'time' },
+            valuesColumns: [{ reference: 'revenue', aggregation: 'sum' }],
+            groupByColumns: [{ reference: 'category' }],
+            sortBy: undefined,
+        };
+        const validQueryArgs = {
+            projectUuid: 'p',
+            tableId: 'orders',
+            query: { dimensions: [], metrics: [], filters: {} },
+            pivotResults: true,
+            pivotConfiguration,
+        } as never;
+
+        it('omits pivotConfiguration from the download query when exportPivotedResults is false', async () => {
+            vi.mocked(useExplorerQueryManager).mockReturnValue(
+                buildManagerMock({
+                    validQueryArgs,
+                    queryResults: {
+                        queryUuid: 'current-uuid',
+                        totalResults: 100,
+                        isFetchingFirstPage: false,
+                        isFetchingAllPages: false,
+                        error: null,
+                    } as never,
+                }),
+            );
+            // USE_SQL_PIVOT_RESULTS feature flag enabled — the worst-case
+            // path where the leak manifested in production.
+            vi.mocked(useServerFeatureFlag).mockReturnValue({
+                data: { enabled: true },
+            } as never);
+
+            const { result } = renderHook(() => useExplorerQuery(), {
+                wrapper: createWrapper(),
+            });
+
+            // Force a new query (limit !== totalResults) so the function
+            // calls executeQueryAndWaitForResults rather than reusing the
+            // existing queryUuid.
+            await result.current.getDownloadQueryUuid(50, false);
+
+            expect(executeQueryAndWaitForResults).toHaveBeenCalledTimes(1);
+            const callArg = vi.mocked(executeQueryAndWaitForResults).mock
+                .calls[0][0];
+            expect(callArg).not.toBeNull();
+
+            // The leak prevention: pivotConfiguration must be explicitly
+            // undefined, NOT spread from validQueryArgs.
+            expect(callArg).toHaveProperty('pivotConfiguration', undefined);
+            expect(callArg).toHaveProperty('pivotResults', false);
+            // csvLimit was actually applied so we know we hit the new-query
+            // path, not the queryUuid-reuse path.
+            expect(callArg).toHaveProperty('csvLimit', 50);
+        });
+
+        it('preserves pivotConfiguration in the download query when exportPivotedResults is true and the SQL pivot flag is enabled', async () => {
+            vi.mocked(useExplorerQueryManager).mockReturnValue(
+                buildManagerMock({
+                    validQueryArgs,
+                    queryResults: {
+                        queryUuid: 'current-uuid',
+                        totalResults: 100,
+                        isFetchingFirstPage: false,
+                        isFetchingAllPages: false,
+                        error: null,
+                    } as never,
+                }),
+            );
+            vi.mocked(useServerFeatureFlag).mockReturnValue({
+                data: { enabled: true },
+            } as never);
+
+            const { result } = renderHook(() => useExplorerQuery(), {
+                wrapper: createWrapper(),
+            });
+
+            await result.current.getDownloadQueryUuid(50, true);
+
+            expect(executeQueryAndWaitForResults).toHaveBeenCalledTimes(1);
+            const callArg = vi.mocked(executeQueryAndWaitForResults).mock
+                .calls[0][0];
+            expect(callArg).toMatchObject({
+                pivotResults: true,
+                pivotConfiguration,
+                csvLimit: 50,
+            });
+        });
+
+        it('omits pivotConfiguration when SQL pivot flag is disabled even if exportPivotedResults is requested', async () => {
+            // shouldPivot = exportPivotedResults && useSqlPivotResults.enabled.
+            // Locks the second half of that ternary — flag-off should also
+            // strip the configuration.
+            vi.mocked(useExplorerQueryManager).mockReturnValue(
+                buildManagerMock({
+                    validQueryArgs,
+                    queryResults: {
+                        queryUuid: 'current-uuid',
+                        totalResults: 100,
+                        isFetchingFirstPage: false,
+                        isFetchingAllPages: false,
+                        error: null,
+                    } as never,
+                }),
+            );
+            vi.mocked(useServerFeatureFlag).mockReturnValue({
+                data: { enabled: false },
+            } as never);
+
+            const { result } = renderHook(() => useExplorerQuery(), {
+                wrapper: createWrapper(),
+            });
+
+            await result.current.getDownloadQueryUuid(50, true);
+
+            expect(executeQueryAndWaitForResults).toHaveBeenCalledTimes(1);
+            const callArg = vi.mocked(executeQueryAndWaitForResults).mock
+                .calls[0][0];
+            expect(callArg).toHaveProperty('pivotConfiguration', undefined);
+            expect(callArg).toHaveProperty('pivotResults', false);
+        });
     });
 });


### PR DESCRIPTION
## Summary

Re-applies #22479 on top of current `main`. #22479 was reverted in #22622 only as collateral damage when reverting #22458 — the actual #22479 fix and its regression-lock test suite were behaviorally unrelated to the customer-reported bug.

**Production code (1 line)**: adds the `sort.fieldId !== xField` guard to the metric/TC arm of `sortOnlyMetrics` in `derivePivotConfigFromChart.ts`. Mirrors the existing dimension arm so the x-axis is protected when it's a TC sorted by itself (locked by the existing "keeps x-axis table calculation as an index column when sorted by itself" test).

**Test suite (~2,270 lines)**: restores all named regression-lock tests anchored to GitHub issues — #16871, #17018, #9767/#11038, #19838, #20683, #20681, #19202, #19509, #21965, #18064, #19767, #18245, #20566, #16866, #19117, #19252, #14187, #12560, #19509-column-side, plus PROD-2927.

## Refit notes (vs. the original #22479)

- The 1-line fix is mapped onto the post-#22622 `sortOnlyMetrics` filter shape (not the post-#22458 `sortOnlyColumns` flatMap shape, which no longer exists).
- Two literal-SQL assertions updated to match the post-#22569 NULL-safe join shape (`OR (col IS NULL AND col IS NULL)`):
  - Databricks self-contained ranking CTEs (#20681) — `row_ranking … LEFT JOIN ON …` literal updated; mock Databricks builder gained `getNullSafeEqualSql: defaultNullSafeEqualSql` so the metric-anchor pipeline can emit the null-safe predicate.
  - Metric sort orders rows by leftmost anchor column (#19509) — `MAX(CASE WHEN…)` literal updated to the null-safe equality form.
- The intent of every regression test is preserved.

## Test plan

- [x] `pnpm -F common test derivePivotConfigFromChart pivotResultsAsCsv pivotQueryResults` — 48 tests pass
- [x] `pnpm -F backend test PivotQueryBuilder SubtotalsCalculator` — 117 tests pass
- [x] `pnpm -F frontend test ChartDataTable.test useCartesianChartConfig getPlottedData useExplorerQuery` — 55 tests pass
- [x] `pnpm -F common typecheck` / `pnpm -F backend typecheck` / `pnpm -F frontend typecheck` — clean
- [x] `pnpm -F common lint` / `pnpm -F backend lint` / `pnpm -F frontend lint` — clean
- [ ] Manual: chart with TC on x-axis sorted by itself renders with TC as index column, not stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)