### PR TITLE
fix: mobile spaces view shows space heirarchy

### DIFF
--- a/packages/frontend/src/pages/MobileSpace.tsx
+++ b/packages/frontend/src/pages/MobileSpace.tsx
@@ -1,5 +1,6 @@
 import {
     ResourceViewItemType,
+    spaceToResourceViewItem,
     wrapResourceView,
     type ResourceViewItem,
 } from '@lightdash/common';
@@ -16,7 +17,7 @@ import ResourceView from '../components/common/ResourceView';
 import { ResourceSortDirection } from '../components/common/ResourceView/types';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
-import { useSpace } from '../hooks/useSpaces';
+import { useSpace, useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
 
 const MobileSpace: FC = () => {
@@ -29,12 +30,20 @@ const MobileSpace: FC = () => {
         isInitialLoading,
         error,
     } = useSpace(projectUuid, spaceUuid);
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true);
     const { user } = useApp();
     const [search, setSearch] = useState<string>('');
     const visibleItems = useMemo(() => {
+        const childSpaces = spaces.filter(
+            (s) => s.parentSpaceUuid === spaceUuid,
+        );
         const dashboardsInSpace = space?.dashboards || [];
         const chartsInSpace = space?.queries || [];
         const allItems = [
+            ...wrapResourceView(
+                childSpaces.map(spaceToResourceViewItem),
+                ResourceViewItemType.SPACE,
+            ),
             ...wrapResourceView(
                 dashboardsInSpace,
                 ResourceViewItemType.DASHBOARD,
@@ -53,7 +62,7 @@ const MobileSpace: FC = () => {
             return matchingItems;
         }
         return allItems;
-    }, [space, search]);
+    }, [space, spaces, spaceUuid, search]);
 
     if (user.data?.ability?.cannot('view', 'SavedChart')) {
         return <ForbiddenPanel />;

--- a/packages/frontend/src/pages/MobileSpaces.tsx
+++ b/packages/frontend/src/pages/MobileSpaces.tsx
@@ -37,8 +37,11 @@ const MobileSpaces: FC = () => {
     );
     const [search, setSearch] = useState<string>('');
     const visibleItems = useMemo(() => {
+        const rootSpaces = spaces.filter(
+            (space) => space.parentSpaceUuid === null,
+        );
         const items = wrapResourceView(
-            spaces.map(spaceToResourceViewItem),
+            rootSpaces.map(spaceToResourceViewItem),
             ResourceViewItemType.SPACE,
         );
         if (search && search !== '') {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #21857, PROD-6901


### Description:

The mobile spaces view wasnt showing nested spaces. Now it does. 

Before, this view
<img width="1032" height="722" alt="Screenshot 2026-05-07 at 15 29 27" src="https://github.com/user-attachments/assets/0be4258c-cc94-4849-a8ef-866186fb236f" />

looked like this on mobile
<img width="682" height="1307" alt="Screenshot 2026-05-07 at 15 29 49" src="https://github.com/user-attachments/assets/49c86e63-779f-4f99-8804-8d0b3dc3cb17" />

Now they have the same logic
