### PR TITLE
feat: add rotate token UI for service accounts

### DIFF
--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsRotateModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsRotateModal.tsx
@@ -1,0 +1,182 @@
+import { type ServiceAccount } from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    CopyButton,
+    Select,
+    Stack,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconCheck, IconCopy, IconRefresh } from '@tabler/icons-react';
+import { useCallback, useEffect, useState, type FC } from 'react';
+import Callout from '../../../components/common/Callout';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import { useExpireOptions } from '../../../components/UserSettings/AccessTokensPanel/useExpireOptions';
+import { useServiceAccounts } from './useServiceAccounts';
+
+const ROTATE_FORM_ID = 'rotate-service-account-form';
+
+interface RotateFormState {
+    isLoading: boolean;
+    isSuccess: boolean;
+}
+
+const RotateForm: FC<{
+    serviceAccount: ServiceAccount;
+    onStateChange: (state: RotateFormState) => void;
+}> = ({ serviceAccount, onStateChange }) => {
+    const { rotateAccount } = useServiceAccounts();
+    const { mutate, isLoading, isSuccess, data: rotatedData } = rotateAccount;
+
+    const onRotate = useCallback(
+        (expiresAt: string) => {
+            mutate({ uuid: serviceAccount.uuid, expiresAt });
+        },
+        [serviceAccount.uuid, mutate],
+    );
+
+    const expireOptions = useExpireOptions();
+
+    const form = useForm({
+        initialValues: {
+            expiresAt: expireOptions[0]?.value || '30',
+        },
+    });
+
+    const handleOnSubmit = form.onSubmit(({ expiresAt }) => {
+        const currentDate = new Date();
+        const dateWhenExpires = new Date(
+            currentDate.setDate(currentDate.getDate() + Number(expiresAt)),
+        );
+        onRotate(dateWhenExpires.toISOString());
+    });
+
+    useEffect(() => {
+        onStateChange({ isLoading, isSuccess });
+    }, [isLoading, isSuccess, onStateChange]);
+
+    if (isSuccess && rotatedData) {
+        return (
+            <Stack gap="md">
+                <Callout variant="success" title="Token rotated successfully!">
+                    Your old token is now invalid.
+                </Callout>
+
+                <TextInput
+                    label="New Token"
+                    readOnly
+                    className="sentry-block ph-no-capture"
+                    value={rotatedData.token}
+                    rightSection={
+                        <CopyButton value={rotatedData.token}>
+                            {({ copied, copy }) => (
+                                <Tooltip
+                                    label={copied ? 'Copied' : 'Copy'}
+                                    withArrow
+                                    position="right"
+                                >
+                                    <ActionIcon
+                                        color={copied ? 'teal' : 'gray'}
+                                        onClick={copy}
+                                    >
+                                        <MantineIcon
+                                            icon={copied ? IconCheck : IconCopy}
+                                        />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                        </CopyButton>
+                    }
+                />
+
+                <Callout
+                    variant="info"
+                    title="Make sure to copy your new token now"
+                >
+                    You won't be able to see it again! Your old token is now
+                    invalid.
+                </Callout>
+            </Stack>
+        );
+    }
+
+    return (
+        <form id={ROTATE_FORM_ID} onSubmit={handleOnSubmit}>
+            <Stack gap="md">
+                <Callout
+                    variant="info"
+                    title={`Rotating token for "${serviceAccount.description}"`}
+                >
+                    This will generate a new token and invalidate the current
+                    one. You must specify a new expiration date.
+                </Callout>
+
+                <Select
+                    label="New Expiration"
+                    data={expireOptions}
+                    required
+                    disabled={isLoading}
+                    {...form.getInputProps('expiresAt')}
+                />
+            </Stack>
+        </form>
+    );
+};
+
+type Props = {
+    isOpen: boolean;
+    onClose: () => void;
+    serviceAccount: ServiceAccount | undefined;
+};
+
+export const ServiceAccountsRotateModal: FC<Props> = ({
+    isOpen,
+    onClose,
+    serviceAccount,
+}) => {
+    const [formState, setFormState] = useState<RotateFormState>({
+        isLoading: false,
+        isSuccess: false,
+    });
+
+    const handleClose = useCallback(() => {
+        onClose();
+        setFormState({ isLoading: false, isSuccess: false });
+    }, [onClose]);
+
+    return (
+        <MantineModal
+            opened={isOpen}
+            onClose={handleClose}
+            title="Rotate token"
+            icon={IconRefresh}
+            size="md"
+            cancelLabel={formState.isSuccess ? false : 'Cancel'}
+            cancelDisabled={formState.isLoading}
+            actions={
+                formState.isSuccess ? (
+                    <Button onClick={handleClose}>Done</Button>
+                ) : (
+                    <Button
+                        type="submit"
+                        form={ROTATE_FORM_ID}
+                        loading={formState.isLoading}
+                    >
+                        Rotate Token
+                    </Button>
+                )
+            }
+        >
+            {serviceAccount ? (
+                <RotateForm
+                    key={serviceAccount.uuid}
+                    serviceAccount={serviceAccount}
+                    onStateChange={setFormState}
+                />
+            ) : null}
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -32,6 +32,7 @@ import {
     IconDots,
     IconFilter,
     IconInfoCircle,
+    IconRefresh,
     IconSearch,
     IconShieldLock,
     IconTextCaption,
@@ -49,6 +50,7 @@ import { Link } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useCustomRoles } from '../customRoles/useCustomRoles';
 import { ServiceAccountsDeleteModal } from './ServiceAccountsDeleteModal';
+import { ServiceAccountsRotateModal } from './ServiceAccountsRotateModal';
 import classes from './ServiceAccountsToolbar.module.css';
 import { isServiceAccountStale, STALE_THRESHOLD_DAYS } from './staleness';
 
@@ -130,6 +132,8 @@ export const ServiceAccountsTable: FC<Props> = ({
 }) => {
     const theme = useMantineTheme();
     const [opened, { open, close }] = useDisclosure(false);
+    const [rotateOpened, { open: openRotate, close: closeRotate }] =
+        useDisclosure(false);
 
     const [search, setSearch] = useState('');
     const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
@@ -186,6 +190,9 @@ export const ServiceAccountsTable: FC<Props> = ({
     const [serviceAccountToDelete, setServiceAccountToDelete] = useState<
         ServiceAccount | undefined
     >();
+    const [serviceAccountToRotate, setServiceAccountToRotate] = useState<
+        ServiceAccount | undefined
+    >();
 
     const handleOpenDelete = useCallback(
         (sa: ServiceAccount) => {
@@ -205,6 +212,19 @@ export const ServiceAccountsTable: FC<Props> = ({
         setServiceAccountToDelete(undefined);
         close();
     }, [onDelete, serviceAccountToDelete, close]);
+
+    const handleOpenRotate = useCallback(
+        (sa: ServiceAccount) => {
+            setServiceAccountToRotate(sa);
+            openRotate();
+        },
+        [openRotate],
+    );
+
+    const handleCloseRotate = useCallback(() => {
+        setServiceAccountToRotate(undefined);
+        closeRotate();
+    }, [closeRotate]);
 
     const columns: MRT_ColumnDef<ServiceAccount>[] = useMemo(
         () => [
@@ -498,20 +518,30 @@ export const ServiceAccountsTable: FC<Props> = ({
                             </Menu.Target>
                             <Menu.Dropdown>
                                 {sa.roleUuid && (
-                                    <>
-                                        <Menu.Item
-                                            component={Link}
-                                            to={`/generalSettings/customRoles/${sa.roleUuid}`}
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconShieldLock}
-                                                />
-                                            }
-                                        >
-                                            View custom role
-                                        </Menu.Item>
-                                        <Menu.Divider />
-                                    </>
+                                    <Menu.Item
+                                        component={Link}
+                                        to={`/generalSettings/customRoles/${sa.roleUuid}`}
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconShieldLock}
+                                            />
+                                        }
+                                    >
+                                        View custom role
+                                    </Menu.Item>
+                                )}
+                                {sa.expiresAt && (
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon icon={IconRefresh} />
+                                        }
+                                        onClick={() => handleOpenRotate(sa)}
+                                    >
+                                        Rotate token
+                                    </Menu.Item>
+                                )}
+                                {(sa.roleUuid || sa.expiresAt) && (
+                                    <Menu.Divider />
                                 )}
                                 <Menu.Item
                                     color="red"
@@ -528,7 +558,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                 },
             },
         ],
-        [rolesByUuid, handleOpenDelete],
+        [rolesByUuid, handleOpenRotate, handleOpenDelete],
     );
 
     const handleStatusFilterChange = useCallback((value: string) => {
@@ -829,6 +859,12 @@ export const ServiceAccountsTable: FC<Props> = ({
                 isDeleting={isDeleting}
                 onDelete={handleConfirmDelete}
                 serviceAccount={serviceAccountToDelete!}
+            />
+
+            <ServiceAccountsRotateModal
+                isOpen={rotateOpened}
+                onClose={handleCloseRotate}
+                serviceAccount={serviceAccountToRotate}
             />
         </>
     );

--- a/packages/frontend/src/ee/features/serviceAccounts/useServiceAccounts.ts
+++ b/packages/frontend/src/ee/features/serviceAccounts/useServiceAccounts.ts
@@ -67,11 +67,38 @@ export const useServiceAccounts = () => {
         },
     });
 
+    const rotateAccount = useMutation<
+        CreateServiceAccountResult,
+        ApiError,
+        { uuid: string; expiresAt: string }
+    >({
+        mutationKey: [CACHE_KEY],
+        mutationFn: ({ uuid, expiresAt }) =>
+            lightdashApi<CreateServiceAccountResult>({
+                method: 'PATCH',
+                url: `/service-accounts/${uuid}/rotate`,
+                body: JSON.stringify({ expiresAt }),
+            }),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries([CACHE_KEY]);
+            showToastSuccess({
+                title: `Success! Your token was rotated.`,
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: `Failed to rotate token`,
+                apiError: error,
+            });
+        },
+    });
+
     return useMemo(() => {
         return {
             listAccounts,
             createAccount,
             deleteAccount,
+            rotateAccount,
         };
-    }, [listAccounts, createAccount, deleteAccount]);
+    }, [listAccounts, createAccount, deleteAccount, rotateAccount]);
 };


### PR DESCRIPTION
closes: [PROD-7416](https://linear.app/lightdash/issue/PROD-7416/review-expiration-and-token-rotation-logic)

<img width="978" height="820" alt="CleanShot 2026-05-07 at 13 42 32@2x" src="https://github.com/user-attachments/assets/8ae348db-c7c3-4e00-8520-6c0a395b0a7c" />

## Summary

Adds rotate-token UI for service accounts, mirroring the personal-access-token rotate flow.

- New `useRotateServiceAccount` mutation in `useServiceAccounts.ts` calling `PATCH /service-accounts/{uuid}/rotate` (introduced in #22785)
- New `ServiceAccountsRotateModal` containing the same form + success state as PAT's `RotateTokenForm`: select-based expiration picker, success Callout, copy-to-clipboard new-token field, "Make sure to copy your new token now" warning
- "Rotate token" menu item added to each row's action menu, conditional on the SA having an `expiresAt` (matches PAT)
- Reuses `useExpireOptions` so available expiration windows stay consistent with PAT

Stacked on #22785 (backend endpoint).

## Test plan

- [ ] Settings → Service accounts → row menu shows "Rotate token" only for SAs with an expiry
- [ ] Click "Rotate token" → modal opens with the SA description, expiration select, and "Rotate Token" button
- [ ] Submit → backend returns new `ldsvc_`-prefixed token; modal switches to success state with copyable token and "Done" button
- [ ] Cancel before submit → modal closes cleanly, list reloads with updated `rotatedAt`
- [ ] Repeat rotate within an hour → toast surfaces backend error "Token can only be rotated once per hour"
- [ ] No "Rotate token" item appears for SAs created without an expiry