### PR TITLE
feat(service-accounts): add permissions modal with action menu

### DIFF
--- a/docs/superpowers/specs/2026-05-06-service-account-permissions-modal-design.md
+++ b/docs/superpowers/specs/2026-05-06-service-account-permissions-modal-design.md
@@ -1,0 +1,45 @@
+# Service Account Permissions Modal — Design
+
+## Goal
+
+Add a way to view a detailed list of permissions for a service account from the service accounts list table. Permissions data is faked for this iteration; no backend or API changes.
+
+## User-facing behavior
+
+- Each row in the service accounts table gains an info-icon button inside the existing **Scopes** column, placed after the scope badges or "N scopes" hover preview.
+- Clicking the info button opens a modal titled **Permissions**, with the service account's description shown as a subtitle.
+- The modal body is a flat list of permission entries, each formatted as `**Name** — description` (e.g. `**View charts** — Can view charts in this project`).
+- The modal is dismissible via the standard close button / overlay click. Closing returns to the table with no state change.
+
+## Component changes
+
+**New file:** `packages/frontend/src/ee/features/serviceAccounts/ServiceAccountPermissionsModal.tsx`
+
+- Uses `MantineModal` from `components/common/MantineModal` (per frontend style guide).
+- Props: `{ isOpen: boolean; onClose: () => void; serviceAccount: ServiceAccount | undefined }`.
+- Defines `FAKE_PERMISSIONS: Array<{ name: string; description: string }>` as a module-level constant — roughly 12 entries spanning dashboards, charts, projects, spaces, members. Values are illustrative only.
+- Renders the description (if present) as a subtitle under the title, then a `<List>` of the fake permission entries.
+
+**Updated file:** `packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx`
+
+- Inside `TableRow`, add an `IconInfoCircle` icon button rendered inline at the end of the Scopes cell (after the badges or "N scopes" hover content). Calls a new `onClickInfo` handler with the row's service account.
+- In `ServiceAccountsTable`, add:
+  - A second `useDisclosure` for the permissions modal.
+  - State `serviceAccountToView: ServiceAccount | undefined` paired with open/close handlers (mirroring the existing delete-modal pattern).
+  - Render `ServiceAccountPermissionsModal` next to the existing `ServiceAccountsDeleteModal`.
+
+## Data
+
+`FAKE_PERMISSIONS` is hardcoded in the new modal file. Same list rendered for every service account regardless of its actual `scopes` array. This is intentional for the prototype — wiring real scope-to-permission resolution is out of scope.
+
+## Out of scope
+
+- Backend or API changes.
+- Wiring the modal to the service account's actual `scopes` list.
+- Localization of permission names/descriptions.
+- Permission grouping or action matrix (deferred; a flat list was preferred for this iteration).
+
+## Non-goals / design decisions
+
+- **Placement:** Info button lives in the Scopes column (option A from brainstorming) rather than the right-hand actions area, to keep scopes-related UI co-located.
+- **Modal content:** Flat list (option A from brainstorming) rather than grouped-by-resource or action matrix, for fastest implementation of a fake-data prototype.

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountPermissionsModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountPermissionsModal.tsx
@@ -1,0 +1,727 @@
+import { type ServiceAccount } from '@lightdash/common';
+import { Code, Stack, Table, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import MantineModal from '../../../components/common/MantineModal';
+
+type Props = {
+    isOpen: boolean;
+    onClose: () => void;
+    serviceAccount: ServiceAccount | undefined;
+};
+
+type Permission = { action: string; subject: string; description: string };
+
+const getPermissionKey = (permission: Permission): string =>
+    `${permission.action}:${permission.subject}`;
+
+const PERMISSIONS_BY_SCOPE: Record<string, Permission[]> = {
+    'org:read': [
+        {
+            action: 'view',
+            subject: 'AiAgent',
+            description: 'View AI agents available in the organization',
+        },
+        {
+            action: 'view',
+            subject: 'AiAgentThread',
+            description: 'View AI agent conversation threads',
+        },
+        {
+            action: 'create',
+            subject: 'AiAgentThread',
+            description: 'Start new AI agent conversation threads',
+        },
+        {
+            action: 'manage',
+            subject: 'ChangeCsvResults',
+            description: 'Track and manage changes in CSV results',
+        },
+        {
+            action: 'view',
+            subject: 'Dashboard',
+            description: 'View dashboards in this project',
+        },
+        {
+            action: 'manage',
+            subject: 'Dashboard',
+            description: 'Create, edit, and delete dashboards',
+        },
+        {
+            action: 'view',
+            subject: 'DashboardComments',
+            description: 'Read comments on dashboards',
+        },
+        {
+            action: 'create',
+            subject: 'DashboardComments',
+            description: 'Add new comments to dashboards',
+        },
+        {
+            action: 'manage',
+            subject: 'Explore',
+            description: 'Run queries against tables and explores',
+        },
+        {
+            action: 'manage',
+            subject: 'ExportCsv',
+            description: 'Export query results to CSV files',
+        },
+        {
+            action: 'view',
+            subject: 'Job',
+            description: 'View background job history',
+        },
+        {
+            action: 'create',
+            subject: 'Job',
+            description: 'Trigger background jobs',
+        },
+        {
+            action: 'view',
+            subject: 'JobStatus',
+            description: 'View live status of running jobs',
+        },
+        {
+            action: 'view',
+            subject: 'MetricsTree',
+            description: 'View relationships between metrics',
+        },
+        {
+            action: 'view',
+            subject: 'Organization',
+            description: 'View organization details',
+        },
+        {
+            action: 'view',
+            subject: 'OrganizationMemberProfile',
+            description: 'View profiles of other organization members',
+        },
+        {
+            action: 'view',
+            subject: 'PinnedItems',
+            description: 'See charts and dashboards pinned in spaces',
+        },
+        {
+            action: 'view',
+            subject: 'Project',
+            description: 'View project metadata',
+        },
+        {
+            action: 'view',
+            subject: 'SavedChart',
+            description: 'View saved charts in this project',
+        },
+        {
+            action: 'manage',
+            subject: 'SavedChart',
+            description: 'Create, edit, and delete saved charts',
+        },
+        {
+            action: 'create',
+            subject: 'ScheduledDeliveries',
+            description: 'Create scheduled deliveries of charts and dashboards',
+        },
+        {
+            action: 'view',
+            subject: 'SemanticViewer',
+            description: 'Open and explore the semantic viewer',
+        },
+        {
+            action: 'manage',
+            subject: 'SemanticViewer',
+            description: 'Build and save semantic viewer queries',
+        },
+        {
+            action: 'view',
+            subject: 'Space',
+            description: 'View spaces and their contents',
+        },
+        {
+            action: 'manage',
+            subject: 'Space',
+            description: 'Edit space settings, sharing, and contents',
+        },
+        {
+            action: 'view',
+            subject: 'SpotlightTableConfig',
+            description: 'View configuration of the Spotlight metric catalog',
+        },
+        {
+            action: 'view',
+            subject: 'Tags',
+            description: 'View tags applied to content',
+        },
+        {
+            action: 'view',
+            subject: 'UnderlyingData',
+            description: 'View the underlying rows behind a chart',
+        },
+    ],
+    'org:edit': [
+        {
+            action: 'view',
+            subject: 'AiAgent',
+            description: 'View AI agents available in the organization',
+        },
+        {
+            action: 'view',
+            subject: 'AiAgentThread',
+            description: 'View AI agent conversation threads',
+        },
+        {
+            action: 'create',
+            subject: 'AiAgentThread',
+            description: 'Start new AI agent conversation threads',
+        },
+        {
+            action: 'manage',
+            subject: 'ChangeCsvResults',
+            description: 'Track and manage changes in CSV results',
+        },
+        {
+            action: 'view',
+            subject: 'Dashboard',
+            description: 'View dashboards in this project',
+        },
+        {
+            action: 'manage',
+            subject: 'Dashboard',
+            description: 'Create, edit, and delete dashboards',
+        },
+        {
+            action: 'view',
+            subject: 'DashboardComments',
+            description: 'Read comments on dashboards',
+        },
+        {
+            action: 'create',
+            subject: 'DashboardComments',
+            description: 'Add new comments to dashboards',
+        },
+        {
+            action: 'manage',
+            subject: 'DashboardComments',
+            description: 'Edit and delete dashboard comments from any user',
+        },
+        {
+            action: 'manage',
+            subject: 'Explore',
+            description: 'Run queries against tables and explores',
+        },
+        {
+            action: 'manage',
+            subject: 'ExportCsv',
+            description: 'Export query results to CSV files',
+        },
+        {
+            action: 'view',
+            subject: 'Job',
+            description: 'View background job history',
+        },
+        {
+            action: 'create',
+            subject: 'Job',
+            description: 'Trigger background jobs',
+        },
+        {
+            action: 'manage',
+            subject: 'Job',
+            description: 'Manage all background jobs across users',
+        },
+        {
+            action: 'view',
+            subject: 'JobStatus',
+            description: 'View live status of running jobs',
+        },
+        {
+            action: 'view',
+            subject: 'MetricsTree',
+            description: 'View relationships between metrics',
+        },
+        {
+            action: 'manage',
+            subject: 'MetricsTree',
+            description: 'Edit relationships between metrics in the tree',
+        },
+        {
+            action: 'view',
+            subject: 'Organization',
+            description: 'View organization details',
+        },
+        {
+            action: 'view',
+            subject: 'OrganizationMemberProfile',
+            description: 'View profiles of other organization members',
+        },
+        {
+            action: 'view',
+            subject: 'PinnedItems',
+            description: 'See charts and dashboards pinned in spaces',
+        },
+        {
+            action: 'manage',
+            subject: 'PinnedItems',
+            description: 'Pin and unpin charts and dashboards',
+        },
+        {
+            action: 'view',
+            subject: 'Project',
+            description: 'View project metadata',
+        },
+        {
+            action: 'view',
+            subject: 'SavedChart',
+            description: 'View saved charts in this project',
+        },
+        {
+            action: 'manage',
+            subject: 'SavedChart',
+            description: 'Create, edit, and delete saved charts',
+        },
+        {
+            action: 'create',
+            subject: 'ScheduledDeliveries',
+            description: 'Create scheduled deliveries of charts and dashboards',
+        },
+        {
+            action: 'manage',
+            subject: 'ScheduledDeliveries',
+            description: 'Manage scheduled deliveries created by any user',
+        },
+        {
+            action: 'view',
+            subject: 'SemanticViewer',
+            description: 'Open and explore the semantic viewer',
+        },
+        {
+            action: 'manage',
+            subject: 'SemanticViewer',
+            description: 'Build and save semantic viewer queries',
+        },
+        {
+            action: 'view',
+            subject: 'Space',
+            description: 'View spaces and their contents',
+        },
+        {
+            action: 'create',
+            subject: 'Space',
+            description: 'Create new spaces in this project',
+        },
+        {
+            action: 'manage',
+            subject: 'Space',
+            description: 'Edit space settings, sharing, and contents',
+        },
+        {
+            action: 'view',
+            subject: 'SpotlightTableConfig',
+            description: 'View configuration of the Spotlight metric catalog',
+        },
+        {
+            action: 'view',
+            subject: 'Tags',
+            description: 'View tags applied to content',
+        },
+        {
+            action: 'manage',
+            subject: 'Tags',
+            description: 'Create, edit, and delete tags',
+        },
+        {
+            action: 'view',
+            subject: 'UnderlyingData',
+            description: 'View the underlying rows behind a chart',
+        },
+    ],
+    'org:admin': [
+        {
+            action: 'view',
+            subject: 'AiAgent',
+            description: 'View AI agents available in the organization',
+        },
+        {
+            action: 'manage',
+            subject: 'AiAgent',
+            description: 'Create, configure, and delete AI agents',
+        },
+        {
+            action: 'view',
+            subject: 'AiAgentThread',
+            description: 'View AI agent conversation threads',
+        },
+        {
+            action: 'create',
+            subject: 'AiAgentThread',
+            description: 'Start new AI agent conversation threads',
+        },
+        {
+            action: 'manage',
+            subject: 'AiAgentThread',
+            description: 'Manage all AI agent threads across users',
+        },
+        {
+            action: 'view',
+            subject: 'Analytics',
+            description: 'View usage analytics and audit logs',
+        },
+        {
+            action: 'manage',
+            subject: 'ChangeCsvResults',
+            description: 'Track and manage changes in CSV results',
+        },
+        {
+            action: 'manage',
+            subject: 'CompileProject',
+            description: 'Compile dbt projects to refresh metadata',
+        },
+        {
+            action: 'manage',
+            subject: 'ContentAsCode',
+            description: 'Download and upload Lightdash content as YAML files',
+        },
+        {
+            action: 'manage',
+            subject: 'ContentVerification',
+            description: 'Mark charts and dashboards as verified content',
+        },
+        {
+            action: 'manage',
+            subject: 'CustomFields',
+            description:
+                'Create and edit custom dimensions and metrics on the fly',
+        },
+        {
+            action: 'manage',
+            subject: 'CustomSql',
+            description: 'Use custom SQL when running queries',
+        },
+        {
+            action: 'view',
+            subject: 'Dashboard',
+            description: 'View dashboards in this project',
+        },
+        {
+            action: 'manage',
+            subject: 'Dashboard',
+            description: 'Create, edit, and delete dashboards',
+        },
+        {
+            action: 'promote',
+            subject: 'Dashboard',
+            description: 'Promote dashboards to upstream projects',
+        },
+        {
+            action: 'view',
+            subject: 'DashboardComments',
+            description: 'Read comments on dashboards',
+        },
+        {
+            action: 'create',
+            subject: 'DashboardComments',
+            description: 'Add new comments to dashboards',
+        },
+        {
+            action: 'manage',
+            subject: 'DashboardComments',
+            description: 'Edit and delete dashboard comments from any user',
+        },
+        {
+            action: 'manage',
+            subject: 'DataApp',
+            description: 'Build and manage embedded data apps',
+        },
+        {
+            action: 'manage',
+            subject: 'DeployProject',
+            description: 'Deploy projects and update their connections',
+        },
+        {
+            action: 'manage',
+            subject: 'Explore',
+            description: 'Run queries against tables and explores',
+        },
+        {
+            action: 'manage',
+            subject: 'ExportCsv',
+            description: 'Export query results to CSV files',
+        },
+        {
+            action: 'manage',
+            subject: 'Group',
+            description: 'Create and manage user groups',
+        },
+        {
+            action: 'manage',
+            subject: 'InviteLink',
+            description: 'Create and revoke organization invite links',
+        },
+        {
+            action: 'view',
+            subject: 'Job',
+            description: 'View background job history',
+        },
+        {
+            action: 'create',
+            subject: 'Job',
+            description: 'Trigger background jobs',
+        },
+        {
+            action: 'manage',
+            subject: 'Job',
+            description: 'Manage all background jobs across users',
+        },
+        {
+            action: 'view',
+            subject: 'JobStatus',
+            description: 'View live status of running jobs',
+        },
+        {
+            action: 'view',
+            subject: 'MetricsTree',
+            description: 'View relationships between metrics',
+        },
+        {
+            action: 'manage',
+            subject: 'MetricsTree',
+            description: 'Edit relationships between metrics in the tree',
+        },
+        {
+            action: 'view',
+            subject: 'Organization',
+            description: 'View organization details',
+        },
+        {
+            action: 'manage',
+            subject: 'Organization',
+            description: 'Edit organization settings such as name and defaults',
+        },
+        {
+            action: 'view',
+            subject: 'OrganizationMemberProfile',
+            description: 'View profiles of other organization members',
+        },
+        {
+            action: 'manage',
+            subject: 'OrganizationMemberProfile',
+            description:
+                'Change member roles and remove members from the organization',
+        },
+        {
+            action: 'view',
+            subject: 'PinnedItems',
+            description: 'See charts and dashboards pinned in spaces',
+        },
+        {
+            action: 'manage',
+            subject: 'PinnedItems',
+            description: 'Pin and unpin charts and dashboards',
+        },
+        {
+            action: 'manage',
+            subject: 'PreAggregation',
+            description: 'Configure caching of pre-aggregated query results',
+        },
+        {
+            action: 'view',
+            subject: 'Project',
+            description: 'View project metadata',
+        },
+        {
+            action: 'create',
+            subject: 'Project',
+            description: 'Create new projects in the organization',
+        },
+        {
+            action: 'update',
+            subject: 'Project',
+            description: 'Update settings on existing projects',
+        },
+        {
+            action: 'delete',
+            subject: 'Project',
+            description: 'Delete projects from the organization',
+        },
+        {
+            action: 'manage',
+            subject: 'Project',
+            description: 'Full administrative control over projects',
+        },
+        {
+            action: 'view',
+            subject: 'SavedChart',
+            description: 'View saved charts in this project',
+        },
+        {
+            action: 'manage',
+            subject: 'SavedChart',
+            description: 'Create, edit, and delete saved charts',
+        },
+        {
+            action: 'promote',
+            subject: 'SavedChart',
+            description: 'Promote saved charts to upstream projects',
+        },
+        {
+            action: 'create',
+            subject: 'ScheduledDeliveries',
+            description: 'Create scheduled deliveries of charts and dashboards',
+        },
+        {
+            action: 'manage',
+            subject: 'ScheduledDeliveries',
+            description: 'Manage scheduled deliveries created by any user',
+        },
+        {
+            action: 'view',
+            subject: 'SemanticViewer',
+            description: 'Open and explore the semantic viewer',
+        },
+        {
+            action: 'manage',
+            subject: 'SemanticViewer',
+            description: 'Build and save semantic viewer queries',
+        },
+        {
+            action: 'view',
+            subject: 'Space',
+            description: 'View spaces and their contents',
+        },
+        {
+            action: 'create',
+            subject: 'Space',
+            description: 'Create new spaces in this project',
+        },
+        {
+            action: 'manage',
+            subject: 'Space',
+            description: 'Edit space settings, sharing, and contents',
+        },
+        {
+            action: 'view',
+            subject: 'SpotlightTableConfig',
+            description: 'View configuration of the Spotlight metric catalog',
+        },
+        {
+            action: 'manage',
+            subject: 'SpotlightTableConfig',
+            description:
+                'Configure which tables and metrics appear in Spotlight',
+        },
+        {
+            action: 'manage',
+            subject: 'SqlRunner',
+            description: 'Run ad-hoc SQL queries via the SQL runner',
+        },
+        {
+            action: 'view',
+            subject: 'Tags',
+            description: 'View tags applied to content',
+        },
+        {
+            action: 'manage',
+            subject: 'Tags',
+            description: 'Create, edit, and delete tags',
+        },
+        {
+            action: 'view',
+            subject: 'UnderlyingData',
+            description: 'View the underlying rows behind a chart',
+        },
+        {
+            action: 'manage',
+            subject: 'Validation',
+            description: 'Run project validation to check for errors',
+        },
+        {
+            action: 'manage',
+            subject: 'VirtualView',
+            description: 'Create and edit virtual views',
+        },
+    ],
+};
+
+const getPermissionsForScopes = (scopes: string[]): Permission[] => {
+    const seen = new Set<string>();
+    const result: Permission[] = [];
+    for (const scope of scopes) {
+        const permissions = PERMISSIONS_BY_SCOPE[scope] ?? [];
+        for (const permission of permissions) {
+            const key = getPermissionKey(permission);
+            if (!seen.has(key)) {
+                seen.add(key);
+                result.push(permission);
+            }
+        }
+    }
+    return result;
+};
+
+export const ServiceAccountPermissionsModal: FC<Props> = ({
+    isOpen,
+    onClose,
+    serviceAccount,
+}) => {
+    const permissions = getPermissionsForScopes(serviceAccount?.scopes ?? []);
+    const title = serviceAccount?.description
+        ? `Permissions for ${serviceAccount.description}`
+        : 'Permissions';
+
+    return (
+        <MantineModal
+            opened={isOpen}
+            onClose={onClose}
+            title={title}
+            size="xl"
+            cancelLabel={false}
+            modalBodyProps={{ px: 0, py: 0 }}
+        >
+            <Stack gap="sm">
+                {permissions.length === 0 ? (
+                    <Text fz="sm" c="dimmed">
+                        No permissions granted by this service account's scopes.
+                    </Text>
+                ) : (
+                    <Table
+                        striped
+                        withRowBorders
+                        verticalSpacing="xs"
+                        horizontalSpacing="md"
+                    >
+                        <Table.Thead>
+                            <Table.Tr>
+                                <Table.Th>Action</Table.Th>
+                                <Table.Th>Resource</Table.Th>
+                                <Table.Th>Description</Table.Th>
+                            </Table.Tr>
+                        </Table.Thead>
+                        <Table.Tbody>
+                            {permissions.map((permission) => {
+                                const key = getPermissionKey(permission);
+                                return (
+                                    <Table.Tr key={key}>
+                                        <Table.Td>
+                                            <Code fz="xs">
+                                                {permission.action}
+                                            </Code>
+                                        </Table.Td>
+                                        <Table.Td>
+                                            <Code fz="xs">
+                                                {permission.subject}
+                                            </Code>
+                                        </Table.Td>
+                                        <Table.Td>
+                                            <Text fz="sm" c="dimmed">
+                                                {permission.description}
+                                            </Text>
+                                        </Table.Td>
+                                    </Table.Tr>
+                                );
+                            })}
+                        </Table.Tbody>
+                    </Table>
+                )}
+            </Stack>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -4,27 +4,35 @@ import {
     type ServiceAccount,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Badge,
-    Button,
     Group,
     HoverCard,
+    Menu,
     Stack,
     Table,
     Text,
     Tooltip,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconInfoCircle, IconTrash } from '@tabler/icons-react';
+import {
+    IconDots,
+    IconInfoCircle,
+    IconKey,
+    IconTrash,
+} from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
+import { ServiceAccountPermissionsModal } from './ServiceAccountPermissionsModal';
 import { ServiceAccountsDeleteModal } from './ServiceAccountsDeleteModal';
 import { isServiceAccountStale, STALE_THRESHOLD_DAYS } from './staleness';
 
 const TableRow: FC<{
     onClickDelete: (serviceAccount: ServiceAccount) => void;
+    onClickInfo: (serviceAccount: ServiceAccount) => void;
     serviceAccount: ServiceAccount;
-}> = ({ onClickDelete, serviceAccount }) => {
+}> = ({ onClickDelete, onClickInfo, serviceAccount }) => {
     const { description, scopes, lastUsedAt, rotatedAt, expiresAt } =
         serviceAccount;
     const stale = isServiceAccountStale(serviceAccount);
@@ -119,15 +127,32 @@ const TableRow: FC<{
                 )}
             </td>
             <td width="1%">
-                <Button
-                    px="xs"
-                    variant="outline"
-                    size="xs"
-                    color="red"
-                    onClick={() => onClickDelete(serviceAccount)}
-                >
-                    <MantineIcon icon={IconTrash} />
-                </Button>
+                <Menu position="bottom-end" withinPortal>
+                    <Menu.Target>
+                        <ActionIcon
+                            variant="transparent"
+                            size="sm"
+                            color="ldGray.6"
+                        >
+                            <MantineIcon icon={IconDots} />
+                        </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <Menu.Item
+                            icon={<MantineIcon icon={IconKey} />}
+                            onClick={() => onClickInfo(serviceAccount)}
+                        >
+                            Permissions
+                        </Menu.Item>
+                        <Menu.Item
+                            icon={<MantineIcon icon={IconTrash} />}
+                            color="red"
+                            onClick={() => onClickDelete(serviceAccount)}
+                        >
+                            Delete
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
             </td>
         </tr>
     );
@@ -146,8 +171,15 @@ export const ServiceAccountsTable: FC<TableProps> = ({
 }) => {
     const { cx, classes } = useTableStyles();
     const [opened, { open, close }] = useDisclosure(false);
+    const [
+        permissionsOpened,
+        { open: openPermissions, close: closePermissions },
+    ] = useDisclosure(false);
 
     const [serviceAccountToDelete, setServiceAccountToDelete] = useState<
+        ServiceAccount | undefined
+    >();
+    const [serviceAccountToView, setServiceAccountToView] = useState<
         ServiceAccount | undefined
     >();
 
@@ -165,6 +197,16 @@ export const ServiceAccountsTable: FC<TableProps> = ({
     const handleCloseModal = () => {
         setServiceAccountToDelete(undefined);
         close();
+    };
+
+    const handleOpenPermissions = (serviceAccount: ServiceAccount) => {
+        setServiceAccountToView(serviceAccount);
+        openPermissions();
+    };
+
+    const handleClosePermissions = () => {
+        setServiceAccountToView(undefined);
+        closePermissions();
     };
 
     return (
@@ -191,6 +233,7 @@ export const ServiceAccountsTable: FC<TableProps> = ({
                             key={serviceAccount.uuid}
                             serviceAccount={serviceAccount}
                             onClickDelete={handleOpenModal}
+                            onClickInfo={handleOpenPermissions}
                         />
                     ))}
                 </tbody>
@@ -202,6 +245,12 @@ export const ServiceAccountsTable: FC<TableProps> = ({
                 isDeleting={isDeleting}
                 onDelete={handleDelete}
                 serviceAccount={serviceAccountToDelete!}
+            />
+
+            <ServiceAccountPermissionsModal
+                isOpen={permissionsOpened}
+                onClose={handleClosePermissions}
+                serviceAccount={serviceAccountToView}
             />
         </>
     );


### PR DESCRIPTION
## Summary
- Adds a permissions modal that displays a service account's resolved scopes in a three-column table (action / resource / description).
- Consolidates the row's info and delete actions into a single triple-dots menu with Permissions and Delete entries.

## Test plan
- [ ] Open the service accounts table and confirm the action menu shows Permissions and Delete
- [ ] Click Permissions for accounts with various scope sets and verify the action/resource/description rows render correctly
- [ ] Verify Delete still works from the new menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)