### PR TITLE
feat(roles): list assignees in custom-role delete modal (PROD-7465)

### DIFF
--- a/packages/frontend/src/ee/features/customRoles/CustomRolesDeleteModal.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesDeleteModal.tsx
@@ -1,7 +1,35 @@
-import { type RoleWithScopes } from '@lightdash/common';
-import { Text } from '@mantine-8/core';
-import { type FC } from 'react';
+import {
+    assertUnreachable,
+    type RoleAssignee,
+    type RoleAssigneeKind,
+    type RoleWithScopes,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Badge,
+    Box,
+    Center,
+    Divider,
+    Group,
+    Loader,
+    Paper,
+    Stack,
+    Text,
+    ThemeIcon,
+    type MantineColor,
+} from '@mantine-8/core';
+import {
+    IconRobot,
+    IconUser,
+    IconUsers,
+    type Icon as TablerIcon,
+} from '@tabler/icons-react';
+import { Fragment, useMemo, type FC } from 'react';
+import { Link } from 'react-router';
+import Callout from '../../../components/common/Callout';
+import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
+import { useRoleAssignees } from './useCustomRoles';
 
 type DeleteModalProps = {
     isOpen: boolean;
@@ -11,6 +39,66 @@ type DeleteModalProps = {
     role: RoleWithScopes;
 };
 
+type KindMeta = {
+    label: string;
+    color: MantineColor;
+    icon: TablerIcon;
+    order: number;
+};
+
+const KIND_META: Record<RoleAssigneeKind, KindMeta> = {
+    service_account: {
+        label: 'Service account',
+        color: 'blue',
+        icon: IconRobot,
+        order: 0,
+    },
+    organization_user: {
+        label: 'Org member',
+        color: 'gray',
+        icon: IconUser,
+        order: 1,
+    },
+    project_user: {
+        label: 'Project member',
+        color: 'gray',
+        icon: IconUser,
+        order: 2,
+    },
+    project_group: {
+        label: 'Project group',
+        color: 'gray',
+        icon: IconUsers,
+        order: 3,
+    },
+};
+
+const sortAssignees = (assignees: RoleAssignee[]): RoleAssignee[] =>
+    [...assignees].sort((a, b) => {
+        const kindDiff = KIND_META[a.kind].order - KIND_META[b.kind].order;
+        if (kindDiff !== 0) return kindDiff;
+        return a.assigneeName.localeCompare(b.assigneeName);
+    });
+
+const getAssigneeHref = (assignee: RoleAssignee): string | null => {
+    switch (assignee.kind) {
+        case 'service_account':
+            return '/generalSettings/serviceAccounts';
+        case 'organization_user':
+            return '/generalSettings/userManagement';
+        case 'project_user':
+        case 'project_group':
+            return assignee.projectUuid
+                ? `/generalSettings/projectManagement/${assignee.projectUuid}/projectAccess`
+                : null;
+        default:
+            return assertUnreachable(
+                assignee.kind,
+                'Unknown role assignee kind',
+            );
+    }
+};
+
 export const CustomRolesDeleteModal: FC<DeleteModalProps> = ({
     isOpen,
     onClose,
@@ -18,22 +106,139 @@ export const CustomRolesDeleteModal: FC<DeleteModalProps> = ({
     isDeleting = false,
     role,
 }) => {
+    const { data: assignees, isLoading } = useRoleAssignees(
+        isOpen ? role.roleUuid : undefined,
+    );
+
+    const sortedAssignees = useMemo(
+        () => (assignees ? sortAssignees(assignees) : []),
+        [assignees],
+    );
+
+    const hasAssignees = sortedAssignees.length > 0;
+
     return (
         <MantineModal
             opened={isOpen}
             onClose={onClose}
-            title="Delete custom role"
+            title={
+                hasAssignees ? 'Custom role is assigned' : 'Delete custom role'
+            }
             variant="delete"
-            resourceType="role"
-            resourceLabel={role.name}
+            resourceType={hasAssignees ? undefined : 'role'}
+            resourceLabel={hasAssignees ? undefined : role.name}
             cancelDisabled={isDeleting}
             onConfirm={onDelete}
+            confirmDisabled={hasAssignees || isLoading}
             confirmLoading={isDeleting}
         >
-            <Text fz="sm" c="dimmed">
-                This action cannot be undone. Users and groups will no longer be
-                able to use this role.
-            </Text>
+            {isLoading ? (
+                <Center py="md">
+                    <Loader size="sm" />
+                </Center>
+            ) : hasAssignees ? (
+                <Stack gap="md">
+                    <Callout variant="warning">
+                        This role is currently in use. Unassign it from the
+                        items below before you can delete it.
+                    </Callout>
+                    <Paper withBorder radius="md">
+                        <Stack gap={0}>
+                            {sortedAssignees.map((assignee, idx) => {
+                                const meta = KIND_META[assignee.kind];
+                                const href = getAssigneeHref(assignee);
+                                return (
+                                    <Fragment
+                                        key={`${assignee.kind}-${
+                                            assignee.assigneeId
+                                        }-${assignee.projectUuid ?? 'org'}`}
+                                    >
+                                        {idx > 0 && <Divider />}
+                                        <Group
+                                            justify="space-between"
+                                            wrap="nowrap"
+                                            gap="md"
+                                            px="md"
+                                            py="sm"
+                                        >
+                                            <Group
+                                                gap="sm"
+                                                wrap="nowrap"
+                                                style={{
+                                                    minWidth: 0,
+                                                    flex: 1,
+                                                }}
+                                            >
+                                                <ThemeIcon
+                                                    color={meta.color}
+                                                    variant="light"
+                                                    size="lg"
+                                                    radius="xl"
+                                                >
+                                                    <MantineIcon
+                                                        icon={meta.icon}
+                                                        size="sm"
+                                                    />
+                                                </ThemeIcon>
+                                                <Box style={{ minWidth: 0 }}>
+                                                    {href ? (
+                                                        <Anchor
+                                                            component={Link}
+                                                            to={href}
+                                                            onClick={onClose}
+                                                            fz="sm"
+                                                            fw={500}
+                                                            truncate
+                                                            c="inherit"
+                                                        >
+                                                            {
+                                                                assignee.assigneeName
+                                                            }
+                                                        </Anchor>
+                                                    ) : (
+                                                        <Text
+                                                            fz="sm"
+                                                            fw={500}
+                                                            truncate
+                                                        >
+                                                            {
+                                                                assignee.assigneeName
+                                                            }
+                                                        </Text>
+                                                    )}
+                                                    {assignee.projectName && (
+                                                        <Text
+                                                            fz="xs"
+                                                            c="dimmed"
+                                                            truncate
+                                                        >
+                                                            {
+                                                                assignee.projectName
+                                                            }
+                                                        </Text>
+                                                    )}
+                                                </Box>
+                                            </Group>
+                                            <Badge
+                                                color={meta.color}
+                                                variant="light"
+                                                size="sm"
+                                            >
+                                                {meta.label}
+                                            </Badge>
+                                        </Group>
+                                    </Fragment>
+                                );
+                            })}
+                        </Stack>
+                    </Paper>
+                </Stack>
+            ) : (
+                <Text fz="sm" c="dimmed">
+                    This action cannot be undone. Users and groups will no
+                    longer be able to use this role.
+                </Text>
+            )}
         </MantineModal>
     );
 };

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
@@ -23,7 +23,6 @@ const TableRow: FC<{
     onClickDelete: (role: RoleWithScopes) => void;
 }> = ({ role, onClickDelete }) => {
     const { name, description, createdAt } = role;
-    console.log('description', description);
     const { ref: nameRef, isTruncated: isNameTruncated } =
         useIsTruncated<HTMLDivElement>();
     const { ref: descriptionRef, isTruncated: isDescriptionTruncated } =

--- a/packages/frontend/src/ee/features/customRoles/useCustomRoles.ts
+++ b/packages/frontend/src/ee/features/customRoles/useCustomRoles.ts
@@ -2,6 +2,7 @@ import {
     type ApiError,
     type CreateRole,
     type Role,
+    type RoleAssignee,
     type RoleWithScopes,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -171,4 +172,31 @@ export const useCustomRoles = () => {
             duplicateRole,
         };
     }, [listRoles, createRole, deleteRole, getAllRoles, duplicateRole]);
+};
+
+export const useRoleAssignees = (roleUuid: string | undefined) => {
+    const { data: organization } = useOrganization();
+
+    return useQuery<RoleAssignee[], ApiError>({
+        queryKey: [
+            CACHE_KEY,
+            organization?.organizationUuid,
+            roleUuid,
+            'assignees',
+        ],
+        queryFn: async () => {
+            if (!organization?.organizationUuid) {
+                throw new Error('Organization UUID not available');
+            }
+            if (!roleUuid) {
+                throw new Error('Role UUID not provided');
+            }
+            return lightdashApi<RoleAssignee[]>({
+                method: 'GET',
+                url: `/orgs/${organization.organizationUuid}/roles/${roleUuid}/assignees`,
+                version: 'v2',
+            });
+        },
+        enabled: !!organization?.organizationUuid && !!roleUuid,
+    });
 };


### PR DESCRIPTION
Closes: [PROD-7465](https://linear.app/lightdash/issue/PROD-7465)

<img width="1332" height="989" alt="CleanShot 2026-05-07 at 14 36 30@2x" src="https://github.com/user-attachments/assets/00e3b632-0dc3-45d6-be5f-c543b73d2e6c" />

Stacked on #22797.

### Description

When a user tries to delete a custom role that's still in use, the delete modal now lists every assignee (service account, org member, project member, project group) with a kind badge and project name. The Delete button stays disabled until the role is unassigned.

Replaces the opaque "Role cannot be deleted if assigned" toast with an actionable explanation — the user can see exactly what to unassign.

Also drops a stray `console.log` in `CustomRolesTable`.

### Before / after

| Before | After |
|---|---|
| Generic "Failed to delete custom role — Role cannot be deleted if assigned" toast | Modal lists each assignee with kind badge + project name; Delete button disabled until empty |