### PR TITLE
fix: preserve isEditMode when clearing explore query (PROD-7475)

### DIFF
--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -962,7 +962,7 @@ const explorerSlice = createSlice({
         // Convenience action: Clear query but preserve tableName
         // Note: Components should also handle navigation side effects
         clearQuery: (
-            _state,
+            state,
             {
                 payload: { defaultState: d, tableName },
             }: PayloadAction<{
@@ -970,9 +970,12 @@ const explorerSlice = createSlice({
                 tableName: string;
             }>,
         ) => {
+            const { isEditMode, isMinimal } = state;
             return createNextState(d, (draft: ExplorerSliceState) => {
                 draft.unsavedChartVersion.tableName = tableName;
                 draft.unsavedChartVersion.metricQuery.exploreName = tableName;
+                draft.isEditMode = isEditMode;
+                draft.isMinimal = isMinimal;
             });
         },
 


### PR DESCRIPTION
## Summary

- Fixes [PROD-7475](https://linear.app/lightdash/issue/PROD-7475/explore-view-buttons-disappear-after-clearing-query): pressing cmd+opt+k in the explore view caused the top-left buttons (Run query, Save chart, Share) to disappear, and the user couldn't run another query.
- The `clearQuery` reducer was replacing the entire explorer state with `defaultState`, which has `isEditMode: false`. Since `<ExplorerHeader>` only renders in edit mode (`Explorer/index.tsx:226`), the whole header was removed.
- Fix preserves `isEditMode` and `isMinimal` (UI/route state, not query state) across the clear.

## Test plan

- [x] Open an explore, add a metric → top-left buttons visible
- [x] Press cmd+opt+k → query clears, buttons remain visible (disabled while empty)
- [x] Add a metric again → buttons re-enable and Run query works
- [x] `pnpm -F frontend typecheck` clean
- [x] `pnpm -F frontend lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)