### PR TITLE
feat: set `service_account_user_uuid` NOT NULL (PROD-7427)

### DIFF
--- a/packages/backend/src/ee/database/migrations/20260507151700_set_service_account_user_uuid_not_null.ts
+++ b/packages/backend/src/ee/database/migrations/20260507151700_set_service_account_user_uuid_not_null.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+const ServiceAccountsTableName = 'service_accounts';
+const ColumnName = 'service_account_user_uuid';
+
+// Set `service_account_user_uuid` to NOT NULL. Deferred follow-up to
+// the column-add + backfill that shipped in #22661 (PROD-7427) — we
+// kept the column nullable for one stability window so rolling deploys
+// and code-without-migration rollbacks didn't trip on the constraint.
+//
+// `service_accounts` is a tiny table (typically <100 rows), so
+// validating the constraint is near-instant.
+//
+// Wrapped in try/catch as a defensive net: if a stray NULL row slipped
+// through (e.g. an old-code replica created an SA during the deploy
+// window before the new INSERT path was running), the SET NOT NULL
+// will fail with `column ... contains null values`. We log and
+// continue rather than block the deploy chain — operators can backfill
+// the offender and re-run the migration.
+export async function up(knex: Knex): Promise<void> {
+    try {
+        await knex.schema.alterTable(ServiceAccountsTableName, (table) => {
+            table.uuid(ColumnName).notNullable().alter();
+        });
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `Could not set NOT NULL on ${ServiceAccountsTableName}.${ColumnName}: ${
+                error instanceof Error ? error.message : String(error)
+            }. Backfill orphan rows and re-run.`,
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ServiceAccountsTableName, (table) => {
+        table.uuid(ColumnName).nullable().alter();
+    });
+}


### PR DESCRIPTION
Closes: #22661

### Description:

Adds a follow-up migration to enforce `NOT NULL` on the `service_account_user_uuid` column in the `service_accounts` table. The column was intentionally left nullable when it was first introduced to allow safe rolling deploys and rollbacks. Now that the stability window has passed, this migration tightens the constraint.

The migration is wrapped in a `try/catch` so that if any stray `NULL` rows exist (e.g. created by an old-code replica during the deploy window), the migration will log a warning and continue rather than blocking the deploy chain. Affected rows can be backfilled manually and the migration re-run.

The `down` migration reverts the column back to nullable.