### PR TITLE
feat(timezone): consult disableTimestampConversion in shouldSkipTimezoneConversion

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3105,6 +3105,15 @@ export class ProjectService extends BaseService {
         return { explore, dateZoomApplied: false };
     }
 
+    private static getSnowflakeDisableConvertTimezoneWrap(
+        credentials: CreateWarehouseCredentials,
+    ): boolean {
+        return (
+            credentials.type === WarehouseTypes.SNOWFLAKE &&
+            credentials.disableTimestampConversion === true
+        );
+    }
+
     static async _compileQuery({
         metricQuery,
         explore,
@@ -3120,7 +3129,7 @@ export class ProjectService extends BaseService {
         continueOnError,
         useTimezoneAwareDateTrunc,
         dataTimezone,
-        whSkipUtcNormalization,
+        snowflakeDisableConvertTimezoneWrap,
     }: {
         metricQuery: MetricQuery;
         explore: Explore;
@@ -3136,7 +3145,7 @@ export class ProjectService extends BaseService {
         continueOnError?: boolean;
         useTimezoneAwareDateTrunc?: boolean;
         dataTimezone?: string;
-        whSkipUtcNormalization?: boolean;
+        snowflakeDisableConvertTimezoneWrap?: boolean;
     }): Promise<CompiledQuery> {
         const availableParameters = Object.keys(availableParameterDefinitions);
 
@@ -3171,7 +3180,7 @@ export class ProjectService extends BaseService {
             originalExplore: dateZoom ? explore : undefined,
             useTimezoneAwareDateTrunc,
             dataTimezone,
-            whSkipUtcNormalization,
+            snowflakeDisableConvertTimezoneWrap,
         });
 
         return wrapSentryTransactionSync('QueryBuilder.buildQuery', {}, () =>
@@ -3311,9 +3320,10 @@ export class ProjectService extends BaseService {
             continueOnError: true, // Return SQL even with compilation errors for debugging
             useTimezoneAwareDateTrunc,
             dataTimezone: warehouseCredentials.dataTimezone,
-            whSkipUtcNormalization:
-                warehouseCredentials.type === WarehouseTypes.SNOWFLAKE &&
-                warehouseCredentials.disableTimestampConversion,
+            snowflakeDisableConvertTimezoneWrap:
+                ProjectService.getSnowflakeDisableConvertTimezoneWrap(
+                    warehouseCredentials,
+                ),
         });
 
         // Generate pivot query if pivot configuration is provided
@@ -4308,11 +4318,10 @@ export class ProjectService extends BaseService {
                         pivotDimensions: metricQueryWithLimit.pivotDimensions,
                         useTimezoneAwareDateTrunc,
                         dataTimezone: warehouseClient.credentials.dataTimezone,
-                        whSkipUtcNormalization:
-                            warehouseClient.credentials.type ===
-                                WarehouseTypes.SNOWFLAKE &&
-                            warehouseClient.credentials
-                                .disableTimestampConversion,
+                        snowflakeDisableConvertTimezoneWrap:
+                            ProjectService.getSnowflakeDisableConvertTimezoneWrap(
+                                warehouseClient.credentials,
+                            ),
                     });
 
                     const { query } = fullQuery;
@@ -4882,9 +4891,10 @@ export class ProjectService extends BaseService {
             availableParameterDefinitions,
             useTimezoneAwareDateTrunc,
             dataTimezone: warehouseClient.credentials.dataTimezone,
-            whSkipUtcNormalization:
-                warehouseClient.credentials.type === WarehouseTypes.SNOWFLAKE &&
-                warehouseClient.credentials.disableTimestampConversion,
+            snowflakeDisableConvertTimezoneWrap:
+                ProjectService.getSnowflakeDisableConvertTimezoneWrap(
+                    warehouseClient.credentials,
+                ),
         });
 
         const isUserCacheEnabled =

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3120,6 +3120,7 @@ export class ProjectService extends BaseService {
         continueOnError,
         useTimezoneAwareDateTrunc,
         dataTimezone,
+        whSkipUtcNormalization,
     }: {
         metricQuery: MetricQuery;
         explore: Explore;
@@ -3135,6 +3136,7 @@ export class ProjectService extends BaseService {
         continueOnError?: boolean;
         useTimezoneAwareDateTrunc?: boolean;
         dataTimezone?: string;
+        whSkipUtcNormalization?: boolean;
     }): Promise<CompiledQuery> {
         const availableParameters = Object.keys(availableParameterDefinitions);
 
@@ -3169,6 +3171,7 @@ export class ProjectService extends BaseService {
             originalExplore: dateZoom ? explore : undefined,
             useTimezoneAwareDateTrunc,
             dataTimezone,
+            whSkipUtcNormalization,
         });
 
         return wrapSentryTransactionSync('QueryBuilder.buildQuery', {}, () =>
@@ -3308,6 +3311,9 @@ export class ProjectService extends BaseService {
             continueOnError: true, // Return SQL even with compilation errors for debugging
             useTimezoneAwareDateTrunc,
             dataTimezone: warehouseCredentials.dataTimezone,
+            whSkipUtcNormalization:
+                warehouseCredentials.type === WarehouseTypes.SNOWFLAKE &&
+                warehouseCredentials.disableTimestampConversion,
         });
 
         // Generate pivot query if pivot configuration is provided
