### PR TITLE
feat: create data app directly inside a space (GLITCH-410)

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -34,7 +34,10 @@ flowchart LR
 ### Step-by-step
 
 1. **App creation** — The API creates a `DbApp` record and a v1 `DbAppVersion` with `status='building'`, then returns
-   immediately with `{ appUuid, version }`. The pipeline runs asynchronously in the background.
+   immediately with `{ appUuid, version }`. The pipeline runs asynchronously in the background. The create request
+   accepts an optional `spaceUuid`: when present, the app is created with `space_uuid` populated and the caller must
+   have manage rights on that space (space EDITOR/ADMIN, or project admin); when omitted, the app is created as a
+   personal app (`space_uuid IS NULL`) and can be moved into a space later.
 
 2. **Sandbox setup** — An [E2B](https://e2b.dev/) sandbox is created from the `lightdash-data-app` template (override
    with `E2B_TEMPLATE_NAME` for development). The template contains a pre-configured React + Vite project with the
@@ -474,7 +477,7 @@ scopes, all defined in `packages/common/src/authorization/scopes.ts`:
 | Scope                  | Granted to          | Effect                                                                                                       |
 | ---------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `view:DataApp`         | viewer+             | View any app whose space the user can view (or where the project inherits org/project access).               |
-| `create:DataApp`       | interactive_viewer+ | Start a new app from a prompt. Newly-created apps are personal until moved into a space.                     |
+| `create:DataApp`       | interactive_viewer+ | Start a new app from a prompt. By default the app is personal until moved into a space; passing `spaceUuid` on the create request creates it directly in a space (also requires `manage:DataApp@space` on that space). |
 | `view:DataApp@self`    | interactive_viewer+ | View own personal apps (matched on `createdByUserUuid`).                                                     |
 | `manage:DataApp@self`  | interactive_viewer+ | Iterate, edit, pin (n/a for personal), move, and delete own personal apps.                                   |
 | `manage:DataApp@space` | interactive_viewer+ | Iterate, edit, cancel, pin, move, and delete apps in spaces where the user has the `EDITOR` or `ADMIN` role. |
@@ -505,8 +508,10 @@ helpers in `AppGenerateService.ts` carry the context-aware logic:
 - `assertCanManageApp(user, app, msg)` — used by `iterateApp`, `cancelVersion`, `updateApp`, `togglePinning`,
   `deleteApp`, `moveToSpace`, and `uploadImage` (when the app exists). Same subject shape, checks the `manage` action.
 
-`generateApp` (creation) checks the `create` action against a project-scoped subject — no app exists yet to provide
-space or creator context.
+`generateApp` (creation) checks the `create` action against a project-scoped subject. When the request carries a
+`spaceUuid` (the app should be created directly in a space, e.g. via the space's "+ Add" menu), it additionally
+checks the `manage` action against a subject that includes that space's access context — so a user creating in a
+space must be EDITOR/ADMIN of it, the same gate dashboards/charts get implicitly via their space-scoped create scope.
 
 `restoreApp` and `permanentDeleteApp` deliberately bypass the context-aware helper and use the bare project-wide
 `manage:DataApp` check, since restoring deleted content is an admin-only recovery flow.

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -67,6 +67,7 @@ export class AppGenerateController extends BaseController {
             body.dashboard,
             body.template,
             body.clarifications,
+            body.spaceUuid,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2706,6 +2706,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         dashboard?: AppDashboardReference,
         template?: DataAppTemplate,
         clarifications?: AppClarification[],
+        spaceUuid?: string,
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
         const organizationUuid = await this.getProjectOrgUuid(projectUuid);
@@ -2716,6 +2717,25 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             projectUuid,
             'Insufficient permissions to create data apps',
         );
+
+        // When the caller wants the app to live in a space directly, also
+        // require manage rights on that space — same gate space EDITOR/ADMIN
+        // (or project admin) already pass through `manage:DataApp@space`.
+        if (spaceUuid) {
+            const spaceContext =
+                await this.spacePermissionService.getSpaceAccessContext(
+                    user.userUuid,
+                    spaceUuid,
+                );
+            this.assertDataAppAbility(
+                user,
+                'manage',
+                organizationUuid,
+                projectUuid,
+                'Insufficient permissions to create a data app in this space',
+                spaceContext,
+            );
+        }
 
         AppGenerateService.validateImageIds(imageIds);
 
@@ -2767,6 +2787,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                     project_uuid: projectUuid,
                     created_by_user_uuid: user.userUuid,
                     template: persistedTemplate,
+                    space_uuid: spaceUuid ?? null,
                 },
                 { version, prompt },
                 'pending',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7343,6 +7343,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                spaceUuid: { dataType: 'string' },
                 clarifications: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'AppClarification' },
