### PR TITLE
fix(timezone): thread column timezone through Snowflake DATE_TRUNC/EXTRACT wrap

### DIFF
--- a/docs/timezone-handling.md
+++ b/docs/timezone-handling.md
@@ -90,9 +90,11 @@ flowchart LR
 
 With `useTimezoneAwareDateTrunc` on, truncation is timezone-aware. The base dimension SQL is round-tripped through the project timezone so boundaries fall on project-local wall-clock midnights, but the returned value is still a real UTC instant:
 
-1. Shift the UTC value into project wall-clock
+1. Shift the column value from its source TZ into project wall-clock
 2. Truncate on that wall-clock
 3. Convert the truncated wall-clock back to UTC
+
+The source TZ for step 1 is derived once per query at the service boundary via `getColumnTimezone(credentials)` (in `packages/common/src/types/projects.ts`) and threaded through `timeFrames.ts` as `sourceTimezone`. It returns `'UTC'` for Snowflake when the translator wrap is active, `dataTimezone` when Snowflake's `disableTimestampConversion` opts out of that wrap, and `dataTimezone` (defaulting to UTC) for every other adapter. Most warehouses ignore it because their `toProjectTz` doesn't take a source TZ; Snowflake threads it into the inner `CONVERT_TIMEZONE`.
 
 The SQL differs per warehouse (some have native TZ-aware truncation, others compose `AT TIME ZONE` / `CONVERT_TIMEZONE` / `to_utc_timestamp`), but the shape is identical everywhere. Flag off → falls back to raw `DATE_TRUNC` grouping in UTC (old behavior).
 
