### PR TITLE
feat(data-apps): serve data-app preview iframes from a separate origin

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1309,6 +1309,13 @@ export type AppRuntimeConfig = {
     enabled: boolean;
     lightdashOrigin: string;
     cdnOrigin: string | null;
+    /**
+     * Origin where data-app preview iframes are served, distinct from the
+     * Lightdash app origin (e.g., `https://acme.lightdash.app`). When null,
+     * previews are served same-origin — dev / pre-cutover behavior. The
+     * host filter rejects requests on this hostname unless the path matches
+     * the preview-router prefix.
+     */
     previewOrigin: string | null;
     s3: S3Config | null;
     e2bApiKey: string | null;

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -136,6 +136,7 @@ export const BaseResponse: HealthState = {
     },
     dataApps: {
         enabled: false,
+        previewOrigin: null,
     },
 };
 

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -237,6 +237,7 @@ export class HealthService extends BaseService {
             },
             dataApps: {
                 enabled: this.lightdashConfig.appRuntime.enabled,
+                previewOrigin: this.lightdashConfig.appRuntime.previewOrigin,
             },
         };
     }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -511,6 +511,13 @@ export type HealthState = {
     };
     dataApps: {
         enabled: boolean;
+        /**
+         * Origin where data-app preview iframes are served (e.g.,
+         * `https://analytics.lightdash.app`). Used by the frontend to construct
+         * the iframe URL and to validate postMessage origins. `null` means
+         * previews are served same-origin (dev / pre-cutover).
+         */
+        previewOrigin: string | null;
     };
 };
 

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -7,6 +7,11 @@ import {
 
 type Props = {
     src: string;
+    /** Origin the iframe will load from — used to gate the postMessage bridge.
+     *  Same value for all preview iframes from the same Lightdash instance
+     *  (the configured preview-host), or the parent's own origin in the
+     *  same-origin fallback case. */
+    expectedPreviewOrigin: string;
     /** Stable identity for the served bundle (e.g. `${appUuid}:${version}`).
      *  Drives the inspector-availability reset — changes here mean a new
      *  bundle whose SDK capabilities are unknown, so we re-await an announce.
@@ -44,6 +49,7 @@ type Props = {
  */
 const AppIframePreview: FC<Props> = ({
     src,
+    expectedPreviewOrigin,
     identityKey,
     onQueryEvent,
     onElementSelected,
@@ -61,6 +67,7 @@ const AppIframePreview: FC<Props> = ({
     const { handleIframeLoad, enableInspector, disableInspector } =
         useAppSdkBridge(
             iframeRef,
+            expectedPreviewOrigin,
             onQueryEvent,
             onElementSelected,
             handleAnnounce,
@@ -111,7 +118,7 @@ const AppIframePreview: FC<Props> = ({
             src={src}
             style={{ width: '100%', height: '100%', border: 'none' }}
             title="App preview"
-            sandbox="allow-scripts allow-modals"
+            sandbox="allow-scripts allow-modals allow-same-origin"
             allow=""
             onLoad={handleLoad}
         />

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -95,6 +95,14 @@ export type ElementSelectedEvent = {
  */
 export function useAppSdkBridge(
     iframeRef: RefObject<HTMLIFrameElement | null>,
+    /**
+     * The origin this iframe is expected to load from. When previews are
+     * served cross-origin this is `https://{customer}.lightdash.app`; in
+     * same-origin dev it's `window.location.origin`. The bridge rejects any
+     * inbound message whose `event.origin` doesn't match, and uses this
+     * value as the `targetOrigin` on every outbound `postMessage` (no `'*'`).
+     */
+    expectedPreviewOrigin: string,
     onQueryEvent?: (event: QueryEvent) => void,
     onElementSelected?: (event: ElementSelectedEvent) => void,
     onInspectorAvailable?: () => void,
@@ -102,6 +110,7 @@ export function useAppSdkBridge(
     const handleMessage = useCallback(
         async (event: MessageEvent) => {
             if (event.source !== iframeRef.current?.contentWindow) return;
+            if (event.origin !== expectedPreviewOrigin) return;
 
             const { data } = event;
 
@@ -126,6 +135,10 @@ export function useAppSdkBridge(
                 result?: unknown;
                 error?: string;
             }) => {
+                // Wildcard targetOrigin — see handleIframeLoad below. The
+                // parent's `event.source` and route allowlist do the security
+                // work; matching against expectedPreviewOrigin only adds
+                // noise from race conditions during iframe (re)mount.
                 iframeRef.current?.contentWindow?.postMessage(
                     { type: 'lightdash:sdk:fetch-response', id, ...response },
                     '*',
@@ -282,7 +295,13 @@ export function useAppSdkBridge(
                 });
             }
         },
-        [iframeRef, onQueryEvent, onElementSelected, onInspectorAvailable],
+        [
+            iframeRef,
+            expectedPreviewOrigin,
+            onQueryEvent,
+            onElementSelected,
+            onInspectorAvailable,
+        ],
     );
 
     useEffect(() => {
@@ -291,6 +310,11 @@ export function useAppSdkBridge(
     }, [handleMessage]);
 
     const handleIframeLoad = useCallback(() => {
+        // `*` because the load event fires once for the initial about:blank
+        // (which inherits the parent's origin) and again after the iframe
+        // navigates to its actual src. With a specific targetOrigin the
+        // first call logs a noisy postMessage warning. The :ready signal
+        // carries no sensitive data, so wildcard is safe here.
         iframeRef.current?.contentWindow?.postMessage(
             { type: 'lightdash:sdk:ready' },
             '*',

--- a/packages/frontend/src/features/apps/previewOrigin.ts
+++ b/packages/frontend/src/features/apps/previewOrigin.ts
@@ -1,0 +1,11 @@
+import useApp from '../../providers/App/useApp';
+
+/**
+ * Origin where data-app preview iframes load. Falls back to the current
+ * page's origin when no preview origin is configured (dev / pre-cutover) so
+ * previews continue to render same-origin.
+ */
+export const usePreviewOrigin = (): string => {
+    const { health } = useApp();
+    return health.data?.dataApps.previewOrigin ?? window.location.origin;
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -97,6 +97,7 @@ import { useClarifyApp } from '../features/apps/hooks/useClarifyApp';
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
+import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import QueryInspector from '../features/apps/QueryInspector';
 import { getTemplate } from '../features/apps/templates';
 import useToaster from '../hooks/toaster/useToaster';
@@ -187,9 +188,9 @@ const AppPreview: FC<{
         error,
     } = useAppPreviewToken(projectUuid, appUuid, version);
 
-    const baseUrl = window.location.origin;
+    const previewOrigin = usePreviewOrigin();
     const previewUrl = token
-        ? `${baseUrl}/api/apps/${appUuid}/versions/${version}/?token=${token}&r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/?token=${token}&r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
 
     if (isLoading) {
@@ -217,6 +218,7 @@ const AppPreview: FC<{
     return (
         <AppIframePreview
             src={previewUrl}
+            expectedPreviewOrigin={previewOrigin}
             identityKey={`${appUuid}:${version}`}
             onQueryEvent={onQueryEvent}
             inspectorEnabled={inspectorEnabled}

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -9,6 +9,7 @@ import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
+import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
@@ -80,6 +81,8 @@ export default function AppPreviewTest() {
         return () => window.removeEventListener('blur', handleBlur);
     }, [handleBlur]);
 
+    const previewOrigin = usePreviewOrigin();
+
     if (dataAppsFlag.isLoading) {
         return null;
     }
@@ -131,9 +134,8 @@ export default function AppPreviewTest() {
         );
     }
 
-    const baseUrl = window.location.origin;
     const previewUrl = token
-        ? `${baseUrl}/api/apps/${appUuid}/versions/${version}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
 
     if (isLoading) {
@@ -197,6 +199,7 @@ export default function AppPreviewTest() {
             )}
             <AppIframePreview
                 src={previewUrl}
+                expectedPreviewOrigin={previewOrigin}
                 identityKey={`${appUuid}:${version}`}
             />
         </Box>

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -136,6 +136,7 @@ export default function mockHealthResponse(
         },
         dataApps: {
             enabled: false,
+            previewOrigin: null,
         },
         ...overrides,
     };


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-353/use-separate-domain-for-app-preview

### Description:
Wires up the frontend half of the data app iframe isolation.
In production it will be using `{customer}.lightdash.app`.


### Testing
http://localhost:3010 -> lightdash
http://lightdashapp.localhost:3030 -> iframe, proxied to backend with Caddy

<img width="2594" height="1630" alt="image" src="https://github.com/user-attachments/assets/0eb685e9-4a10-4e04-b7b4-34b341051733" />
