### PR TITLE
fix: add CORP header and configurable CSP origins for app preview

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -355,6 +355,7 @@ export const lightdashConfigMock: LightdashConfig = {
         lightdashOrigin: 'https://test.lightdash.cloud',
         cdnOrigin: null,
         previewOrigin: null,
+        cspAllowedOrigins: [],
         s3: null,
         e2bApiKey: null,
         e2bTemplateName: 'lightdash-data-app',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1320,6 +1320,12 @@ export type AppRuntimeConfig = {
      * the preview-router prefix.
      */
     previewOrigin: string | null;
+    /**
+     * Additional origins allowed in the preview iframe CSP for style-src
+     * and font-src directives. Parsed from a comma-separated env var
+     * (e.g. `https://fonts.googleapis.com,https://fonts.gstatic.com`).
+     */
+    cspAllowedOrigins: string[];
     s3: S3Config | null;
     e2bApiKey: string | null;
     e2bTemplateName: string;
@@ -1535,6 +1541,10 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
         lightdashOrigin: process.env.APP_RUNTIME_LIGHTDASH_ORIGIN || siteUrl,
         cdnOrigin: process.env.APP_RUNTIME_CDN_ORIGIN || null,
         previewOrigin: process.env.APP_RUNTIME_PREVIEW_ORIGIN || null,
+        cspAllowedOrigins: (process.env.APP_RUNTIME_CSP_ALLOWED_ORIGINS || '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean),
         s3,
         e2bApiKey: process.env.E2B_API_KEY || null,
         e2bTemplateName: process.env.E2B_TEMPLATE_NAME || 'lightdash-data-app',

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -31,15 +31,19 @@ const CONTENT_TYPE_BY_EXT: Record<string, string> = {
 };
 
 const buildCspHeader = (config: AppRuntimeConfig): string => {
-    const { lightdashOrigin, cdnOrigin } = config;
+    const { lightdashOrigin, cdnOrigin, cspAllowedOrigins } = config;
+
+    const extra = cspAllowedOrigins.length
+        ? ` ${cspAllowedOrigins.join(' ')}`
+        : '';
 
     const directives: string[] = [
         `default-src 'none'`,
         `script-src 'self'${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
-        `style-src 'self' 'unsafe-inline'${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
+        `style-src 'self' 'unsafe-inline'${extra}${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
         `connect-src 'self' ${lightdashOrigin} https:`,
         `img-src 'self' data:${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
-        `font-src 'self'${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
+        `font-src 'self'${extra}${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
         `frame-ancestors ${lightdashOrigin}`,
         `object-src 'none'`,
         `base-uri 'none'`,
@@ -377,6 +381,7 @@ export const createAppPreviewRouter = (
             // Allow cross-origin loading from sandboxed iframes (opaque origin).
             // Safe because assets are static build artifacts, not user data.
             res.setHeader('Access-Control-Allow-Origin', '*');
+            res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
             res.setHeader('Content-Type', contentType);
             res.setHeader('X-Content-Type-Options', 'nosniff');
             res.setHeader(


### PR DESCRIPTION
## Summary
- Add `Cross-Origin-Resource-Policy: cross-origin` on preview asset responses so cross-origin iframes can load CSS/JS
- Add `APP_RUNTIME_CSP_ALLOWED_ORIGINS` env var for configurable `style-src` and `font-src` origins (e.g. Google Fonts)

Fixes CSP and CORP errors when data app previews are served from a separate origin.

## Test plan
- [ ] Set `APP_RUNTIME_CSP_ALLOWED_ORIGINS=https://fonts.googleapis.com,https://fonts.gstatic.com`
- [ ] Load a data app that uses Google Fonts — no CSP errors in console
- [ ] Load a data app via cross-origin preview — CSS/JS loads without CORP errors