### PR TITLE
fix(data-apps): pass attached resources to clarifying-questions LLM call

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -95,6 +95,30 @@ Where the template metadata lives:
 | Frontend metadata + prompt composition | `packages/frontend/src/features/apps/templates.ts`                                           |
 | Wizard UI                              | `AppTemplatePicker.tsx`, `AppTemplateQuestions.tsx`; orchestrated by `pages/AppGenerate.tsx` |
 
+### Pre-build clarifying questions
+
+There is a **second** clarifying-question flow that runs after the template wizard and before code generation. It's a
+single LLM call (`POST /api/v1/ee/projects/{projectUuid}/apps/clarify`) that returns 0–4 short questions whose answers
+would materially change what gets built. The user answers them inline in the chat before the build kicks off; their
+answers are sent back as `clarifications` on the eventual generate request and persisted on
+`app_versions.resources.clarifications` for chat rendering.
+
+Properties of this flow:
+
+- **Stateless and best-effort.** No DB writes, no sandbox spin-up. The frontend ignores errors and falls through to
+  build without clarifications — a clarifier outage must not block the actual feature. Capped at a 15s LLM timeout.
+- **First-build only.** Iteration prompts (v2+) skip clarify entirely; intent is already grounded in the prior version.
+- **Inputs the LLM sees.** Prompt + template + a compact catalog summary (top 30 tables, up to 5 dimensions/metrics
+  each) + the resources the user has already attached in the picker (chart names + their explores, dashboard name,
+  count of attached images).
+- **What it deliberately doesn't do.** No sample-data fetch and no S3 image read for the clarify call. Sample rows and
+  pixel content don't change *whether* a question is worth asking, and skipping them keeps the call inside the 15s
+  budget. Both happen later in the generate pipeline if opted in.
+- **Resources flow.** The frontend forwards the same `charts: { uuid, includeSampleData }[]`,
+  `dashboard: { uuid, includeSampleData }`, and `imageIds` already in scope at the chat input. `includeSampleData` is
+  ignored at this stage. The system prompt explicitly tells the model not to ask which chart/dashboard/image to use
+  when the resources block is non-empty.
+
 ### Sample data (opt-in)
 
 Chart and dashboard references are passed to Claude as **structure only by default** — the metric query JSON tells the

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -97,6 +97,9 @@ export class AppGenerateController extends BaseController {
             projectUuid,
             body.prompt,
             body.template,
+            body.charts,
+            body.dashboard,
+            body.imageIds,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2418,6 +2418,9 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         prompt: string,
         template?: DataAppTemplate,
+        charts?: AppChartReference[],
+        dashboard?: AppDashboardReference,
+        imageIds?: string[],
     ): Promise<{ questions: string[] }> {
         await this.assertDataAppsEnabled(user);
         const organizationUuid = await this.getProjectOrgUuid(projectUuid);
@@ -2453,8 +2456,11 @@ export class AppGenerateService extends BaseService {
             enableReasoning: false,
         });
 
-        const catalogSummary =
-            await this.buildCatalogSummaryForClarifier(projectUuid);
+        const [catalogSummary, attachedResources] = await Promise.all([
+            this.buildCatalogSummaryForClarifier(projectUuid),
+            this.buildAttachedResourcesForClarifier(charts, dashboard, user),
+        ]);
+        const imageCount = imageIds?.length ?? 0;
 
         // No `.max()` on the array — Anthropic's structured-output mode
         // rejects `maxItems` in the schema. The prompt already pins the
@@ -2506,14 +2512,25 @@ Do NOT ask about:
 - Things you can look up in the catalog (table names, field names).
 - Picking between two readings of a phrase when one is the obvious interpretation.
 - Multi-part or open-ended — each question must be answerable in one short line.