@@ -4302,6 +4308,11 @@ export class ProjectService extends BaseService {
                         pivotDimensions: metricQueryWithLimit.pivotDimensions,
                         useTimezoneAwareDateTrunc,
                         dataTimezone: warehouseClient.credentials.dataTimezone,
+                        whSkipUtcNormalization:
+                            warehouseClient.credentials.type ===
+                                WarehouseTypes.SNOWFLAKE &&
+                            warehouseClient.credentials
+                                .disableTimestampConversion,
                     });
 
                     const { query } = fullQuery;
@@ -4871,6 +4882,9 @@ export class ProjectService extends BaseService {
             availableParameterDefinitions,
             useTimezoneAwareDateTrunc,
             dataTimezone: warehouseClient.credentials.dataTimezone,
+            whSkipUtcNormalization:
+                warehouseClient.credentials.type === WarehouseTypes.SNOWFLAKE &&
+                warehouseClient.credentials.disableTimestampConversion,
         });
 
         const isUserCacheEnabled =

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -20,6 +20,7 @@ import {
 import {
     BuildQueryProps,
     CompiledQuery,
+    getEffectiveInputTimezone,
     getIntervalSyntax,
     MetricQueryBuilder,
 } from './MetricQueryBuilder';
@@ -5183,68 +5184,45 @@ describe('Timezone-aware EXTRACT-based time dimensions', () => {
         );
     });
 