@@ -102,7 +104,7 @@ The SQL differs per warehouse (some have native TZ-aware truncation, others comp
 
 ### SELECT — EXTRACT-based grouping
 
-EXTRACT/DATE_PART intervals (`DAY_OF_WEEK_INDEX`, `DAY_OF_MONTH_NUM`, `DAY_OF_YEAR_NUM`, `WEEK_NUM`, `MONTH_NUM`, `QUARTER_NUM`, `YEAR_NUM`, `HOUR_OF_DAY_NUM`, `MINUTE_OF_HOUR_NUM`) and the format/name variants (`DAY_OF_WEEK_NAME`, `MONTH_NAME`, `QUARTER_NAME`) compile to UTC-only SQL and are rewritten at query time to extract calendar components in the project timezone. Unlike DATE_TRUNC there is no round-trip — EXTRACT returns a number/string, not a timestamp — so the input is shifted *into* the project zone once before extracting. The shift expression is the same per-warehouse pattern used by DATE_TRUNC's `toProjectTz`, except for BigQuery, whose native form is `<expr> AT TIME ZONE 'tz'` concatenated inside `EXTRACT(... FROM ...)`. Defined in `dateExtractsTimezoneConversions`.
+EXTRACT/DATE_PART intervals (`DAY_OF_WEEK_INDEX`, `DAY_OF_MONTH_NUM`, `DAY_OF_YEAR_NUM`, `WEEK_NUM`, `MONTH_NUM`, `QUARTER_NUM`, `YEAR_NUM`, `HOUR_OF_DAY_NUM`, `MINUTE_OF_HOUR_NUM`) and the format/name variants (`DAY_OF_WEEK_NAME`, `MONTH_NAME`, `QUARTER_NAME`) compile to UTC-only SQL and are rewritten at query time to extract calendar components in the project timezone. Unlike DATE_TRUNC there is no round-trip — EXTRACT returns a number/string, not a timestamp — so the input is shifted from its source TZ into the project zone once before extracting. The source TZ comes from the same `getColumnTimezone(credentials)` helper described above. The shift expression is the same per-warehouse pattern used by DATE_TRUNC's `toProjectTz`, except for BigQuery, whose native form is `<expr> AT TIME ZONE 'tz'` concatenated inside `EXTRACT(... FROM ...)`. Defined in `dateExtractsTimezoneConversions`.
 
 A "Day of week" or "Month number" dimension grouped next to a DATE_TRUNC sibling now buckets rows on the same project-TZ calendar — the previous gap where the two could disagree (e.g. one row showing under "Tue" and the other under "Mon" for the same instant) is closed.
 
@@ -326,7 +328,7 @@ For Postgres **timestamptz** columns, the `+00:00` offset ensures the literal is
 
 ### Impact on DATE_TRUNC
 
-The timezone-aware DATE_TRUNC round-trip uses `baseDimension.compiledSql` as input. On Snowflake the input is already UTC-normalized by the wrapper, so the round-trip sees clean UTC instants. On other warehouses the input is the raw column and correctness comes from two different mechanisms:
+The timezone-aware DATE_TRUNC round-trip uses `baseDimension.compiledSql` as input. On Snowflake the input is normally UTC-normalized by the wrapper, so the round-trip sees clean UTC instants. When `disableTimestampConversion: true` opts out of the wrap, the column is in `dataTimezone` instead — the round-trip's inner `CONVERT_TIMEZONE` then uses `dataTimezone` as its source TZ (resolved via `getColumnTimezone(credentials)`) so the shift still lands on the right wall-clock. On other warehouses the input is the raw column and correctness comes from two different mechanisms:
 
 - **Session-TZ-aware warehouses** (Postgres, Redshift, Databricks, DuckDB, Trino) rely on the warehouse reading naive values through the session timezone — `::timestamptz` casts on Postgres, `current_timezone()` on Databricks, etc.
 - **BigQuery** uses the native `TIMESTAMP_TRUNC(col, part, 'tz')` directly; the `toProjectTz`/`toUTC` helpers are deliberate no-ops because the truncation itself accepts the zone. TIMESTAMP columns (UTC instants) round-trip correctly this way.
@@ -379,6 +381,6 @@ flowchart TD
 | AsyncQueryService       | `packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts` |
 | Project timezone config | `packages/backend/src/services/ProjectService/ProjectService.ts`       |
 | Feature flags           | `packages/common/src/types/featureFlags.ts`                            |
-| Warehouse credentials   | `packages/common/src/types/projects.ts`                                |
+| Warehouse credentials   | `packages/common/src/types/projects.ts` (incl. `getColumnTimezone`)    |
 | Result formatting       | `packages/common/src/utils/formatting.ts`                              |
 | Warehouse clients       | `packages/warehouses/src/warehouseClients/`                            |

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -29,6 +29,7 @@ import {
     formatRawRows,
     formatRows,
     getAvailableFilterFieldIds,
+    getColumnTimezone,
     getDashboardFiltersForTileAndTables,
     getDimensionMapFromTables,
     getDimensions,
@@ -919,7 +920,7 @@ export class EmbedService extends BaseService {
             parameters: combinedParameters,
             availableParameterDefinitions,
             useTimezoneAwareDateTrunc,
-            dataTimezone: warehouseClient.credentials.dataTimezone,
+            columnTimezone: getColumnTimezone(warehouseClient.credentials),
         });
 
         const results =

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -36,6 +36,7 @@ import {
     formatRawValue,
     formatRow,
     getAvailableFilterFieldIds,
+    getColumnTimezone,
     getDashboardFilterRulesForTables,
     getDashboardFilterRulesForTileAndReferences,
     getDimensions,
@@ -2845,7 +2846,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration,
         userAttributeOverrides,
         materializationRole,
-        dataTimezone,
+        columnTimezone,
     }: Pick<
         ExecuteAsyncMetricQueryArgs,
         | 'account'
@@ -2859,7 +2860,7 @@ export class AsyncQueryService extends ProjectService {
         warehouseSqlBuilder: WarehouseSqlBuilder;
         explore: Explore;
         pivotConfiguration?: PivotConfiguration;
-        dataTimezone?: string;
+        columnTimezone?: string;
     }) {
         assertIsAccountWithOrg(account);
 
@@ -2902,7 +2903,7 @@ export class AsyncQueryService extends ProjectService {
             pivotConfiguration,
             pivotDimensions: metricQuery.pivotDimensions,
             useTimezoneAwareDateTrunc,
-            dataTimezone,
+            columnTimezone,
         });
 
         const resolvedMetricOverrides =
@@ -3684,7 +3685,7 @@ export class AsyncQueryService extends ProjectService {
             pivotConfiguration,
             userAttributeOverrides,
             materializationRole,
-            dataTimezone: warehouseCredentials.dataTimezone,
+            columnTimezone: getColumnTimezone(warehouseCredentials),
         });
         const prepareMs = Date.now() - prepareStart;
 
@@ -3843,7 +3844,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             projectUuid,
             userAttributeOverrides,
