### PR TITLE
feat(managed-agent): gate autopilot home card and /improve route to developers and admins

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     type ApiError,
     type ContentVerificationInfo,
@@ -58,12 +59,14 @@ import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
 import InfoRow from '../../../components/common/PageHeader/InfoRow';
 import { SlackChannelSelect } from '../../../components/common/SlackChannelSelect';
 import TruncatedText from '../../../components/common/TruncatedText';
+import ForbiddenPanel from '../../../components/ForbiddenPanel';
 import { useChartViewStats } from '../../../hooks/chart/useChartViewStats';
 import { useDashboardQuery } from '../../../hooks/dashboard/useDashboard';
 import { useGetSlack } from '../../../hooks/slack/useSlack';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProject } from '../../../hooks/useProject';
 import { useSavedQuery } from '../../../hooks/useSavedQuery';
+import useApp from '../../../providers/App/useApp';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
 import classes from './ManagedAgentActivityPage.module.css';
@@ -1315,10 +1318,21 @@ const RunHeaderRow: FC<{
 export const ManagedAgentActivityPage: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
+    const { user } = useApp();
+    const canManageAutopilot =
+        user.data?.ability?.can(
+            'manage',
+            subject('AiAgent', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
     const { showToastSuccess, showToastApiError } = useToaster();
-    const { data: actions, isLoading } = useManagedAgentActions();
+    const { data: actions, isLoading } = useManagedAgentActions({
+        enabled: canManageAutopilot,
+    });
     const { data: settings, isLoading: settingsLoading } =
-        useManagedAgentSettings();
+        useManagedAgentSettings({ enabled: canManageAutopilot });
     const [selected, setSelected] = useState<ManagedAgentAction | null>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
     const [userOpenState, setUserOpenState] = useState<Map<string, boolean>>(
@@ -1398,6 +1412,10 @@ export const ManagedAgentActivityPage: FC = () => {
             });
         },
     });
+
+    if (!canManageAutopilot) {
+        return <ForbiddenPanel />;
+    }
 
     if (isLoading || settingsLoading) {
         return (

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     assertUnreachable,
     FeatureFlags,
@@ -28,6 +29,7 @@ import {
 import { useNavigate } from 'react-router';
 import { BetaBadge } from '../../../components/common/BetaBadge';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../providers/App/useApp';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
 import classes from './ManagedAgentHomeCard.module.css';
@@ -118,15 +120,24 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
     projectUuid,
 }) => {
     const navigate = useNavigate();
+    const { user } = useApp();
+    const canManageAutopilot =
+        user.data?.ability?.can(
+            'manage',
+            subject('AiAgent', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
     const { data: aiAutopilotFlag } = useServerFeatureFlag(
         FeatureFlags.AiAutopilot,
     );
     const managedAgentEnabled = !!aiAutopilotFlag?.enabled;
     const { data: settings } = useManagedAgentSettings({
-        enabled: managedAgentEnabled,
+        enabled: managedAgentEnabled && canManageAutopilot,
     });
     const { data: actions } = useManagedAgentActions({
-        enabled: managedAgentEnabled,
+        enabled: managedAgentEnabled && canManageAutopilot,
     });
 
     const isEnabled = settings?.enabled ?? false;
@@ -161,6 +172,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
     const [setupOpen, setSetupOpen] = useState(false);
 
     if (!managedAgentEnabled) return null;
+    if (!canManageAutopilot) return null;
 
     const handleClick = () => {
         if (isEnabled) {


### PR DESCRIPTION
## Summary
Hides the Autopilot home card and `/improve` page from non-developer roles. Gated on `manage AiAgent` (developer + admin).

- Home card returns `null` when ability denies; data hooks also short-circuit
- `/improve` page shows `ForbiddenPanel` when ability denies

## Test plan
- [ ] As a viewer / interactive_viewer / editor: home card is hidden and `/projects/:uuid/improve` shows ForbiddenPanel
- [ ] As a developer / admin: home card and page work as before