### PR TITLE
feat(managed-agent): track heartbeat runs with status surface

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -353,6 +353,8 @@ import {
 import {
     ManagedAgentActionsTable,
     ManagedAgentActionsTableName,
+    ManagedAgentRunsTable,
+    ManagedAgentRunsTableName,
     ManagedAgentSettingsTable,
     ManagedAgentSettingsTableName,
 } from '../ee/database/entities/managedAgent';
@@ -504,6 +506,7 @@ declare module 'knex/types/tables' {
         [ChangesTableName]: ChangesTable;
         [ManagedAgentSettingsTableName]: ManagedAgentSettingsTable;
         [ManagedAgentActionsTableName]: ManagedAgentActionsTable;
+        [ManagedAgentRunsTableName]: ManagedAgentRunsTable;
         [UserFavoritesTableName]: UserFavoritesTable;
         [ContentVerificationTableName]: ContentVerificationTable;
         [AppsTableName]: AppsTable;

--- a/packages/backend/src/ee/controllers/managedAgentController.ts
+++ b/packages/backend/src/ee/controllers/managedAgentController.ts
@@ -3,6 +3,7 @@ import {
     assertRegisteredAccount,
     ManagedAgentAction,
     ManagedAgentActionType,
+    ManagedAgentRun,
     ManagedAgentSettings,
     UpdateManagedAgentSettings,
 } from '@lightdash/common';
@@ -88,6 +89,22 @@ export class ManagedAgentController extends BaseController {
         );
         this.setStatus(202);
         return { status: 'ok', results: undefined };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/runs/latest')
+    @OperationId('getLatestManagedAgentRun')
+    async getLatestRun(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<{ status: 'ok'; results: ManagedAgentRun | null }> {
+        assertRegisteredAccount(req.account);
+        const results = await this.getManagedAgentService().getLatestRun(
+            toSessionUser(req.account),
+            projectUuid,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results };
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/ee/database/entities/managedAgent.ts
+++ b/packages/backend/src/ee/database/entities/managedAgent.ts
@@ -2,6 +2,7 @@ import { type Knex } from 'knex';
 
 export const ManagedAgentSettingsTableName = 'managed_agent_settings';
 export const ManagedAgentActionsTableName = 'managed_agent_actions';
+export const ManagedAgentRunsTableName = 'managed_agent_runs';
 
 export type DbManagedAgentSettings = {
     project_uuid: string;
@@ -70,6 +71,7 @@ export type DbManagedAgentAction = {
     action_uuid: string;
     project_uuid: string;
     session_id: string;
+    managed_agent_run_uuid: string | null;
     action_type: string;
     target_type: string;
     target_uuid: string;
@@ -89,7 +91,7 @@ export type DbManagedAgentActionWithReverser = DbManagedAgentAction & {
 export type DbManagedAgentActionCreate = Omit<
     DbManagedAgentAction,
     'action_uuid' | 'reversed_at' | 'reversed_by_user_uuid' | 'created_at'
->;
+> & { managed_agent_run_uuid: string | null };
 
 export type DbManagedAgentActionUpdate = Partial<
     Pick<DbManagedAgentAction, 'reversed_at' | 'reversed_by_user_uuid'>
@@ -99,4 +101,43 @@ export type ManagedAgentActionsTable = Knex.CompositeTableType<
     DbManagedAgentAction,
     DbManagedAgentActionCreate,
     DbManagedAgentActionUpdate
+>;
+
+export type DbManagedAgentRun = {
+    managed_agent_run_uuid: string;
+    project_uuid: string;
+    triggered_by: string;
+    status: string;
+    session_id: string | null;
+    started_at: Date;
+    finished_at: Date | null;
+    action_count: number;
+    summary: string | null;
+    error: string | null;
+    current_activity: string | null;
+    created_at: Date;
+};
+
+export type DbManagedAgentRunCreate = Pick<
+    DbManagedAgentRun,
+    'project_uuid' | 'triggered_by' | 'status'
+>;
+
+export type DbManagedAgentRunUpdate = Partial<
+    Pick<
+        DbManagedAgentRun,
+        | 'status'
+        | 'session_id'
+        | 'finished_at'
+        | 'action_count'
+        | 'summary'
+        | 'error'
+        | 'current_activity'
+    >
+>;
+
+export type ManagedAgentRunsTable = Knex.CompositeTableType<
+    DbManagedAgentRun,
+    DbManagedAgentRunCreate,
+    DbManagedAgentRunUpdate
 >;

--- a/packages/backend/src/ee/database/migrations/20260507114342_add_managed_agent_runs.ts
+++ b/packages/backend/src/ee/database/migrations/20260507114342_add_managed_agent_runs.ts
@@ -1,0 +1,68 @@
+import { type Knex } from 'knex';
+
+const ManagedAgentRunsTableName = 'managed_agent_runs';
+const ManagedAgentActionsTableName = 'managed_agent_actions';
+
+export const up = async (knex: Knex): Promise<void> => {
+    await knex.schema.createTable(ManagedAgentRunsTableName, (table) => {
+        table
+            .uuid('managed_agent_run_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        table.text('triggered_by').notNullable();
+        table.text('status').notNullable();
+        table.text('session_id').nullable();
+        table
+            .timestamp('started_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.timestamp('finished_at', { useTz: false }).nullable();
+        table.integer('action_count').notNullable().defaultTo(0);
+        table.text('summary').nullable();
+        table.text('error').nullable();
+        table.text('current_activity').nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+
+    await knex.raw(`
+        CREATE INDEX managed_agent_runs_project_started_idx
+        ON ${ManagedAgentRunsTableName} (project_uuid, started_at DESC)
+    `);
+
+    await knex.raw(`
+        CREATE INDEX managed_agent_runs_active_idx
+        ON ${ManagedAgentRunsTableName} (project_uuid)
+        WHERE status = 'started'
+    `);
+
+    await knex.schema.alterTable(ManagedAgentActionsTableName, (table) => {
+        table
+            .uuid('managed_agent_run_uuid')
+            .nullable()
+            .references('managed_agent_run_uuid')
+            .inTable(ManagedAgentRunsTableName)
+            .onDelete('SET NULL');
+    });
+
+    await knex.raw(`
+        CREATE INDEX managed_agent_actions_run_idx
+        ON ${ManagedAgentActionsTableName} (managed_agent_run_uuid)
+        WHERE managed_agent_run_uuid IS NOT NULL
+    `);
+};
+
+export const down = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable(ManagedAgentActionsTableName, (table) => {
+        table.dropColumn('managed_agent_run_uuid');
+    });
+    await knex.schema.dropTableIfExists(ManagedAgentRunsTableName);
+};

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -1,9 +1,12 @@
 import {
     getManagedAgentScheduleCron,
     getManagedAgentScheduleOption,
+    ManagedAgentRunStatus,
     type CreateManagedAgentAction,
     type ManagedAgentAction,
     type ManagedAgentActionFilters,
+    type ManagedAgentRun,
+    type ManagedAgentRunTriggeredBy,
     type ManagedAgentSettings,
     type UpdateManagedAgentSettings,
 } from '@lightdash/common';
@@ -11,8 +14,10 @@ import { type Knex } from 'knex';
 import type { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     ManagedAgentActionsTableName,
+    ManagedAgentRunsTableName,
     ManagedAgentSettingsTableName,
     type DbManagedAgentActionWithReverser,
+    type DbManagedAgentRun,
     type DbManagedAgentSettings,
 } from '../database/entities/managedAgent';
 
@@ -224,6 +229,7 @@ export class ManagedAgentModel {
             .insert({
                 project_uuid: action.projectUuid,
                 session_id: action.sessionId,
+                managed_agent_run_uuid: action.managedAgentRunUuid,
                 action_type: action.actionType,
                 target_type: action.targetType,
                 target_uuid: action.targetUuid,
@@ -438,5 +444,103 @@ export class ManagedAgentModel {
                 createdAt: r.created_at,
             }),
         );
+    }
+
+    // --- Runs ---
+
+    // Defensive: a run row stuck in 'started' for this long is treated as
+    // errored at read time. Covers worker-pod crashes between createRun and
+    // finishRun that would otherwise leave the row (and the play button)
+    // locked forever.
+    private static readonly STALE_RUN_THRESHOLD_MS = 15 * 60 * 1000;
+
+    static mapDbRun(row: DbManagedAgentRun): ManagedAgentRun {
+        const rawStatus = row.status as ManagedAgentRunStatus;
+        const isStale =
+            rawStatus === ManagedAgentRunStatus.STARTED &&
+            row.started_at.getTime() <
+                Date.now() - ManagedAgentModel.STALE_RUN_THRESHOLD_MS;
+        // Synthesised finish for stale runs: pin to started_at + threshold
+        // (the latest moment the run could plausibly have been alive).
+        // Using `new Date()` instead would shift on every read, breaking
+        // duration display; using `started_at` would imply 0 duration.
+        const synthesisedFinishedAt = new Date(
+            row.started_at.getTime() + ManagedAgentModel.STALE_RUN_THRESHOLD_MS,
+        );
+        return {
+            runUuid: row.managed_agent_run_uuid,
+            projectUuid: row.project_uuid,
+            triggeredBy: row.triggered_by as ManagedAgentRunTriggeredBy,
+            status: isStale ? ManagedAgentRunStatus.ERROR : rawStatus,
+            sessionId: row.session_id,
+            startedAt: row.started_at,
+            finishedAt:
+                isStale && !row.finished_at
+                    ? synthesisedFinishedAt
+                    : row.finished_at,
+            actionCount: row.action_count,
+            summary: row.summary,
+            error: isStale
+                ? (row.error ?? 'Run timed out — worker may have crashed')
+                : row.error,
+        };
+    }
+
+    async createRun(input: {
+        projectUuid: string;
+        triggeredBy: ManagedAgentRunTriggeredBy;
+    }): Promise<ManagedAgentRun> {
+        const [row] = await this.database(ManagedAgentRunsTableName)
+            .insert({
+                project_uuid: input.projectUuid,
+                triggered_by: input.triggeredBy,
+                status: ManagedAgentRunStatus.STARTED,
+            })
+            .returning('*');
+        return ManagedAgentModel.mapDbRun(row);
+    }
+
+    async setRunSessionId(runUuid: string, sessionId: string): Promise<void> {
+        await this.database(ManagedAgentRunsTableName)
+            .where({ managed_agent_run_uuid: runUuid })
+            .update({ session_id: sessionId });
+    }
+
+    async finishRun(
+        runUuid: string,
+        update: {
+            status:
+                | ManagedAgentRunStatus.COMPLETED
+                | ManagedAgentRunStatus.ERROR;
+            actionCount: number;
+            summary: string | null;
+            error: string | null;
+        },
+    ): Promise<void> {
+        await this.database(ManagedAgentRunsTableName)
+            .where({ managed_agent_run_uuid: runUuid })
+            .update({
+                status: update.status,
+                finished_at: new Date(),
+                action_count: update.actionCount,
+                summary: update.summary,
+                error: update.error,
+            });
+    }
+
+    async countActionsForRun(runUuid: string): Promise<number> {
+        const result = await this.database(ManagedAgentActionsTableName)
+            .where({ managed_agent_run_uuid: runUuid })
+            .count<{ count: string }[]>('* as count')
+            .first();
+        return result ? Number(result.count) : 0;
+    }
+
+    async getLatestRun(projectUuid: string): Promise<ManagedAgentRun | null> {
+        const row = await this.database(ManagedAgentRunsTableName)
+            .where({ project_uuid: projectUuid })
+            .orderBy('started_at', 'desc')
+            .first();
+        return row ? ManagedAgentModel.mapDbRun(row) : null;
     }
 }

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -161,8 +161,16 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     `Running managed agent heartbeat for project ${projectUuid} (${triggeredBy})`,
                 );
 
+                const { runUuid } = await this.managedAgentService.startRun(
+                    projectUuid,
+                    triggeredBy,
+                );
+
                 try {
-                    await this.managedAgentService.runHeartbeat(projectUuid);
+                    await this.managedAgentService.runHeartbeat(
+                        projectUuid,
+                        runUuid,
+                    );
                     Logger.info(
                         `Heartbeat completed for project ${projectUuid}`,
                     );

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -6,6 +6,7 @@ import {
     getManagedAgentActionCategory,
     getManagedAgentScheduleCron,
     ManagedAgentActionType,
+    ManagedAgentRunStatus,
     ManagedAgentTargetType,
     NotFoundError,
     ParameterError,
@@ -14,6 +15,8 @@ import {
     type ChartConfig,
     type ManagedAgentAction,
     type ManagedAgentActionFilters,
+    type ManagedAgentRun,
+    type ManagedAgentRunTriggeredBy,
     type ManagedAgentSettings,
     type MetricQuery,
     type SavedChart,
@@ -460,6 +463,26 @@ export class ManagedAgentService extends BaseService {
         return this.managedAgentModel.getEnabledProjects();
     }
 
+    // Worker-only entry point: creates the run row at the start of a
+    // heartbeat. No permission check because the only caller is the scheduler
+    // worker (system context, no SessionUser). User-facing triggers go
+    // through `startHeartbeat` which performs `assertCanManageProject`
+    // before enqueueing the worker job.
+    async startRun(
+        projectUuid: string,
+        triggeredBy: ManagedAgentRunTriggeredBy,
+    ): Promise<ManagedAgentRun> {
+        return this.managedAgentModel.createRun({ projectUuid, triggeredBy });
+    }
+
+    async getLatestRun(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ManagedAgentRun | null> {
+        await this.assertCanViewProject(user, projectUuid);
+        return this.managedAgentModel.getLatestRun(projectUuid);
+    }
+
     async isAiAutopilotEnabledForProject(
         settings: ManagedAgentSettings,
     ): Promise<boolean> {
@@ -596,9 +619,10 @@ export class ManagedAgentService extends BaseService {
 
     // --- Heartbeat ---
 
-    async runHeartbeat(projectUuid: string): Promise<void> {
+    async runHeartbeat(projectUuid: string, runUuid: string): Promise<void> {
         const settings = await this.managedAgentModel.getSettings(projectUuid);
         if (!settings?.enabled) {
+            await this.failRunSafely(runUuid, 'Autopilot disabled');
             return;
         }
 
@@ -609,6 +633,7 @@ export class ManagedAgentService extends BaseService {
             this.logger.warn(
                 `No service account token for project ${projectUuid}, skipping heartbeat`,
             );
+            await this.failRunSafely(runUuid, 'No service account token');
             return;
         }
 
@@ -620,15 +645,31 @@ export class ManagedAgentService extends BaseService {
         );
         let sessionId = '';
         let agentSummary = '';
+        let runError: string | null = null;
 
         const onToolCall = async (
             toolName: string,
             input: Record<string, unknown>,
         ): Promise<string> =>
-            this.handleToolCall(projectUuid, sessionId, toolName, input);
+            this.handleToolCall(
+                projectUuid,
+                sessionId,
+                runUuid,
+                toolName,
+                input,
+            );
 
         const onSessionCreated = (id: string) => {
             sessionId = id;
+            void this.managedAgentModel
+                .setRunSessionId(runUuid, id)
+                .catch((e) =>
+                    this.logger.error(
+                        `Failed to set session_id on run ${runUuid}: ${
+                            e instanceof Error ? e.message : 'Unknown'
+                        }`,
+                    ),
+                );
         };
 
         try {
@@ -645,7 +686,28 @@ export class ManagedAgentService extends BaseService {
             this.logger.error(
                 `Heartbeat session error for project ${projectUuid}: ${error instanceof Error ? error.message : 'Unknown'}`,
             );
+            runError = error instanceof Error ? error.message : 'Unknown';
         } finally {
+            const actionCount = await this.managedAgentModel
+                .countActionsForRun(runUuid)
+                .catch(() => 0);
+            await this.managedAgentModel
+                .finishRun(runUuid, {
+                    status: runError
+                        ? ManagedAgentRunStatus.ERROR
+                        : ManagedAgentRunStatus.COMPLETED,
+                    actionCount,
+                    summary: agentSummary || null,
+                    error: runError,
+                })
+                .catch((e) =>
+                    this.logger.error(
+                        `Failed to finish run ${runUuid}: ${
+                            e instanceof Error ? e.message : 'Unknown'
+                        }`,
+                    ),
+                );
+
             // Post summary to Slack even if the session errored — actions
             // recorded via custom tools before the crash are still valuable.
             this.logger.info(
@@ -660,6 +722,23 @@ export class ManagedAgentService extends BaseService {
                 );
             }
         }
+    }
+
+    private async failRunSafely(runUuid: string, error: string): Promise<void> {
+        await this.managedAgentModel
+            .finishRun(runUuid, {
+                status: ManagedAgentRunStatus.ERROR,
+                actionCount: 0,
+                summary: null,
+                error,
+            })
+            .catch((e) =>
+                this.logger.error(
+                    `Failed to fail run ${runUuid}: ${
+                        e instanceof Error ? e.message : 'Unknown'
+                    }`,
+                ),
+            );
     }
 
     async startHeartbeat(
@@ -822,6 +901,7 @@ export class ManagedAgentService extends BaseService {
     private async handleToolCall(
         projectUuid: string,
         sessionId: string,
+        runUuid: string,
         toolName: string,
         input: Record<string, unknown>,
     ): Promise<string> {
@@ -842,19 +922,44 @@ export class ManagedAgentService extends BaseService {
             case 'get_popular_content':
                 return this.handleGetPopularContent(projectUuid);
             case 'flag_content':
-                return this.handleFlagContent(projectUuid, sessionId, input);
+                return this.handleFlagContent(
+                    projectUuid,
+                    sessionId,
+                    runUuid,
+                    input,
+                );
             case 'soft_delete_content':
-                return this.handleSoftDelete(projectUuid, sessionId, input);
+                return this.handleSoftDelete(
+                    projectUuid,
+                    sessionId,
+                    runUuid,
+                    input,
+                );
             case 'log_insight':
-                return this.handleLogInsight(projectUuid, sessionId, input);
+                return this.handleLogInsight(
+                    projectUuid,
+                    sessionId,
+                    runUuid,
+                    input,
+                );
             case 'get_chart_details':
                 return this.handleGetChartDetails(projectUuid, input);
             case 'get_chart_schema':
                 return this.handleGetChartSchema();
             case 'fix_broken_chart':
-                return this.handleFixBrokenChart(projectUuid, sessionId, input);
+                return this.handleFixBrokenChart(
+                    projectUuid,
+                    sessionId,
+                    runUuid,
+                    input,
+                );
             case 'create_content_from_code':
-                return this.handleCreateContent(projectUuid, sessionId, input);
+                return this.handleCreateContent(
+                    projectUuid,
+                    sessionId,
+                    runUuid,
+                    input,
+                );
             case 'get_user_questions':
                 return this.handleGetUserQuestions(projectUuid, input);
             case 'get_slow_queries':
@@ -1114,6 +1219,7 @@ chartConfig:
     private async handleFixBrokenChart(
         projectUuid: string,
         sessionId: string,
+        runUuid: string,
         input: Record<string, unknown>,
     ): Promise<string> {
         const chartUuid = input.chart_uuid as string;
@@ -1172,6 +1278,7 @@ chartConfig:
         const action = await this.managedAgentModel.createAction({
             projectUuid,
             sessionId,
+            managedAgentRunUuid: runUuid,
             actionType: ManagedAgentActionType.FIXED_BROKEN,
             targetType: ManagedAgentTargetType.CHART,
             targetUuid: chartUuid,
@@ -1223,6 +1330,7 @@ chartConfig:
     private async handleCreateContent(
         projectUuid: string,
         sessionId: string,
+        runUuid: string,
         input: Record<string, unknown>,
     ): Promise<string> {
         const chartAsCode = input.chart_as_code as Record<string, unknown>;
@@ -1349,6 +1457,7 @@ chartConfig:
         const action = await this.managedAgentModel.createAction({
             projectUuid,
             sessionId,
+            managedAgentRunUuid: runUuid,
             actionType: ManagedAgentActionType.CREATED_CONTENT,
             targetType: ManagedAgentTargetType.CHART,
             targetUuid: chart.uuid,
@@ -1373,6 +1482,7 @@ chartConfig:
     private async handleFlagContent(
         projectUuid: string,
         sessionId: string,
+        runUuid: string,
         input: Record<string, unknown>,
     ): Promise<string> {
         const targetUuid = input.target_uuid as string;
@@ -1418,6 +1528,7 @@ chartConfig:
         const action = await this.managedAgentModel.createAction({
             projectUuid,
             sessionId,
+            managedAgentRunUuid: runUuid,
             actionType: flagType as ManagedAgentActionType,
             targetType,
             targetUuid,
@@ -1431,6 +1542,7 @@ chartConfig:
     private async handleSoftDelete(
         projectUuid: string,
         sessionId: string,
+        runUuid: string,
         input: Record<string, unknown>,
     ): Promise<string> {
         const targetUuid = input.target_uuid as string;
@@ -1509,6 +1621,7 @@ chartConfig:
         const action = await this.managedAgentModel.createAction({
             projectUuid,
             sessionId,
+            managedAgentRunUuid: runUuid,
             actionType: ManagedAgentActionType.SOFT_DELETED,
             targetType,
             targetUuid,
@@ -1525,6 +1638,7 @@ chartConfig:
     private async handleLogInsight(
         projectUuid: string,
         sessionId: string,
+        runUuid: string,
         input: Record<string, unknown>,
     ): Promise<string> {
         const targetUuid = input.target_uuid as string;
@@ -1545,6 +1659,7 @@ chartConfig:
         const action = await this.managedAgentModel.createAction({
             projectUuid,
             sessionId,
+            managedAgentRunUuid: runUuid,
             actionType: ManagedAgentActionType.INSIGHT,
             targetType,
             targetUuid,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1260,6 +1260,75 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ManagedAgentRunTriggeredBy: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['cron'] },
+                { dataType: 'enum', enums: ['manual'] },
+                { dataType: 'enum', enums: ['on_enable'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ManagedAgentRunStatus: {
+        dataType: 'refEnum',
+        enums: ['started', 'completed', 'error'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ManagedAgentRun: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                error: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                summary: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                actionCount: { dataType: 'double', required: true },
+                finishedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                startedAt: { dataType: 'datetime', required: true },
+                sessionId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { ref: 'ManagedAgentRunStatus', required: true },
+                triggeredBy: {
+                    ref: 'ManagedAgentRunTriggeredBy',
+                    required: true,
+                },
+                projectUuid: { dataType: 'string', required: true },
+                runUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ManagedAgentActionType: {
         dataType: 'refEnum',
         enums: [
@@ -2330,14 +2399,6 @@ const models: TsoaRoute.Models = {
                     ],
                 },
                 deletedAt: { dataType: 'datetime' },
-                colorPaletteUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
                 config: { ref: 'DashboardConfig' },
                 slug: { dataType: 'string', required: true },
                 access: {
@@ -9460,17 +9521,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9499,7 +9560,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9507,7 +9568,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9522,7 +9587,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9530,11 +9595,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9718,17 +9779,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9836,11 +9897,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16890,14 +16951,6 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
-                    colorPaletteUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
                     deletedAt: {
                         dataType: 'union',
                         subSchemas: [
@@ -17036,14 +17089,6 @@ const models: TsoaRoute.Models = {
                         ],
                     },
                     spaceName: { dataType: 'string', required: true },
-                    colorPaletteUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
                     deletedAt: {
                         dataType: 'union',
                         subSchemas: [
@@ -17115,6 +17160,14 @@ const models: TsoaRoute.Models = {
                     colorPalette: {
                         dataType: 'array',
                         array: { dataType: 'string' },
+                        required: true,
+                    },
+                    colorPaletteUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
                         required: true,
                     },
                     resolvedColorPalette: {
@@ -17921,6 +17974,7 @@ const models: TsoaRoute.Models = {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
                     name: { dataType: 'string', required: true },
+                    cron: { dataType: 'string', required: true },
                     projectUuid: {
                         dataType: 'union',
                         subSchemas: [
@@ -17929,7 +17983,6 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
-                    cron: { dataType: 'string', required: true },
                     message: {
                         dataType: 'union',
                         subSchemas: [
@@ -20822,13 +20875,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                colorPaletteUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                },
                 config: { ref: 'DashboardConfig' },
                 tabs: {
                     dataType: 'array',
@@ -21580,7 +21626,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21590,7 +21636,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21600,7 +21646,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21613,7 +21659,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -22024,7 +22070,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22034,7 +22080,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22044,7 +22090,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -22057,7 +22103,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -28986,44 +29032,35 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateDashboard.name-or-description-or-spaceUuid-or-colorPaletteUuid_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    description: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    name: { dataType: 'string', required: true },
-                    spaceUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    colorPaletteUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                            { dataType: 'undefined' },
-                        ],
-                    },
+    'Pick_CreateDashboard.name-or-description-or-spaceUuid_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
                 },
-                validators: {},
+                name: { dataType: 'string', required: true },
+                spaceUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
+            validators: {},
         },
+    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardUnversionedFields: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_CreateDashboard.name-or-description-or-spaceUuid-or-colorPaletteUuid_',
+            ref: 'Pick_CreateDashboard.name-or-description-or-spaceUuid_',
             validators: {},
         },
     },
@@ -32605,6 +32642,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'runHeartbeat',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsManagedAgentController_getLatestRun: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/managed-agent/runs/latest',
+        ...fetchMiddlewares<RequestHandler>(ManagedAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            ManagedAgentController.prototype.getLatestRun,
+        ),
+
+        async function ManagedAgentController_getLatestRun(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsManagedAgentController_getLatestRun,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ManagedAgentController>(
+                        ManagedAgentController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getLatestRun',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1302,6 +1302,68 @@
                 },
                 "type": "object"
             },
+            "ManagedAgentRunTriggeredBy": {
+                "type": "string",
+                "enum": ["cron", "manual", "on_enable"]
+            },
+            "ManagedAgentRunStatus": {
+                "enum": ["started", "completed", "error"],
+                "type": "string"
+            },
+            "ManagedAgentRun": {
+                "properties": {
+                    "error": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "summary": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "actionCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "finishedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "sessionId": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/ManagedAgentRunStatus"
+                    },
+                    "triggeredBy": {
+                        "$ref": "#/components/schemas/ManagedAgentRunTriggeredBy"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "runUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "error",
+                    "summary",
+                    "actionCount",
+                    "finishedAt",
+                    "startedAt",
+                    "sessionId",
+                    "status",
+                    "triggeredBy",
+                    "projectUuid",
+                    "runUuid"
+                ],
+                "type": "object"
+            },
             "ManagedAgentActionType": {
                 "enum": [
                     "flagged_stale",
@@ -2487,10 +2549,6 @@
                         "type": "string",
                         "format": "date-time"
                     },
-                    "colorPaletteUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "config": {
                         "$ref": "#/components/schemas/DashboardConfig"
                     },
@@ -2595,7 +2653,6 @@
                     }
                 },
                 "required": [
-                    "colorPaletteUuid",
                     "slug",
                     "access",
                     "inheritsFromOrgOrProject",
@@ -10821,10 +10878,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -10833,8 +10890,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10844,16 +10901,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -10941,10 +10998,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -10953,8 +11010,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10984,19 +11041,6 @@
                                                         "enum": [
                                                             "error",
                                                             "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -17885,10 +17929,6 @@
                     "config": {
                         "$ref": "#/components/schemas/DashboardConfig"
                     },
-                    "colorPaletteUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "deletedAt": {
                         "type": "string",
                         "format": "date-time"
@@ -17928,8 +17968,7 @@
                     "spaceName",
                     "views",
                     "firstViewedAt",
-                    "tabs",
-                    "colorPaletteUuid"
+                    "tabs"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
@@ -18026,11 +18065,6 @@
                     "spaceName": {
                         "type": "string"
                     },
-                    "colorPaletteUuid": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Chart-level palette override pointer. `null` means inherit from the\ncontaining dashboard / space / project / org. Writable via\n`UpdateSavedChart`."
-                    },
                     "deletedAt": {
                         "type": "string",
                         "format": "date-time"
@@ -18096,6 +18130,11 @@
                         "type": "array",
                         "deprecated": true
                     },
+                    "colorPaletteUuid": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Chart-level palette override pointer. `null` means inherit from the\ncontaining dashboard / space / project / org. Writable via\n`UpdateSavedChart`."
+                    },
                     "resolvedColorPalette": {
                         "$ref": "#/components/schemas/ResolvedProjectColorPalette",
                         "description": "Fully resolved palette for this chart, computed from the\norg → project → space → dashboard → chart hierarchy. Read-only — set\nthe chart's own palette via `colorPaletteUuid`."
@@ -18115,12 +18154,12 @@
                     "slug",
                     "verification",
                     "spaceName",
-                    "colorPaletteUuid",
                     "tableName",
                     "metricQuery",
                     "tableConfig",
                     "dashboardName",
                     "colorPalette",
+                    "colorPaletteUuid",
                     "resolvedColorPalette"
                 ],
                 "type": "object",
@@ -19092,12 +19131,12 @@
                     "name": {
                         "type": "string"
                     },
+                    "cron": {
+                        "type": "string"
+                    },
                     "projectUuid": {
                         "type": "string",
                         "nullable": true
-                    },
-                    "cron": {
-                        "type": "string"
                     },
                     "message": {
                         "type": "string"
@@ -22237,10 +22276,6 @@
             },
             "CreateDashboard": {
                 "properties": {
-                    "colorPaletteUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "config": {
                         "$ref": "#/components/schemas/DashboardConfig"
                     },
@@ -22984,22 +23019,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -23354,22 +23389,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -30174,7 +30209,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_CreateDashboard.name-or-description-or-spaceUuid-or-colorPaletteUuid_": {
+            "Pick_CreateDashboard.name-or-description-or-spaceUuid_": {
                 "properties": {
                     "description": {
                         "type": "string"
@@ -30184,10 +30219,6 @@
                     },
                     "spaceUuid": {
                         "type": "string"
-                    },
-                    "colorPaletteUuid": {
-                        "type": "string",
-                        "nullable": true
                     }
                 },
                 "required": ["name"],
@@ -30195,7 +30226,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "DashboardUnversionedFields": {
-                "$ref": "#/components/schemas/Pick_CreateDashboard.name-or-description-or-spaceUuid-or-colorPaletteUuid_"
+                "$ref": "#/components/schemas/Pick_CreateDashboard.name-or-description-or-spaceUuid_"
             },
             "Pick_CreateDashboard.tiles-or-filters-or-parameters-or-updatedByUser-or-tabs-or-config_": {
                 "properties": {
@@ -31881,7 +31912,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2893.1",
+        "version": "0.2893.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -1,3 +1,5 @@
+import { type ApiSuccess } from '../../types/api/success';
+
 export enum ManagedAgentActionType {
     FLAGGED_STALE = 'flagged_stale',
     SOFT_DELETED = 'soft_deleted',
@@ -123,6 +125,7 @@ export type UpdateManagedAgentSettings = {
 export type CreateManagedAgentAction = {
     projectUuid: string;
     sessionId: string;
+    managedAgentRunUuid: string | null;
     actionType: ManagedAgentActionType;
     targetType: ManagedAgentTargetType;
     targetUuid: string;
@@ -130,6 +133,29 @@ export type CreateManagedAgentAction = {
     description: string;
     metadata: Record<string, unknown>;
 };
+
+export enum ManagedAgentRunStatus {
+    STARTED = 'started',
+    COMPLETED = 'completed',
+    ERROR = 'error',
+}
+
+export type ManagedAgentRunTriggeredBy = 'cron' | 'manual' | 'on_enable';
+
+export type ManagedAgentRun = {
+    runUuid: string;
+    projectUuid: string;
+    triggeredBy: ManagedAgentRunTriggeredBy;
+    status: ManagedAgentRunStatus;
+    sessionId: string | null;
+    startedAt: Date;
+    finishedAt: Date | null;
+    actionCount: number;
+    summary: string | null;
+    error: string | null;
+};
+
+export type ApiManagedAgentRunResponse = ApiSuccess<ManagedAgentRun | null>;
 
 export type ManagedAgentActionFilters = {
     date?: string;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -29,6 +29,7 @@ import type {
     ApiGenerateAppResponse,
     ApiGetAppResponse,
     ApiGetUserAgentPreferencesResponse,
+    ApiManagedAgentRunResponse,
     ApiMyAppsResponse,
     ApiPreviewTokenResponse,
     ApiUpdateAiOrganizationSettingsResponse,
@@ -1049,6 +1050,7 @@ type ApiResults =
     | ApiPreviewTokenResponse['results']
     | ApiAppImageUploadResponse['results']
     | ApiProjectColorPaletteResponse['results']
+    | ApiManagedAgentRunResponse['results']
     | DashboardPreAggregateAudit;
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -4,6 +4,7 @@ import {
     type ContentVerificationInfo,
     type Dashboard,
     getManagedAgentActionCategory,
+    ManagedAgentRunStatus,
     ManagedAgentScheduleOption,
     type Project,
     type SavedChart,
@@ -50,7 +51,14 @@ import {
 } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { format, formatDistanceToNowStrict } from 'date-fns';
-import { useCallback, useEffect, useMemo, type FC, useState } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
@@ -68,6 +76,7 @@ import { useProject } from '../../../hooks/useProject';
 import { useSavedQuery } from '../../../hooks/useSavedQuery';
 import useApp from '../../../providers/App/useApp';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
+import { useManagedAgentLatestRun } from './hooks/useManagedAgentLatestRun';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
 import classes from './ManagedAgentActivityPage.module.css';
 import type { ManagedAgentAction } from './types';
@@ -100,6 +109,24 @@ const runHeartbeat = async (projectUuid: string) =>
         method: 'POST',
         body: undefined,
     });
+
+const SUMMARY_SUBTITLE_MAX = 120;
+
+const summaryToSubtitle = (
+    summary: string | null | undefined,
+): string | null => {
+    if (!summary) return null;
+    const firstLine = summary
+        .split('\n')
+        .map((l) => l.trim())
+        .find(
+            (l) => l.length > 0 && !l.startsWith('#') && !l.startsWith('---'),
+        );
+    if (!firstLine) return null;
+    return firstLine.length <= SUMMARY_SUBTITLE_MAX
+        ? firstLine
+        : `${firstLine.slice(0, SUMMARY_SUBTITLE_MAX - 1)}…`;
+};
 
 const SCHEDULE_OPTIONS = [
     { value: ManagedAgentScheduleOption.EVERY_6_HOURS, label: 'Every 6 hours' },
@@ -143,6 +170,7 @@ const SetupSection: FC<{
     onOpenSettings: () => void;
     onRunNow: () => void;
     isRunNowLoading: boolean;
+    isRunning: boolean;
 }> = ({
     enabled,
     schedule: initialSchedule,
@@ -150,6 +178,7 @@ const SetupSection: FC<{
     onOpenSettings,
     onRunNow,
     isRunNowLoading,
+    isRunning,
 }) => {
     const scheduleLabel =
         SCHEDULE_OPTIONS.find((o) => o.value === initialSchedule)?.label ??
@@ -189,9 +218,11 @@ const SetupSection: FC<{
                 <Group gap="xs">
                     <Tooltip
                         label={
-                            enabled
-                                ? 'Run Autopilot now'
-                                : 'Enable Autopilot to run now'
+                            isRunning
+                                ? 'Autopilot is running…'
+                                : enabled
+                                  ? 'Run Autopilot now'
+                                  : 'Enable Autopilot to run now'
                         }
                     >
                         <ActionIcon
@@ -201,8 +232,8 @@ const SetupSection: FC<{
                             size="md"
                             radius="md"
                             onClick={onRunNow}
-                            disabled={!enabled || isRunNowLoading}
-                            loading={isRunNowLoading}
+                            disabled={!enabled || isRunNowLoading || isRunning}
+                            loading={isRunNowLoading || isRunning}
                         >
                             <MantineIcon icon={IconPlayerPlay} size="sm" />
                         </ActionIcon>
@@ -1327,12 +1358,59 @@ export const ManagedAgentActivityPage: FC = () => {
                 projectUuid,
             }),
         ) ?? false;
-    const { showToastSuccess, showToastApiError } = useToaster();
-    const { data: actions, isLoading } = useManagedAgentActions({
-        enabled: canManageAutopilot,
-    });
+    const { showToastSuccess, showToastError, showToastApiError } =
+        useToaster();
     const { data: settings, isLoading: settingsLoading } =
         useManagedAgentSettings({ enabled: canManageAutopilot });
+    const { data: latestRun } = useManagedAgentLatestRun({
+        enabled: canManageAutopilot,
+    });
+    const isRunning = latestRun?.status === ManagedAgentRunStatus.STARTED;
+    const { data: actions, isLoading } = useManagedAgentActions({
+        enabled: canManageAutopilot,
+        fastPoll: isRunning,
+    });
+    const previousRunStatus = useRef(latestRun?.status);
+    useEffect(() => {
+        const prev = previousRunStatus.current;
+        const curr = latestRun?.status;
+        if (
+            prev === ManagedAgentRunStatus.STARTED &&
+            curr &&
+            curr !== ManagedAgentRunStatus.STARTED
+        ) {
+            void queryClient.invalidateQueries({
+                queryKey: ['managed-agent-actions', projectUuid],
+            });
+            if (curr === ManagedAgentRunStatus.COMPLETED) {
+                const count = latestRun?.actionCount ?? 0;
+                const summarySnippet = summaryToSubtitle(latestRun?.summary);
+                const countFallback =
+                    count === 0
+                        ? 'No actions needed'
+                        : `${count} action${count === 1 ? '' : 's'} taken`;
+                showToastSuccess({
+                    title: 'Autopilot finished',
+                    subtitle: summarySnippet ?? countFallback,
+                });
+            } else if (curr === ManagedAgentRunStatus.ERROR) {
+                showToastError({
+                    title: 'Autopilot run failed',
+                    subtitle: latestRun?.error ?? 'Unknown error',
+                });
+            }
+        }
+        previousRunStatus.current = curr;
+    }, [
+        latestRun?.status,
+        latestRun?.actionCount,
+        latestRun?.error,
+        latestRun?.summary,
+        projectUuid,
+        queryClient,
+        showToastSuccess,
+        showToastError,
+    ]);
     const [selected, setSelected] = useState<ManagedAgentAction | null>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
     const [userOpenState, setUserOpenState] = useState<Map<string, boolean>>(
@@ -1404,6 +1482,9 @@ export const ManagedAgentActivityPage: FC = () => {
             void queryClient.invalidateQueries({
                 queryKey: ['managed-agent-actions', projectUuid],
             });
+            void queryClient.invalidateQueries({
+                queryKey: ['managed-agent-latest-run', projectUuid],
+            });
         },
         onError: ({ error }) => {
             showToastApiError({
@@ -1447,6 +1528,7 @@ export const ManagedAgentActivityPage: FC = () => {
                                 }
                                 settingsOpen={settingsOpen}
                                 isRunNowLoading={runNowMutation.isLoading}
+                                isRunning={isRunning}
                                 onRunNow={() => runNowMutation.mutate()}
                                 onOpenSettings={() => {
                                     setSelected(null);

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentActions.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentActions.ts
@@ -10,13 +10,15 @@ const getActions = async (projectUuid: string): Promise<ManagedAgentAction[]> =>
         body: undefined,
     });
 
-export const useManagedAgentActions = (opts: { enabled?: boolean } = {}) => {
+export const useManagedAgentActions = (
+    opts: { enabled?: boolean; fastPoll?: boolean } = {},
+) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const isEnabled = opts.enabled ?? true;
     return useQuery<ManagedAgentAction[]>({
         queryKey: ['managed-agent-actions', projectUuid],
         queryFn: () => getActions(projectUuid!),
         enabled: !!projectUuid && isEnabled,
-        refetchInterval: isEnabled ? 30000 : false,
+        refetchInterval: isEnabled ? (opts.fastPoll ? 3000 : 30000) : false,
     });
 };

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentLatestRun.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentLatestRun.ts
@@ -1,0 +1,30 @@
+import { ManagedAgentRunStatus, type ManagedAgentRun } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router';
+import { lightdashApi } from '../../../../api';
+
+const POLL_INTERVAL_RUNNING_MS = 3000;
+const POLL_INTERVAL_IDLE_MS = 30000;
+
+const getLatestRun = async (
+    projectUuid: string,
+): Promise<ManagedAgentRun | null> =>
+    lightdashApi<ManagedAgentRun | null>({
+        url: `/projects/${projectUuid}/managed-agent/runs/latest`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useManagedAgentLatestRun = (opts: { enabled?: boolean } = {}) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const isEnabled = opts.enabled ?? true;
+    return useQuery<ManagedAgentRun | null>({
+        queryKey: ['managed-agent-latest-run', projectUuid],
+        queryFn: () => getLatestRun(projectUuid!),
+        enabled: !!projectUuid && isEnabled,
+        refetchInterval: (data) =>
+            data?.status === ManagedAgentRunStatus.STARTED
+                ? POLL_INTERVAL_RUNNING_MS
+                : POLL_INTERVAL_IDLE_MS,
+    });
+};


### PR DESCRIPTION
## Summary

Make heartbeat runs first-class entities so the UI can show "currently running."

- New `managed_agent_runs` table (run UUID, project, triggeredBy, status, started/finished, action_count, summary, error).
- `managed_agent_actions.managed_agent_run_uuid` FK ties each action to its parent run.
- New `GET /projects/:projectUuid/managed-agent/runs/latest` endpoint.
- New `useManagedAgentLatestRun()` hook polls every 3s; `ManagedAgentActivityPage` derives `isRunning` from `latestRun.status === STARTED`.
- **Manual / on-enable triggers create the run row at enqueue time** (`startHeartbeat` calls `startRun()` before enqueueing, threads `runUuid` through the job payload). This eliminates the worker-pickup latency from the user-facing "Running" indicator — the next poll after click sees the run instantly.

## Why

Previously, the activity page only showed completed *actions* — there was no way to tell "is the agent running right now?" or "did the last run error?". Runs as a first-class concept also unblocks future per-run summaries / Slack notifications.

The eager run-row creation closes a UX gap introduced by #22756: with the heartbeat now executing on the scheduler worker, there's a 0–3s window between click and worker pickup. Without an eager row, the activity page would briefly show stale state. Creating the row at enqueue time means the UI reflects the trigger immediately.

## Regression analysis

- **Migration**: additive only — new table + nullable FK column + 3 indexes. No data backfill needed; existing actions stay with `managed_agent_run_uuid = NULL`.
- **Polling cost**: 3s polling only fires on the activity page and is gated by `canManageAutopilot`, so non-developers do not poll.
- **Endpoint authz**: gated by `assertCanManageProject` inside the service.
- **Cron path unchanged**: cron jobs do not pre-create the run row (no user is watching). Worker still creates the row at pickup. Asymmetric but pragmatic.
- **Orphaned STARTED rows**: if `startRun()` succeeds but the enqueue fails, the row is stuck at STARTED. Acceptable trade-off for now — the next successful run becomes "latest" and the orphan drops off the UI. A sweeper for stuck runs is a follow-up.

## Test plan
- [ ] Run migration up + down on a populated db
- [ ] Click "Run now" → activity page shows running indicator within ~3s (no ghost window)
- [ ] Enable agent → activity page shows running indicator within ~3s
- [ ] Wait for cron tick → activity page shows running indicator (worker creates row on pickup, ~3s after tick)
- [ ] Force-error a run → status surfaces as `error`
- [ ] Verify non-developer users don't poll (network tab)