+- Which chart, dashboard, or image to use, when the user has already attached resources — those are listed under "Resources the user attached".
 
 Each question, when asked, must be a single sentence, 5–15 words.`,
                     },
                     {
                         role: 'user',
-                        content: `App kind: ${template ?? 'custom'}\n\nUser prompt:\n${trimmed}\n\nAvailable tables and key fields:\n${
-                            catalogSummary || '(no catalog available)'
-                        }`,
+                        content: [
+                            `App kind: ${template ?? 'custom'}`,
+                            `\nUser prompt:\n${trimmed}`,
+                            `\nResources the user attached:\n${
+                                AppGenerateService.formatAttachedResourcesForClarifier(
+                                    attachedResources,
+                                    imageCount,
+                                ) || '(none)'
+                            }`,
+                            `\nAvailable tables and key fields:\n${
+                                catalogSummary || '(no catalog available)'
+                            }`,
+                        ].join('\n'),
                     },
                 ],
             });
@@ -2535,6 +2552,88 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         );
 
         return { questions };
+    }
+
+    /**
+     * Light resolution of attached resources for `clarifyApp`. Returns chart
+     * names + explore names and the dashboard name, but does NOT run sample
+     * queries or read any image bytes — sample rows and pixel content don't
+     * change *whether* a clarifying question is worth asking, and the clarify
+     * call has a 15s budget. Charts the user can't view, that don't exist, or
+     * that fail to load are skipped silently (same forgiving behavior as the
+     * generate path).
+     */
+    private async buildAttachedResourcesForClarifier(
+        charts: AppChartReference[] | undefined,
+        dashboard: AppDashboardReference | undefined,
+        user: SessionUser,
+    ): Promise<{
+        charts: { name: string; exploreName: string }[];
+        dashboardName: string | null;
+    }> {
+        const uuids = new Set<string>();
+        for (const c of charts ?? []) uuids.add(c.uuid);
+        let dashboardName: string | null = null;
+        if (dashboard) {
+            try {
+                const result = await this.resolveDashboardToChartUuids(
+                    dashboard.uuid,
+                    user,
+                );
+                dashboardName = result.dashboardName;
+                for (const uuid of result.chartUuids) uuids.add(uuid);
+            } catch (error) {
+                this.logger.warn(
+                    `Clarifier: dashboard ${dashboard.uuid} could not be resolved: ${getErrorMessage(error)}`,
+                );
+            }
+        }
+        if (uuids.size === 0) {
+            return { charts: [], dashboardName };
+        }
+        const account = fromSession(user);
+        const chartResults = await Promise.allSettled(
+            [...uuids].map((uuid) => this.savedChartService.get(uuid, account)),
+        );
+        const resolvedCharts: { name: string; exploreName: string }[] = [];
+        for (const result of chartResults) {
+            if (result.status === 'fulfilled') {
+                resolvedCharts.push({
+                    name: result.value.name,
+                    exploreName: result.value.tableName,
+                });
+            }
+        }
+        return { charts: resolvedCharts, dashboardName };
+    }
+
+    /**
+     * Render the resolved attached-resources context as a short bullet list
+     * for the clarifier's user message. Empty string when nothing was
+     * attached — the caller handles the "(none)" fallback.
+     */
+    private static formatAttachedResourcesForClarifier(
+        attached: {
+            charts: { name: string; exploreName: string }[];
+            dashboardName: string | null;
+        },
+        imageCount: number,
+    ): string {
+        const lines: string[] = [];
+        if (attached.dashboardName) {
+            lines.push(`- Dashboard: "${attached.dashboardName}"`);
+        }
+        for (const chart of attached.charts) {
+            lines.push(
+                `- Chart: "${chart.name}" (explore: ${chart.exploreName})`,
+            );
+        }
+        if (imageCount > 0) {
+            lines.push(
+                `- ${imageCount} image${imageCount === 1 ? '' : 's'} attached as design reference`,
+            );
+        }
+        return lines.join('\n');
     }
 
     /**

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7230,6 +7230,12 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                imageIds: { dataType: 'array', array: { dataType: 'string' } },
+                dashboard: { ref: 'AppDashboardReference' },
+                charts: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AppChartReference' },
+                },
                 template: { ref: 'DataAppTemplate' },
                 prompt: { dataType: 'string', required: true },
             },
@@ -9316,11 +9322,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9460,17 +9466,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9499,7 +9505,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9507,7 +9513,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9522,7 +9532,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9530,11 +9540,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9718,17 +9724,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9798,30 +9804,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['success'],
                                                         },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9855,11 +9842,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9874,11 +9861,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8646,6 +8646,21 @@
             },
             "ApiClarifyAppRequest": {
                 "properties": {
+                    "imageIds": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "dashboard": {
+                        "$ref": "#/components/schemas/AppDashboardReference"
+                    },
+                    "charts": {
+                        "items": {
+                            "$ref": "#/components/schemas/AppChartReference"
+                        },
+                        "type": "array"
+                    },
                     "template": {
                         "$ref": "#/components/schemas/DataAppTemplate"
                     },
@@ -10793,6 +10808,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -10821,10 +10849,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -10833,8 +10861,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10844,16 +10872,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -10941,10 +10969,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -10953,8 +10981,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10984,19 +11012,6 @@
                                                         "enum": [
                                                             "error",
                                                             "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -31881,7 +31896,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2893.1",
+        "version": "0.2893.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -107,6 +107,15 @@ export type GenerateAppRequestBody = {
 export type ApiClarifyAppRequest = {
     prompt: string;
     template?: DataAppTemplate;
+    // Resources the user has already attached in the picker. The clarifier
+    // resolves them lightly (names + explore only — no sample queries, no S3
+    // image reads) and surfaces them to the LLM so it doesn't ask "which
+    // chart?" when the user already pinned one. `includeSampleData` on the
+    // refs is ignored at this stage; sample rows don't change *whether* a
+    // question is worth asking.
+    charts?: AppChartReference[];
+    dashboard?: AppDashboardReference;
+    imageIds?: string[];
 };
 
 export type ApiClarifyAppResponse = ApiSuccess<{

--- a/packages/frontend/src/features/apps/hooks/useClarifyApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useClarifyApp.ts
@@ -1,6 +1,8 @@
 import {
     type ApiClarifyAppResponse,
     type ApiError,
+    type AppChartReference,
+    type AppDashboardReference,
     type DataAppTemplate,
 } from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
@@ -10,6 +12,9 @@ type ClarifyAppParams = {
     projectUuid: string;
     prompt: string;
     template?: DataAppTemplate;
+    charts?: AppChartReference[];
+    dashboard?: AppDashboardReference;
+    imageIds?: string[];
 };
 
 type ClarifyAppResult = ApiClarifyAppResponse['results'];
@@ -18,11 +23,20 @@ const clarifyApp = async ({
     projectUuid,
     prompt,
     template,
+    charts,
+    dashboard,
+    imageIds,
 }: ClarifyAppParams): Promise<ClarifyAppResult> =>
     lightdashApi<ClarifyAppResult>({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/apps/clarify`,
