### PR TITLE
fix: optional chain on `dashboardComments` health check

### DIFF
--- a/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
+++ b/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
@@ -18,7 +18,7 @@ export const useDashboardCommentsCheck = (
 
     // Default-on; opt out via DISABLE_DASHBOARD_COMMENTS=true on the backend.
     const isDashboardCommentsEnabled =
-        health.data?.dashboardComments.enabled ?? true;
+        health.data?.dashboardComments?.enabled ?? true;
 
     return {
         canViewDashboardComments:


### PR DESCRIPTION
Closes: LIGHTDASH-FRONTEND-502

### Description:

Adds optional chaining (`?.`) when accessing `dashboardComments.enabled` from `health.data` to prevent a potential runtime error when `dashboardComments` is `undefined`.