### PR TITLE
fix(managed-agent): handle deleted target in action sidebar

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -307,6 +307,16 @@
         light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
 }
 
+.deletedBanner {
+    padding: 8px 12px 8px 16px;
+    background-color: light-dark(
+        var(--mantine-color-red-0),
+        var(--mantine-color-dark-6)
+    );
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-red-2), var(--mantine-color-dark-4));
+}
+
 .closeBtn {
     display: flex;
     align-items: center;

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -846,7 +846,9 @@ const DetailSidebar: FC<{
                     <Button
                         size="xs"
                         variant="default"
-                        leftSection={<IconArrowBackUp size={14} />}
+                        leftSection={
+                            <MantineIcon icon={IconArrowBackUp} size={14} />
+                        }
                         loading={revertMutation.isLoading}
                         onClick={() => revertMutation.mutate()}
                     >

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -4,6 +4,7 @@ import {
     type ContentVerificationInfo,
     type Dashboard,
     getManagedAgentActionCategory,
+    ManagedAgentActionType,
     type ManagedAgentRun,
     ManagedAgentRunStatus,
     ManagedAgentScheduleOption,
@@ -607,6 +608,21 @@ const DetailSidebar: FC<{
     const isProjectTarget = action.targetType === 'project';
     const category = getManagedAgentActionCategory(action.actionType);
 
+    // Target is currently soft-deleted in two cases:
+    // 1. Autopilot soft-deleted it and the action hasn't been undone yet.
+    // 2. Autopilot created it and an admin clicked Undo (which soft-deletes
+    //    the agent-created chart via reverseAction).
+    // In both cases, fetching the chart/dashboard 404s and the "Open" link
+    // would lead to a deleted-resource page.
+    const isTargetDeleted =
+        (action.actionType === ManagedAgentActionType.SOFT_DELETED &&
+            !isReversed) ||
+        (action.actionType === ManagedAgentActionType.CREATED_CONTENT &&
+            isReversed);
+    const showRestoreBanner =
+        action.actionType === ManagedAgentActionType.SOFT_DELETED &&
+        !isReversed;
+
     const revertMutation = useMutation<unknown, ApiError>({
         mutationFn: () => reverseAction(action.projectUuid, action.actionUuid),
         onSuccess: () => {
@@ -615,35 +631,46 @@ const DetailSidebar: FC<{
             });
         },
         onError: ({ error }) => {
+            const isHardDeleted =
+                showRestoreBanner && error?.statusCode === 404;
             showToastApiError({
-                title:
-                    category === 'undo'
-                        ? 'Could not undo action'
-                        : 'Could not dismiss action',
+                title: isHardDeleted
+                    ? 'Could not restore — the original was permanently deleted'
+                    : category === 'undo'
+                      ? 'Could not undo action'
+                      : 'Could not dismiss action',
                 apiError: error,
             });
         },
     });
 
-    const targetLink = isProjectTarget
-        ? `/projects/${action.targetUuid}`
-        : action.targetType === 'chart'
-          ? `/projects/${action.projectUuid}/saved/${action.targetUuid}`
-          : action.targetType === 'dashboard'
-            ? `/projects/${action.projectUuid}/dashboards/${action.targetUuid}`
-            : null;
+    const targetLink = isTargetDeleted
+        ? null
+        : isProjectTarget
+          ? `/projects/${action.targetUuid}`
+          : action.targetType === 'chart'
+            ? `/projects/${action.projectUuid}/saved/${action.targetUuid}`
+            : action.targetType === 'dashboard'
+              ? `/projects/${action.projectUuid}/dashboards/${action.targetUuid}`
+              : null;
 
     const TargetIcon = TARGET_ICON[action.targetType];
 
-    // Fetch chart description from the API when viewing a chart action
+    // Skip the chart/dashboard fetch when the target is currently deleted —
+    // the action row already carries `target_name` + `description` captured at
+    // action time, which is the truth about what was deleted.
     const { data: savedChart } = useSavedQuery({
         uuidOrSlug:
-            action.targetType === 'chart' ? action.targetUuid : undefined,
+            !isTargetDeleted && action.targetType === 'chart'
+                ? action.targetUuid
+                : undefined,
         projectUuid: action.projectUuid,
     });
     const { data: dashboard } = useDashboardQuery({
         uuidOrSlug:
-            action.targetType === 'dashboard' ? action.targetUuid : undefined,
+            !isTargetDeleted && action.targetType === 'dashboard'
+                ? action.targetUuid
+                : undefined,
         projectUuid: action.projectUuid,
         useQueryOptions: {
             onError: () => undefined,
@@ -796,6 +823,35 @@ const DetailSidebar: FC<{
                         {category === 'undo' ? 'Undone' : 'Dismissed'}{' '}
                         {reversedLabel}
                     </Text>
+                </Group>
+            )}
+
+            {showRestoreBanner && (
+                <Group
+                    gap={8}
+                    className={classes.deletedBanner}
+                    justify="space-between"
+                    wrap="nowrap"
+                >
+                    <Group gap={6} wrap="nowrap">
+                        <MantineIcon
+                            icon={IconTrash}
+                            size="sm"
+                            color="var(--mantine-color-red-6)"
+                        />
+                        <Text fz="xs" c="dimmed">
+                            Deleted by Autopilot
+                        </Text>
+                    </Group>
+                    <Button
+                        size="xs"
+                        variant="default"
+                        leftSection={<IconArrowBackUp size={14} />}
+                        loading={revertMutation.isLoading}
+                        onClick={() => revertMutation.mutate()}
+                    >
+                        Restore
+                    </Button>
                 </Group>
             )}
 


### PR DESCRIPTION
## Summary

Closes [PROD-7390](https://linear.app/lightdash/issue/PROD-7390). Fixes a UX bug where clicking a `soft_deleted` action row in the Autopilot activity sidebar produced a "not found" toast (it tried to load the now-deleted chart/dashboard) and then rendered a broken "Open" CTA that linked to the deleted resource.

## The bug

`DetailSidebar` in `ManagedAgentActivityPage.tsx` unconditionally fetches chart/dashboard metadata via `useSavedQuery` / `useDashboardQuery` whenever an action is selected. For an action whose target is currently soft-deleted (which is the entire purpose of a `soft_deleted` action), the backend filters `whereNull('deleted_at')` by default → 404 → global error toast. The "Open" CTA then renders a link to the deleted resource's URL anyway, which 404s on click.

## The fix

- New `isTargetDeleted` predicate covers two cases:
  - `SOFT_DELETED` action that hasn't been undone yet
  - `CREATED_CONTENT` action that has been reversed (which soft-deletes the agent-created chart via `reverseAction`)
- Skip `useSavedQuery` / `useDashboardQuery` when `isTargetDeleted`. The action row already carries `target_name` + `description` captured at action time — that's the truth about what was deleted, no need to fetch live state.
- Hide the "Open" CTA in the header when the target is deleted (the link would 404 anyway).
- Add a prominent **Restore** banner with a primary button — only for the `SOFT_DELETED`-not-yet-reversed case. Red-tinted, trash icon, calls the existing `reverseAction` flow which restores the chart/dashboard via `savedChartModel.restore()` / `dashboardModel.restore()`. The symmetric `CREATED_CONTENT`-reversed case keeps the existing "Undone X ago" reversed banner — no extra surface needed there.
- **Hard-delete edge case**: if a user externally hard-deleted the chart, `reverseAction` 404s. `revertMutation`'s `onError` now detects `statusCode === 404` and surfaces a specific toast: *"Could not restore — the original was permanently deleted"* instead of a generic API error.

## Files changed

- `packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx` — predicate, fetch guards, banner render, error handling
- `packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css` — `.deletedBanner` style (red tint to distinguish from `.reversedBanner`)

## Test plan

- [ ] Trigger Autopilot to soft-delete a chart/dashboard, click the action row in the activity sidebar — no "not found" toast, no broken Open link, prominent Restore button visible
- [ ] Click Restore — chart/dashboard reappears, action row transitions to "Undone X ago"
- [ ] Trigger Autopilot to create a chart, click Undo — action row no longer shows broken Open link or 404 toast (existing reversed banner stays)
- [ ] Soft-delete a chart, hard-delete it from a separate session, click Restore — toast says "Could not restore — the original was permanently deleted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)