-    describe('shouldSkipTimezoneConversion (via timezoneForDateTrunc)', () => {
-        const snowflakeWarehouseClient = {
-            ...warehouseClientMock,
-            getAdapterType: () => SupportedDbtAdapter.SNOWFLAKE,
-        };
-        const buildBuilder = (
-            overrides: Partial<BuildQueryProps>,
-        ): MetricQueryBuilder =>
-            new MetricQueryBuilder({
-                explore: buildExtractExplore(DimensionType.TIMESTAMP),
-                compiledMetricQuery: baseDowQuery(),
-                warehouseSqlBuilder: snowflakeWarehouseClient,
-                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                timezone: 'UTC',
-                parameterDefinitions: {},
-                useTimezoneAwareDateTrunc: true,
-                ...overrides,
-            });
-
-        // `timezoneForDateTrunc` returns undefined when the skip-check passes,
-        // and the project timezone otherwise. Used for DATE_TRUNC localization
-        // in PoP / custom-metric / filter dim resolution paths.
-        const tzForDateTrunc = (b: MetricQueryBuilder): string | undefined =>
-            (b as unknown as { timezoneForDateTrunc: string | undefined })
-                .timezoneForDateTrunc;
-
-        test('Snowflake + Layer 1 active + project tz === UTC → skip', () => {
-            expect(tzForDateTrunc(buildBuilder({ timezone: 'UTC' }))).toBe(
-                undefined,
-            );
-        });
-
-        test('Snowflake + Layer 1 active + project tz !== UTC → no skip', () => {
+    describe('getEffectiveInputTimezone (Snowflake)', () => {
+        test('default: input is UTC (compile-time wrap normalises)', () => {
             expect(
-                tzForDateTrunc(buildBuilder({ timezone: 'America/New_York' })),
-            ).toBe('America/New_York');
-        });
-
-        test('Snowflake + whSkipUtcNormalization + dataTimezone !== project tz → no skip', () => {
-            // Pre-fix this returned undefined (incorrectly skipped) — leaving
-            // non-UTC values to display as if they were UTC.
-            expect(
-                tzForDateTrunc(
-                    buildBuilder({
-                        timezone: 'UTC',
-                        dataTimezone: 'America/New_York',
-                        whSkipUtcNormalization: true,
-                    }),
+                getEffectiveInputTimezone(
+                    SupportedDbtAdapter.SNOWFLAKE,
+                    'America/New_York',
+                    undefined,
                 ),
             ).toBe('UTC');
         });
 
-        test('Snowflake + whSkipUtcNormalization + dataTimezone === project tz → skip', () => {
+        test('snowflakeDisableConvertTimezoneWrap: input is dataTimezone', () => {
             expect(
-                tzForDateTrunc(
-                    buildBuilder({
-                        timezone: 'America/New_York',
-                        dataTimezone: 'America/New_York',
-                        whSkipUtcNormalization: true,
-                    }),
+                getEffectiveInputTimezone(
+                    SupportedDbtAdapter.SNOWFLAKE,
+                    'America/New_York',
+                    true,
                 ),
-            ).toBe(undefined);
+            ).toBe('America/New_York');
+        });
+
+        test('snowflakeDisableConvertTimezoneWrap + no dataTimezone: falls back to UTC', () => {
+            expect(
+                getEffectiveInputTimezone(
+                    SupportedDbtAdapter.SNOWFLAKE,
+                    undefined,
+                    true,
+                ),
+            ).toBe('UTC');
+        });
+
+        test('non-Snowflake: input is dataTimezone (flag ignored)', () => {
+            expect(
+                getEffectiveInputTimezone(
+                    SupportedDbtAdapter.POSTGRES,
+                    'America/New_York',
+                    true,
+                ),
+            ).toBe('America/New_York');
         });
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -5182,4 +5182,69 @@ describe('Timezone-aware EXTRACT-based time dimensions', () => {
             `DATE_PART('WEEK', (("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York' - interval '2 days'))`,
         );
     });
+
+    describe('shouldSkipTimezoneConversion (via timezoneForDateTrunc)', () => {
+        const snowflakeWarehouseClient = {
+            ...warehouseClientMock,
+            getAdapterType: () => SupportedDbtAdapter.SNOWFLAKE,
+        };
+        const buildBuilder = (
+            overrides: Partial<BuildQueryProps>,
+        ): MetricQueryBuilder =>
+            new MetricQueryBuilder({
+                explore: buildExtractExplore(DimensionType.TIMESTAMP),
+                compiledMetricQuery: baseDowQuery(),
+                warehouseSqlBuilder: snowflakeWarehouseClient,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'UTC',
+                parameterDefinitions: {},
+                useTimezoneAwareDateTrunc: true,
+                ...overrides,
+            });
+
+        // `timezoneForDateTrunc` returns undefined when the skip-check passes,
+        // and the project timezone otherwise. Used for DATE_TRUNC localization
+        // in PoP / custom-metric / filter dim resolution paths.
+        const tzForDateTrunc = (b: MetricQueryBuilder): string | undefined =>
+            (b as unknown as { timezoneForDateTrunc: string | undefined })
+                .timezoneForDateTrunc;
+
+        test('Snowflake + Layer 1 active + project tz === UTC → skip', () => {
+            expect(tzForDateTrunc(buildBuilder({ timezone: 'UTC' }))).toBe(
+                undefined,
+            );
+        });
+
+        test('Snowflake + Layer 1 active + project tz !== UTC → no skip', () => {
+            expect(
+                tzForDateTrunc(buildBuilder({ timezone: 'America/New_York' })),
+            ).toBe('America/New_York');
+        });
+
+        test('Snowflake + whSkipUtcNormalization + dataTimezone !== project tz → no skip', () => {
+            // Pre-fix this returned undefined (incorrectly skipped) — leaving
+            // non-UTC values to display as if they were UTC.
+            expect(
+                tzForDateTrunc(
+                    buildBuilder({
+                        timezone: 'UTC',
+                        dataTimezone: 'America/New_York',
+                        whSkipUtcNormalization: true,
+                    }),
+                ),
+            ).toBe('UTC');
+        });
+
+        test('Snowflake + whSkipUtcNormalization + dataTimezone === project tz → skip', () => {
+            expect(
+                tzForDateTrunc(
+                    buildBuilder({
+                        timezone: 'America/New_York',
+                        dataTimezone: 'America/New_York',
+                        whSkipUtcNormalization: true,
+                    }),
+                ),
+            ).toBe(undefined);
+        });
+    });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -137,11 +137,23 @@ export type BuildQueryProps = {
     useTimezoneAwareDateTrunc?: boolean;
     /** Warehouse session timezone — used to skip wrapping when it matches queryTimezone. */
     dataTimezone?: string;
-    /**
-     * Snowflake-only: when true, the compile-time CONVERT_TIMEZONE wrap is
-     * disabled, so values flow through Layer 2 in `dataTimezone` rather than UTC.
-     */
-    whSkipUtcNormalization?: boolean;
+    /** Snowflake-only: skip the compile-time CONVERT_TIMEZONE-to-UTC wrap. */
+    snowflakeDisableConvertTimezoneWrap?: boolean;
+};
+
+/** Timezone of warehouse rows reaching Layer 2. Exported for testing. */
+export const getEffectiveInputTimezone = (
+    adapterType: SupportedDbtAdapter,
+    dataTimezone: string | undefined,
+    snowflakeDisableConvertTimezoneWrap: boolean | undefined,
+): string => {
+    if (
+        adapterType === SupportedDbtAdapter.SNOWFLAKE &&
+        !snowflakeDisableConvertTimezoneWrap
+    ) {
+        return 'UTC';
+    }
+    return dataTimezone ?? 'UTC';
 };
 
 /**
@@ -326,19 +338,13 @@ export class MetricQueryBuilder {
 
     /**
      * Skip timezone conversion when the effective input TZ matches the query TZ.
-     * Snowflake's effective input is UTC when the compile-time CONVERT_TIMEZONE
-     * wrap is active; when whSkipUtcNormalization is set the wrap is skipped
-     * and values flow through in dataTimezone, just like the other warehouses.
      */
     private shouldSkipTimezoneConversion(): boolean {
-        const adapterType = this.args.warehouseSqlBuilder.getAdapterType();
-
-        const effectiveInputTz =
-            adapterType === SupportedDbtAdapter.SNOWFLAKE &&
-            !this.args.whSkipUtcNormalization
-                ? 'UTC'
-                : (this.args.dataTimezone ?? 'UTC');
-
+        const effectiveInputTz = getEffectiveInputTimezone(
+            this.args.warehouseSqlBuilder.getAdapterType(),
+            this.args.dataTimezone,
+            this.args.snowflakeDisableConvertTimezoneWrap,
+        );
         return effectiveInputTz === this.args.timezone;
     }
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -137,6 +137,11 @@ export type BuildQueryProps = {
     useTimezoneAwareDateTrunc?: boolean;
     /** Warehouse session timezone — used to skip wrapping when it matches queryTimezone. */
     dataTimezone?: string;
+    /**
+     * Snowflake-only: when true, the compile-time CONVERT_TIMEZONE wrap is
+     * disabled, so values flow through Layer 2 in `dataTimezone` rather than UTC.
+     */
+    whSkipUtcNormalization?: boolean;
 };
 
 /**
@@ -321,14 +326,16 @@ export class MetricQueryBuilder {
 
     /**
      * Skip timezone conversion when the effective input TZ matches the query TZ.
-     * Snowflake's effective input is always UTC (convertTimezone normalizes at
-     * compile time); all others use dataTimezone (defaulting to UTC).
+     * Snowflake's effective input is UTC when the compile-time CONVERT_TIMEZONE
+     * wrap is active; when whSkipUtcNormalization is set the wrap is skipped
+     * and values flow through in dataTimezone, just like the other warehouses.
      */
     private shouldSkipTimezoneConversion(): boolean {
         const adapterType = this.args.warehouseSqlBuilder.getAdapterType();
 
         const effectiveInputTz =
-            adapterType === SupportedDbtAdapter.SNOWFLAKE
+            adapterType === SupportedDbtAdapter.SNOWFLAKE &&
+            !this.args.whSkipUtcNormalization
                 ? 'UTC'
                 : (this.args.dataTimezone ?? 'UTC');
 


### PR DESCRIPTION
Linear: https://linear.app/lightdash/issue/GLITCH-413

## Why

`shouldSkipTimezoneConversion` hardcodes `effectiveInputTz='UTC'` for Snowflake, assuming the compile-time `CONVERT_TIMEZONE` wrap normalized the input. That assumption breaks when a project sets `disableTimestampConversion: true` on Snowflake credentials - values flow through in `dataTimezone`, not UTC. The skip-check can then either skip a needed DATE_TRUNC localization (silent misdisplay) or emit a redundant identity conversion.

## What

Plumb `whSkipUtcNormalization?: boolean` through `BuildQueryProps` → `ProjectService._compileQuery`, sourced from `credentials.disableTimestampConversion` (Snowflake-only). The skip-check now falls back to `dataTimezone` for Snowflake when the flag is set, mirroring the non-Snowflake branch.

## Test plan

- [x] Unit tests for the four config combinations (Layer 1 active vs disabled × project tz === or !== input tz)
- [x] Backend typecheck passes
- [x] Backend lint passes
- [ ] Manual curl verification on a Snowflake project with `disableTimestampConversion: true` + non-UTC `dataTimezone` (sanity-check on a real warehouse — multi-warehouse tests are not in CI)