### PR TITLE
feat(service-accounts): tag stale accounts and add toolbar filters

### DIFF
--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -68,7 +68,7 @@ const TableRow: FC<{
                     )}
                 </Group>
             </td>
-            <td width="200px">
+            <td style={{ whiteSpace: 'nowrap' }}>
                 {scopes.length > 2 ? (
                     <HoverCard offset={-20}>
                         <HoverCard.Target>
@@ -85,7 +85,7 @@ const TableRow: FC<{
                     <Group spacing="xs">{scopeBadges}</Group>
                 )}
             </td>
-            <td>
+            <td style={{ whiteSpace: 'nowrap' }}>
                 <Group align="center" position="left" spacing="xs">
                     {expiresAt ? formatDate(expiresAt) : 'No expiration date'}
                     {rotatedAt && (
@@ -106,7 +106,7 @@ const TableRow: FC<{
                     )}
                 </Group>
             </td>
-            <td>
+            <td style={{ whiteSpace: 'nowrap' }}>
                 {lastUsedAt && (
                     <Tooltip
                         withinPortal
@@ -173,10 +173,16 @@ export const ServiceAccountsTable: FC<TableProps> = ({
                 <thead>
                     <tr>
                         <th>Description</th>
-                        <th>Scopes</th>
-                        <th>Expires at</th>
-                        <th>Last used at</th>
-                        <th></th>
+                        <th style={{ whiteSpace: 'nowrap', width: '1%' }}>
+                            Scopes
+                        </th>
+                        <th style={{ whiteSpace: 'nowrap', width: '1%' }}>
+                            Expires at
+                        </th>
+                        <th style={{ whiteSpace: 'nowrap', width: '1%' }}>
+                            Last used at
+                        </th>
+                        <th style={{ width: '1%' }}></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -65,10 +65,10 @@ const TableRow: FC<{
                         >
                             <Badge
                                 variant="light"
-                                color="yellow"
-                                radius="xs"
+                                color="red"
+                                radius="md"
                                 sx={{ textTransform: 'none' }}
-                                px="xs"
+                                px="xxs"
                             >
                                 Stale
                             </Badge>

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -21,12 +21,21 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import { ServiceAccountsDeleteModal } from './ServiceAccountsDeleteModal';
 
+const STALE_THRESHOLD_DAYS = 30;
+const STALE_THRESHOLD_MS = STALE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000;
+
+const isStale = (serviceAccount: ServiceAccount): boolean => {
+    const reference = serviceAccount.lastUsedAt ?? serviceAccount.createdAt;
+    return Date.now() - new Date(reference).getTime() > STALE_THRESHOLD_MS;
+};
+
 const TableRow: FC<{
     onClickDelete: (serviceAccount: ServiceAccount) => void;
     serviceAccount: ServiceAccount;
 }> = ({ onClickDelete, serviceAccount }) => {
     const { description, scopes, lastUsedAt, rotatedAt, expiresAt } =
         serviceAccount;
+    const stale = isStale(serviceAccount);
 
     const scopeBadges = scopes.map((scope) => (
         <Badge
@@ -45,7 +54,28 @@ const TableRow: FC<{
 
     return (
         <tr>
-            <td>{description}</td>
+            <td>
+                <Group spacing="xs" noWrap>
+                    <Text>{description}</Text>
+                    {stale && (
+                        <Tooltip
+                            withinPortal
+                            position="top"
+                            label={`Not used in the last ${STALE_THRESHOLD_DAYS} days`}
+                        >
+                            <Badge
+                                variant="light"
+                                color="yellow"
+                                radius="xs"
+                                sx={{ textTransform: 'none' }}
+                                px="xs"
+                            >
+                                Stale
+                            </Badge>
+                        </Tooltip>
+                    )}
+                </Group>
+            </td>
             <td width="200px">
                 {scopes.length > 2 ? (
                     <HoverCard offset={-20}>

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -8,7 +8,6 @@ import {
     Button,
     Group,
     HoverCard,
-    Paper,
     Stack,
     Table,
     Text,
@@ -20,14 +19,7 @@ import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import { ServiceAccountsDeleteModal } from './ServiceAccountsDeleteModal';
-
-const STALE_THRESHOLD_DAYS = 30;
-const STALE_THRESHOLD_MS = STALE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000;
-
-const isStale = (serviceAccount: ServiceAccount): boolean => {
-    const reference = serviceAccount.lastUsedAt ?? serviceAccount.createdAt;
-    return Date.now() - new Date(reference).getTime() > STALE_THRESHOLD_MS;
-};
+import { isServiceAccountStale, STALE_THRESHOLD_DAYS } from './staleness';
 
 const TableRow: FC<{
     onClickDelete: (serviceAccount: ServiceAccount) => void;
@@ -35,7 +27,7 @@ const TableRow: FC<{
 }> = ({ onClickDelete, serviceAccount }) => {
     const { description, scopes, lastUsedAt, rotatedAt, expiresAt } =
         serviceAccount;
-    const stale = isStale(serviceAccount);
+    const stale = isServiceAccountStale(serviceAccount);
 
     const scopeBadges = scopes.map((scope) => (
         <Badge
@@ -177,28 +169,26 @@ export const ServiceAccountsTable: FC<TableProps> = ({
 
     return (
         <>
-            <Paper withBorder sx={{ overflow: 'hidden' }}>
-                <Table className={cx(classes.root, classes.alignLastTdRight)}>
-                    <thead>
-                        <tr>
-                            <th>Description</th>
-                            <th>Scopes</th>
-                            <th>Expires at</th>
-                            <th>Last used at</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {accounts.map((serviceAccount) => (
-                            <TableRow
-                                key={serviceAccount.uuid}
-                                serviceAccount={serviceAccount}
-                                onClickDelete={handleOpenModal}
-                            />
-                        ))}
-                    </tbody>
-                </Table>
-            </Paper>
+            <Table className={cx(classes.root, classes.alignLastTdRight)}>
+                <thead>
+                    <tr>
+                        <th>Description</th>
+                        <th>Scopes</th>
+                        <th>Expires at</th>
+                        <th>Last used at</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {accounts.map((serviceAccount) => (
+                        <TableRow
+                            key={serviceAccount.uuid}
+                            serviceAccount={serviceAccount}
+                            onClickDelete={handleOpenModal}
+                        />
+                    ))}
+                </tbody>
+            </Table>
 
             <ServiceAccountsDeleteModal
                 isOpen={opened}

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsToolbar.module.css
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsToolbar.module.css
@@ -1,0 +1,91 @@
+.searchInput {
+    height: 36px;
+    width: 420px;
+    text-overflow: ellipsis;
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 400;
+    color: var(--mantine-color-ldGray-5);
+    box-shadow: var(--mantine-shadow-subtle);
+    border: 1px solid var(--mantine-color-ldGray-3);
+    background: var(--mantine-color-background-0);
+    transition:
+        border-color 0.2s ease,
+        box-shadow 0.2s ease;
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldGray-4);
+    }
+}
+
+.searchInput:hover {
+    border: 1px solid var(--mantine-color-ldGray-4);
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldGray-5);
+    }
+}
+
+.searchInput:focus {
+    border: 1px solid var(--mantine-color-indigo-4);
+    box-shadow: 0 0 0 2px
+        color-mix(in oklch, var(--mantine-color-indigo-4) 20%, transparent);
+}
+
+.searchInputWithValue {
+    height: 36px;
+    width: 420px;
+    text-overflow: ellipsis;
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 400;
+    color: var(--mantine-color-foreground);
+    box-shadow: var(--mantine-shadow-subtle);
+    border: 1px solid var(--mantine-color-ldGray-3);
+    background: var(--mantine-color-background-0);
+    transition:
+        border-color 0.2s ease,
+        box-shadow 0.2s ease;
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldGray-4);
+    }
+}
+
+.searchInputWithValue:hover {
+    border: 1px solid var(--mantine-color-ldGray-4);
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldGray-5);
+    }
+}
+
+.searchInputWithValue:focus {
+    border: 1px solid var(--mantine-color-indigo-4);
+    box-shadow: 0 0 0 2px
+        color-mix(in oklch, var(--mantine-color-indigo-4) 20%, transparent);
+}
+
+.segmentedControl {
+    border: 1px solid var(--mantine-color-ldGray-3);
+    background: var(--mantine-color-background-0);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.segmentedIndicator {
+    background: var(--mantine-color-indigo-0);
+    border: 1px solid var(--mantine-color-indigo-2);
+
+    @mixin dark {
+        background: var(--mantine-color-indigo-8);
+        border-color: var(--mantine-color-indigo-4);
+    }
+}
+
+.segmentedLabel p {
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    color: var(--mantine-color-foreground);
+}
+
+.toolbar {
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+}

--- a/packages/frontend/src/ee/features/serviceAccounts/index.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/index.tsx
@@ -1,17 +1,56 @@
-import { Button, Group, Stack, Title } from '@mantine/core';
+import {
+    ActionIcon,
+    Box,
+    Button,
+    Divider,
+    Group,
+    Paper,
+    SegmentedControl,
+    Stack,
+    Text,
+    TextInput,
+    Title,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconUsersGroup } from '@tabler/icons-react';
-import { useState } from 'react';
+import { IconSearch, IconUsersGroup, IconX } from '@tabler/icons-react';
+import { useCallback, useMemo, useState } from 'react';
 import { EmptyState } from '../../../components/common/EmptyState';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { ServiceAccountsCreateModal } from './ServiceAccountsCreateModal';
 import { ServiceAccountsTable } from './ServiceAccountsTable';
+import classes from './ServiceAccountsToolbar.module.css';
+import { isServiceAccountStale } from './staleness';
 import { useServiceAccounts } from './useServiceAccounts';
 
+type StatusFilter = 'all' | 'active' | 'stale';
+
+const STATUS_FILTER_OPTIONS: {
+    value: StatusFilter;
+    label: string;
+    tooltip: string;
+}[] = [
+    { value: 'all', label: 'All', tooltip: 'Show all service accounts' },
+    {
+        value: 'active',
+        label: 'Active',
+        tooltip: 'Show accounts used in the last 30 days',
+    },
+    {
+        value: 'stale',
+        label: 'Stale',
+        tooltip: 'Show accounts not used in the last 30 days',
+    },
+];
+
 export function ServiceAccountsPage() {
+    const theme = useMantineTheme();
     const [opened, { open, close }] = useDisclosure(false);
     const { listAccounts, createAccount, deleteAccount } = useServiceAccounts();
     const [token, setToken] = useState<string>();
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+    const [search, setSearch] = useState('');
 
     const handleCloseModal = () => {
         setToken(undefined);
@@ -23,23 +62,140 @@ export function ServiceAccountsPage() {
         setToken(data.token);
     };
 
-    const hasAccounts = listAccounts?.data?.length ?? 0 > 0;
+    const handleStatusFilterChange = useCallback((value: string) => {
+        setStatusFilter(value as StatusFilter);
+    }, []);
+
+    const accountsData = listAccounts?.data;
+    const hasAccounts = (accountsData?.length ?? 0) > 0;
+
+    const filteredAccounts = useMemo(() => {
+        const all = accountsData ?? [];
+        const trimmedSearch = search.trim().toLowerCase();
+        return all.filter((account) => {
+            const matchesSearch =
+                !trimmedSearch ||
+                account.description.toLowerCase().includes(trimmedSearch);
+            const matchesStatus =
+                statusFilter === 'all' ||
+                (statusFilter === 'stale'
+                    ? isServiceAccountStale(account)
+                    : !isServiceAccountStale(account));
+            return matchesSearch && matchesStatus;
+        });
+    }, [accountsData, search, statusFilter]);
 
     return (
         <Stack mb="lg">
             {hasAccounts ? (
                 <>
-                    <Group position="apart">
-                        <Title size="h5">Service accounts</Title>
+                    <Group justify="space-between">
+                        <Title order={5}>Service accounts</Title>
                         <Button onClick={open} size="xs">
                             Add service account
                         </Button>
                     </Group>
-                    <ServiceAccountsTable
-                        accounts={listAccounts?.data ?? []}
-                        onDelete={deleteAccount.mutate}
-                        isDeleting={deleteAccount.isLoading}
-                    />
+                    <Paper
+                        withBorder
+                        style={{
+                            overflow: 'hidden',
+                            display: 'flex',
+                            flexDirection: 'column',
+                        }}
+                    >
+                        <Group
+                            justify="space-between"
+                            wrap="nowrap"
+                            p={`${theme.spacing.sm} ${theme.spacing.md}`}
+                            className={classes.toolbar}
+                        >
+                            <Group gap="xs" wrap="nowrap">
+                                <Tooltip
+                                    withinPortal
+                                    label="Search by description"
+                                >
+                                    <TextInput
+                                        size="xs"
+                                        radius="md"
+                                        type="search"
+                                        variant="default"
+                                        placeholder="Search service accounts..."
+                                        value={search}
+                                        classNames={{
+                                            input: search
+                                                ? classes.searchInputWithValue
+                                                : classes.searchInput,
+                                        }}
+                                        leftSection={
+                                            <MantineIcon
+                                                size="md"
+                                                color="ldGray.6"
+                                                icon={IconSearch}
+                                            />
+                                        }
+                                        onChange={(e) =>
+                                            setSearch(e.target.value)
+                                        }
+                                        rightSection={
+                                            search ? (
+                                                <ActionIcon
+                                                    onClick={() =>
+                                                        setSearch('')
+                                                    }
+                                                    variant="transparent"
+                                                    size="xs"
+                                                    color="ldGray.5"
+                                                >
+                                                    <MantineIcon icon={IconX} />
+                                                </ActionIcon>
+                                            ) : null
+                                        }
+                                    />
+                                </Tooltip>
+
+                                <Divider
+                                    orientation="vertical"
+                                    w={1}
+                                    h={20}
+                                    style={{ alignSelf: 'center' }}
+                                />
+
+                                <SegmentedControl
+                                    size="xs"
+                                    radius="md"
+                                    value={statusFilter}
+                                    onChange={handleStatusFilterChange}
+                                    classNames={{
+                                        root: classes.segmentedControl,
+                                        indicator: classes.segmentedIndicator,
+                                        label: classes.segmentedLabel,
+                                    }}
+                                    data={STATUS_FILTER_OPTIONS.map(
+                                        (option) => ({
+                                            value: option.value,
+                                            label: (
+                                                <Tooltip
+                                                    label={option.tooltip}
+                                                    withinPortal
+                                                >
+                                                    <Box>
+                                                        <Text fz="xs" fw={500}>
+                                                            {option.label}
+                                                        </Text>
+                                                    </Box>
+                                                </Tooltip>
+                                            ),
+                                        }),
+                                    )}
+                                />
+                            </Group>
+                        </Group>
+                        <ServiceAccountsTable
+                            accounts={filteredAccounts}
+                            onDelete={deleteAccount.mutate}
+                            isDeleting={deleteAccount.isLoading}
+                        />
+                    </Paper>
                 </>
             ) : (
                 <EmptyState

--- a/packages/frontend/src/ee/features/serviceAccounts/staleness.ts
+++ b/packages/frontend/src/ee/features/serviceAccounts/staleness.ts
@@ -1,0 +1,11 @@
+import { type ServiceAccount } from '@lightdash/common';
+
+export const STALE_THRESHOLD_DAYS = 30;
+const STALE_THRESHOLD_MS = STALE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000;
+
+export const isServiceAccountStale = (
+    serviceAccount: ServiceAccount,
+): boolean => {
+    const reference = serviceAccount.lastUsedAt ?? serviceAccount.createdAt;
+    return Date.now() - new Date(reference).getTime() > STALE_THRESHOLD_MS;
+};


### PR DESCRIPTION
Closes: [PROD-7451](https://linear.app/lightdash/issue/PROD-7451/last-used-telemetry-surfaced-in-ui)

<img width="1988" height="822" alt="CleanShot 2026-05-06 at 15 25 04@2x" src="https://github.com/user-attachments/assets/a4824ee1-a9be-4495-bfa0-0591053cfae3" />

## Summary
- Adds a "Stale" badge next to a service account's description when the most recent activity (`lastUsedAt`, falling back to `createdAt`) is older than 30 days.
- Wraps the table in a unified bordered card with a top toolbar — modelled on the project management page — featuring a search input (filters by description) and a SegmentedControl for **All / Active / Stale** status filtering.

## Test plan
- [x] Visit `/generalSettings/serviceAccounts` and confirm the Stale badge renders only on accounts unused for 30+ days.
- [x] Type into the search box — table filters by description.
- [x] Toggle SegmentedControl between All / Active / Stale and verify the row set updates.
- [x] Confirm the toolbar styling matches `/generalSettings/projectManagement` (border, search input, segmented control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)