### PR TITLE
feat(managed-agent): rename /improve to /autopilot with redirect

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -707,7 +707,7 @@ export class ManagedAgentService extends BaseService {
             const { organizationUuid } =
                 await this.projectModel.getSummary(projectUuid);
             const { siteUrl } = this.lightdashConfig;
-            const activityUrl = `${siteUrl}/projects/${projectUuid}/improve`;
+            const activityUrl = `${siteUrl}/projects/${projectUuid}/autopilot`;
 
             // Build compact action counts
             const counts: Record<string, number> = {};

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -339,12 +339,16 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         ),
     },
     {
-        path: 'improve',
+        path: 'autopilot',
         lazy: async () => {
             const { ManagedAgentActivityPage } =
                 await import('./ee/features/managedAgent/ManagedAgentActivityPage');
             return { Component: ManagedAgentActivityPage };
         },
+    },
+    {
+        path: 'improve',
+        element: <Navigate to="../autopilot" replace />,
     },
     {
         path: 'apps/generate',

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -176,7 +176,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
 
     const handleClick = () => {
         if (isEnabled) {
-            void navigate(`/projects/${projectUuid}/improve`);
+            void navigate(`/projects/${projectUuid}/autopilot`);
         } else {
             setSetupOpen(true);
         }
@@ -285,7 +285,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                 onClose={() => setSetupOpen(false)}
                 onEnabled={() => {
                     setSetupOpen(false);
-                    void navigate(`/projects/${projectUuid}/improve`);
+                    void navigate(`/projects/${projectUuid}/autopilot`);
                 }}
             />
         </>


### PR DESCRIPTION
## Summary
Renames `/improve` → `/autopilot`. Old `/improve` path redirects to `/autopilot` so existing bookmarks keep working. Slack activity link from heartbeat reports also uses the new path.

## Test plan
- [ ] `/projects/:uuid/autopilot` loads the page
- [ ] `/projects/:uuid/improve` redirects to `/autopilot`
- [ ] Slack notification link points to `/autopilot`