### PR TITLE
fix(data-apps): validate image against app_id

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -15,6 +15,7 @@ import {
     getErrorMessage,
     isDashboardChartTileType,
     MissingConfigError,
+    NotFoundError,
     ParameterError,
     QueryExecutionContext,
     type AppChartReference,
@@ -535,17 +536,24 @@ export class AppGenerateService extends BaseService {
         imageId: string,
     ): Promise<{ imageUrl: string }> {
         await this.assertDataAppsEnabled(user);
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-        this.assertDataAppAbility(
-            user,
-            'manage',
-            organizationUuid,
-            projectUuid,
-            'Insufficient permissions to view app images',
-        );
 
         if (!isValidUuid(imageId)) {
             throw new ParameterError('Invalid imageId: must be a valid UUID');
+        }
+
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+        await this.assertCanManageApp(
+            user,
+            app,
+            'Insufficient permissions to view app images',
+        );
+
+        const belongsToApp = await this.appModel.appImageExists(
+            appUuid,
+            imageId,
+        );
+        if (!belongsToApp) {
+            throw new NotFoundError(`Image not found: ${imageId}`);
         }
 
         const { client: s3Client, bucket } = this.getS3Client();

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -241,6 +241,17 @@ export class AppModel {
         return row ?? null;
     }
 
+    async appImageExists(appId: string, imageId: string): Promise<boolean> {
+        const row = await this.database(AppVersionsTableName)
+            .where('app_id', appId)
+            .whereRaw(`resources->'images' @> ?::jsonb`, [
+                JSON.stringify([{ imageId }]),
+            ])
+            .select(this.database.raw('1'))
+            .first();
+        return !!row;
+    }
+
     async createVersion(
         appId: string,
         version: Pick<DbAppVersion, 'version' | 'prompt'>,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-417/validate-that-image-belongs-to-app-when-fetching-the-image

### Description:
Adding a check to validate that the requested image actually belongs to the app by scanning the `app_versions.resources`.

A mis-match will simply result in a 404.
