### PR TITLE
feat: nested groups for the tables sidebar (PROD-482)

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -44,6 +44,7 @@ import {
     type ApiGetTagsResponse,
     type ApiRefreshResults,
     type ApiSuccess,
+    type ApiTableGroupsResults,
     type ApiUpdateDashboardsResponse,
     type ApiVerifiedContentListResponse,
     type CalculateSubtotalsFromQuery,
@@ -661,6 +662,31 @@ export class ProjectController extends BaseController {
      * they become available.
      * @summary Get project color palette
      */
+    /**
+     * Project-level table-group definitions (label & description for each
+     * group key referenced by models in their `meta.groups` array). Sourced
+     * from `table_groups` in lightdash.config.yml.
+     * @summary Get project table groups
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{projectUuid}/table-groups')
+    @OperationId('getProjectTableGroups')
+    async getProjectTableGroups(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccess<ApiTableGroupsResults>> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const tableGroups = await this.services
+            .getProjectService()
+            .getTableGroups(req.account, projectUuid);
+        return {
+            status: 'ok',
+            results: tableGroups,
+        };
+    }
+
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('{projectUuid}/colorPalette')

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -1,6 +1,7 @@
 import {
     AnyType,
     DbtProjectType,
+    GroupType,
     ProjectDefaults,
     ProjectType,
     TableSelectionType,
@@ -32,6 +33,7 @@ export type DbProject = {
     has_default_user_spaces: boolean;
     project_defaults: ProjectDefaults | null;
     color_palette_uuid: string | null;
+    table_groups: Record<string, GroupType> | null;
 };
 
 type CreateDbProject = Pick<
@@ -65,6 +67,7 @@ type UpdateDbProject = Partial<
         | 'has_default_user_spaces'
         | 'project_defaults'
         | 'color_palette_uuid'
+        | 'table_groups'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260506135156_add_table_groups_to_projects.ts
+++ b/packages/backend/src/database/migrations/20260506135156_add_table_groups_to_projects.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const ProjectsTable = 'projects';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ProjectsTable, (table) => {
+        table.jsonb('table_groups').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ProjectsTable, (table) => {
+        table.dropColumn('table_groups');
+    });
+}

--- a/packages/backend/src/ee/preAggregates/postProcessor.ts
+++ b/packages/backend/src/ee/preAggregates/postProcessor.ts
@@ -25,6 +25,9 @@ export const preAggregatePostProcessor: ExplorePostProcessor = (
                     name: explore.name,
                     label: explore.label,
                     groupLabel: explore.groupLabel,
+                    ...(explore.groups && explore.groups.length > 0
+                        ? { groups: explore.groups }
+                        : {}),
                     errors: [
                         {
                             type: InlineErrorType.METADATA_PARSE_ERROR,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5298,6 +5298,136 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Record_string.ParameterValue_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ColorPaletteSource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: {
+                            dataType: 'enum',
+                            enums: ['config'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: {
+                            dataType: 'enum',
+                            enums: ['default'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['organization'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['project'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['space'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['dashboard'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['chart'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResolvedProjectColorPalette: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                source: { ref: 'ColorPaletteSource', required: true },
+                paletteName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                paletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                darkColors: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                colors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SavedChart: {
         dataType: 'refAlias',
         type: {
@@ -5343,6 +5473,18 @@ const models: TsoaRoute.Models = {
                 },
                 inheritsFromOrgOrProject: {
                     dataType: 'boolean',
+                    required: true,
+                },
+                resolvedColorPalette: {
+                    ref: 'ResolvedProjectColorPalette',
+                    required: true,
+                },
+                colorPaletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
                     required: true,
                 },
                 colorPalette: {
@@ -9140,11 +9282,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9622,11 +9764,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9641,11 +9783,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9660,11 +9802,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9679,11 +9821,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9698,11 +9840,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16917,6 +17059,18 @@ const models: TsoaRoute.Models = {
                         array: { dataType: 'string' },
                         required: true,
                     },
+                    colorPaletteUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    resolvedColorPalette: {
+                        ref: 'ResolvedProjectColorPalette',
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -20438,136 +20592,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ColorPaletteSource: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        type: {
-                            dataType: 'enum',
-                            enums: ['config'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        type: {
-                            dataType: 'enum',
-                            enums: ['default'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['organization'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['project'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['space'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['dashboard'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['chart'],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResolvedProjectColorPalette: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                source: { ref: 'ColorPaletteSource', required: true },
-                paletteName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                paletteUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                darkColors: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'array', array: { dataType: 'string' } },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                colors: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiProjectColorPaletteResponse: {
         dataType: 'refAlias',
         type: {
@@ -21499,7 +21523,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21509,7 +21533,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21519,7 +21543,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21532,7 +21556,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21943,7 +21967,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21953,7 +21977,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21963,7 +21987,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21976,7 +22000,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -23589,6 +23613,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                colorPaletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 chartColors: {
                     dataType: 'union',
                     subSchemas: [
@@ -23600,13 +23631,6 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'array', array: { dataType: 'string' } },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                colorPaletteUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
                         { dataType: 'undefined' },
                     ],
                 },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5298,136 +5298,6 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Record_string.ParameterValue_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ColorPaletteSource: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        type: {
-                            dataType: 'enum',
-                            enums: ['config'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        type: {
-                            dataType: 'enum',
-                            enums: ['default'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['organization'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['project'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['space'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['dashboard'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['chart'],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResolvedProjectColorPalette: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                source: { ref: 'ColorPaletteSource', required: true },
-                paletteName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                paletteUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                darkColors: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'array', array: { dataType: 'string' } },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                colors: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SavedChart: {
         dataType: 'refAlias',
         type: {
@@ -5473,18 +5343,6 @@ const models: TsoaRoute.Models = {
                 },
                 inheritsFromOrgOrProject: {
                     dataType: 'boolean',
-                    required: true,
-                },
-                resolvedColorPalette: {
-                    ref: 'ResolvedProjectColorPalette',
-                    required: true,
-                },
-                colorPaletteUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
                     required: true,
                 },
                 colorPalette: {
@@ -6280,6 +6138,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 baseTable: { dataType: 'string', required: true },
+                groups: { dataType: 'array', array: { dataType: 'string' } },
                 groupLabel: { dataType: 'string' },
                 tags: {
                     dataType: 'array',
@@ -9425,17 +9284,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9464,7 +9323,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9472,7 +9331,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9487,7 +9350,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9495,11 +9358,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9683,17 +9542,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -17058,18 +16917,6 @@ const models: TsoaRoute.Models = {
                         array: { dataType: 'string' },
                         required: true,
                     },
-                    colorPaletteUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    resolvedColorPalette: {
-                        ref: 'ResolvedProjectColorPalette',
-                        required: true,
-                    },
                 },
                 validators: {},
             },
@@ -20574,6 +20421,153 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiTableGroupsResults: {
+        dataType: 'refAlias',
+        type: { ref: 'Record_string.GroupType_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_ApiTableGroupsResults_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ApiTableGroupsResults', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ColorPaletteSource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: {
+                            dataType: 'enum',
+                            enums: ['config'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: {
+                            dataType: 'enum',
+                            enums: ['default'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['organization'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['project'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['space'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['dashboard'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['chart'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResolvedProjectColorPalette: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                source: { ref: 'ColorPaletteSource', required: true },
+                paletteName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                paletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                darkColors: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                colors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiProjectColorPaletteResponse: {
         dataType: 'refAlias',
         type: {
@@ -22620,6 +22614,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                groups: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 baseTable: {
                     dataType: 'union',
                     subSchemas: [
@@ -22804,7 +22805,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Explore.name-or-label-or-groupLabel_': {
+    'Pick_Explore.name-or-label-or-groupLabel-or-groups_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -22815,6 +22816,13 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                groups: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -22829,7 +22837,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 { ref: 'Partial_Explore_' },
-                { ref: 'Pick_Explore.name-or-label-or-groupLabel_' },
+                { ref: 'Pick_Explore.name-or-label-or-groupLabel-or-groups_' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -23581,13 +23589,6 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-                colorPaletteUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'undefined' },
-                    ],
-                },
                 chartColors: {
                     dataType: 'union',
                     subSchemas: [
@@ -23599,6 +23600,13 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                colorPaletteUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -25553,6 +25561,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                groups: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 aiHint: {
                     dataType: 'union',
                     subSchemas: [
@@ -25621,6 +25636,13 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                groups: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -25786,6 +25808,13 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                groups: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -47312,6 +47341,65 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateDefaultUserSpaces',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_getProjectTableGroups: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/table-groups',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.getProjectTableGroups,
+        ),
+
+        async function ProjectController_getProjectTableGroups(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_getProjectTableGroups,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getProjectTableGroups',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6330,154 +6330,6 @@
             "ParametersValuesMap": {
                 "$ref": "#/components/schemas/Record_string.ParameterValue_"
             },
-            "ColorPaletteSource": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "enum": ["config"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "enum": ["default"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["organization"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["project"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["space"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["dashboard"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["chart"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    }
-                ],
-                "description": "Where a resolved colour palette came from. The `config` and `default` cases\ncarry no entity reference; the rest expose the UUID and human-readable name\nof the entity (organization, project, space, dashboard or chart) that owns\nthe winning palette in the resolution chain."
-            },
-            "ResolvedProjectColorPalette": {
-                "properties": {
-                    "source": {
-                        "$ref": "#/components/schemas/ColorPaletteSource"
-                    },
-                    "paletteName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "paletteUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "darkColors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "nullable": true
-                    },
-                    "colors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "source",
-                    "paletteName",
-                    "paletteUuid",
-                    "darkColors",
-                    "colors"
-                ],
-                "type": "object"
-            },
             "SavedChart": {
                 "properties": {
                     "deletedBy": {
@@ -6521,21 +6373,11 @@
                     "inheritsFromOrgOrProject": {
                         "type": "boolean"
                     },
-                    "resolvedColorPalette": {
-                        "$ref": "#/components/schemas/ResolvedProjectColorPalette",
-                        "description": "Fully resolved palette for this chart, computed from the\norg → project → space → dashboard → chart hierarchy. Read-only — set\nthe chart's own palette via `colorPaletteUuid`."
-                    },
-                    "colorPaletteUuid": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Chart-level palette override pointer. `null` means inherit from the\ncontaining dashboard / space / project / org. Writable via\n`UpdateSavedChart`."
-                    },
                     "colorPalette": {
                         "items": {
                             "type": "string"
                         },
-                        "type": "array",
-                        "deprecated": true
+                        "type": "array"
                     },
                     "dashboardName": {
                         "type": "string",
@@ -6635,8 +6477,6 @@
                     "slug",
                     "access",
                     "inheritsFromOrgOrProject",
-                    "resolvedColorPalette",
-                    "colorPaletteUuid",
                     "colorPalette",
                     "dashboardName",
                     "dashboardUuid",
@@ -7543,8 +7383,16 @@
                     "baseTable": {
                         "type": "string"
                     },
+                    "groups": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
+                    },
                     "groupLabel": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
                     },
                     "tags": {
                         "items": {
@@ -10798,10 +10646,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -10810,8 +10658,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10821,16 +10669,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -10918,10 +10766,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -10930,8 +10778,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -18041,17 +17889,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "type": "array",
-                        "deprecated": true
-                    },
-                    "colorPaletteUuid": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Chart-level palette override pointer. `null` means inherit from the\ncontaining dashboard / space / project / org. Writable via\n`UpdateSavedChart`."
-                    },
-                    "resolvedColorPalette": {
-                        "$ref": "#/components/schemas/ResolvedProjectColorPalette",
-                        "description": "Fully resolved palette for this chart, computed from the\norg → project → space → dashboard → chart hierarchy. Read-only — set\nthe chart's own palette via `colorPaletteUuid`."
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -18072,9 +17910,7 @@
                     "metricQuery",
                     "tableConfig",
                     "dashboardName",
-                    "colorPalette",
-                    "colorPaletteUuid",
-                    "resolvedColorPalette"
+                    "colorPalette"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
@@ -22003,6 +21839,171 @@
                 "required": ["hasDefaultUserSpaces"],
                 "type": "object"
             },
+            "ApiTableGroupsResults": {
+                "$ref": "#/components/schemas/Record_string.GroupType_"
+            },
+            "ApiSuccess_ApiTableGroupsResults_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ApiTableGroupsResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ColorPaletteSource": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["config"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["default"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["organization"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["project"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["space"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["dashboard"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["chart"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    }
+                ],
+                "description": "Where a resolved colour palette came from. The `config` and `default` cases\ncarry no entity reference; the rest expose the UUID and human-readable name\nof the entity (organization, project, space, dashboard or chart) that owns\nthe winning palette in the resolution chain."
+            },
+            "ResolvedProjectColorPalette": {
+                "properties": {
+                    "source": {
+                        "$ref": "#/components/schemas/ColorPaletteSource"
+                    },
+                    "paletteName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "paletteUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "darkColors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true
+                    },
+                    "colors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "source",
+                    "paletteName",
+                    "paletteUuid",
+                    "darkColors",
+                    "colors"
+                ],
+                "type": "object"
+            },
             "ApiProjectColorPaletteResponse": {
                 "properties": {
                     "results": {
@@ -23931,7 +23932,15 @@
                         "type": "array"
                     },
                     "groupLabel": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
+                    },
+                    "groups": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     },
                     "baseTable": {
                         "type": "string"
@@ -24035,7 +24044,7 @@
                 "type": "object",
                 "description": "Make all properties in T optional"
             },
-            "Pick_Explore.name-or-label-or-groupLabel_": {
+            "Pick_Explore.name-or-label-or-groupLabel-or-groups_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -24044,7 +24053,15 @@
                         "type": "string"
                     },
                     "groupLabel": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
+                    },
+                    "groups": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     }
                 },
                 "required": ["name", "label"],
@@ -24057,7 +24074,7 @@
                         "$ref": "#/components/schemas/Partial_Explore_"
                     },
                     {
-                        "$ref": "#/components/schemas/Pick_Explore.name-or-label-or-groupLabel_"
+                        "$ref": "#/components/schemas/Pick_Explore.name-or-label-or-groupLabel-or-groups_"
                     },
                     {
                         "properties": {
@@ -24839,10 +24856,6 @@
                         "type": "string",
                         "format": "date-time"
                     },
-                    "colorPaletteUuid": {
-                        "type": "string",
-                        "description": "The active color palette uuid for all projects in the organization"
-                    },
                     "chartColors": {
                         "items": {
                             "type": "string"
@@ -24856,6 +24869,10 @@
                         },
                         "type": "array",
                         "description": "The default dark color palette for all projects in the organization"
+                    },
+                    "colorPaletteUuid": {
+                        "type": "string",
+                        "description": "The active color palette uuid for all projects in the organization"
                     },
                     "defaultProjectUuid": {
                         "type": "string",
@@ -26879,7 +26896,15 @@
                         "type": "array"
                     },
                     "groupLabel": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
+                    },
+                    "groups": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     },
                     "aiHint": {
                         "anyOf": [
@@ -26942,7 +26967,15 @@
                         "type": "array"
                     },
                     "groupLabel": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
+                    },
+                    "groups": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     },
                     "aiHint": {
                         "anyOf": [
@@ -27059,7 +27092,15 @@
                         "type": "boolean"
                     },
                     "groupLabel": {
-                        "type": "string"
+                        "type": "string",
+                        "deprecated": true
+                    },
+                    "groups": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     },
                     "baseTable": {
                         "type": "string"
@@ -31769,7 +31810,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2887.0",
+        "version": "0.2888.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -40896,6 +40937,47 @@
                 }
             }
         },
+        "/api/v1/projects/{projectUuid}/table-groups": {
+            "get": {
+                "operationId": "getProjectTableGroups",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccess_ApiTableGroupsResults_"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the resolved color palette for a project, walking the\nchart -> dashboard -> space -> project -> organization fallback chain\n(matches saved-chart resolution). The optional UUIDs let unsaved\nrenderers (Explore, AI viz, sql runner) opt into deeper layers as\nthey become available.",
+                "summary": "Get project color palette",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
         "/api/v1/projects/{projectUuid}/colorPalette": {
             "get": {
                 "operationId": "getProjectColorPalette",
@@ -40921,8 +41003,6 @@
                         }
                     }
                 },
-                "description": "Get the resolved color palette for a project, walking the\nchart -> dashboard -> space -> project -> organization fallback chain\n(matches saved-chart resolution). The optional UUIDs let unsaved\nrenderers (Explore, AI viz, sql runner) opt into deeper layers as\nthey become available.",
-                "summary": "Get project color palette",
                 "tags": ["Projects"],
                 "security": [],
                 "parameters": [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6330,6 +6330,154 @@
             "ParametersValuesMap": {
                 "$ref": "#/components/schemas/Record_string.ParameterValue_"
             },
+            "ColorPaletteSource": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["config"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["default"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["organization"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["project"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["space"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["dashboard"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["chart"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "uuid", "type"],
+                        "type": "object"
+                    }
+                ],
+                "description": "Where a resolved colour palette came from. The `config` and `default` cases\ncarry no entity reference; the rest expose the UUID and human-readable name\nof the entity (organization, project, space, dashboard or chart) that owns\nthe winning palette in the resolution chain."
+            },
+            "ResolvedProjectColorPalette": {
+                "properties": {
+                    "source": {
+                        "$ref": "#/components/schemas/ColorPaletteSource"
+                    },
+                    "paletteName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "paletteUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "darkColors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true
+                    },
+                    "colors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "source",
+                    "paletteName",
+                    "paletteUuid",
+                    "darkColors",
+                    "colors"
+                ],
+                "type": "object"
+            },
             "SavedChart": {
                 "properties": {
                     "deletedBy": {
@@ -6373,11 +6521,21 @@
                     "inheritsFromOrgOrProject": {
                         "type": "boolean"
                     },
+                    "resolvedColorPalette": {
+                        "$ref": "#/components/schemas/ResolvedProjectColorPalette",
+                        "description": "Fully resolved palette for this chart, computed from the\norg → project → space → dashboard → chart hierarchy. Read-only — set\nthe chart's own palette via `colorPaletteUuid`."
+                    },
+                    "colorPaletteUuid": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Chart-level palette override pointer. `null` means inherit from the\ncontaining dashboard / space / project / org. Writable via\n`UpdateSavedChart`."
+                    },
                     "colorPalette": {
                         "items": {
                             "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "deprecated": true
                     },
                     "dashboardName": {
                         "type": "string",
@@ -6477,6 +6635,8 @@
                     "slug",
                     "access",
                     "inheritsFromOrgOrProject",
+                    "resolvedColorPalette",
+                    "colorPaletteUuid",
                     "colorPalette",
                     "dashboardName",
                     "dashboardUuid",
@@ -10595,19 +10755,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -17889,7 +18036,17 @@
                         "items": {
                             "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "deprecated": true
+                    },
+                    "colorPaletteUuid": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Chart-level palette override pointer. `null` means inherit from the\ncontaining dashboard / space / project / org. Writable via\n`UpdateSavedChart`."
+                    },
+                    "resolvedColorPalette": {
+                        "$ref": "#/components/schemas/ResolvedProjectColorPalette",
+                        "description": "Fully resolved palette for this chart, computed from the\norg → project → space → dashboard → chart hierarchy. Read-only — set\nthe chart's own palette via `colorPaletteUuid`."
                     }
                 },
                 "required": [
@@ -17910,7 +18067,9 @@
                     "metricQuery",
                     "tableConfig",
                     "dashboardName",
-                    "colorPalette"
+                    "colorPalette",
+                    "colorPaletteUuid",
+                    "resolvedColorPalette"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
@@ -21856,154 +22015,6 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "ColorPaletteSource": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "enum": ["config"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "enum": ["default"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["organization"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["project"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["space"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["dashboard"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["chart"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "uuid", "type"],
-                        "type": "object"
-                    }
-                ],
-                "description": "Where a resolved colour palette came from. The `config` and `default` cases\ncarry no entity reference; the rest expose the UUID and human-readable name\nof the entity (organization, project, space, dashboard or chart) that owns\nthe winning palette in the resolution chain."
-            },
-            "ResolvedProjectColorPalette": {
-                "properties": {
-                    "source": {
-                        "$ref": "#/components/schemas/ColorPaletteSource"
-                    },
-                    "paletteName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "paletteUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "darkColors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "nullable": true
-                    },
-                    "colors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": [
-                    "source",
-                    "paletteName",
-                    "paletteUuid",
-                    "darkColors",
-                    "colors"
-                ],
-                "type": "object"
-            },
             "ApiProjectColorPaletteResponse": {
                 "properties": {
                     "results": {
@@ -22917,22 +22928,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -23287,22 +23298,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -24856,6 +24867,10 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "colorPaletteUuid": {
+                        "type": "string",
+                        "description": "The active color palette uuid for all projects in the organization"
+                    },
                     "chartColors": {
                         "items": {
                             "type": "string"
@@ -24869,10 +24884,6 @@
                         },
                         "type": "array",
                         "description": "The default dark color palette for all projects in the organization"
-                    },
-                    "colorPaletteUuid": {
-                        "type": "string",
-                        "description": "The active color palette uuid for all projects in the organization"
                     },
                     "defaultProjectUuid": {
                         "type": "string",
@@ -31810,7 +31821,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2888.0",
+        "version": "0.2889.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -17,6 +17,7 @@ import {
     ExploreError,
     ExploreType,
     getLtreePathFromSlug,
+    GroupType,
     IdContentMapping,
     isExploreError,
     NotFoundError,
@@ -157,6 +158,7 @@ type RawSummaryRow = {
     label: Explore['label'];
     tags: Explore['tags'];
     groupLabel: Explore['groupLabel'] | null;
+    groups: Explore['groups'] | null;
     type: Explore['type'] | null;
     preAggregateSource: Explore['preAggregateSource'] | null;
     errors: ExploreError['errors'] | null; // Fatal errors from ExploreError
@@ -592,6 +594,29 @@ export class ProjectModel {
         await this.database('projects')
             .update({
                 color_palette_uuid: colorPaletteUuid,
+            })
+            .where('project_uuid', projectUuid);
+    }
+
+    async getTableGroups(
+        projectUuid: string,
+    ): Promise<Record<string, GroupType>> {
+        const [row] = await this.database(ProjectTableName)
+            .select('table_groups')
+            .where('project_uuid', projectUuid);
+        return row?.table_groups ?? {};
+    }
+
+    async setTableGroups(
+        projectUuid: string,
+        tableGroups: Record<string, GroupType> | undefined,
+    ): Promise<void> {
+        await this.database(ProjectTableName)
+            .update({
+                table_groups:
+                    tableGroups && Object.keys(tableGroups).length > 0
+                        ? tableGroups
+                        : null,
             })
             .where('project_uuid', projectUuid);
     }
@@ -1218,6 +1243,7 @@ export class ProjectModel {
                     explore->'label' as label,
                     explore->'tags' as tags,
                     explore->'groupLabel' as "groupLabel",
+                    explore->'groups' as "groups",
                     explore->'type' as type,
                     explore->'preAggregateSource' as "preAggregateSource",
                     explore->'errors' as errors,
@@ -1238,6 +1264,7 @@ export class ProjectModel {
             label: row.label,
             tags: row.tags,
             groupLabel: row.groupLabel ?? undefined,
+            groups: row.groups ?? undefined,
             databaseName: row.baseTableDatabase,
             schemaName: row.baseTableSchema,
             description: row.baseTableDescription ?? undefined,

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -371,10 +371,15 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     if (model.resource_type === 'seed') {
                         return [validModels, invalidModels];
                     }
+                    const metaGroups: string[] | undefined =
+                        model.meta.groups;
                     const exploreError: ExploreError = {
                         name: model.name,
                         label: model.meta.label || friendlyName(model.name),
                         groupLabel: model.meta.group_label,
+                        ...(metaGroups && metaGroups.length > 0
+                            ? { groups: metaGroups }
+                            : {}),
                         errors: [
                             error.type === InlineErrorType.METADATA_PARSE_ERROR
                                 ? {

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -371,8 +371,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     if (model.resource_type === 'seed') {
                         return [validModels, invalidModels];
                     }
-                    const metaGroups: string[] | undefined =
-                        model.meta.groups;
+                    const metaGroups: string[] | undefined = model.meta.groups;
                     const exploreError: ExploreError = {
                         name: model.name,
                         label: model.meta.label || friendlyName(model.name),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -78,6 +78,7 @@ import {
     getPreAggregateExploreName,
     getTimeDimensionsMap,
     getTimezoneLabel,
+    GroupType,
     hasConnectionChanges,
     hasIntersection,
     hasWarehouseCredentials,
@@ -2215,6 +2216,10 @@ export class ProjectService extends BaseService {
                         projectUuid: newProjectUuid,
                         parameters: lightdashProjectConfig.parameters,
                     });
+                    await this.projectModel.setTableGroups(
+                        newProjectUuid,
+                        lightdashProjectConfig.table_groups,
+                    );
                     await this.saveExploresToCacheAndIndexCatalog({
                         userUuid: user.userUuid,
                         projectUuid: newProjectUuid,
@@ -2698,6 +2703,10 @@ export class ProjectService extends BaseService {
                                 projectUuid,
                                 parameters: lightdashProjectConfig.parameters,
                             });
+                            await this.projectModel.setTableGroups(
+                                projectUuid,
+                                lightdashProjectConfig.table_groups,
+                            );
                             timings.parameters.end = performance.now();
                             timings.cacheExplores.start = performance.now();
                             await this.saveExploresToCacheAndIndexCatalog({
@@ -5463,6 +5472,10 @@ export class ProjectService extends BaseService {
                             projectUuid,
                             parameters: lightdashProjectConfig.parameters,
                         });
+                        await this.projectModel.setTableGroups(
+                            projectUuid,
+                            lightdashProjectConfig.table_groups,
+                        );
                         timings.parameters.end = performance.now();
                         timings.cacheExplores.start = performance.now();
                         const result = this.saveExploresToCacheAndIndexCatalog({
@@ -7715,6 +7728,28 @@ export class ProjectService extends BaseService {
         }
 
         return this.tagsModel.list(projectUuid);
+    }
+
+    async getTableGroups(
+        account: Account,
+        projectUuid: string,
+    ): Promise<Record<string, GroupType>> {
+        const { organizationUuid, type } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', {
+                    projectUuid,
+                    organizationUuid,
+                    type,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return this.projectModel.getTableGroups(projectUuid);
     }
 
     async replaceProjectParameters({

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -242,7 +242,9 @@ export type UncompiledExplore = {
     label: string;
     tags: string[];
     baseTable: string;
+    /** @deprecated Use groups instead */
     groupLabel?: string;
+    groups?: string[];
     joinedTables: ExploreJoin[];
     tables: Record<string, Table>;
     targetDatabase: SupportedDbtAdapter;
@@ -295,6 +297,7 @@ export class ExploreCompiler {
         tables,
         targetDatabase,
         groupLabel,
+        groups,
         warehouse,
         ymlPath,
         sqlPath,
@@ -632,6 +635,7 @@ export class ExploreCompiler {
             tables: compiledTables,
             targetDatabase,
             groupLabel,
+            ...(groups && groups.length > 0 ? { groups } : {}),
             warehouse,
             ymlPath,
             sqlPath,

--- a/packages/common/src/compiler/lightdashModelConverter.ts
+++ b/packages/common/src/compiler/lightdashModelConverter.ts
@@ -79,6 +79,7 @@ export function convertLightdashModelToDbtModel(
         sets: model.sets,
         order_fields_by: model.order_fields_by,
         group_label: model.group_label,
+        groups: model.groups,
         sql_filter: model.sql_filter,
         sql_where: model.sql_where,
         sql_from: sqlFrom, // from_sql maps directly to sql_from

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1254,8 +1254,7 @@ export const convertExplores = async (
                               (meta.groups && meta.groups.length > 0)
                                   ? {
                                         groups:
-                                            exploreConfig.groups ||
-                                            meta.groups,
+                                            exploreConfig.groups || meta.groups,
                                     }
                                   : {}),
                               // Inherit joins from base model if not specified in explore config

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1142,6 +1142,9 @@ export const convertExplores = async (
                     label: meta.label || friendlyName(model.name),
                     tags,
                     groupLabel: meta.group_label,
+                    ...(meta.groups && meta.groups.length > 0
+                        ? { groups: meta.groups }
+                        : {}),
                     errors: [
                         {
                             type:
@@ -1194,6 +1197,9 @@ export const convertExplores = async (
                 name: model.name,
                 label: meta.label || friendlyName(model.name),
                 groupLabel: meta.group_label,
+                ...(meta.groups && meta.groups.length > 0
+                    ? { groups: meta.groups }
+                    : {}),
                 joins: meta?.joins || [],
                 description: meta.description,
                 caseSensitive: meta.case_sensitive,
@@ -1243,6 +1249,15 @@ export const convertExplores = async (
                                   friendlyName(exploreName),
                               groupLabel:
                                   exploreConfig.group_label || meta.group_label,
+                              ...((exploreConfig.groups &&
+                                  exploreConfig.groups.length > 0) ||
+                              (meta.groups && meta.groups.length > 0)
+                                  ? {
+                                        groups:
+                                            exploreConfig.groups ||
+                                            meta.groups,
+                                    }
+                                  : {}),
                               // Inherit joins from base model if not specified in explore config
                               joins: exploreConfig.joins || meta?.joins || [],
                               description: exploreConfig.description,
@@ -1287,6 +1302,10 @@ export const convertExplores = async (
                     tags: tags || [],
                     baseTable: model.name,
                     groupLabel: exploreToCreate.groupLabel,
+                    ...(exploreToCreate.groups &&
+                    exploreToCreate.groups.length > 0
+                        ? { groups: exploreToCreate.groups }
+                        : {}),
                     caseSensitive: exploreToCreate.caseSensitive,
                     joinedTables: exploreToCreate.joins.map((join) => ({
                         table: join.join,
@@ -1327,6 +1346,10 @@ export const convertExplores = async (
                     name: exploreToCreate.name,
                     label: exploreToCreate.label,
                     groupLabel: exploreToCreate.groupLabel,
+                    ...(exploreToCreate.groups &&
+                    exploreToCreate.groups.length > 0
+                        ? { groups: exploreToCreate.groups }
+                        : {}),
                     errors: [
                         {
                             // TODO improve parsing of error type

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -444,6 +444,20 @@
                 "sql_from": {
                     "type": "string"
                 },
+                "group_label": {
+                    "type": "string",
+                    "deprecated": true,
+                    "description": "Deprecated: use groups instead"
+                },
+                "groups": {
+                    "type": "array",
+                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 3 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "maxItems": 3
+                },
                 "required_attributes": {
                     "$ref": "#/definitions/RequiredAttributes"
                 },

--- a/packages/common/src/preAggregates/postProcessor.ts
+++ b/packages/common/src/preAggregates/postProcessor.ts
@@ -27,6 +27,9 @@ export const preAggregatePostProcessor: ExplorePostProcessor = (
                     name: explore.name,
                     label: explore.label,
                     groupLabel: explore.groupLabel,
+                    ...(explore.groups && explore.groups.length > 0
+                        ? { groups: explore.groups }
+                        : {}),
                     errors: [
                         {
                             type: InlineErrorType.METADATA_PARSE_ERROR,

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -474,6 +474,20 @@
                     "type": "string",
                     "enum": ["index", "label"]
                 },
+                "group_label": {
+                    "type": "string",
+                    "deprecated": true,
+                    "description": "Deprecated: use groups instead"
+                },
+                "groups": {
+                    "type": "array",
+                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 3 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "maxItems": 3
+                },
                 "group_details": {
                     "type": "object",
                     "description": "Set up group_details so you can group your dimensions and metrics in the sidebar using the groups parameter. You can create nested groups up to 3 levels",
@@ -1068,6 +1082,20 @@
                                 "sql_where": {
                                     "type": "string",
                                     "description": "Alias for sql_filter (deprecated, use sql_filter instead)"
+                                },
+                                "group_label": {
+                                    "type": "string",
+                                    "deprecated": true,
+                                    "description": "Deprecated: use groups instead"
+                                },
+                                "groups": {
+                                    "type": "array",
+                                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 3 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
+                                    "items": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "maxItems": 3
                                 }
                             }
                         }

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -160,6 +160,27 @@
                     "required": ["label", "sql"]
                 }
             }
+        },
+        "table_groups": {
+            "type": ["object", "null"],
+            "description": "Define labels and descriptions for the group keys referenced by models in their meta.groups array. Used to render nested table groups in the sidebar.",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "description": "Display label shown in the sidebar for this table group",
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "description": {
+                            "description": "Optional description of this table group",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["label"]
+                }
+            }
         }
     }
 }

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -54,7 +54,17 @@
                 },
                 "group_label": {
                     "type": "string",
-                    "description": "Group label for organizing models in the sidebar"
+                    "deprecated": true,
+                    "description": "Deprecated: use groups instead"
+                },
+                "groups": {
+                    "type": "array",
+                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 3 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "maxItems": 3
                 },
                 "sql_filter": {
                     "type": "string",

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -207,7 +207,7 @@ import {
     type SortBy,
 } from './sqlRunner';
 import { type ApiSshKeyPairResponse } from './SshKeyPair';
-import { type TableBase } from './table';
+import { type GroupType, type TableBase } from './table';
 import { type ApiCreateTagResponse } from './tags';
 import {
     type LightdashUser,
@@ -279,6 +279,8 @@ export type ApiCompiledQueryResults = {
 export type ApiExploresResults = SummaryExplore[];
 
 export type ApiExploreResults = Omit<Explore, 'unfilteredTables'>;
+
+export type ApiTableGroupsResults = Record<string, GroupType>;
 
 export type ApiStatusResults = 'loading' | 'ready' | 'error';
 

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -100,7 +100,14 @@ export type DbtExploreLightdashAdditionalDimension =
 type ExploreConfig = {
     label?: string;
     description?: string;
+    /** @deprecated Use groups instead */
     group_label?: string;
+    /**
+     * Nested groups for tables in the sidebar (max 3 levels). Group keys
+     * resolve to labels via `table_groups` in lightdash.config.yml; missing
+     * keys fall back to using the key as the label.
+     */
+    groups?: string[];
     joins?: DbtModelJoin[];
     case_sensitive?: boolean; // When false, all string filters in this explore will be case insensitive. Default is true
     sql_filter?: string;

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -89,7 +89,15 @@ export type Explore = {
     name: string; // Must be sql friendly (a-Z, 0-9, _)
     label: string; // Friendly name
     tags: string[];
+    /** @deprecated Use `groups` instead */
     groupLabel?: string;
+    /**
+     * Nested groups for the sidebar (max 3 levels). Group keys resolve to
+     * labels/descriptions via the project-level `table_groups` config
+     * (fetched separately); missing keys fall back to using the key as
+     * the label.
+     */
+    groups?: string[];
     baseTable: string; // Must match a tableName in tables
     joinedTables: CompiledExploreJoin[]; // Must match a tableName in tables
     tables: { [tableName: string]: CompiledTable }; // All tables in this explore, potentially filtered by user attributes
@@ -121,7 +129,7 @@ export type Explore = {
 };
 
 export type ExploreError = Partial<Explore> &
-    Pick<Explore, 'name' | 'label' | 'groupLabel'> & {
+    Pick<Explore, 'name' | 'label' | 'groupLabel' | 'groups'> & {
         errors: InlineError[];
     };
 
@@ -138,6 +146,7 @@ type SummaryExploreFields =
     | 'label'
     | 'tags'
     | 'groupLabel'
+    | 'groups'
     | 'type'
     | 'preAggregateSource'
     | 'aiHint'
@@ -147,6 +156,7 @@ type SummaryExploreErrorFields =
     | 'label'
     | 'tags'
     | 'groupLabel'
+    | 'groups'
     | 'type'
     | 'aiHint'
     | 'errors';

--- a/packages/common/src/types/lightdashModel.ts
+++ b/packages/common/src/types/lightdashModel.ts
@@ -50,7 +50,9 @@ export type LightdashModelMetric = DbtColumnLightdashMetric;
 export type LightdashModelExplore = {
     label?: string;
     description?: string;
+    /** @deprecated Use groups instead */
     group_label?: string;
+    groups?: string[];
     joins?: DbtModelJoin[]; // Reuses DbtModelJoin directly
     required_filters?: RequiredFilter[];
     default_filters?: RequiredFilter[];

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -1,6 +1,7 @@
 import { type DimensionType } from './field';
 import type { ParameterValue } from './parameters';
 import type { WarehouseTypes } from './projects';
+import type { GroupType } from './table';
 
 type SpotlightCategory = {
     label: string;
@@ -65,6 +66,12 @@ export type LightdashProjectConfig = {
     warehouse?: WarehouseConfig; // Required for Lightdash-only projects (no dbt)
     defaults?: ProjectDefaults; // Project-wide defaults for various settings
     custom_granularities?: Record<string, CustomGranularity>;
+    /**
+     * Labels & descriptions for the group keys referenced by models'
+     * `meta.groups` array. Used to render nested table groups in the
+     * Explore sidebar. Missing keys fall back to using the key as the label.
+     */
+    table_groups?: Record<string, GroupType>;
 };
 
 export const DEFAULT_SPOTLIGHT_CONFIG: SpotlightConfig = {

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -80,7 +80,12 @@ const BasePanel = () => {
         sortedPreAggregateExplores,
     ] = useMemo(() => {
         if (!filteredExplores) {
-            return [[], [] as SummaryExplore[], [] as SummaryExplore[], [] as SummaryExplore[]];
+            return [
+                [],
+                [] as SummaryExplore[],
+                [] as SummaryExplore[],
+                [] as SummaryExplore[],
+            ];
         }
         const groupedExplores: SummaryExplore[] = [];
         const defaultExplores: SummaryExplore[] = [];

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -13,6 +13,7 @@ import { useCallback, useMemo, useState, useTransition } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplores } from '../../../hooks/useExplores';
+import { useProjectTableGroups } from '../../../hooks/useProjectTableGroups';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
 import MantineIcon from '../../common/MantineIcon';
@@ -20,12 +21,16 @@ import PageBreadcrumbs from '../../common/PageBreadcrumbs';
 import SuboptimalState from '../../common/SuboptimalState/SuboptimalState';
 import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
+import { buildExploreTree, sortExploreTree } from './exploreTree';
 import VirtualizedExploreList from './VirtualizedExploreList';
 
 const getPreAggregateName = (explore: SummaryExplore) =>
     'preAggregateSource' in explore
         ? explore.preAggregateSource?.preAggregateName
         : undefined;
+
+const exploreHasGroups = (explore: SummaryExplore): boolean =>
+    !!(explore.groups && explore.groups.length > 0) || !!explore.groupLabel;
 
 const BasePanel = () => {
     const navigate = useNavigate();
@@ -35,6 +40,7 @@ const BasePanel = () => {
     const [debouncedSearch] = useDebouncedValue(search, 300);
     const [, startTransition] = useTransition();
     const exploresResult = useExplores(projectUuid, true, true);
+    const tableGroupsResult = useProjectTableGroups(projectUuid);
     const { data: org } = useOrganization();
 
     const filteredExplores = useMemo(() => {
@@ -62,76 +68,51 @@ const BasePanel = () => {
         return undefined;
     }, [exploresResult.data, debouncedSearch]);
 
+    const tableGroupDetails = useMemo(
+        () => tableGroupsResult.data ?? {},
+        [tableGroupsResult.data],
+    );
+
     const [
-        sortedGroupLabels,
-        exploreGroupMap,
+        groupedExploreTree,
         defaultUngroupedExplores,
         customUngroupedExplores,
         sortedPreAggregateExplores,
-    ] = useMemo<
-        [
-            string[],
-            Record<string, SummaryExplore[]>,
-            SummaryExplore[],
-            SummaryExplore[],
-            SummaryExplore[],
-        ]
-    >(() => {
-        if (filteredExplores) {
-            // Pre-allocate collections for better performance
-            const groupMap: Record<string, SummaryExplore[]> = {};
-            const defaultExplores: SummaryExplore[] = [];
-            const customExplores: SummaryExplore[] = [];
-            const preAggregateExplores: SummaryExplore[] = [];
-
-            // Single-pass categorization without object spreads
-            for (const explore of filteredExplores) {
-                if (explore.type === ExploreType.PRE_AGGREGATE) {
-                    preAggregateExplores.push(explore);
-                } else if (explore.groupLabel) {
-                    if (groupMap[explore.groupLabel]) {
-                        groupMap[explore.groupLabel].push(explore);
-                    } else {
-                        groupMap[explore.groupLabel] = [explore];
-                    }
-                } else if (explore.type === ExploreType.VIRTUAL) {
-                    customExplores.push(explore);
-                } else {
-                    defaultExplores.push(explore);
-                }
-            }
-
-            // Pre-sort group labels once
-            const sortedLabels = Object.keys(groupMap).sort((a, b) =>
-                a.localeCompare(b),
-            );
-
-            // Sort explores within each group
-            for (const groupLabel of sortedLabels) {
-                groupMap[groupLabel].sort((a, b) =>
-                    a.label.localeCompare(b.label),
-                );
-            }
-
-            // Sort ungrouped explores
-            defaultExplores.sort((a, b) => a.label.localeCompare(b.label));
-            customExplores.sort((a, b) => a.label.localeCompare(b.label));
-            preAggregateExplores.sort((a, b) =>
-                (getPreAggregateName(a) ?? '').localeCompare(
-                    getPreAggregateName(b) ?? '',
-                ),
-            );
-
-            return [
-                sortedLabels,
-                groupMap,
-                defaultExplores,
-                customExplores,
-                preAggregateExplores,
-            ];
+    ] = useMemo(() => {
+        if (!filteredExplores) {
+            return [[], [] as SummaryExplore[], [] as SummaryExplore[], [] as SummaryExplore[]];
         }
-        return [[], {}, [], [], []];
-    }, [filteredExplores]);
+        const groupedExplores: SummaryExplore[] = [];
+        const defaultExplores: SummaryExplore[] = [];
+        const customExplores: SummaryExplore[] = [];
+        const preAggregateExplores: SummaryExplore[] = [];
+
+        for (const explore of filteredExplores) {
+            if (explore.type === ExploreType.PRE_AGGREGATE) {
+                preAggregateExplores.push(explore);
+            } else if (exploreHasGroups(explore)) {
+                groupedExplores.push(explore);
+            } else if (explore.type === ExploreType.VIRTUAL) {
+                customExplores.push(explore);
+            } else {
+                defaultExplores.push(explore);
+            }
+        }
+
+        const tree = sortExploreTree(
+            buildExploreTree(groupedExplores, tableGroupDetails),
+        );
+
+        defaultExplores.sort((a, b) => a.label.localeCompare(b.label));
+        customExplores.sort((a, b) => a.label.localeCompare(b.label));
+        preAggregateExplores.sort((a, b) =>
+            (getPreAggregateName(a) ?? '').localeCompare(
+                getPreAggregateName(b) ?? '',
+            ),
+        );
+
+        return [tree, defaultExplores, customExplores, preAggregateExplores];
+    }, [filteredExplores, tableGroupDetails]);
 
     const handleExploreClick = useCallback(
         (explore: SummaryExplore) => {
@@ -191,8 +172,7 @@ const BasePanel = () => {
                         />
 
                         <VirtualizedExploreList
-                            sortedGroupLabels={sortedGroupLabels}
-                            exploreGroupMap={exploreGroupMap}
+                            groupedExploreTree={groupedExploreTree}
                             defaultUngroupedExplores={defaultUngroupedExplores}
                             customUngroupedExplores={customUngroupedExplores}
                             preAggregateExplores={sortedPreAggregateExplores}

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/GroupHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/GroupHeader.tsx
@@ -1,4 +1,4 @@
-import { Group, NavLink, Text } from '@mantine-8/core';
+import { Box, Group, NavLink, Text } from '@mantine-8/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
@@ -19,7 +19,7 @@ const GroupHeader: FC<GroupHeaderProps> = ({
     depth = 0,
 }) => {
     return (
-        <div style={{ paddingLeft: `${depth * INDENT_PER_DEPTH}px` }}>
+        <Box style={{ paddingLeft: `${depth * INDENT_PER_DEPTH}px` }}>
             <NavLink
                 opened={isExpanded}
                 onClick={onToggle}
@@ -29,9 +29,7 @@ const GroupHeader: FC<GroupHeaderProps> = ({
                 rightSection={<></>}
                 leftSection={
                     <MantineIcon
-                        icon={
-                            isExpanded ? IconChevronDown : IconChevronRight
-                        }
+                        icon={isExpanded ? IconChevronDown : IconChevronRight}
                         size={14}
                         style={{
                             margin: 1,
@@ -47,7 +45,7 @@ const GroupHeader: FC<GroupHeaderProps> = ({
                     </Group>
                 }
             />
-        </div>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/GroupHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/GroupHeader.tsx
@@ -3,39 +3,51 @@ import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 
+const INDENT_PER_DEPTH = 16;
+
 type GroupHeaderProps = {
     label: string;
     isExpanded: boolean;
     onToggle: () => void;
+    depth?: number;
 };
 
-const GroupHeader: FC<GroupHeaderProps> = ({ label, isExpanded, onToggle }) => {
+const GroupHeader: FC<GroupHeaderProps> = ({
+    label,
+    isExpanded,
+    onToggle,
+    depth = 0,
+}) => {
     return (
-        <NavLink
-            opened={isExpanded}
-            onClick={onToggle}
-            // --start moves chevron to the left
-            // mostly hardcoded, to match mantine's internal sizes
-            disableRightSectionRotation
-            rightSection={<></>}
-            leftSection={
-                <MantineIcon
-                    icon={isExpanded ? IconChevronDown : IconChevronRight}
-                    size={14}
-                    style={{
-                        margin: 1,
-                    }}
-                />
-            }
-            // --end
-            label={
-                <Group>
-                    <Text fz="sm" fw={500} c="ldGray.7">
-                        {label}
-                    </Text>
-                </Group>
-            }
-        />
+        <div style={{ paddingLeft: `${depth * INDENT_PER_DEPTH}px` }}>
+            <NavLink
+                opened={isExpanded}
+                onClick={onToggle}
+                // --start moves chevron to the left
+                // mostly hardcoded, to match mantine's internal sizes
+                disableRightSectionRotation
+                rightSection={<></>}
+                leftSection={
+                    <MantineIcon
+                        icon={
+                            isExpanded ? IconChevronDown : IconChevronRight
+                        }
+                        size={14}
+                        style={{
+                            margin: 1,
+                        }}
+                    />
+                }
+                // --end
+                label={
+                    <Group>
+                        <Text fz="sm" fw={500} c="ldGray.7">
+                            {label}
+                        </Text>
+                    </Group>
+                }
+            />
+        </div>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
@@ -1,24 +1,39 @@
 import { type SummaryExplore } from '@lightdash/common';
 import { Divider } from '@mantine-8/core';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { memo, useCallback, useMemo, useRef, useState, type FC } from 'react';
+import {
+    memo,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import {
+    collectMatchingGroupPathsFromArray,
+    type ExploreNode,
+} from './exploreTree';
 import ExploreNavLink from './ExploreNavLink';
 import GroupHeader from './GroupHeader';
 import SectionHeader from './SectionHeader';
 
-// Define item types for the virtualized list
+const INDENT_PER_DEPTH = 16;
+
 export type VirtualListItem =
     | {
           type: 'group-header';
           id: string;
           label: string;
+          path: string;
+          depth: number;
           isExpanded: boolean;
       }
     | {
           type: 'explore';
           id: string;
           explore: SummaryExplore;
-          groupLabel?: string;
+          depth: number;
       }
     | { type: 'divider'; id: string }
     | {
@@ -29,8 +44,7 @@ export type VirtualListItem =
       };
 
 interface VirtualizedExploreListProps {
-    sortedGroupLabels: string[];
-    exploreGroupMap: Record<string, SummaryExplore[]>;
+    groupedExploreTree: ExploreNode[];
     defaultUngroupedExplores: SummaryExplore[];
     customUngroupedExplores: SummaryExplore[];
     preAggregateExplores: SummaryExplore[];
@@ -38,21 +52,34 @@ interface VirtualizedExploreListProps {
     onExploreClick: (explore: SummaryExplore) => void;
 }
 
-const ITEM_HEIGHT = 40; // Base height for most items
+const ITEM_HEIGHT = 40;
 const GROUP_HEADER_HEIGHT = 40;
 const SECTION_HEADER_HEIGHT = 32;
 const DIVIDER_HEIGHT = 16;
 
+const collectExploreNamesInTree = (
+    nodes: ExploreNode[],
+    out: Set<string>,
+): Set<string> => {
+    for (const node of nodes) {
+        if (node.type === 'explore') {
+            out.add(node.key);
+        } else {
+            collectExploreNamesInTree(Object.values(node.children), out);
+        }
+    }
+    return out;
+};
+
 const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
-    sortedGroupLabels,
-    exploreGroupMap,
+    groupedExploreTree,
     defaultUngroupedExplores,
     customUngroupedExplores,
     preAggregateExplores,
     searchQuery,
     onExploreClick,
 }) => {
-    const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+    const [expandedGroupPaths, setExpandedGroupPaths] = useState<Set<string>>(
         new Set(),
     );
     // Sections are collapsed by default (empty set means all collapsed)
@@ -61,119 +88,132 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
     );
     const parentRef = useRef<HTMLDivElement>(null);
 
-    const toggleGroup = useCallback((groupLabel: string) => {
-        setExpandedGroups((prev) => {
-            const newSet = new Set(prev);
-            if (newSet.has(groupLabel)) {
-                newSet.delete(groupLabel);
+    const toggleGroup = useCallback((path: string) => {
+        setExpandedGroupPaths((prev) => {
+            const next = new Set(prev);
+            if (next.has(path)) {
+                next.delete(path);
             } else {
-                newSet.add(groupLabel);
+                next.add(path);
             }
-            return newSet;
+            return next;
         });
     }, []);
 
     const toggleSection = useCallback((sectionLabel: string) => {
         setExpandedSections((prev) => {
-            const newSet = new Set(prev);
-            if (newSet.has(sectionLabel)) {
-                newSet.delete(sectionLabel);
+            const next = new Set(prev);
+            if (next.has(sectionLabel)) {
+                next.delete(sectionLabel);
             } else {
-                newSet.add(sectionLabel);
+                next.add(sectionLabel);
             }
-            return newSet;
+            return next;
         });
     }, []);
 
-    // Create flattened list of items for virtualization
-    const virtualItems = useMemo((): VirtualListItem[] => {
+    // Auto-expand group paths whose subtree contains a search match.
+    // groupedExploreTree was already filtered by the search in the parent,
+    // so every explore in the tree counts as a match.
+    const searchMatchPaths = useMemo<Set<string>>(() => {
+        if (!searchQuery) return new Set();
+        const matching = new Set<string>();
+        collectExploreNamesInTree(groupedExploreTree, matching);
+        return collectMatchingGroupPathsFromArray(
+            groupedExploreTree,
+            matching,
+        );
+    }, [groupedExploreTree, searchQuery]);
+
+    useEffect(() => {
+        if (searchMatchPaths.size === 0) return;
+        setExpandedGroupPaths((prev) => {
+            const next = new Set(prev);
+            searchMatchPaths.forEach((path) => next.add(path));
+            return next;
+        });
+    }, [searchMatchPaths]);
+
+    const virtualItems = useMemo<VirtualListItem[]>(() => {
         const items: VirtualListItem[] = [];
         let itemId = 0;
 
-        // Add grouped explores
-        for (const groupLabel of sortedGroupLabels) {
-            const explores = exploreGroupMap[groupLabel] || [];
-            const isExpanded = expandedGroups.has(groupLabel);
-
-            // Add group header
-            items.push({
-                type: 'group-header',
-                id: `group-${itemId++}`,
-                label: groupLabel,
-                isExpanded,
-            });
-
-            // Add explores if group is expanded
-            if (isExpanded) {
-                for (const explore of explores) {
+        const visit = (nodes: ExploreNode[], depth: number): void => {
+            for (const node of nodes) {
+                if (node.type === 'group') {
+                    const isExpanded = expandedGroupPaths.has(node.path);
+                    items.push({
+                        type: 'group-header',
+                        id: `group-${itemId++}`,
+                        label: node.label,
+                        path: node.path,
+                        depth,
+                        isExpanded,
+                    });
+                    if (isExpanded) {
+                        visit(Object.values(node.children), depth + 1);
+                    }
+                } else {
                     items.push({
                         type: 'explore',
                         id: `explore-${itemId++}`,
-                        explore,
-                        groupLabel,
+                        explore: node.explore,
+                        depth,
                     });
                 }
             }
-        }
+        };
 
-        // Add ungrouped explores
+        visit(groupedExploreTree, 0);
+
         for (const explore of defaultUngroupedExplores) {
             items.push({
                 type: 'explore',
                 id: `ungrouped-${itemId++}`,
                 explore,
+                depth: 0,
             });
         }
 
-        // Add virtual views section if there are custom explores
         if (customUngroupedExplores.length > 0) {
             const isVirtualViewsExpanded =
                 expandedSections.has('Virtual Views');
-
-            items.push({
-                type: 'divider',
-                id: `divider-${itemId++}`,
-            });
+            items.push({ type: 'divider', id: `divider-${itemId++}` });
             items.push({
                 type: 'section-header',
                 id: `section-${itemId++}`,
                 label: 'Virtual Views',
                 isExpanded: isVirtualViewsExpanded,
             });
-
             if (isVirtualViewsExpanded) {
                 for (const explore of customUngroupedExplores) {
                     items.push({
                         type: 'explore',
                         id: `virtual-${itemId++}`,
                         explore,
+                        depth: 0,
                     });
                 }
             }
         }
 
-        // Add pre-aggregates section if there are pre-aggregate explores
         if (preAggregateExplores.length > 0) {
             const isPreAggregatesExpanded =
                 expandedSections.has('Pre-aggregates');
-
-            items.push({
-                type: 'divider',
-                id: `divider-${itemId++}`,
-            });
+            items.push({ type: 'divider', id: `divider-${itemId++}` });
             items.push({
                 type: 'section-header',
                 id: `section-${itemId++}`,
                 label: 'Pre-aggregates',
                 isExpanded: isPreAggregatesExpanded,
             });
-
             if (isPreAggregatesExpanded) {
                 for (const explore of preAggregateExplores) {
                     items.push({
                         type: 'explore',
                         id: `pre-aggregate-${itemId++}`,
                         explore,
+                        depth: 0,
                     });
                 }
             }
@@ -181,12 +221,11 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
 
         return items;
     }, [
-        sortedGroupLabels,
-        exploreGroupMap,
+        groupedExploreTree,
         defaultUngroupedExplores,
         customUngroupedExplores,
         preAggregateExplores,
-        expandedGroups,
+        expandedGroupPaths,
         expandedSections,
     ]);
 
@@ -194,7 +233,6 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
         (index: number) => {
             const item = virtualItems[index];
             if (!item) return ITEM_HEIGHT;
-
             switch (item.type) {
                 case 'group-header':
                     return GROUP_HEADER_HEIGHT;
@@ -227,16 +265,16 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                             key={item.id}
                             label={item.label}
                             isExpanded={item.isExpanded}
-                            onToggle={() => toggleGroup(item.label)}
+                            depth={item.depth}
+                            onToggle={() => toggleGroup(item.path)}
                         />
                     );
-
                 case 'explore':
                     return (
                         <div
                             key={item.id}
                             style={{
-                                paddingLeft: item.groupLabel ? '16px' : '0px',
+                                paddingLeft: `${item.depth * INDENT_PER_DEPTH}px`,
                             }}
                         >
                             <ExploreNavLink
@@ -246,7 +284,6 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                             />
                         </div>
                     );
-
                 case 'divider':
                     return (
                         <Divider
@@ -256,7 +293,6 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                             my="xs"
                         />
                     );
-
                 case 'section-header':
                     return (
                         <SectionHeader
@@ -266,7 +302,6 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                             onToggle={() => toggleSection(item.label)}
                         />
                     );
-
                 default:
                     return null;
             }
@@ -291,7 +326,6 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                 {virtualizer.getVirtualItems().map((virtualItem) => {
                     const item = virtualItems[virtualItem.index];
                     if (!item) return null;
-
                     return (
                         <div
                             key={virtualItem.key}

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
@@ -1,20 +1,12 @@
 import { type SummaryExplore } from '@lightdash/common';
-import { Divider } from '@mantine-8/core';
+import { Box, Divider } from '@mantine-8/core';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import {
-    memo,
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type FC,
-} from 'react';
+import { memo, useCallback, useMemo, useRef, useState, type FC } from 'react';
+import ExploreNavLink from './ExploreNavLink';
 import {
     collectMatchingGroupPathsFromArray,
     type ExploreNode,
 } from './exploreTree';
-import ExploreNavLink from './ExploreNavLink';
 import GroupHeader from './GroupHeader';
 import SectionHeader from './SectionHeader';
 
@@ -112,36 +104,28 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
         });
     }, []);
 
-    // Auto-expand group paths whose subtree contains a search match.
-    // groupedExploreTree was already filtered by the search in the parent,
-    // so every explore in the tree counts as a match.
-    const searchMatchPaths = useMemo<Set<string>>(() => {
-        if (!searchQuery) return new Set();
-        const matching = new Set<string>();
-        collectExploreNamesInTree(groupedExploreTree, matching);
-        return collectMatchingGroupPathsFromArray(
-            groupedExploreTree,
-            matching,
-        );
-    }, [groupedExploreTree, searchQuery]);
-
-    useEffect(() => {
-        if (searchMatchPaths.size === 0) return;
-        setExpandedGroupPaths((prev) => {
-            const next = new Set(prev);
-            searchMatchPaths.forEach((path) => next.add(path));
-            return next;
-        });
-    }, [searchMatchPaths]);
-
     const virtualItems = useMemo<VirtualListItem[]>(() => {
+        // Auto-expand any group whose subtree contains a search match.
+        // Derived inline (rather than via setState in an effect) so the
+        // expansion is purely visual and resets when search clears.
+        const searchExpansion = searchQuery
+            ? collectMatchingGroupPathsFromArray(
+                  groupedExploreTree,
+                  collectExploreNamesInTree(groupedExploreTree, new Set()),
+              )
+            : null;
+
+        const isPathExpanded = (path: string): boolean =>
+            expandedGroupPaths.has(path) ||
+            (searchExpansion?.has(path) ?? false);
+
         const items: VirtualListItem[] = [];
         let itemId = 0;
 
         const visit = (nodes: ExploreNode[], depth: number): void => {
             for (const node of nodes) {
                 if (node.type === 'group') {
-                    const isExpanded = expandedGroupPaths.has(node.path);
+                    const isExpanded = isPathExpanded(node.path);
                     items.push({
                         type: 'group-header',
                         id: `group-${itemId++}`,
@@ -227,6 +211,7 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
         preAggregateExplores,
         expandedGroupPaths,
         expandedSections,
+        searchQuery,
     ]);
 
     const getItemHeight = useCallback(
@@ -271,7 +256,7 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                     );
                 case 'explore':
                     return (
-                        <div
+                        <Box
                             key={item.id}
                             style={{
                                 paddingLeft: `${item.depth * INDENT_PER_DEPTH}px`,
@@ -282,7 +267,7 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                                 query={searchQuery}
                                 onClick={() => onExploreClick(item.explore)}
                             />
-                        </div>
+                        </Box>
                     );
                 case 'divider':
                     return (
@@ -310,14 +295,14 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
     );
 
     return (
-        <div
+        <Box
             ref={parentRef}
             style={{
                 height: '100%',
                 overflow: 'auto',
             }}
         >
-            <div
+            <Box
                 style={{
                     height: virtualizer.getTotalSize() + 16,
                     position: 'relative',
@@ -327,7 +312,7 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                     const item = virtualItems[virtualItem.index];
                     if (!item) return null;
                     return (
-                        <div
+                        <Box
                             key={virtualItem.key}
                             style={{
                                 position: 'absolute',
@@ -339,11 +324,11 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                             }}
                         >
                             {renderItem(item)}
-                        </div>
+                        </Box>
                     );
                 })}
-            </div>
-        </div>
+            </Box>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.test.ts
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.test.ts
@@ -17,7 +17,7 @@ const explore = (
         schemaName: 'schema',
         groups: options.groups,
         groupLabel: options.groupLabel,
-    } as unknown as SummaryExplore);
+    }) as unknown as SummaryExplore;
 
 describe('buildExploreTree', () => {
     it('groups explores by their nested `groups` array', () => {

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.test.ts
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.test.ts
@@ -1,0 +1,113 @@
+import { type SummaryExplore } from '@lightdash/common';
+import {
+    buildExploreTree,
+    collectMatchingGroupPaths,
+    sortExploreTree,
+} from './exploreTree';
+
+const explore = (
+    name: string,
+    options: { groups?: string[]; groupLabel?: string; label?: string } = {},
+): SummaryExplore =>
+    ({
+        name,
+        label: options.label ?? name,
+        tags: [],
+        databaseName: 'db',
+        schemaName: 'schema',
+        groups: options.groups,
+        groupLabel: options.groupLabel,
+    } as unknown as SummaryExplore);
+
+describe('buildExploreTree', () => {
+    it('groups explores by their nested `groups` array', () => {
+        const tree = buildExploreTree([
+            explore('orders', { groups: ['marketing', 'email'] }),
+            explore('signups', { groups: ['marketing', 'email'] }),
+            explore('ads', { groups: ['marketing', 'paid'] }),
+        ]);
+
+        const sorted = sortExploreTree(tree);
+        expect(sorted).toHaveLength(1);
+        const marketing = sorted[0];
+        expect(marketing.type).toBe('group');
+        if (marketing.type !== 'group') return;
+        expect(marketing.path).toBe('marketing');
+
+        const subgroups = sortExploreTree(marketing.children);
+        expect(subgroups.map((n) => n.key)).toEqual(['email', 'paid']);
+        const email = subgroups[0];
+        if (email.type !== 'group') return;
+        expect(email.path).toBe('marketing/email');
+        expect(Object.keys(email.children).sort()).toEqual([
+            'orders',
+            'signups',
+        ]);
+    });
+
+    it('falls back to the legacy `groupLabel` when `groups` is missing', () => {
+        const tree = buildExploreTree([
+            explore('legacy', { groupLabel: 'legacy_group' }),
+        ]);
+        const sorted = sortExploreTree(tree);
+        expect(sorted).toHaveLength(1);
+        expect(sorted[0].type).toBe('group');
+        if (sorted[0].type !== 'group') return;
+        expect(sorted[0].key).toBe('legacy_group');
+        expect(Object.keys(sorted[0].children)).toEqual(['legacy']);
+    });
+
+    it('uses `tableGroupDetails` to resolve labels & descriptions', () => {
+        const tree = buildExploreTree(
+            [explore('orders', { groups: ['mktg'] })],
+            {
+                mktg: { label: 'Marketing', description: 'All marketing' },
+            },
+        );
+        const sorted = sortExploreTree(tree);
+        const mktg = sorted[0];
+        expect(mktg.type).toBe('group');
+        if (mktg.type !== 'group') return;
+        expect(mktg.label).toBe('Marketing');
+        expect(mktg.description).toBe('All marketing');
+    });
+
+    it('falls back to the group key when no detail is provided', () => {
+        const tree = buildExploreTree([
+            explore('orders', { groups: ['Marketing'] }),
+        ]);
+        const sorted = sortExploreTree(tree);
+        const mktg = sorted[0];
+        if (mktg.type !== 'group') return;
+        expect(mktg.label).toBe('Marketing');
+    });
+
+    it('caps nesting at 3 levels', () => {
+        const tree = buildExploreTree([
+            explore('orders', { groups: ['a', 'b', 'c', 'd'] }),
+        ]);
+        let depth = 0;
+        let cursor: ReturnType<typeof sortExploreTree>[number] | undefined =
+            sortExploreTree(tree)[0];
+        while (cursor && cursor.type === 'group') {
+            depth += 1;
+            cursor = sortExploreTree(cursor.children)[0];
+        }
+        expect(depth).toBe(3);
+    });
+});
+
+describe('collectMatchingGroupPaths', () => {
+    it('returns paths of groups whose subtree contains a matching explore', () => {
+        const tree = buildExploreTree([
+            explore('orders', { groups: ['marketing', 'email'] }),
+            explore('ads', { groups: ['marketing', 'paid'] }),
+            explore('users', { groups: ['ops'] }),
+        ]);
+        const matches = collectMatchingGroupPaths(tree, new Set(['orders']));
+        expect(matches.has('marketing')).toBe(true);
+        expect(matches.has('marketing/email')).toBe(true);
+        expect(matches.has('marketing/paid')).toBe(false);
+        expect(matches.has('ops')).toBe(false);
+    });
+});

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.ts
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.ts
@@ -1,6 +1,6 @@
 import { type GroupType, type SummaryExplore } from '@lightdash/common';
 
-export const MAX_EXPLORE_GROUP_DEPTH = 3;
+const MAX_EXPLORE_GROUP_DEPTH = 3;
 
 export type ExploreLeafNode = {
     type: 'explore';

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.ts
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.ts
@@ -1,0 +1,216 @@
+import { type GroupType, type SummaryExplore } from '@lightdash/common';
+
+export const MAX_EXPLORE_GROUP_DEPTH = 3;
+
+export type ExploreLeafNode = {
+    type: 'explore';
+    key: string; // explore name
+    label: string;
+    explore: SummaryExplore;
+};
+
+export type ExploreGroupNode = {
+    type: 'group';
+    key: string; // raw group key
+    label: string;
+    description?: string;
+    path: string; // full path used for expansion state
+    children: ExploreNodeMap;
+};
+
+export type ExploreNode = ExploreLeafNode | ExploreGroupNode;
+
+export type ExploreNodeMap = Record<string, ExploreNode>;
+
+const PATH_SEPARATOR = '/';
+
+const buildPath = (parentPath: string, key: string): string =>
+    parentPath ? `${parentPath}${PATH_SEPARATOR}${key}` : key;
+
+const resolveGroupLabel = (
+    key: string,
+    groupDetails: Record<string, GroupType>,
+): { label: string; description?: string } => {
+    const detail = groupDetails[key];
+    if (detail) {
+        return { label: detail.label, description: detail.description };
+    }
+    return { label: key };
+};
+
+// Mutates `nodeMap`. Tree is constructed fresh per `buildExploreTree` call,
+// so there's no shared-state concern — and avoiding immutable spreads makes
+// insertion O(depth) instead of O(n) per explore.
+const insertExploreIntoTree = (
+    nodeMap: ExploreNodeMap,
+    explore: SummaryExplore,
+    groups: string[],
+    groupDetails: Record<string, GroupType>,
+    parentPath: string,
+): void => {
+    if (groups.length === 0) {
+        nodeMap[explore.name] = {
+            type: 'explore',
+            key: explore.name,
+            label: explore.label || explore.name,
+            explore,
+        };
+        return;
+    }
+
+    const [head, ...tail] = groups;
+    const existing = nodeMap[head];
+
+    // Collision: an explore already lives at this key. Drop grouping for this
+    // explore and add at the current level (mirrors field tree behaviour).
+    if (existing && existing.type === 'explore') {
+        nodeMap[explore.name] = {
+            type: 'explore',
+            key: explore.name,
+            label: explore.label || explore.name,
+            explore,
+        };
+        return;
+    }
+
+    let groupNode: ExploreGroupNode;
+    if (existing && existing.type === 'group') {
+        groupNode = existing;
+    } else {
+        const { label, description } = resolveGroupLabel(head, groupDetails);
+        groupNode = {
+            type: 'group',
+            key: head,
+            label,
+            description,
+            path: buildPath(parentPath, head),
+            children: {},
+        };
+        nodeMap[head] = groupNode;
+    }
+
+    insertExploreIntoTree(
+        groupNode.children,
+        explore,
+        tail,
+        groupDetails,
+        groupNode.path,
+    );
+};
+
+const getExploreGroups = (explore: SummaryExplore): string[] => {
+    if (explore.groups && explore.groups.length > 0) {
+        return explore.groups.slice(0, MAX_EXPLORE_GROUP_DEPTH);
+    }
+    if (explore.groupLabel) {
+        return [explore.groupLabel];
+    }
+    return [];
+};
+
+export const buildExploreTree = (
+    explores: SummaryExplore[],
+    tableGroupDetails: Record<string, GroupType> = {},
+): ExploreNodeMap => {
+    const tree: ExploreNodeMap = {};
+    for (const explore of explores) {
+        insertExploreIntoTree(
+            tree,
+            explore,
+            getExploreGroups(explore),
+            tableGroupDetails,
+            '',
+        );
+    }
+    return tree;
+};
+
+const sortNodes = (a: ExploreNode, b: ExploreNode): number => {
+    // Groups first, then explores, each alphabetised.
+    if (a.type !== b.type) {
+        return a.type === 'group' ? -1 : 1;
+    }
+    return a.label.localeCompare(b.label);
+};
+
+// Sorts in place and returns the same node references so iteration order
+// (Object.values / for..in) follows insertion order. Groups are mutated to
+// reorder their `children` map.
+const sortNodeMapInPlace = (nodeMap: ExploreNodeMap): ExploreNode[] => {
+    const sorted = Object.values(nodeMap).sort(sortNodes);
+    // Reset insertion order on the original map.
+    for (const node of sorted) {
+        delete nodeMap[node.key];
+    }
+    for (const node of sorted) {
+        nodeMap[node.key] = node;
+        if (node.type === 'group') {
+            sortNodeMapInPlace(node.children);
+        }
+    }
+    return sorted;
+};
+
+export const sortExploreTree = (nodeMap: ExploreNodeMap): ExploreNode[] =>
+    sortNodeMapInPlace(nodeMap);
+
+/**
+ * Walk the tree and collect the paths of every group whose subtree contains
+ * a matching explore (by name). Used to auto-expand groups when the user
+ * searches.
+ */
+export const collectMatchingGroupPaths = (
+    nodeMap: ExploreNodeMap,
+    matchingExploreNames: Set<string>,
+): Set<string> => {
+    const matches = new Set<string>();
+    const visit = (nodes: ExploreNodeMap): boolean => {
+        let found = false;
+        for (const node of Object.values(nodes)) {
+            if (node.type === 'explore') {
+                if (matchingExploreNames.has(node.key)) {
+                    found = true;
+                }
+            } else {
+                const childMatch = visit(node.children);
+                if (childMatch) {
+                    matches.add(node.path);
+                    found = true;
+                }
+            }
+        }
+        return found;
+    };
+    visit(nodeMap);
+    return matches;
+};
+
+/**
+ * Same as `collectMatchingGroupPaths` but operates on a pre-sorted array
+ * of root nodes — saves rebuilding a Record for the caller.
+ */
+export const collectMatchingGroupPathsFromArray = (
+    rootNodes: ExploreNode[],
+    matchingExploreNames: Set<string>,
+): Set<string> => {
+    const matches = new Set<string>();
+    const visit = (nodes: Iterable<ExploreNode>): boolean => {
+        let found = false;
+        for (const node of nodes) {
+            if (node.type === 'explore') {
+                if (matchingExploreNames.has(node.key)) {
+                    found = true;
+                }
+            } else {
+                const childMatch = visit(Object.values(node.children));
+                if (childMatch) {
+                    matches.add(node.path);
+                    found = true;
+                }
+            }
+        }
+        return found;
+    };
+    visit(rootNodes);
+    return matches;
+};

--- a/packages/frontend/src/hooks/useProjectTableGroups.ts
+++ b/packages/frontend/src/hooks/useProjectTableGroups.ts
@@ -1,7 +1,4 @@
-import {
-    type ApiError,
-    type ApiTableGroupsResults,
-} from '@lightdash/common';
+import { type ApiError, type ApiTableGroupsResults } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 

--- a/packages/frontend/src/hooks/useProjectTableGroups.ts
+++ b/packages/frontend/src/hooks/useProjectTableGroups.ts
@@ -1,0 +1,20 @@
+import {
+    type ApiError,
+    type ApiTableGroupsResults,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+
+const getProjectTableGroups = (projectUuid: string) =>
+    lightdashApi<ApiTableGroupsResults>({
+        url: `/projects/${projectUuid}/table-groups`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useProjectTableGroups = (projectUuid: string | undefined) =>
+    useQuery<ApiTableGroupsResults, ApiError>({
+        queryKey: ['project', projectUuid, 'table-groups'],
+        queryFn: () => getProjectTableGroups(projectUuid!),
+        enabled: Boolean(projectUuid),
+    });


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/11308
Closes: [PROD-482](https://linear.app/lightdash/issue/PROD-482/allow-nested-grouping-in-the-tables-list)

### Description:

Adds nested grouping for tables in the Explore sidebar, mirroring the existing dimension/metric `groups` feature. Models declare `meta.groups: string[]` (max 3 levels) in their dbt YAML, and project-wide labels & descriptions are defined in `lightdash.config.yml` under a new \`table_groups\` map — persisted on a new \`projects.table_groups\` jsonb column and exposed via \`GET /projects/:uuid/table-groups\`. The sidebar now renders a recursive, depth-indented tree with auto-expand on search, virtualized end-to-end, and the tree builder uses mutable inserts so construction stays linear at thousands of explores. Backwards compatible with the legacy \`group_label\` field.

### Example

Project's `table_groups`:
```yaml
table_groups:
    sales:
        label: Sales
        description: All things customer & revenue
    sales_orders:
        label: Orders
        description: Order-level data
    sales_customers:
        label: Customers
        description: Customer profiles
    marketing:
        label: Marketing
        description: Campaigns & touchpoints
    marketing_campaigns:
        label: Campaigns
    marketing_events:
        label: Events
```

Models tagged with two-level groups, e.g.:
```yaml
- name: orders
  meta:
    groups: [sales, sales_orders]

- name: customers
  meta:
    groups: [sales, sales_customers]

- name: campaigns
  meta:
    groups: [marketing, marketing_campaigns]

- name: events
  meta:
    groups: [marketing, marketing_events]
```

#### Collapsed top-level groups (label resolved from `table_groups`):
<img width="2400" height="2454" alt="01-sidebar-collapsed" src="https://github.com/user-attachments/assets/ee3b0eb0-ee1b-4c74-b735-84ba13500835" />


#### Sales and Marketing expanded — three levels deep with depth indentation:
<img width="2400" height="2454" alt="02-sidebar-nested-expanded" src="https://github.com/user-attachments/assets/38db9150-f2c2-4ad4-be39-983ef06089fe" />


#### Search auto-expands only the ancestors of matching tables:
<img width="2400" height="2454" alt="03-sidebar-search-autoexpand" src="https://github.com/user-attachments/assets/5d7bb8b6-f5f0-41e4-8ee4-afb6a6ce22dd" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)