-        body: JSON.stringify({ prompt, template }),
+        body: JSON.stringify({
+            prompt,
+            template,
+            charts,
+            dashboard,
+            imageIds,
+        }),
     });
 
 export const useClarifyApp = () =>

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1060,6 +1060,9 @@ const AppGenerate: FC = () => {
                         projectUuid: projectUuid!,
                         prompt: trimmed,
                         template: selectedTemplate ?? undefined,
+                        charts,
+                        dashboard,
+                        imageIds,
                     });
                     if (questions.length > 0) {
                         setPendingClarification({


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-418/extra-resources-arent-passed-before-clarifying-questions

### Description:
The pre-build clarifier ran on prompt + template + a generic catalog summary only, with no awareness of charts/dashboards/images the user had already pinned in the picker — leading to redundant "which chart do you mean?" questions. Forward the same resource refs the generate request already carries, resolve them lightly (names + explore, no sample queries, no S3 image reads to stay inside the 15s budget), and inject a "Resources the user attached" block into the user message with a matching system-prompt rule. Also documents the previously-undocumented dynamic clarify endpoint in docs/data-apps.md.

This is how it manifested:
<img width="794" height="346" alt="before" src="https://github.com/user-attachments/assets/a3c585e3-a832-4207-9e52-482c960fbdc5" />
