### PR TITLE
feat(managed-agent): tool-activity badge with icon stack

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -564,23 +564,10 @@
     padding: 8px 12px;
     border-bottom: 1px solid
         light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
-    animation: liveBreathing 2.4s ease-in-out infinite;
-}
-
-@keyframes liveBreathing {
-    0%,
-    100% {
-        background-color: light-dark(
-            var(--mantine-color-white),
-            var(--mantine-color-dark-7)
-        );
-    }
-    50% {
-        background-color: light-dark(
-            var(--mantine-color-gray-0),
-            var(--mantine-color-dark-6)
-        );
-    }
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-ldDark-1)
+    );
 }
 
 .activityText {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -81,6 +81,7 @@ import { useManagedAgentLatestRun } from './hooks/useManagedAgentLatestRun';
 import { useManagedAgentRuns } from './hooks/useManagedAgentRuns';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
 import classes from './ManagedAgentActivityPage.module.css';
+import { ToolActivityBadge } from './ToolActivityBadge';
 import type { ManagedAgentAction } from './types';
 
 const reverseAction = async (projectUuid: string, actionUuid: string) =>
@@ -1412,16 +1413,9 @@ const RunRow: FC<{
                         <Table.Tr className={classes.liveActivityRow}>
                             <Table.Td colSpan={3}>
                                 <Group gap="xs" justify="center" py="xs">
-                                    <BoltPulseLoader size={14} />
-                                    <Text
-                                        key={run.currentActivity ?? 'idle'}
-                                        className={classes.activityText}
-                                        fz="xs"
-                                        c="dimmed"
-                                    >
-                                        {run.currentActivity ??
-                                            'Autopilot is working…'}
-                                    </Text>
+                                    <ToolActivityBadge
+                                        currentActivity={run.currentActivity}
+                                    />
                                 </Group>
                             </Table.Td>
                         </Table.Tr>

--- a/packages/frontend/src/ee/features/managedAgent/ToolActivityBadge.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ToolActivityBadge.module.css
@@ -1,0 +1,207 @@
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 4px 12px 4px 6px;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-ldDark-3));
+    border-radius: 999px;
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-ldDark-1)
+    );
+    color: light-dark(
+        var(--mantine-color-gray-7),
+        var(--mantine-color-ldDark-9)
+    );
+    box-shadow: light-dark(
+        0 1px 2px rgba(0, 0, 0, 0.04),
+        0 1px 2px rgba(0, 0, 0, 0.4)
+    );
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+}
+
+.badge::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+        110deg,
+        transparent 35%,
+        light-dark(rgba(207, 207, 207, 0.122), rgba(255, 255, 255, 0.077)) 50%,
+        transparent 65%
+    );
+    transform: translateX(-100%);
+    animation: glisten 4.2s ease-in-out infinite;
+    pointer-events: none;
+    z-index: 0;
+}
+
+@keyframes glisten {
+    0%,
+    70%,
+    100% {
+        transform: translateX(-100%);
+    }
+    45% {
+        transform: translateX(100%);
+    }
+}
+
+.iconSlot {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background-color: light-dark(
+        var(--mantine-color-gray-1),
+        var(--mantine-color-ldDark-3)
+    );
+    color: light-dark(
+        var(--mantine-color-gray-7),
+        var(--mantine-color-ldGray-4)
+    );
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-ldDark-4));
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+    z-index: 1;
+    animation: iconPulse 2.2s ease-in-out infinite;
+}
+
+.iconInner {
+    display: inline-flex;
+    animation: iconRollIn 320ms var(--ease-out-quart);
+}
+
+@keyframes iconRollIn {
+    from {
+        opacity: 0;
+        transform: translateY(60%);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes iconPulse {
+    0%,
+    100% {
+        transform: scale(1);
+        opacity: 0.92;
+    }
+    50% {
+        transform: scale(1.06);
+        opacity: 1;
+    }
+}
+
+.spinnerRing {
+    position: absolute;
+    inset: -3px;
+    border-radius: 50%;
+    border: 1px solid transparent;
+    border-top-color: light-dark(
+        rgba(0, 0, 0, 0.35),
+        rgba(255, 255, 255, 0.45)
+    );
+    animation: spinRing 1.6s linear infinite;
+    pointer-events: none;
+}
+
+@keyframes spinRing {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.activityText {
+    display: inline-block;
+    animation: textRollIn 320ms var(--ease-out-quart) both;
+    color: light-dark(
+        var(--mantine-color-gray-6),
+        var(--mantine-color-ldDark-7)
+    );
+}
+
+.srOnlyEllipsis {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@keyframes textRollIn {
+    from {
+        opacity: 0;
+        transform: translateY(30%);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.dots {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 1px;
+    margin-left: 1px;
+    color: light-dark(
+        var(--mantine-color-gray-6),
+        var(--mantine-color-ldDark-7)
+    );
+    line-height: 1;
+}
+
+.dot {
+    animation: dotPulse 1.4s ease-in-out infinite;
+}
+
+.dot:nth-child(2) {
+    animation-delay: 0.18s;
+}
+
+.dot:nth-child(3) {
+    animation-delay: 0.36s;
+}
+
+@keyframes dotPulse {
+    0%,
+    100% {
+        opacity: 0.25;
+    }
+    50% {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .badge::before,
+    .spinnerRing,
+    .iconSlot,
+    .dot {
+        animation: none;
+    }
+    /* `iconInner` and `activityText` use entrance keyframes that start at
+       opacity:0; setting `animation: none` alone strands them invisible. */
+    .iconInner,
+    .activityText {
+        animation: none;
+        opacity: 1;
+        transform: none;
+    }
+    .dot {
+        opacity: 1;
+    }
+}

--- a/packages/frontend/src/ee/features/managedAgent/ToolActivityBadge.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ToolActivityBadge.tsx
@@ -1,0 +1,87 @@
+import { Box, Text } from '@mantine-8/core';
+import {
+    IconAlertTriangle,
+    IconArrowBackUp,
+    IconBolt,
+    IconBulb,
+    IconChartBar,
+    IconClock,
+    IconDatabase,
+    IconEye,
+    IconFlag,
+    IconFolder,
+    IconHistory,
+    IconLayoutDashboard,
+    IconMessageQuestion,
+    IconPlus,
+    IconStar,
+    IconTool,
+    IconTrash,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import classes from './ToolActivityBadge.module.css';
+
+// Mirrors backend FRIENDLY_TOOL_LABELS values from
+// packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts.
+// Out-of-map labels fall back to IconBolt.
+const ACTIVITY_ICON: Record<string, typeof IconBolt> = {
+    'Reviewing recent activity': IconHistory,
+    'Looking for stale charts': IconChartBar,
+    'Looking for stale dashboards': IconLayoutDashboard,
+    'Looking for broken content': IconAlertTriangle,
+    'Inspecting preview projects': IconFolder,
+    'Checking popular content': IconStar,
+    'Inspecting chart details': IconEye,
+    'Loading chart schema': IconDatabase,
+    'Flagging content': IconFlag,
+    'Cleaning up stale content': IconTrash,
+    'Logging an insight': IconBulb,
+    'Fixing a broken chart': IconTool,
+    'Creating chart suggestion': IconPlus,
+    'Reviewing user questions': IconMessageQuestion,
+    'Checking slow queries': IconClock,
+    'Reverting earlier change': IconArrowBackUp,
+};
+
+const iconFor = (label: string) => ACTIVITY_ICON[label] ?? IconBolt;
+
+const FALLBACK_LABEL = 'Autopilot is working';
+
+const stripTrailingEllipsis = (s: string) => s.replace(/[…\.]+$/, '').trimEnd();
+
+const AnimatedDots: FC = () => (
+    <span className={classes.dots} aria-hidden>
+        <span className={classes.dot}>.</span>
+        <span className={classes.dot}>.</span>
+        <span className={classes.dot}>.</span>
+    </span>
+);
+
+export const ToolActivityBadge: FC<{ currentActivity: string | null }> = ({
+    currentActivity,
+}) => {
+    const ActiveIcon = currentActivity ? iconFor(currentActivity) : IconBolt;
+    const label = stripTrailingEllipsis(currentActivity ?? FALLBACK_LABEL);
+    return (
+        <Box className={classes.badge} role="status" aria-live="polite">
+            <Box className={classes.iconSlot} aria-hidden>
+                <Box key={label} className={classes.iconInner}>
+                    <ActiveIcon
+                        size={12}
+                        color="light-dark(var(--mantine-color-ldGray-6), var(--mantine-color-ldDark-7))"
+                    />
+                </Box>
+                <Box className={classes.spinnerRing} />
+            </Box>
+            <Text fz="xs" c="dimmed">
+                <span key={`text-${label}`} className={classes.activityText}>
+                    {label}
+                </span>
+                {/* Visually-hidden ellipsis so screen readers say
+                    "Looking for stale charts…" instead of "dot dot dot". */}
+                <span className={classes.srOnlyEllipsis}>…</span>
+                <AnimatedDots />
+            </Text>
+        </Box>
+    );
+};


### PR DESCRIPTION
## Summary

Replaces the bolt-pulse loader + plain text inside the live run row (PR #22787) with a chic, animated activity badge that visualises the agent's currently-executing tool call. Builds on PR #22761's `current_activity` field — **frontend-only, no backend changes**.

## Visual

- Pill-shaped badge with subtle border, soft shadow, theme-aware background (`white` / `ldDark.7`)
- Small circular icon slot inside, lightly tinted (`gray-1` / `ldDark.3`)
- Single thin spinner arc rotates around the slot, semi-transparent so it reads quietly
- Activity label text in `gray-7` / `ldGray.4`
- Animated three-dot ellipsis after every label (continuous, never resets when the label changes)

## Animations

- **Glisten sweep** across the whole badge every 4.2s (linear-gradient `::before` translates -100% → 100% with a light tint)
- **Icon pulse** — scale 1 ↔ 1.06, opacity 0.92 ↔ 1, 2.2s cycle. Super subtle, conveys "alive" without distracting
- **Roll-in** for the icon and text on each new tool call (`translateY(60% → 0)` + opacity, 320ms `ease-out-quart`)
- **Pulsing ellipsis** — three dots staggered 180ms apart, opacity 0.25 ↔ 1

All wrapped in `@media (prefers-reduced-motion: reduce)` so accessibility-conscious users get no motion.

## Architecture

- New `ToolActivityBadge.tsx` + `.module.css` component
- `ACTIVITY_ICON: Record<string, IconType>` maps each backend `FRIENDLY_TOOL_LABELS` value to a Tabler icon (`Looking for stale charts → IconChartBar`, `Fixing a broken chart → IconTool`, etc.)
- Out-of-map labels degrade gracefully to `IconBolt`
- Uses the existing `currentActivity` field from PR #22761 — no `useState` for history, no new endpoint, no migration
- Single icon at a time; React `key` prop drives the icon and text remount which triggers the roll-in animation

## Brittleness note

The icon map keys must mirror the backend `FRIENDLY_TOOL_LABELS` values byte-for-byte. Comment in the component file points at the backend constant. A label rename on the backend → icon falls back to `IconBolt` (graceful, no crash). Long-term we could move the map to `@lightdash/common` to make it impossible to drift.

## Test plan

- [ ] Light mode: badge sits cleanly on the live row, glisten sweeps across periodically, icon pulses, text + icon roll in when activity changes
- [ ] Dark mode: badge background is `ldDark.7`, text in `ldGray.4`, glisten still subtly visible
- [ ] `prefers-reduced-motion`: all animations stop; badge becomes a static pill
- [ ] Trigger a Run-Now in dev — observe each tool call (`get_stale_charts`, `get_chart_details`, `flag_content`, etc.) producing a different icon