### PR TITLE
perf(auth): scope project-membership join columns to drop bytea bloat

### DIFF
--- a/packages/backend/src/models/RolesModel.ts
+++ b/packages/backend/src/models/RolesModel.ts
@@ -322,6 +322,12 @@ export class RolesModel {
                 Pick<Project, 'type'>
         >
     > {
+        type Row = {
+            project_uuid: string;
+            project_type: ProjectType;
+            role: ProjectMemberRole | null;
+            role_uuid: string | null;
+        };
         const rows = await (tx || this.database)('project_memberships')
             .leftJoin(
                 'projects',
@@ -329,7 +335,12 @@ export class RolesModel {
                 'projects.project_id',
             )
             .leftJoin('users', 'project_memberships.user_id', 'users.user_id')
-            .select('*')
+            .select<Row[]>([
+                'projects.project_uuid',
+                'projects.project_type',
+                'project_memberships.role',
+                'project_memberships.role_uuid',
+            ])
             .where('users.user_uuid', userUuid);
 
         return rows.map((row) => ({

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -514,6 +514,11 @@ export class UserModel {
             'projectUuid' | 'role' | 'userUuid' | 'roleUuid'
         >[]
     > {
+        type Row = {
+            project_uuid: string;
+            role: ProjectMemberRole | null;
+            role_uuid: string | null;
+        };
         const projectMemberships = await this.database('project_memberships')
             .leftJoin(
                 ProjectTableName,
@@ -521,7 +526,11 @@ export class UserModel {
                 `${ProjectTableName}.project_id`,
             )
             .leftJoin('users', 'project_memberships.user_id', 'users.user_id')
-            .select('*')
+            .select<Row[]>([
+                `${ProjectTableName}.project_uuid`,
+                'project_memberships.role',
+                'project_memberships.role_uuid',
+            ])
             .where('users.user_uuid', userUuid);
 
         return projectMemberships.map((membership) => ({


### PR DESCRIPTION
## Problem

`UserModel.getUserProjectRoles` and `RolesModel.getUserProjectRoles` both run a 3-table `LEFT JOIN` (`project_memberships` × `projects` × `users`) with `SELECT *`. That pulls every column on `projects` — including `dbt_connection`, an encrypted bytea blob that can be tens of KB per row — even though the result mappers only read 3–4 fields.

Both functions feed `generateUserAbilityBuilder`, which runs on every authenticated request and on every managed-agent / SCIM session hydration. Per-call wire bytes and serialisation cost scale with the user's project count, so on accounts with many projects this query becomes the dominant cost on the auth path.

## Change

Narrow `select()` to the columns the mappers actually use:

- `RolesModel.ts` — `projects.project_uuid`, `projects.project_type`, `project_memberships.role`, `project_memberships.role_uuid`
- `UserModel.ts` — `projects.project_uuid`, `project_memberships.role`, `project_memberships.role_uuid`

Plan shape is unchanged — same JOIN structure, same `WHERE`, same indexes. Only the projected column set changes.

## Regression analysis

- **Result shape unchanged**: both mappers still produce the same `ProjectMemberProfile`-shaped objects. Every column previously consumed off the row is still selected.
- **No other readers**: verified by reading both `getUserProjectRoles` bodies end-to-end — nothing else off the row is referenced.
- **Plan unchanged**: same JOIN order and predicates; PG keeps the existing bitmap-index → nested-loop → hash-join shape.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend test:dev:nowatch` (372 tests pass)