-            dataTimezone: warehouseCredentials.dataTimezone,
+            columnTimezone: getColumnTimezone(warehouseCredentials),
         });
 
         const requestParameters: ExecuteAsyncFieldValueSearchRequestParams = {
@@ -4085,7 +4086,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             projectUuid,
             pivotConfiguration,
-            dataTimezone: warehouseCredentials.dataTimezone,
+            columnTimezone: getColumnTimezone(warehouseCredentials),
         });
 
         const routingDecision = this.getPreAggregationRoutingDecision({
@@ -4403,7 +4404,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             projectUuid,
             pivotConfiguration,
-            dataTimezone: warehouseCredentials.dataTimezone,
+            columnTimezone: getColumnTimezone(warehouseCredentials),
         });
 
         const routingDecision = this.getPreAggregationRoutingDecision({
@@ -4743,7 +4744,7 @@ export class AsyncQueryService extends ProjectService {
             warehouseSqlBuilder,
             parameters: combinedParameters,
             projectUuid,
-            dataTimezone: warehouseCredentials.dataTimezone,
+            columnTimezone: getColumnTimezone(warehouseCredentials),
         });
 
         const { queryUuid: underlyingDataQueryUuid, cacheMetadata } =
@@ -5543,7 +5544,7 @@ export class AsyncQueryService extends ProjectService {
             parameters,
             projectUuid,
             materializationRole: userAccessControls,
-            dataTimezone: warehouseCredentials.dataTimezone,
+            columnTimezone: getColumnTimezone(warehouseCredentials),
         });
 
         const routingDecision = this.getPreAggregationRoutingDecision({

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -66,6 +66,7 @@ import {
     getAllDimensionsMap,
     getAvailableFilterFieldIds,
     getAvailableParametersFromTables,
+    getColumnTimezone,
     getDashboardFilterRulesForTables,
     getDimensions,
     getErrorMessage,
@@ -3127,7 +3128,7 @@ export class ProjectService extends BaseService {
         pivotDimensions,
         continueOnError,
         useTimezoneAwareDateTrunc,
-        dataTimezone,
+        columnTimezone,
     }: {
         metricQuery: MetricQuery;
         explore: Explore;
@@ -3142,7 +3143,7 @@ export class ProjectService extends BaseService {
         pivotDimensions?: string[];
         continueOnError?: boolean;
         useTimezoneAwareDateTrunc?: boolean;
-        dataTimezone?: string;
+        columnTimezone?: string;
     }): Promise<CompiledQuery> {
         const availableParameters = Object.keys(availableParameterDefinitions);
 
@@ -3176,7 +3177,7 @@ export class ProjectService extends BaseService {
             continueOnError,
             originalExplore: dateZoom ? explore : undefined,
             useTimezoneAwareDateTrunc,
-            dataTimezone,
+            columnTimezone,
         });
 
         return wrapSentryTransactionSync('QueryBuilder.buildQuery', {}, () =>
@@ -3315,7 +3316,7 @@ export class ProjectService extends BaseService {
             pivotDimensions,
             continueOnError: true, // Return SQL even with compilation errors for debugging
             useTimezoneAwareDateTrunc,
-            dataTimezone: warehouseCredentials.dataTimezone,
+            columnTimezone: getColumnTimezone(warehouseCredentials),
         });
 
         // Generate pivot query if pivot configuration is provided
@@ -4309,7 +4310,9 @@ export class ProjectService extends BaseService {
                         availableParameterDefinitions,
                         pivotDimensions: metricQueryWithLimit.pivotDimensions,
                         useTimezoneAwareDateTrunc,
-                        dataTimezone: warehouseClient.credentials.dataTimezone,
+                        columnTimezone: getColumnTimezone(
+                            warehouseClient.credentials,
+                        ),
                     });
 
                     const { query } = fullQuery;
@@ -4878,7 +4881,7 @@ export class ProjectService extends BaseService {
             parameters: combinedParameters,
             availableParameterDefinitions,
             useTimezoneAwareDateTrunc,
-            dataTimezone: warehouseClient.credentials.dataTimezone,
+            columnTimezone: getColumnTimezone(warehouseClient.credentials),
         });
 
         const isUserCacheEnabled =

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -135,8 +135,9 @@ export type BuildQueryProps = {
     originalExplore?: Explore;
     /** Wrap DATE_TRUNC with timezone conversion. Gated behind EnableTimezoneSupport. */
     useTimezoneAwareDateTrunc?: boolean;
-    /** Warehouse session timezone — used to skip wrapping when it matches queryTimezone. */
-    dataTimezone?: string;
+    /** Timezone the column data is in — source for the timezone-aware wrap.
+     *  Derived from warehouse credentials via `getColumnTimezone`. */
+    columnTimezone?: string;
 };
 
 /**
@@ -315,24 +316,12 @@ export class MetricQueryBuilder {
     /** Query timezone when timezone-aware DATE_TRUNC is active, undefined otherwise. */
     private get timezoneForDateTrunc(): string | undefined {
         if (!this.args.useTimezoneAwareDateTrunc) return undefined;
-        if (this.isDataInQueryTimezone()) return undefined;
+        if (this.columnTimezone === this.args.timezone) return undefined;
         return this.args.timezone;
     }
 
-    /**
-     * True when the warehouse's effective input TZ already equals the query TZ,
-     * so the project-TZ wrap would be a no-op. Snowflake's input is always UTC
-     * (convertTimezone normalizes at compile time); others use dataTimezone.
-     */
-    private isDataInQueryTimezone(): boolean {
-        const adapterType = this.args.warehouseSqlBuilder.getAdapterType();
-
-        const effectiveInputTz =
-            adapterType === SupportedDbtAdapter.SNOWFLAKE
-                ? 'UTC'
-                : (this.args.dataTimezone ?? 'UTC');
-
-        return effectiveInputTz === this.args.timezone;
+    private get columnTimezone(): string {
+        return this.args.columnTimezone ?? 'UTC';
     }
 
     // Contains the metrics from the Explore and the custom metrics from the metric query
@@ -637,6 +626,7 @@ export class MetricQueryBuilder {
                 baseDimension.type,
                 startOfWeek,
                 timezone,
+                this.columnTimezone,
             );
         }
 
@@ -647,6 +637,7 @@ export class MetricQueryBuilder {
             baseDimension.type,
             startOfWeek,
             timezone,
+            this.columnTimezone,
         );
     }
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -470,6 +470,7 @@ export class MetricQueryBuilder {
             adapterType,
             startOfWeek,
             timezone: this.timezoneForDateTrunc,
+            columnTimezone: this.columnTimezone,
         });
         const popDimensionBaseId = `${popDimension.table}_${
             popDimension.timeIntervalBaseDimensionName ?? popDimension.name
@@ -725,6 +726,7 @@ export class MetricQueryBuilder {
                         adapterType,
                         startOfWeek,
                         timezone: this.timezoneForDateTrunc,
+                        columnTimezone: this.columnTimezone,
                     });
 
                     assertValidDimensionRequiredAttribute(
@@ -1065,6 +1067,7 @@ export class MetricQueryBuilder {
                     adapterType,
                     startOfWeek,
                     timezone: this.timezoneForDateTrunc,
+                    columnTimezone: this.columnTimezone,
                 });
 
                 assertValidDimensionRequiredAttribute(
@@ -2234,6 +2237,7 @@ export class MetricQueryBuilder {
                             adapterType,
                             startOfWeek,
                             timezone: this.timezoneForDateTrunc,
+                            columnTimezone: this.columnTimezone,
                         });
                         const popDimensionFilters =
                             this.getPopDimensionsFilterSQL(popFieldId);
@@ -2449,6 +2453,7 @@ export class MetricQueryBuilder {
                         adapterType,
                         startOfWeek,
                         timezone: this.timezoneForDateTrunc,
+                        columnTimezone: this.columnTimezone,
                     });
                     const popDimensionFilters =
                         this.getPopDimensionsFilterSQL(popFieldId);
@@ -3996,6 +4001,7 @@ export class MetricQueryBuilder {
                     adapterType,
                     startOfWeek,
                     timezone: this.timezoneForDateTrunc,
+                    columnTimezone: this.columnTimezone,
                 });
                 const popDimensionFilters =
                     this.getPopDimensionsFilterSQL(popFieldId);

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -46,6 +46,7 @@ export const getDimensionFromId = ({
     adapterType,
     startOfWeek,
     timezone,
+    columnTimezone,
 }: {
     dimId: FieldId;
     dimensions: Record<string, CompiledDimension>;
@@ -53,6 +54,7 @@ export const getDimensionFromId = ({
     adapterType: SupportedDbtAdapter;
     startOfWeek: WeekDay | null | undefined;
     timezone?: string;
+    columnTimezone?: string;
 }): CompiledDimension => {
     const dimension = dimensions[dimId];
 
@@ -67,6 +69,7 @@ export const getDimensionFromId = ({
                 adapterType,
                 startOfWeek,
                 timezone,
+                columnTimezone,
             });
             if (baseField && newTimeFrame) {
                 const effectiveTimezone = baseField.skipTimezoneConversion
@@ -81,6 +84,7 @@ export const getDimensionFromId = ({
                         baseField.type,
                         startOfWeek,
                         effectiveTimezone,
+                        columnTimezone,
                     ),
                     timeInterval: newTimeFrame,
                 };

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -315,6 +315,21 @@ export type WarehouseCredentials =
     | AthenaCredentials
     | DuckdbCredentials;
 
+// Returns the timezone the column data is in when the query runs.
+// Snowflake's dbt translator wraps timestamps with CONVERT_TIMEZONE('UTC', col),
+// so columns are UTC unless `disableTimestampConversion` opts out of that wrap.
+export const getColumnTimezone = (
+    credentials: CreateWarehouseCredentials | WarehouseCredentials,
+): string => {
+    if (
+        credentials.type === WarehouseTypes.SNOWFLAKE &&
+        !credentials.disableTimestampConversion
+    ) {
+        return 'UTC';
+    }
+    return credentials.dataTimezone ?? 'UTC';
+};
+
 export type CreatePostgresLikeCredentials =
     | CreateRedshiftCredentials
     | CreatePostgresCredentials;

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -579,6 +579,24 @@ describe('TimeFrames', () => {
                 `toTimeZone(toDateTime(truncated, 'Asia/Tokyo'), 'UTC')`,
             );
         });
+
+        test('Snowflake toProjectTz defaults sourceTimezone to UTC', () => {
+            const { toProjectTz } =
+                dateTruncTimezoneConversions[SupportedDbtAdapter.SNOWFLAKE];
+            expect(toProjectTz('col', 'America/New_York')).toEqual(
+                `CONVERT_TIMEZONE('UTC', 'America/New_York', col)`,
+            );
+        });
+
+        test('Snowflake toProjectTz threads explicit sourceTimezone into CONVERT_TIMEZONE', () => {
+            const { toProjectTz } =
+                dateTruncTimezoneConversions[SupportedDbtAdapter.SNOWFLAKE];
+            expect(
+                toProjectTz('col', 'America/New_York', 'America/New_York'),
+            ).toEqual(
+                `CONVERT_TIMEZONE('America/New_York', 'America/New_York', col)`,
+            );
+        });
     });
 
     describe('getSqlForTruncatedDate type guard for DATE', () => {
@@ -639,6 +657,27 @@ describe('TimeFrames', () => {
                 `CONVERT_TIMEZONE('${tz}', 'UTC', DATE_TRUNC('DAY', CONVERT_TIMEZONE('UTC', '${tz}', ${col})))`,
             );
         });
+
+        // When Snowflake's translator wrap is disabled and columns are stored
+        // in dataTimezone, the inner CONVERT_TIMEZONE source must be that data
+        // timezone — not the hardcoded 'UTC'.
+        test('Snowflake threads non-UTC sourceTimezone into both CONVERT_TIMEZONE wraps', () => {
+            const sourceTz = 'America/New_York';
+            const queryTz = 'America/Los_Angeles';
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.SNOWFLAKE,
+                    TimeFrames.DAY,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    queryTz,
+                    sourceTz,
+                ),
+            ).toEqual(
+                `CONVERT_TIMEZONE('${queryTz}', 'UTC', DATE_TRUNC('DAY', CONVERT_TIMEZONE('${sourceTz}', '${queryTz}', ${col})))`,
+            );
+        });
     });
 
     describe('extractableTimeFrames', () => {
@@ -679,6 +718,20 @@ describe('TimeFrames', () => {
                     SupportedDbtAdapter.SNOWFLAKE
                 ].toExtractInputTz('col', 'America/New_York'),
             ).toEqual(`CONVERT_TIMEZONE('UTC', 'America/New_York', col)`);
+        });
+
+        test('Snowflake threads explicit sourceTimezone into CONVERT_TIMEZONE', () => {
+            expect(
+                dateExtractsTimezoneConversions[
+                    SupportedDbtAdapter.SNOWFLAKE
+                ].toExtractInputTz(
+                    'col',
+                    'America/New_York',
+                    'America/New_York',
+                ),
+            ).toEqual(
+                `CONVERT_TIMEZONE('America/New_York', 'America/New_York', col)`,
+            );
         });
 
         test('Postgres / Redshift / DuckDB share the timestamptz cast form', () => {
@@ -938,6 +991,26 @@ describe('TimeFrames', () => {
                 ),
             ).toEqual(
                 `MOD(EXTRACT(DAYOFWEEK FROM TIMESTAMP(${col}) AT TIME ZONE '${tz}') - 2 + 7, 7) + 1`,
+            );
+        });
+
+        // Snowflake EXTRACT path must use the column's actual source timezone
+        // when the translator wrap is disabled.
+        test('Snowflake threads non-UTC sourceTimezone into EXTRACT input wrap', () => {
+            const sourceTz = 'America/New_York';
+            const queryTz = 'America/Los_Angeles';
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.SNOWFLAKE,
+                    TimeFrames.MONTH_NUM,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    queryTz,
+                    sourceTz,
+                ),
+            ).toEqual(
+                `DATE_PART('MONTH', CONVERT_TIMEZONE('${sourceTz}', '${queryTz}', ${col}))`,
             );
         });
     });

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -77,14 +77,17 @@ type WarehouseConfig = {
         originalSql: string,
         type: DimensionType,
         timezone?: string,
+        sourceTimezone?: string,
     ) => string;
 };
 
 /** Per-warehouse SQL for the DATE_TRUNC timezone round-trip. `toProjectTz`
  *  shifts into project-local wall-clock before truncation; `toUTC` converts
- *  the truncated value back into a proper UTC instant. */
+ *  the truncated value back into a proper UTC instant. `sourceTz` is the
+ *  timezone the column is in — only Snowflake uses it explicitly (in
+ *  `CONVERT_TIMEZONE`); other adapters ignore it. */
 type DateTruncTimezoneConversion = {
-    toProjectTz: (sql: string, tz: string) => string;
+    toProjectTz: (sql: string, tz: string, sourceTz?: string) => string;
     toUTC: (sql: string, tz: string) => string;
 };
 
@@ -99,7 +102,8 @@ export const dateTruncTimezoneConversions: Record<
         toUTC: (sql) => sql,
     },
     [SupportedDbtAdapter.SNOWFLAKE]: {
-        toProjectTz: (sql, tz) => `CONVERT_TIMEZONE('UTC', '${tz}', ${sql})`,
+        toProjectTz: (sql, tz, sourceTz = 'UTC') =>
+            `CONVERT_TIMEZONE('${sourceTz}', '${tz}', ${sql})`,
         toUTC: (sql, tz) => `CONVERT_TIMEZONE('${tz}', 'UTC', ${sql})`,
     },
     [SupportedDbtAdapter.POSTGRES]: {
@@ -145,8 +149,9 @@ export const dateTruncTimezoneConversions: Record<
 };
 
 // EXTRACT returns a number/string, so no `toUTC` inverse — one-way shift only.
+// `sourceTz` semantics match `DateTruncTimezoneConversion.toProjectTz`.
 type DateExtractTimezoneConversion = {
-    toExtractInputTz: (sql: string, tz: string) => string;
+    toExtractInputTz: (sql: string, tz: string, sourceTz?: string) => string;
 };
 
 export const dateExtractsTimezoneConversions: Record<
@@ -159,8 +164,8 @@ export const dateExtractsTimezoneConversions: Record<
         toExtractInputTz: (sql, tz) => `TIMESTAMP(${sql}) AT TIME ZONE '${tz}'`,
     },
     [SupportedDbtAdapter.SNOWFLAKE]: {
-        toExtractInputTz: (sql, tz) =>
-            `CONVERT_TIMEZONE('UTC', '${tz}', ${sql})`,
+        toExtractInputTz: (sql, tz, sourceTz = 'UTC') =>
+            `CONVERT_TIMEZONE('${sourceTz}', '${tz}', ${sql})`,
     },
     [SupportedDbtAdapter.POSTGRES]: {
         toExtractInputTz: (sql, tz) =>
@@ -318,11 +323,12 @@ const snowflakeConfig: WarehouseConfig = {
         originalSql: string,
         _type,
         timezone,
+        sourceTimezone,
     ) => {
         const sql = timezone
             ? dateExtractsTimezoneConversions[
                   SupportedDbtAdapter.SNOWFLAKE
-              ].toExtractInputTz(originalSql, timezone)
+              ].toExtractInputTz(originalSql, timezone, sourceTimezone)
             : originalSql;
         // https://docs.snowflake.com/en/sql-reference/functions/to_char.html
         const timeFrameExpressionsFn: Record<
@@ -676,6 +682,7 @@ export const getSqlForTruncatedDate = (
     type: DimensionType,
     startOfWeek?: WeekDay | null,
     timezone?: string,
+    sourceTimezone?: string,
 ): string => {
     if (!timezone || type !== DimensionType.TIMESTAMP) {
         return warehouseConfigs[adapterType].getSqlForTruncatedDate(
@@ -687,7 +694,7 @@ export const getSqlForTruncatedDate = (
     }
 
     const { toProjectTz, toUTC } = dateTruncTimezoneConversions[adapterType];
-    const input = toProjectTz(originalSql, timezone);
+    const input = toProjectTz(originalSql, timezone, sourceTimezone);
     const truncated = warehouseConfigs[adapterType].getSqlForTruncatedDate(
         timeFrame,
         input,
@@ -706,12 +713,14 @@ export const getSqlForDatePart = (
     type: DimensionType,
     startOfWeek?: WeekDay | null,
     timezone?: string,
+    sourceTimezone?: string,
 ): string => {
     const wrappedSql =
         timezone && type === DimensionType.TIMESTAMP
             ? dateExtractsTimezoneConversions[adapterType].toExtractInputTz(
                   originalSql,
                   timezone,
+                  sourceTimezone,
               )
             : originalSql;
     return warehouseConfigs[adapterType].getSqlForDatePart(
@@ -732,6 +741,7 @@ export const getSqlForDatePartName = (
     type: DimensionType,
     _startOfWeek?: WeekDay | null,
     timezone?: string,
+    sourceTimezone?: string,
 ): string => {
     if (!timezone || type !== DimensionType.TIMESTAMP) {
         return warehouseConfigs[adapterType].getSqlForDatePartName(
@@ -745,6 +755,7 @@ export const getSqlForDatePartName = (
         originalSql,
         type,
         timezone,
+        sourceTimezone,
     );
 };
 
@@ -758,6 +769,7 @@ type TimeFrameConfig = {
         type: DimensionType,
         startOfWeek?: WeekDay | null,
         timezone?: string,
+        sourceTimezone?: string,
     ) => string;
     getAxisMinInterval: () => number | null;
     getAxisLabelFormatter: () => Record<string, string> | null;

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -83,11 +83,11 @@ type WarehouseConfig = {
 
 /** Per-warehouse SQL for the DATE_TRUNC timezone round-trip. `toProjectTz`
  *  shifts into project-local wall-clock before truncation; `toUTC` converts
- *  the truncated value back into a proper UTC instant. `sourceTz` is the
- *  timezone the column is in — only Snowflake uses it explicitly (in
+ *  the truncated value back into a proper UTC instant. `sourceTimezone` is
+ *  the timezone the column is in — only Snowflake uses it explicitly (in
  *  `CONVERT_TIMEZONE`); other adapters ignore it. */
 type DateTruncTimezoneConversion = {
-    toProjectTz: (sql: string, tz: string, sourceTz?: string) => string;
+    toProjectTz: (sql: string, tz: string, sourceTimezone?: string) => string;
     toUTC: (sql: string, tz: string) => string;
 };
 
@@ -102,8 +102,8 @@ export const dateTruncTimezoneConversions: Record<
         toUTC: (sql) => sql,
     },
     [SupportedDbtAdapter.SNOWFLAKE]: {
-        toProjectTz: (sql, tz, sourceTz = 'UTC') =>
-            `CONVERT_TIMEZONE('${sourceTz}', '${tz}', ${sql})`,
+        toProjectTz: (sql, tz, sourceTimezone = 'UTC') =>
+            `CONVERT_TIMEZONE('${sourceTimezone}', '${tz}', ${sql})`,
         toUTC: (sql, tz) => `CONVERT_TIMEZONE('${tz}', 'UTC', ${sql})`,
     },
     [SupportedDbtAdapter.POSTGRES]: {
@@ -149,9 +149,13 @@ export const dateTruncTimezoneConversions: Record<
 };
 
 // EXTRACT returns a number/string, so no `toUTC` inverse — one-way shift only.
-// `sourceTz` semantics match `DateTruncTimezoneConversion.toProjectTz`.
+// `sourceTimezone` semantics match `DateTruncTimezoneConversion.toProjectTz`.
 type DateExtractTimezoneConversion = {
-    toExtractInputTz: (sql: string, tz: string, sourceTz?: string) => string;
+    toExtractInputTz: (
+        sql: string,
+        tz: string,
+        sourceTimezone?: string,
+    ) => string;
 };
 
 export const dateExtractsTimezoneConversions: Record<
@@ -164,8 +168,8 @@ export const dateExtractsTimezoneConversions: Record<
         toExtractInputTz: (sql, tz) => `TIMESTAMP(${sql}) AT TIME ZONE '${tz}'`,
     },
     [SupportedDbtAdapter.SNOWFLAKE]: {
-        toExtractInputTz: (sql, tz, sourceTz = 'UTC') =>
-            `CONVERT_TIMEZONE('${sourceTz}', '${tz}', ${sql})`,
+        toExtractInputTz: (sql, tz, sourceTimezone = 'UTC') =>
+            `CONVERT_TIMEZONE('${sourceTimezone}', '${tz}', ${sql})`,
     },
     [SupportedDbtAdapter.POSTGRES]: {
         toExtractInputTz: (sql, tz) =>


### PR DESCRIPTION
## Problem

Snowflake projects with `disableTimestampConversion: true` and a non-UTC `dataTimezone` produced wrong timezone-aware `DATE_TRUNC` / `EXTRACT` SQL — the wrap hardcoded `UTC` as the column source TZ, but with the dbt translator wrap disabled, columns are actually in `dataTimezone`.

## Fix

Replace the `dataTimezone` + `columnInDataTimezone` pair on `BuildQueryProps` with a single derived `columnTimezone: string`. Compute it once at the service boundary via `getColumnTimezone(credentials)`, co-located with the credential types in `projects.ts`.

- Snowflake: returns `UTC` (translator wraps timestamps with `CONVERT_TIMEZONE('UTC', col)`) unless `disableTimestampConversion` opts out — then returns `dataTimezone`.
- Other adapters: returns `dataTimezone` (defaulting to `UTC`).

`MetricQueryBuilder` no longer carries the Snowflake `if`. The conversion maps in `timeFrames.ts` accept `sourceTimezone` as an explicit parameter.

Also in this PR:
- New unit tests cover the non-UTC `sourceTimezone` path through both `dateTruncTimezoneConversions` / `dateExtractsTimezoneConversions` and end-to-end via `getSqlForTruncatedDate` / `getSqlForDatePart`.
- `docs/timezone-handling.md` updated to describe the `getColumnTimezone`-derived source TZ and the `disableTimestampConversion` case.

## Test plan

- [x] `pnpm -F common typecheck`
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F common test -- timeFrames` (79 pass)
- [x] `pnpm -F backend test -- MetricQueryBuilder` (175 pass)
- [x] Manual repro on Snowflake — see below