@@ -9485,11 +9486,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9967,30 +9968,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10024,11 +10006,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10043,11 +10025,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8705,6 +8705,9 @@
             },
             "GenerateAppRequestBody": {
                 "properties": {
+                    "spaceUuid": {
+                        "type": "string"
+                    },
                     "clarifications": {
                         "items": {
                             "$ref": "#/components/schemas/AppClarification"
@@ -10919,19 +10922,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -32017,7 +32007,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2893.2",
+        "version": "0.2897.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -34,7 +34,14 @@ export class AppModel {
     async createWithVersion(
         app: Pick<DbApp, 'project_uuid' | 'created_by_user_uuid'> &
             Partial<
-                Pick<DbApp, 'app_id' | 'name' | 'description' | 'template'>
+                Pick<
+                    DbApp,
+                    | 'app_id'
+                    | 'name'
+                    | 'description'
+                    | 'template'
+                    | 'space_uuid'
+                >
             >,
         version: Pick<DbAppVersion, 'version' | 'prompt'>,
         status: AppVersionStatus,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -102,6 +102,11 @@ export type GenerateAppRequestBody = {
     charts?: AppChartReference[]; // saved charts to resolve, optionally with sample rows
     dashboard?: AppDashboardReference; // dashboard — resolved server-side to its chart tiles
     clarifications?: AppClarification[]; // pre-build Q&A folded into the prompt server-side
+    // Optional target space. When set, the app is created with `space_uuid`
+    // populated and the caller must have manage rights on that space (space
+    // EDITOR/ADMIN, or project admin). When omitted, the app is created as
+    // personal and can be moved into a space later.
+    spaceUuid?: string;
 };
 
 export type ApiClarifyAppRequest = {

--- a/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
@@ -18,6 +18,7 @@ type GenerateAppParams = {
     charts?: AppChartReference[];
     dashboard?: AppDashboardReference;
     clarifications?: AppClarification[];
+    spaceUuid?: string; // create directly inside this space (skips the personal-app step)
 };
 
 type GenerateAppResult = ApiGenerateAppResponse['results'];
@@ -31,6 +32,7 @@ const generateApp = async ({
     charts,
     dashboard,
     clarifications,
+    spaceUuid,
 }: GenerateAppParams): Promise<GenerateAppResult> => {
     const data = await lightdashApi<GenerateAppResult>({
         method: 'POST',
@@ -43,6 +45,7 @@ const generateApp = async ({
             charts,
             dashboard,
             clarifications,
+            spaceUuid,
         }),
     });
     return data;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -261,6 +261,15 @@ const AppGenerate: FC = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const queryClient = useQueryClient();
+    // When the user lands here from a space's "+ Add" menu we get
+    // ?spaceUuid=<uuid> on the URL. We only honour it for first-time creation
+    // (urlAppUuid undefined) — once we're editing an existing app the space
+    // assignment is already on the app row and this query param is ignored.
+    const targetSpaceUuid = useMemo(() => {
+        if (urlAppUuid) return undefined;
+        const value = new URLSearchParams(location.search).get('spaceUuid');
+        return value ?? undefined;
+    }, [urlAppUuid, location.search]);
     // Editor handle (TipTap-based) — replaces the previous controlled
     // textarea + `prompt` state. The editor owns its content; the parent
     // reads on submit via `getText()` and tracks emptiness via the
@@ -432,6 +441,7 @@ const AppGenerate: FC = () => {
         appUuid: string;
         charts: AppChartReference[] | undefined;
         dashboard: AppDashboardReference | undefined;
+        spaceUuid: string | undefined;
     } | null>(null);
     const [clarificationAnswers, setClarificationAnswers] = useState<string[]>(
         [],
@@ -1073,6 +1083,7 @@ const AppGenerate: FC = () => {
                             appUuid: newAppUuid,
                             charts,
                             dashboard,
+                            spaceUuid: targetSpaceUuid,
                         });
                         setClarificationAnswers(
                             new Array(questions.length).fill(''),
@@ -1116,6 +1127,7 @@ const AppGenerate: FC = () => {
                         appUuid: newAppUuid,
                         charts,
                         dashboard,
+                        spaceUuid: targetSpaceUuid,
                     },
                     callbacks,
                 );
@@ -1182,6 +1194,7 @@ const AppGenerate: FC = () => {
                 dashboard: captured.dashboard,
                 clarifications:
                     clarifications.length > 0 ? clarifications : undefined,
+                spaceUuid: captured.spaceUuid,
             },
             buildSubmitCallbacks(),
         );

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -132,6 +132,22 @@ const Space: FC = () => {
         subject('SavedChart', { ...space }),
     );
 
+    // Data apps have a project-level `create:DataApp` scope (no @space variant
+    // for create), so we combine it with `manage:DataApp` against the space —
+    // the latter is only granted to space EDITOR/ADMIN (or project admins),
+    // mirroring the implicit space-role check that dashboards/charts get for
+    // free via their space-scoped create scope.
+    const userCanCreateDataApps =
+        dataAppsEnabled &&
+        user.data?.ability?.can(
+            'create',
+            subject('DataApp', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        ) &&
+        user.data?.ability?.can('manage', subject('DataApp', { ...space }));
+
     const userCanManageProject = user.data?.ability?.can(
         'manage',
         subject('Project', {
@@ -233,6 +249,7 @@ const Space: FC = () => {
                             {!isDemo &&
                                 (userCanCreateDashboards ||
                                     userCanCreateCharts ||
+                                    userCanCreateDataApps ||
                                     userCanManageSpace) && (
                                     <Menu
                                         position="bottom-end"
@@ -310,6 +327,23 @@ const Space: FC = () => {
                                                     }}
                                                 >
                                                     Create new chart
+                                                </Menu.Item>
+                                            ) : null}
+
+                                            {userCanCreateDataApps ? (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconPlus}
+                                                        />
+                                                    }
+                                                    onClick={() => {
+                                                        void navigate(
+                                                            `/projects/${projectUuid}/apps/generate?spaceUuid=${space.uuid}`,
+                                                        );
+                                                    }}
+                                                >
+                                                    Create new data app
                                                 </Menu.Item>
                                             ) : null}
                                         </Menu.Dropdown>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-410/create-data-app-directly-in-space

### Description:
Adds a "Create new data app" item to the space "+ Add" menu and threads an optional spaceUuid through the app generation flow so the app is created with space_uuid populated instead of personal.

<img width="274" height="207" alt="image" src="https://github.com/user-attachments/assets/791414f4-a0ad-4b9c-bcec-58e6f3904517" />

