### PR TITLE
feat(managed-agent): unify heartbeat execution onto scheduler worker

### DIFF
--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -134,6 +134,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             },
             [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: async (payload) => {
                 const { projectUuid } = payload;
+                const triggeredBy = payload.triggeredBy ?? 'cron';
                 const settings = (
                     await this.managedAgentService.getEnabledProjects()
                 ).find((project) => project.projectUuid === projectUuid);
@@ -157,7 +158,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 }
 
                 Logger.info(
-                    `Running managed agent heartbeat for project ${projectUuid}`,
+                    `Running managed agent heartbeat for project ${projectUuid} (${triggeredBy})`,
                 );
 
                 try {
@@ -171,13 +172,15 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                         error,
                     );
                 } finally {
-                    const schedule =
-                        getManagedAgentScheduleCron(settings.schedule) ??
-                        this.lightdashConfig.managedAgent.schedule;
-                    await this.schedulerClient.scheduleManagedAgentHeartbeat(
-                        schedule,
-                        projectUuid,
-                    );
+                    if (triggeredBy === 'cron') {
+                        const schedule =
+                            getManagedAgentScheduleCron(settings.schedule) ??
+                            this.lightdashConfig.managedAgent.schedule;
+                        await this.schedulerClient.scheduleManagedAgentHeartbeat(
+                            schedule,
+                            projectUuid,
+                        );
+                    }
                 }
             },
             [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: async (

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -367,13 +367,15 @@ export class ManagedAgentService extends BaseService {
         );
 
         if (!previous?.enabled && settings.enabled) {
-            void this.startHeartbeat(user, projectUuid).catch((error) => {
-                this.logger.error(
-                    `Failed to trigger run-on-enable for project ${projectUuid}: ${
-                        error instanceof Error ? error.message : 'Unknown'
-                    }`,
-                );
-            });
+            void this.startHeartbeat(user, projectUuid, 'on_enable').catch(
+                (error) => {
+                    this.logger.error(
+                        `Failed to trigger run-on-enable for project ${projectUuid}: ${
+                            error instanceof Error ? error.message : 'Unknown'
+                        }`,
+                    );
+                },
+            );
         }
 
         return settings;
@@ -663,6 +665,7 @@ export class ManagedAgentService extends BaseService {
     async startHeartbeat(
         user: SessionUser,
         projectUuid: string,
+        triggeredBy: 'manual' | 'on_enable' = 'manual',
     ): Promise<void> {
         await this.assertCanManageProject(user, projectUuid);
 
@@ -677,15 +680,15 @@ export class ManagedAgentService extends BaseService {
                     organizationId: organizationUuid,
                     projectId: projectUuid,
                     schedule: settings.schedule,
+                    triggeredBy,
                 },
             });
         }
 
-        void this.runHeartbeat(projectUuid).catch((error) => {
-            this.logger.error(
-                `Manual heartbeat failed for project ${projectUuid}: ${error instanceof Error ? error.message : 'Unknown'}`,
-            );
-        });
+        await this.schedulerClient.triggerManagedAgentHeartbeat(
+            projectUuid,
+            triggeredBy,
+        );
     }
 
     private async postHeartbeatSummaryToSlack(

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -20,6 +20,7 @@ import {
     isMsTeamsTarget,
     isSlackTarget,
     JobPriority,
+    ManagedAgentHeartbeatPayload,
     MaterializePreAggregatePayload,
     MsTeamsBatchNotificationPayload,
     MsTeamsNotificationPayload,
@@ -1579,12 +1580,8 @@ export class SchedulerClient {
         return jobId;
     }
 
-    // --- Managed Agent Heartbeat (self-scheduling) ---
+    // --- Managed Agent Heartbeat ---
 
-    /**
-     * Schedule the next managed agent heartbeat for a specific project.
-     * Uses a per-project jobKey so each project has its own schedule.
-     */
     async scheduleManagedAgentHeartbeat(
         cronPattern: string,
         projectUuid: string,
@@ -1595,20 +1592,19 @@ export class SchedulerClient {
         const schedule = getSchedule(arr, new Date(), 'UTC');
         const nextRun = schedule.next().toJSDate();
 
-        const jobKey = `managed-agent-heartbeat:${projectUuid}`;
-
         await graphileClient.addJob(
             SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT,
             {
                 projectUuid,
                 organizationUuid: '',
                 userUuid: '',
-            } satisfies TraceTaskBase,
+                triggeredBy: 'cron',
+            } satisfies ManagedAgentHeartbeatPayload,
             {
                 runAt: nextRun,
                 maxAttempts: 1,
                 priority: JobPriority.LOW,
-                jobKey,
+                jobKey: `managed-agent-heartbeat:${projectUuid}`,
             },
         );
 
@@ -1617,19 +1613,44 @@ export class SchedulerClient {
         );
     }
 
-    /**
-     * Cancel pending managed agent heartbeat job(s).
-     * If projectUuid is provided, cancels only that project's job.
-     * Otherwise cancels all managed agent heartbeat jobs.
-     */
+    async triggerManagedAgentHeartbeat(
+        projectUuid: string,
+        triggeredBy: 'manual' | 'on_enable',
+    ): Promise<void> {
+        const graphileClient = await this.graphileUtils;
+
+        await graphileClient.addJob(
+            SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT,
+            {
+                projectUuid,
+                organizationUuid: '',
+                userUuid: '',
+                triggeredBy,
+            } satisfies ManagedAgentHeartbeatPayload,
+            {
+                runAt: new Date(),
+                maxAttempts: 1,
+                priority: JobPriority.LOW,
+                jobKey: `managed-agent-heartbeat:immediate:${projectUuid}`,
+            },
+        );
+
+        Logger.info(
+            `Triggered immediate managed agent heartbeat for ${projectUuid} (${triggeredBy})`,
+        );
+    }
+
     async cancelManagedAgentHeartbeat(projectUuid?: string): Promise<void> {
         const graphileClient = await this.graphileUtils;
         await graphileClient.withPgClient(async (pgClient) => {
             if (projectUuid) {
                 await pgClient.query(
                     `DELETE FROM graphile_worker.jobs
-                     WHERE key = $1 AND locked_by IS NULL`,
-                    [`managed-agent-heartbeat:${projectUuid}`],
+                     WHERE locked_by IS NULL AND key IN ($1, $2)`,
+                    [
+                        `managed-agent-heartbeat:${projectUuid}`,
+                        `managed-agent-heartbeat:immediate:${projectUuid}`,
+                    ],
                 );
             } else {
                 await pgClient.query(

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -184,6 +184,7 @@ const getTagsForTask: {
     [SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS]: () => ({}),
     [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: (payload) => ({
         'project.uuid': payload.projectUuid,
+        'managed_agent.triggered_by': payload.triggeredBy ?? 'cron',
     }),
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: (payload) => ({
         'organization.uuid': payload.organizationUuid,

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -499,7 +499,11 @@ export type TraceTaskBase = {
     schedulerUuid?: string;
 };
 
-export type ManagedAgentHeartbeatPayload = TraceTaskBase;
+export type ManagedAgentHeartbeatTriggeredBy = 'cron' | 'manual' | 'on_enable';
+
+export type ManagedAgentHeartbeatPayload = TraceTaskBase & {
+    triggeredBy?: ManagedAgentHeartbeatTriggeredBy;
+};
 
 export type QueueTraceProperties = {
     traceHeader?: string;


### PR DESCRIPTION
## Summary

Move all managed-agent heartbeat execution onto the scheduler worker. Manual and on-enable triggers used to run fire-and-forget on the API pod (`void this.runHeartbeat(...)`); they now enqueue a `MANAGED_AGENT_HEARTBEAT` job via the new `triggerManagedAgentHeartbeat()` so cron, manual, and on-enable share one execution path.

The payload gains `triggeredBy: 'cron' | 'manual' | 'on_enable'`. Only `cron` re-schedules the next run in `finally` — manual and on-enable are one-offs.

## Why

Long-running work should live on the worker, not the API pod. The previous fire-and-forget pattern blocked an API request slot for the duration of the run and survived only as long as that pod did.

## Regression analysis

- **Existing cron schedules**: unchanged — still re-scheduled in the heartbeat's `finally` block when `triggeredBy === 'cron'`.
- **Manual / on-enable**: now incur queue pickup latency (typically <1s) instead of starting in-process. Acceptable tradeoff for resource isolation.
- **Cancel-pending**: `cancelManagedAgentHeartbeat` now also clears the `:immediate:` jobKey so disabling mid-flight cleans up both cron and one-off jobs.

## Test plan
- [ ] Enable agent → verify a heartbeat fires immediately via worker logs (`triggeredBy=on_enable`)
- [ ] Disable agent → verify both `:cron` and `:immediate:` jobs are cleared from `graphile_worker.jobs`
- [ ] Wait one cron cycle → verify `triggeredBy=cron` and next run is scheduled in `finally`