## Manual repro

Setup: two Snowflake projects pointing at the same warehouse, both `dataTimezone: America/New_York`. One has `disableTimestampConversion: false` (control), the other `true` (the broken case). Same query on `timezone_test`: count rows by day on the NTZ column, sorted by day.

**Bug, in one row:** the NTZ column has a row at `2024-01-01 00:00:00` — that's midnight NY because the project's `dataTimezone` is NY. With NY as the project tz too, that row should land in the `2024-01-01` bucket.

| | bucket for `2024-01-01 00:00:00` (NTZ, NY local) |
|---|---|
| control project | `2024-01-01` ✅ |
| broken project, **pre-fix** (main) | `2023-12-31` ❌ — treats NTZ as UTC, shifts 5h back |
| broken project, **post-fix** (this PR) | `2024-01-01` ✅ |

Why: the inner `CONVERT_TIMEZONE` source argument was hardcoded to `UTC`. Fix sets it to the column's actual timezone (`dataTimezone`):

```diff
- CONVERT_TIMEZONE('UTC',              'America/New_York', event_timestamp_ntz)
+ CONVERT_TIMEZONE('America/New_York', 'America/New_York', event_timestamp_ntz)
```

Full row-by-row counts (project tz = `America/New_York`):

| day bucket | control | broken (pre-fix) | broken (post-fix) |
|---|---|---|---|
| 2023-12-31 | — | 1 | — |
| 2024-01-01 | 1 | — | 1 |
| 2024-01-14 | 1 | 3 | 1 |
| 2024-01-15 | 7 | 6 | 7 |
| 2024-01-16 | 4 | 3 | 4 |

When project tz = `UTC`, the buggy SQL collapses to a no-op (`CONVERT_TIMEZONE('UTC', 'UTC', col)`), so all three columns match and the bug is hidden — that's why this only surfaces for non-UTC users.

Closes: https://linear.app/lightdash/issue/GLITCH-414/snowflake-disabletimestampconversion-non-utc-datatimezone-produces