### PR TITLE
fix: don't throw on fe feature flag error 

### DIFF
--- a/packages/frontend/src/components/ProjectAccess/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/index.tsx
@@ -21,14 +21,8 @@ const ProjectUserAccess: FC<ProjectUserAccessProps> = ({ projectUuid }) => {
 
     if (!user.data) return null;
 
-    if (userGroupsFeatureFlagQuery.isError) {
-        console.error(userGroupsFeatureFlagQuery.error);
-        throw new Error('Error fetching user groups feature flag');
-    }
-
     const isGroupManagementEnabled =
-        userGroupsFeatureFlagQuery.isSuccess &&
-        userGroupsFeatureFlagQuery.data.enabled;
+        userGroupsFeatureFlagQuery.data?.enabled ?? false;
 
     return (
         <Stack gap="md">

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -134,14 +134,8 @@ const UserAttributeModal: FC<{
         handleClose();
     };
 
-    if (userGroupsFeatureFlagQuery.isError) {
-        console.error(userGroupsFeatureFlagQuery.error);
-        throw new Error('Error fetching user groups feature flag');
-    }
-
     const isGroupManagementEnabled =
-        userGroupsFeatureFlagQuery.isSuccess &&
-        userGroupsFeatureFlagQuery.data.enabled;
+        userGroupsFeatureFlagQuery.data?.enabled ?? false;
 
     const { data: orgUsers } = useOrganizationUsers();
     const { data: groups } = useOrganizationGroups(

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -62,8 +62,7 @@ const UserAttributesPanel: FC = () => {
     const { mutate: deleteUserAttribute } = useUserAttributesDeleteMutation();
 
     const isGroupManagementEnabled =
-        userGroupsFeatureFlagQuery.isSuccess &&
-        userGroupsFeatureFlagQuery.data.enabled;
+        userGroupsFeatureFlagQuery.data?.enabled ?? false;
 
     const columns: MRT_ColumnDef<UserAttribute>[] = useMemo(
         () => [
@@ -316,11 +315,6 @@ const UserAttributesPanel: FC = () => {
 
     if (isInitialLoading) {
         return <EmptyStateLoader my="xl" title="Loading user attributes" />;
-    }
-
-    if (userGroupsFeatureFlagQuery.isError) {
-        console.error(userGroupsFeatureFlagQuery.error);
-        throw new Error('Error fetching user groups feature flag');
     }
 
     if (!user.data) return null;

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
@@ -29,14 +29,8 @@ const UsersAndGroupsPanel: FC = () => {
         return <ForbiddenPanel />;
     }
 
-    if (userGroupsFeatureFlagQuery.isError) {
-        console.error(userGroupsFeatureFlagQuery.error);
-        throw new Error('Error fetching user groups feature flag');
-    }
-
     const isGroupManagementEnabled =
-        userGroupsFeatureFlagQuery.isSuccess &&
-        userGroupsFeatureFlagQuery.data.enabled;
+        userGroupsFeatureFlagQuery.data?.enabled ?? false;
 
     return (
         <Stack gap="sm">

--- a/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
@@ -128,14 +128,8 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
         FeatureFlags.UserGroupsEnabled,
     );
 
-    if (userGroupsFeatureFlagQuery.isError) {
-        console.error(userGroupsFeatureFlagQuery.error);
-        throw new Error('Error fetching user groups feature flag');
-    }
-
     const isGroupManagementEnabled =
-        userGroupsFeatureFlagQuery.isSuccess &&
-        userGroupsFeatureFlagQuery.data.enabled;
+        userGroupsFeatureFlagQuery.data?.enabled ?? false;
 
     const { data: groups } = useOrganizationGroups(
         { includeMembers: 5 },

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -159,14 +159,8 @@ const Settings: FC = () => {
         health?.auth.azuread.enabled ||
         health?.auth.oidc.enabled;
 
-    if (userGroupsFeatureFlagQuery.isError) {
-        console.error(userGroupsFeatureFlagQuery.error);
-        throw new Error('Error fetching user groups feature flag');
-    }
-
     const isGroupManagementEnabled =
-        userGroupsFeatureFlagQuery.isSuccess &&
-        userGroupsFeatureFlagQuery.data.enabled;
+        userGroupsFeatureFlagQuery.data?.enabled ?? false;
 
     // This allows us to enable service accounts in the UI for on-premise installations
     const isServiceAccountsEnabled =


### PR DESCRIPTION
Closes:

### Description:

Removes error-throwing behavior when the user groups feature flag query fails. Instead of throwing an error on `isError`, the `isGroupManagementEnabled` flag now safely defaults to `false` using optional chaining and nullish coalescing (`userGroupsFeatureFlagQuery.data?.enabled ?? false`). This prevents unnecessary crashes when the feature flag cannot be fetched, gracefully treating group management as disabled in that case.