### PR TITLE
feat: add rotate endpoint to service-accounts controller

### DIFF
--- a/packages/backend/src/ee/controllers/serviceAccountsController.ts
+++ b/packages/backend/src/ee/controllers/serviceAccountsController.ts
@@ -5,6 +5,7 @@ import {
     AuthTokenPrefix,
     ServiceAccount,
     ServiceAccountScope,
+    ServiceAccountWithToken,
 } from '@lightdash/common';
 import {
     Body,
@@ -13,11 +14,13 @@ import {
     Hidden,
     Middlewares,
     OperationId,
+    Patch,
     Path,
     Post,
     Request,
     Response,
     Route,
+    SuccessResponse,
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
@@ -25,6 +28,7 @@ import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
+    unauthorisedInDemo,
 } from '../../controllers/authentication';
 import { BaseController } from '../../controllers/baseController';
 import { ServiceAccountService } from '../services/ServiceAccountService/ServiceAccountService';
@@ -115,6 +119,42 @@ export class ServiceAccountsController extends BaseController {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    /**
+     * Rotate a service account token by UUID
+     * @summary Rotate service account
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{tokenUuid}/rotate')
+    @OperationId('RotateServiceAccount')
+    async rotateServiceAccount(
+        @Path() tokenUuid: string,
+        @Request() req: express.Request,
+        @Body()
+        body: {
+            expiresAt: Date;
+        },
+    ): Promise<{
+        status: 'ok';
+        results: ServiceAccountWithToken;
+    }> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getServiceAccountService().rotate({
+                user: toSessionUser(req.account),
+                tokenUuid,
+                update: body,
+                prefix: AuthTokenPrefix.SERVICE_ACCOUNT,
+            }),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -343,6 +343,23 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ServiceAccountWithToken: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ServiceAccount' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        token: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ScimSchemaType.LIST_RESPONSE': {
         dataType: 'refEnum',
         enums: ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
@@ -1062,23 +1079,6 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             ref: 'Pick_ServiceAccount.expiresAt-or-description_',
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ServiceAccountWithToken: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'ServiceAccount' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        token: { dataType: 'string', required: true },
-                    },
-                },
-            ],
             validators: {},
         },
     },
@@ -9308,11 +9308,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9790,11 +9790,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9809,11 +9809,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9828,11 +9828,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9847,11 +9847,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9866,11 +9866,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -30843,6 +30843,76 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsServiceAccountsController_rotateServiceAccount: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        tokenUuid: {
+            in: 'path',
+            name: 'tokenUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                expiresAt: { dataType: 'datetime', required: true },
+            },
+        },
+    };
+    app.patch(
+        '/api/v1/service-accounts/:tokenUuid/rotate',
+        ...fetchMiddlewares<RequestHandler>(ServiceAccountsController),
+        ...fetchMiddlewares<RequestHandler>(
+            ServiceAccountsController.prototype.rotateServiceAccount,
+        ),
+
+        async function ServiceAccountsController_rotateServiceAccount(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsServiceAccountsController_rotateServiceAccount,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ServiceAccountsController>(
+                        ServiceAccountsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'rotateServiceAccount',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -188,6 +188,22 @@
                     }
                 ]
             },
+            "ServiceAccountWithToken": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ServiceAccount"
+                    },
+                    {
+                        "properties": {
+                            "token": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["token"],
+                        "type": "object"
+                    }
+                ]
+            },
             "ScimSchemaType.LIST_RESPONSE": {
                 "enum": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
                 "type": "string"
@@ -1052,22 +1068,6 @@
             },
             "ApiCreateScimServiceAccountRequest": {
                 "$ref": "#/components/schemas/Pick_ServiceAccount.expiresAt-or-description_"
-            },
-            "ServiceAccountWithToken": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ServiceAccount"
-                    },
-                    {
-                        "properties": {
-                            "token": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["token"],
-                        "type": "object"
-                    }
-                ]
             },
             "ScimGroupMember": {
                 "properties": {
@@ -10778,6 +10778,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -31850,7 +31863,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2890.1",
+        "version": "0.2891.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"


### PR DESCRIPTION
## Summary

Adds `PATCH /api/v1/service-accounts/{tokenUuid}/rotate` so non-SCIM service accounts can be rotated through the general controller — today rotation is only reachable via the SCIM controller.

Mirrors the existing SCIM rotate route exactly:

- Same middleware: `allowApiKeyAuthentication`, `isAuthenticated`, `unauthorisedInDemo`
- Same body: `{ expiresAt: Date }`
- Same response: `ServiceAccountWithToken`
- Delegates to the unchanged `ServiceAccountService.rotate()`, passing `AuthTokenPrefix.SERVICE_ACCOUNT` so rotated tokens keep the `ldsvc_` prefix

No service, model, or schema changes. Existing 1/hr rate limit, `manage Organization` permission check, and require-expiry rule still apply.

## Test plan

- [ ] `pnpm generate-api`, `pnpm -F backend typecheck`, `pnpm -F backend lint` all pass
- [ ] Create a non-SCIM SA with an expiry; `PATCH .../{uuid}/rotate` returns `200` with new `ldsvc_`-prefixed token
- [ ] DB shows updated `rotated_at` / `rotated_by_user_uuid` / `expires_at`
- [ ] Repeat rotate within an hour returns `400 ParameterError("Token can only be rotated once per hour")`
- [ ] Rotate on an SA with `expires_at = NULL` returns `400 ParameterError("Token with no expiration date cannot be rotated")`