### PR TITLE
fix: index color_palette_uuid on spaces and projects

### DIFF
--- a/packages/backend/src/database/CLAUDE.md
+++ b/packages/backend/src/database/CLAUDE.md
@@ -63,6 +63,19 @@ console.log(`Found ${searchResults.pagination.totalResults} results`);
 - UUIDs are used for external API identifiers while internal IDs are auto-incrementing integers
 - **Every table must have a PRIMARY KEY**: PostgreSQL logical replication and CDC tools rely on it for row identity, and PG can otherwise be forced into expensive `REPLICA IDENTITY FULL`. For new tables, prefer a synthetic UUID PK (`<table>_uuid` defaulting to `uuid_generate_v4()`) — this is consistent with the external API and avoids relying on natural keys that can change. A composite natural-key PK is acceptable when every column is already `NOT NULL` and inherently stable. Append-only audit/log tables are no exception.
 - **Foreign key preference**: When referencing other tables, prefer using UUID columns (e.g., `organization_uuid`) over integer IDs (e.g., `organization_id`). This maintains consistency with the external API and simplifies joins.
+- **Always index FK columns**: every column with a `.references()` clause must also have an index. Postgres does **not** create one automatically, and an unindexed FK turns every `ON DELETE CASCADE` / `ON DELETE SET NULL` cascade — and every JOIN that goes from parent to child — into a sequential scan on the child table. This is a frequent miss in PR review and only shows up in production when the child table grows. Two patterns:
+    - **Adding a brand-new column** in the same migration that creates it: chain `.index()` on the column definition. The column has zero rows, so the build is effectively free and a regular index is fine.
+        ```typescript
+        table
+            .uuid('color_palette_uuid')
+            .nullable()
+            .references('color_palette_uuid')
+            .inTable('organization_color_palettes')
+            .onDelete('SET NULL')
+            .index();
+        ```
+    - **Adding an index to an existing populated column** (e.g. fixing a missed index): use `CREATE INDEX CONCURRENTLY IF NOT EXISTS` with `config = { transaction: false }` so the build doesn't take a write lock. See the safe-migrations bullet below for the full pattern.
+    Same rule applies to columns frequently used as filter/JOIN predicates (e.g. `space_id` on `saved_queries`) even when there's no FK constraint.
 - The migration system supports both up/down functions and includes 150+ historical migrations
 - **Safe migrations on large tables**: Self-hosted instances can have tens of millions of rows. Any migration that backfills data, validates a constraint, or builds an index on a big table must be written defensively:
     - **Disable `statement_timeout` for the session**: at the top of `up()`, `await knex.raw('SET statement_timeout = 0')`, and `await knex.raw('RESET statement_timeout')` in a `finally` block. Production PG often has a session `statement_timeout` that will kill a long-running batch, and with `config = { transaction: false }` the Knex migration lock is *not* released on crash — operators then have to manually `UPDATE knex_migrations_lock SET is_locked = 0` to retry.

--- a/packages/backend/src/database/migrations/20260507100308_add_color_palette_uuid_indexes_to_spaces_and_projects.ts
+++ b/packages/backend/src/database/migrations/20260507100308_add_color_palette_uuid_indexes_to_spaces_and_projects.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex';
+
+const SpacesTable = 'spaces';
+const ProjectsTable = 'projects';
+const SpacesIndex = 'spaces_color_palette_uuid_index';
+const ProjectsIndex = 'projects_color_palette_uuid_index';
+
+export const config = { transaction: false };
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (color_palette_uuid)`,
+            [SpacesIndex, SpacesTable],
+        );
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (color_palette_uuid)`,
+            [ProjectsIndex, ProjectsTable],
+        );
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [SpacesIndex]);
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [ProjectsIndex]);
+}


### PR DESCRIPTION
Related to: https://linear.app/lightdash/issue/SPK-431/i-want-to-set-color-palettes-at-the-project-space-dashboard-or-chart

## Summary

Adds missing indexes on `spaces.color_palette_uuid` and `projects.color_palette_uuid`. Both columns were added in earlier PRs of the color-palette stack (#22708, #22751) without an index, which means:

- `ON DELETE SET NULL` (the FK cascade fired when an `organization_color_palettes` row is deleted) does a sequential scan on each child table to find referencing rows.
- `SavedChartModel.resolveColorPalette` joins on these columns — without an index, every chart load walks the whole `spaces` table.


## Implementation

- `CREATE INDEX CONCURRENTLY IF NOT EXISTS` for both indexes, inside `config = { transaction: false }`.
- `SET statement_timeout = 0` for the session to keep the build alive on long-running tables, then `RESET` in `finally`.
- `down()` uses `DROP INDEX CONCURRENTLY IF EXISTS` symmetrically.

Mirrors the safe-migration patterns in `docs/.../CLAUDE.md` (under `/packages/backend/src/database/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)