### PR TITLE
fix(unfurl): per-tile readiness diagnostics for screenshot timeouts

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -41,7 +41,7 @@ import * as fsPromise from 'fs/promises';
 import { uniq } from 'lodash';
 import { nanoid as useNanoid } from 'nanoid';
 import fetch from 'node-fetch';
-import playwright, { type ElementHandle } from 'playwright';
+import playwright, { type ElementHandle, type Page } from 'playwright';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { SlackClient } from '../../clients/Slack/SlackClient';
@@ -777,6 +777,64 @@ export class UnfurlService extends BaseService {
         return unfurlImage.imageUrl;
     }
 
+    /**
+     * Reads the always-mounted #lightdash-screenshot-progress element and
+     * logs which tile UUIDs are still unaccounted for, so that on
+     * #lightdash-ready-indicator timeouts we can identify the specific
+     * tile(s) blocking the screenshot.
+     *
+     * Best-effort: never throws. If the element is absent the page either
+     * never mounted the React tree (e.g. JS module-init crash) or pre-dates
+     * the progress indicator deploy, both of which are logged distinctly.
+     */
+    private async logUnreadyTilesOnTimeout(
+        page: Page,
+        url: string,
+        unfurlId: string,
+    ): Promise<void> {
+        try {
+            const progress = await page.evaluate((selector) => {
+                const el = document.querySelector(selector);
+                if (!el) return null;
+                const parse = (attr: string): string[] => {
+                    try {
+                        const v = el.getAttribute(attr);
+                        return v ? (JSON.parse(v) as string[]) : [];
+                    } catch {
+                        return [];
+                    }
+                };
+                return {
+                    expected: parse('data-tiles-expected'),
+                    ready: parse('data-tiles-ready'),
+                    errored: parse('data-tiles-errored'),
+                };
+            }, SCREENSHOT_SELECTORS.PROGRESS_INDICATOR);
+
+            if (!progress) {
+                this.logger.error(
+                    `Screenshot ready timeout: progress indicator not in DOM. The frontend likely never mounted (JS module-init failure or pre-deploy build) - unfurlId: ${unfurlId}, url: ${url}`,
+                );
+                return;
+            }
+
+            const accounted = new Set([...progress.ready, ...progress.errored]);
+            const unready = progress.expected.filter(
+                (tileUuid) => !accounted.has(tileUuid),
+            );
+
+            this.logger.error(
+                `Screenshot ready timeout: ${unready.length}/${progress.expected.length} tiles never reported ready or errored - unfurlId: ${unfurlId}, url: ${url}, unreadyTileUuids: ${JSON.stringify(unready)}, expectedTileUuids: ${JSON.stringify(progress.expected)}, readyTileUuids: ${JSON.stringify(progress.ready)}, erroredTileUuids: ${JSON.stringify(progress.errored)}`,
+            );
+        } catch (probeError) {
+            this.logger.warn(
+                `Failed to probe screenshot progress indicator on timeout - unfurlId: ${unfurlId}, url: ${url}, error: ${getErrorMessage(
+                    probeError,
+                )}`,
+            );
+        }
+    }
+
     private async saveScreenshot({
         imageId,
         cookie,
@@ -1264,17 +1322,28 @@ export class UnfurlService extends BaseService {
                         );
                     }
 
-                    this.logger.info('Waiting for screenshot ready indicator');
-                    await page.waitForSelector(
-                        SCREENSHOT_SELECTORS.READY_INDICATOR,
-                        {
-                            state: 'attached',
-                            timeout: RESPONSE_TIMEOUT_MS,
-                        },
-                    );
                     this.logger.info(
-                        'Screenshot ready indicator found - page is ready',
+                        `Waiting for screenshot ready indicator - unfurlId: ${imageId}`,
                     );
+                    try {
+                        await page.waitForSelector(
+                            SCREENSHOT_SELECTORS.READY_INDICATOR,
+                            {
+                                state: 'attached',
+                                timeout: RESPONSE_TIMEOUT_MS,
+                            },
+                        );
+                        this.logger.info(
+                            `Screenshot ready indicator found - page is ready - unfurlId: ${imageId}`,
+                        );
+                    } catch (waitError) {
+                        // Probe the always-mounted progress indicator to find
+                        // out which tiles never reported ready/errored. Logged
+                        // before re-throwing so callers (and retries) can see
+                        // exactly which tile is blocking the indicator.
+                        await this.logUnreadyTilesOnTimeout(page, url, imageId);
+                        throw waitError;
+                    }
 
                     // Auto-detect CJK language from page content and set
                     // <html lang="..."> so CSS :lang() rules select the

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -793,22 +793,35 @@ export class UnfurlService extends BaseService {
         unfurlId: string,
     ): Promise<void> {
         try {
+            // Inline JSON parsing instead of a named inner helper — esbuild's
+            // keep-names option (used by tsx in dev) wraps named consts with
+            // __name(...), which fails in the browser context where __name
+            // is undefined. Inline arrow function args don't get this wrapping.
             const progress = await page.evaluate((selector) => {
                 const el = document.querySelector(selector);
                 if (!el) return null;
-                const parse = (attr: string): string[] => {
-                    try {
-                        const v = el.getAttribute(attr);
-                        return v ? (JSON.parse(v) as string[]) : [];
-                    } catch {
-                        return [];
-                    }
-                };
-                return {
-                    expected: parse('data-tiles-expected'),
-                    ready: parse('data-tiles-ready'),
-                    errored: parse('data-tiles-errored'),
-                };
+                const expected: string[] = [];
+                const ready: string[] = [];
+                const errored: string[] = [];
+                try {
+                    const v = el.getAttribute('data-tiles-expected');
+                    if (v) expected.push(...(JSON.parse(v) as string[]));
+                } catch {
+                    /* ignore malformed attribute */
+                }
+                try {
+                    const v = el.getAttribute('data-tiles-ready');
+                    if (v) ready.push(...(JSON.parse(v) as string[]));
+                } catch {
+                    /* ignore malformed attribute */
+                }
+                try {
+                    const v = el.getAttribute('data-tiles-errored');
+                    if (v) errored.push(...(JSON.parse(v) as string[]));
+                } catch {
+                    /* ignore malformed attribute */
+                }
+                return { expected, ready, errored };
             }, SCREENSHOT_SELECTORS.PROGRESS_INDICATOR);
 
             if (!progress) {
@@ -1055,20 +1068,25 @@ export class UnfurlService extends BaseService {
                         if (type === 'error') {
                             const location = msg.location();
                             const text = msg.text();
-                            // Suppress known-benign noise (Google Fonts CORS,
-                            // CSP report-only directives) so real JS errors
-                            // dominate the error stream.
+                            // Match across both the message text and the
+                            // resource URL: Chrome puts the URL in
+                            // location.url for resource-fetch failures
+                            // ("Failed to load resource: net::ERR_FAILED")
+                            // and in text for CORS rejections
+                            // ("Access to font at '...' has been blocked").
+                            const surface = `${location.url} ${text}`;
+                            // Suppress known-benign noise (Google Fonts
+                            // CORS/fetch failures, CSP report-only
+                            // directives) so real JS errors dominate the
+                            // error stream.
                             const isBenign =
                                 /upgrade-insecure-requests.*report-only/i.test(
-                                    text,
+                                    surface,
                                 ) ||
                                 /Cross-Origin-Opener-Policy.*ignored/i.test(
-                                    text,
+                                    surface,
                                 ) ||
-                                /fonts\.gstatic\.com.*ERR_FAILED/i.test(text) ||
-                                /Failed to load resource: net::ERR_FAILED.*fonts\.gstatic\.com/i.test(
-                                    text,
-                                );
+                                /fonts\.gstatic\.com/i.test(surface);
 
                             if (isBenign) {
                                 this.logger.debug(

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1053,11 +1053,32 @@ export class UnfurlService extends BaseService {
                     page.on('console', (msg) => {
                         const type = msg.type();
                         if (type === 'error') {
-                            this.logger.warn(
-                                `Headless browser console error - file: ${
-                                    msg.location().url
-                                }, text ${msg.text()}`,
-                            );
+                            const location = msg.location();
+                            const text = msg.text();
+                            // Suppress known-benign noise (Google Fonts CORS,
+                            // CSP report-only directives) so real JS errors
+                            // dominate the error stream.
+                            const isBenign =
+                                /upgrade-insecure-requests.*report-only/i.test(
+                                    text,
+                                ) ||
+                                /Cross-Origin-Opener-Policy.*ignored/i.test(
+                                    text,
+                                ) ||
+                                /fonts\.gstatic\.com.*ERR_FAILED/i.test(text) ||
+                                /Failed to load resource: net::ERR_FAILED.*fonts\.gstatic\.com/i.test(
+                                    text,
+                                );
+
+                            if (isBenign) {
+                                this.logger.debug(
+                                    `Headless browser console error (benign) - file: ${location.url}, text: ${text}`,
+                                );
+                            } else {
+                                this.logger.error(
+                                    `Headless browser console error - unfurlId: ${imageId}, pageUrl: ${url}, file: ${location.url}:${location.lineNumber}:${location.columnNumber}, text: ${text}`,
+                                );
+                            }
                         }
                     });
 
@@ -1548,7 +1569,7 @@ export class UnfurlService extends BaseService {
                         this.logger.info(
                             `Retrying screenshot (attempt ${retryCount + 2}/${
                                 maxRetries + 1
-                            }) after ${delay}ms for url ${url}, type: ${lightdashPage}. Error: ${getErrorMessage(
+                            }) after ${delay}ms for url ${url}, type: ${lightdashPage}, unfurlId: ${imageId}. Error: ${getErrorMessage(
                                 e,
                             )}`,
                         );
@@ -1591,7 +1612,7 @@ export class UnfurlService extends BaseService {
                     hasError = true;
 
                     this.logger.error(
-                        `Unable to fetch screenshots for scheduler with url ${url}, of type: ${lightdashPage}. Message: ${getErrorMessage(
+                        `Unable to fetch screenshots for scheduler with url ${url}, of type: ${lightdashPage}, unfurlId: ${imageId}. Message: ${getErrorMessage(
                             e,
                         )}`,
                     );
@@ -1634,7 +1655,7 @@ export class UnfurlService extends BaseService {
 
                     const executionTime = Date.now() - startTime;
                     this.logger.info(
-                        `UnfurlService saveScreenshot took ${executionTime} ms`,
+                        `UnfurlService saveScreenshot took ${executionTime} ms - unfurlId: ${imageId}`,
                     );
                 }
             },

--- a/packages/common/src/constants/screenshot.ts
+++ b/packages/common/src/constants/screenshot.ts
@@ -16,6 +16,25 @@
 export const SCREENSHOT_READY_INDICATOR_ID = 'lightdash-ready-indicator';
 
 /**
+ * ID of an element that is always mounted on minimal pages and exposes the
+ * current screenshot progress: which tiles are expected, ready, and errored.
+ *
+ * Unlike SCREENSHOT_READY_INDICATOR_ID, this element exists from first paint
+ * so the UnfurlService can read it on timeout to identify which tile UUIDs
+ * are still unaccounted for.
+ *
+ * Data attributes:
+ * - data-tiles-expected: JSON array of tile UUIDs expected to render
+ * - data-tiles-ready:    JSON array of tile UUIDs that called markTileScreenshotReady
+ * - data-tiles-errored:  JSON array of tile UUIDs that called markTileScreenshotErrored
+ *
+ * Usage:
+ * - Frontend: Rendered by ScreenshotProgressIndicator on minimal pages
+ * - Backend:  Read by UnfurlService when waitForSelector(READY_INDICATOR) times out
+ */
+export const SCREENSHOT_PROGRESS_INDICATOR_ID = 'lightdash-screenshot-progress';
+
+/**
  * Class name for tile loading skeleton overlays.
  * The UnfurlService waits for these elements to be hidden (loading complete).
  *
@@ -82,6 +101,8 @@ export const LOGIN_PAGE_ID = 'lightdash-login-page';
 export const SCREENSHOT_SELECTORS = {
     /** ID selector: #lightdash-ready-indicator */
     READY_INDICATOR: `#${SCREENSHOT_READY_INDICATOR_ID}`,
+    /** ID selector: #lightdash-screenshot-progress */
+    PROGRESS_INDICATOR: `#${SCREENSHOT_PROGRESS_INDICATOR_ID}`,
     /** Class selector: .loading_chart_overlay */
     LOADING_OVERLAY: `.${LOADING_CHART_OVERLAY_CLASS}`,
     /** Class selector: .loading_chart */

--- a/packages/frontend/src/components/common/ScreenshotProgressIndicator.tsx
+++ b/packages/frontend/src/components/common/ScreenshotProgressIndicator.tsx
@@ -1,0 +1,33 @@
+import { SCREENSHOT_PROGRESS_INDICATOR_ID } from '@lightdash/common';
+import { type FC } from 'react';
+
+type ScreenshotProgressIndicatorProps = {
+    expectedTileUuids: string[];
+    readyTileUuids: string[];
+    erroredTileUuids: string[];
+};
+
+/**
+ * Hidden DOM element that exposes screenshot readiness *progress* — which
+ * tiles are expected, ready, and errored — at any point during rendering.
+ *
+ * Unlike ScreenshotReadyIndicator (which only mounts once everything is
+ * ready), this is mounted from first paint so the UnfurlService can read
+ * it on timeout to identify which tiles never reported ready/errored.
+ */
+const ScreenshotProgressIndicator: FC<ScreenshotProgressIndicatorProps> = ({
+    expectedTileUuids,
+    readyTileUuids,
+    erroredTileUuids,
+}) => (
+    <div
+        id={SCREENSHOT_PROGRESS_INDICATOR_ID}
+        data-tiles-expected={JSON.stringify(expectedTileUuids)}
+        data-tiles-ready={JSON.stringify(readyTileUuids)}
+        data-tiles-errored={JSON.stringify(erroredTileUuids)}
+        style={{ display: 'none' }}
+        aria-hidden="true"
+    />
+);
+
+export default ScreenshotProgressIndicator;

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -15,6 +15,7 @@ import { IconLayoutDashboard } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useParams } from 'react-router';
+import ScreenshotProgressIndicator from '../components/common/ScreenshotProgressIndicator';
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ChartTile from '../components/DashboardTiles/DashboardChartTile';
@@ -80,6 +81,15 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
     );
     const screenshotErroredTilesCount = useDashboardTileStatusContext(
         (c) => c.screenshotErroredTilesCount,
+    );
+    const expectedScreenshotTileUuids = useDashboardTileStatusContext(
+        (c) => c.expectedScreenshotTileUuids,
+    );
+    const screenshotReadyTileUuids = useDashboardTileStatusContext(
+        (c) => c.screenshotReadyTileUuids,
+    );
+    const screenshotErroredTileUuids = useDashboardTileStatusContext(
+        (c) => c.screenshotErroredTileUuids,
     );
 
     useEffect(() => {
@@ -175,6 +185,11 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
                 </ResponsiveGridLayout>
             )}
 
+            <ScreenshotProgressIndicator
+                expectedTileUuids={expectedScreenshotTileUuids}
+                readyTileUuids={screenshotReadyTileUuids}
+                erroredTileUuids={screenshotErroredTileUuids}
+            />
             {isReadyForScreenshot && (
                 <ScreenshotReadyIndicator
                     tilesTotal={expectedScreenshotTilesCount}

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -3,6 +3,7 @@ import { useElementSize } from '@mantine/hooks';
 import { memo, useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
+import ScreenshotProgressIndicator from '../components/common/ScreenshotProgressIndicator';
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
 import LightdashVisualization from '../components/LightdashVisualization';
 import VisualizationProvider from '../components/LightdashVisualization/VisualizationProvider';
@@ -128,6 +129,19 @@ const MinimalExplorerContent = memo(() => {
                     </Box>
                 </MantineProvider>
 
+                <ScreenshotProgressIndicator
+                    expectedTileUuids={[savedChart.uuid]}
+                    readyTileUuids={
+                        isScreenshotReady && !hasQueryError
+                            ? [savedChart.uuid]
+                            : []
+                    }
+                    erroredTileUuids={
+                        isScreenshotReady && hasQueryError
+                            ? [savedChart.uuid]
+                            : []
+                    }
+                />
                 {isScreenshotReady && (
                     <ScreenshotReadyIndicator
                         tilesTotal={1}

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -288,6 +288,9 @@ const DashboardTileStatusProvider: React.FC<
             screenshotReadyTilesCount: screenshotReadyTiles.size,
             screenshotErroredTilesCount: screenshotErroredTiles.size,
             expectedScreenshotTilesCount: expectedScreenshotTileUuids.length,
+            expectedScreenshotTileUuids,
+            screenshotReadyTileUuids: Array.from(screenshotReadyTiles),
+            screenshotErroredTileUuids: Array.from(screenshotErroredTiles),
         }),
         [
             oldestCacheTime,
@@ -308,9 +311,9 @@ const DashboardTileStatusProvider: React.FC<
             markTileScreenshotReady,
             markTileScreenshotErrored,
             isReadyForScreenshot,
-            screenshotReadyTiles.size,
-            screenshotErroredTiles.size,
-            expectedScreenshotTileUuids.length,
+            screenshotReadyTiles,
+            screenshotErroredTiles,
+            expectedScreenshotTileUuids,
         ],
     );
 

--- a/packages/frontend/src/providers/Dashboard/tileStatusTypes.ts
+++ b/packages/frontend/src/providers/Dashboard/tileStatusTypes.ts
@@ -35,4 +35,7 @@ export type DashboardTileStatusContextType = {
     screenshotReadyTilesCount: number;
     screenshotErroredTilesCount: number;
     expectedScreenshotTilesCount: number;
+    expectedScreenshotTileUuids: string[];
+    screenshotReadyTileUuids: string[];
+    screenshotErroredTileUuids: string[];
 };


### PR DESCRIPTION
## Summary

When a scheduled-delivery / Slack-unfurl screenshot times out waiting for `#lightdash-ready-indicator`, we currently only know *that* it timed out — not *which* tile blocked it. This branch surfaces the missing information end-to-end:

- A new always-mounted hidden `#lightdash-screenshot-progress` element on `MinimalDashboard` and `MinimalSavedExplorer` exposes `data-tiles-expected/ready/errored` JSON arrays of tile UUIDs.
- The `UnfurlService` reads it on `waitForSelector` timeout and logs the unaccounted-for tile UUIDs alongside the existing error.
- All unfurl log lines now include `unfurlId:` so per-screenshot logs can be correlated when multiple deliveries run in parallel.
- Known-benign console noise (Google Fonts CORS/fetch failures, CSP report-only directives, COOP) is dropped to `debug` so real JS errors stand out.
- `DashboardTileStatusProvider` exposes the UUID arrays (not just counts) needed for the indicator.

Linear: PROD-3041.

## What changed

- **Backend** — `UnfurlService.ts`: new `logUnreadyTilesOnTimeout()` that probes the progress indicator via `page.evaluate`; benign-error suppression on the `console` listener; `unfurlId:` added to wait/found/took/retry/error log lines.
- **Frontend** — new `ScreenshotProgressIndicator` hidden div mounted from first paint on both minimal pages; `DashboardTileStatusProvider` now exposes `expectedScreenshotTileUuids` / `screenshotReadyTileUuids` / `screenshotErroredTileUuids` arrays.
- **Common** — new `SCREENSHOT_PROGRESS_INDICATOR_ID` constant + selector.

## Test plan

Manual via the `/test-plan` skill (`test-plan-prod-3041.md`):

- [x] DOM contract on MinimalDashboard — `expected` populated from first paint, `ready ⊆ expected ∪ errored` after `#lightdash-ready-indicator` attaches.
- [x] DOM contract on MinimalSavedExplorer — `expected = [chartUuid]` from first paint, populates correctly.
- [x] Happy-path scheduled delivery — screenshot succeeds in ~10s, every relevant log line carries `unfurlId:`, gstatic font CORS / fetch failures now logged at `debug (benign)` and 0 remain at `error`.
- [x] Forced timeout (`RESPONSE_TIMEOUT_MS=100ms`) — diagnostic line `Screenshot ready timeout: N/M tiles never reported ready or errored - unfurlId: ..., unreadyTileUuids: [...], expectedTileUuids: [...], readyTileUuids: [], erroredTileUuids: []` produced with correct UUIDs and set arithmetic.
- [x] No re-render loop from the new context memo deps — `0` mutations on either indicator and stable DOM element count over 5s idle on a fully-loaded MinimalDashboard.

## Notes for reviewers

- The wire protocol between frontend (data attributes) and backend (`page.evaluate`) is implicit; both halves must move together. `SCREENSHOT_PROGRESS_INDICATOR_ID` and `SCREENSHOT_SELECTORS.PROGRESS_INDICATOR` in `@lightdash/common` are the single source of truth.
- `logUnreadyTilesOnTimeout` is best-effort: inner `try/catch` for malformed JSON, outer `try/catch` so a probe failure can never crash the retry loop. The probe deliberately uses inline arrow-function args (no named inner helpers) to avoid esbuild's `keepNames` injecting `__name(...)` into the page-evaluate payload — that fails in the browser context where `__name` is undefined.
- The benign-error regex matches `${location.url} ${text}` together because Chrome serializes resource-fetch failures with the URL in `location.url` and CORS rejections with the URL in `text` — testing only `text` (an earlier iteration) silently missed half the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)