### PR TITLE
feat(managed-agent): diff and revert CTA for auto-fixed charts

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -1088,7 +1088,7 @@ export class ManagedAgentService extends BaseService {
                 }
                 break;
             case ManagedAgentActionType.FIXED_BROKEN:
-                await this.restorePreviousChartVersion(action);
+                await this.restorePreviousChartVersion(action, user);
                 break;
             case ManagedAgentActionType.FLAGGED_STALE:
             case ManagedAgentActionType.FLAGGED_BROKEN:
@@ -1128,6 +1128,7 @@ export class ManagedAgentService extends BaseService {
 
     private async restorePreviousChartVersion(
         action: ManagedAgentAction,
+        user: SessionUser,
     ): Promise<void> {
         if (action.targetType !== ManagedAgentTargetType.CHART) {
             return;
@@ -1145,7 +1146,7 @@ export class ManagedAgentService extends BaseService {
         await this.savedChartModel.createVersion(
             action.targetUuid,
             previousChart,
-            undefined, // user — version creation doesn't require one
+            user,
         );
     }
 
@@ -1924,7 +1925,7 @@ chartConfig:
                 pivotConfig: chart.pivotConfig,
                 parameters: chart.parameters,
             },
-            undefined, // user — not needed for version creation
+            actor,
         );
 
         // Clear stale validation errors for this chart — the fix should resolve them.

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -317,6 +317,16 @@
         light-dark(var(--mantine-color-red-2), var(--mantine-color-dark-4));
 }
 
+.fixedBanner {
+    padding: 8px 12px 8px 16px;
+    background-color: light-dark(
+        var(--mantine-color-teal-0),
+        var(--mantine-color-dark-6)
+    );
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-teal-2), var(--mantine-color-dark-4));
+}
+
 .closeBtn {
     display: flex;
     align-items: center;
@@ -348,6 +358,35 @@
     );
     border: 1px solid
         light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+}
+
+.fieldPillRemoved {
+    padding: 2px 8px;
+    border-radius: 4px;
+    background-color: light-dark(
+        var(--mantine-color-red-0),
+        var(--mantine-color-dark-6)
+    );
+    border: 1px solid
+        light-dark(var(--mantine-color-red-2), var(--mantine-color-red-9));
+    color: light-dark(var(--mantine-color-red-7), var(--mantine-color-red-3));
+    text-decoration: line-through;
+    text-decoration-color: light-dark(
+        var(--mantine-color-red-4),
+        var(--mantine-color-red-7)
+    );
+}
+
+.fieldPillAdded {
+    padding: 2px 8px;
+    border-radius: 4px;
+    background-color: light-dark(
+        var(--mantine-color-teal-0),
+        var(--mantine-color-dark-6)
+    );
+    border: 1px solid
+        light-dark(var(--mantine-color-teal-2), var(--mantine-color-teal-9));
+    color: light-dark(var(--mantine-color-teal-7), var(--mantine-color-teal-3));
 }
 
 /* unused — kept for reference */

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -2,7 +2,9 @@ import { subject } from '@casl/ability';
 import {
     type ApiError,
     type ContentVerificationInfo,
+    countTotalFilterRules,
     type Dashboard,
+    getFixedBrokenMetadata,
     getManagedAgentActionCategory,
     ManagedAgentActionType,
     type ManagedAgentRun,
@@ -75,7 +77,7 @@ import { useDashboardQuery } from '../../../hooks/dashboard/useDashboard';
 import { useGetSlack } from '../../../hooks/slack/useSlack';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProject } from '../../../hooks/useProject';
-import { useSavedQuery } from '../../../hooks/useSavedQuery';
+import { useChartVersion, useSavedQuery } from '../../../hooks/useSavedQuery';
 import useApp from '../../../providers/App/useApp';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentLatestRun } from './hooks/useManagedAgentLatestRun';
@@ -446,6 +448,159 @@ const SlowDetails: FC<{ metadata: Record<string, unknown> }> = ({
     );
 };
 
+type FieldDiff = {
+    label: string;
+    added: string[];
+    removed: string[];
+};
+
+const computeFieldDiff = (
+    label: string,
+    previous: readonly string[],
+    current: readonly string[],
+): FieldDiff => {
+    const previousSet = new Set(previous);
+    const currentSet = new Set(current);
+    return {
+        label,
+        added: current.filter((f) => !previousSet.has(f)),
+        removed: previous.filter((f) => !currentSet.has(f)),
+    };
+};
+
+const FieldDiffRow: FC<{ diff: FieldDiff }> = ({ diff }) => {
+    if (diff.added.length === 0 && diff.removed.length === 0) return null;
+    return (
+        <Stack gap={4}>
+            <MetadataLabel label={diff.label} />
+            <Group gap={4}>
+                {diff.removed.map((f) => (
+                    <Text
+                        key={`removed-${f}`}
+                        fz={11}
+                        ff="monospace"
+                        className={classes.fieldPillRemoved}
+                    >
+                        {f}
+                    </Text>
+                ))}
+                {diff.added.map((f) => (
+                    <Text
+                        key={`added-${f}`}
+                        fz={11}
+                        ff="monospace"
+                        className={classes.fieldPillAdded}
+                    >
+                        {f}
+                    </Text>
+                ))}
+            </Group>
+        </Stack>
+    );
+};
+
+const FixedBrokenDiff: FC<{
+    previousChart: SavedChart | undefined;
+    currentChart: SavedChart | undefined;
+    historyHref: string;
+}> = ({ previousChart, currentChart, historyHref }) => {
+    const historyLink = (
+        <Anchor href={historyHref} target="_blank" rel="noreferrer" fz="xs">
+            View full chart history
+        </Anchor>
+    );
+
+    if (!previousChart || !currentChart) {
+        return (
+            <Stack gap="sm">
+                <MetadataLabel label="Changes applied" />
+                <Text fz="xs" c="dimmed" lh={1.6}>
+                    Diff unavailable for this fix — see chart history for
+                    details.
+                </Text>
+                {historyLink}
+            </Stack>
+        );
+    }
+
+    const dimensionsDiff = computeFieldDiff(
+        'Dimensions',
+        previousChart.metricQuery.dimensions,
+        currentChart.metricQuery.dimensions,
+    );
+    const metricsDiff = computeFieldDiff(
+        'Metrics',
+        previousChart.metricQuery.metrics,
+        currentChart.metricQuery.metrics,
+    );
+    const tableCalcsDiff = computeFieldDiff(
+        'Table calculations',
+        previousChart.metricQuery.tableCalculations.map((tc) => tc.name),
+        currentChart.metricQuery.tableCalculations.map((tc) => tc.name),
+    );
+
+    const previousExplore = previousChart.metricQuery.exploreName;
+    const currentExplore = currentChart.metricQuery.exploreName;
+    const exploreChanged = previousExplore !== currentExplore;
+
+    const previousType = previousChart.chartConfig.type;
+    const currentType = currentChart.chartConfig.type;
+    const typeChanged = previousType !== currentType;
+
+    const previousFilterCount = countTotalFilterRules(
+        previousChart.metricQuery.filters,
+    );
+    const currentFilterCount = countTotalFilterRules(
+        currentChart.metricQuery.filters,
+    );
+    const filtersChanged = previousFilterCount !== currentFilterCount;
+
+    const hasFieldDiffs =
+        dimensionsDiff.added.length + dimensionsDiff.removed.length > 0 ||
+        metricsDiff.added.length + metricsDiff.removed.length > 0 ||
+        tableCalcsDiff.added.length + tableCalcsDiff.removed.length > 0;
+    const hasMeaningfulDiff =
+        hasFieldDiffs || exploreChanged || typeChanged || filtersChanged;
+
+    return (
+        <Stack gap="sm">
+            <MetadataLabel label="Changes applied" />
+            {hasMeaningfulDiff ? (
+                <Stack gap={10}>
+                    <FieldDiffRow diff={dimensionsDiff} />
+                    <FieldDiffRow diff={metricsDiff} />
+                    <FieldDiffRow diff={tableCalcsDiff} />
+                    {exploreChanged && (
+                        <InfoRow icon={IconDatabase} label="Explore">
+                            <Text fz="xs" component="span">
+                                {previousExplore} → {currentExplore}
+                            </Text>
+                        </InfoRow>
+                    )}
+                    {typeChanged && (
+                        <InfoRow icon={IconChartBar} label="Chart type">
+                            <Text fz="xs" component="span">
+                                {previousType} → {currentType}
+                            </Text>
+                        </InfoRow>
+                    )}
+                    {filtersChanged && (
+                        <InfoRow icon={IconHash} label="Filters">
+                            {previousFilterCount} → {currentFilterCount}
+                        </InfoRow>
+                    )}
+                </Stack>
+            ) : (
+                <Text fz="xs" c="dimmed" lh={1.6}>
+                    This fix touched fields not surfaced in this view — see
+                    chart history for details.
+                </Text>
+            )}
+            {historyLink}
+        </Stack>
+    );
+};
+
 type ContentContext = {
     description: string | null;
     projectUuid: string;
@@ -622,6 +777,12 @@ const DetailSidebar: FC<{
     const showRestoreBanner =
         action.actionType === ManagedAgentActionType.SOFT_DELETED &&
         !isReversed;
+    const isFixedBroken =
+        action.actionType === ManagedAgentActionType.FIXED_BROKEN;
+    const previousVersionUuid = isFixedBroken
+        ? (getFixedBrokenMetadata(action.metadata)?.previousVersionUuid ?? null)
+        : null;
+    const showFixedBanner = isFixedBroken && !isReversed;
 
     const revertMutation = useMutation<unknown, ApiError>({
         mutationFn: () => reverseAction(action.projectUuid, action.actionUuid),
@@ -678,6 +839,12 @@ const DetailSidebar: FC<{
     });
     const { data: chartViewStats } = useChartViewStats(
         action.targetType === 'chart' ? action.targetUuid : undefined,
+    );
+    const { data: previousChartVersion } = useChartVersion(
+        showFixedBanner && previousVersionUuid ? action.targetUuid : undefined,
+        showFixedBanner && previousVersionUuid
+            ? previousVersionUuid
+            : undefined,
     );
     const { data: targetProject } = useProject(
         isProjectTarget ? action.targetUuid : undefined,
@@ -857,6 +1024,62 @@ const DetailSidebar: FC<{
                 </Group>
             )}
 
+            {showFixedBanner && (
+                <Group
+                    gap={8}
+                    className={classes.fixedBanner}
+                    justify="space-between"
+                    wrap="nowrap"
+                >
+                    <Group gap={6} wrap="nowrap">
+                        <MantineIcon
+                            icon={IconTool}
+                            size="sm"
+                            color="var(--mantine-color-teal-6)"
+                        />
+                        <Text fz="xs" c="dimmed">
+                            Auto-fixed by Autopilot
+                        </Text>
+                    </Group>
+                    {previousVersionUuid ? (
+                        <Button
+                            size="xs"
+                            variant="default"
+                            leftSection={
+                                <MantineIcon icon={IconArrowBackUp} size={14} />
+                            }
+                            loading={revertMutation.isLoading}
+                            onClick={() => revertMutation.mutate()}
+                        >
+                            Revert
+                        </Button>
+                    ) : (
+                        <Tooltip
+                            label="This fix was recorded before revert support — restore manually via chart history."
+                            withinPortal
+                            multiline
+                            w={240}
+                        >
+                            <Button
+                                size="xs"
+                                variant="default"
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconArrowBackUp}
+                                        size={14}
+                                    />
+                                }
+                                disabled
+                                data-disabled
+                                onClick={(e) => e.preventDefault()}
+                            >
+                                Revert
+                            </Button>
+                        </Tooltip>
+                    )}
+                </Group>
+            )}
+
             {/* Content */}
             <Stack gap="md" p="md" style={{ overflow: 'auto', flex: 1 }}>
                 {/* Resource-side metadata (space, last updated, verified, deleted) */}
@@ -890,11 +1113,19 @@ const DetailSidebar: FC<{
                 {hasBrokenDetails && (
                     <BrokenDetails metadata={action.metadata} />
                 )}
+                {showFixedBanner && (
+                    <FixedBrokenDiff
+                        previousChart={previousChartVersion?.chart}
+                        currentChart={savedChart}
+                        historyHref={`/projects/${action.projectUuid}/saved/${action.targetUuid}/history`}
+                    />
+                )}
 
                 {/* Divider if we showed details above */}
                 {(hasChartDetails ||
                     hasBrokenDetails ||
                     hasSlowDetails ||
+                    showFixedBanner ||
                     !!contentContext ||
                     hasProjectDetails) && (
                     <Box className={classes.headerDivider} />


### PR DESCRIPTION
Closes [PROD-7391](https://linear.app/lightdash/issue/PROD-7391/show-diff-and-revert-cta-for-auto-fixes).

When Autopilot auto-fixes a broken chart, surface what changed and give a prominent revert path. Mirrors the existing soft-deleted "Restore" banner pattern at the top of the action sidebar.

## What's in

- **Auto-fixed banner**: teal-tinted banner with primary `Revert` button (uses the existing `reverseAction` wiring — no new mutation). Hidden once the action is reversed; the existing "Undone" label takes over.
- **Legacy fix fallback**: actions recorded before `previousVersionUuid` was tracked already fail revert with a friendly error (`ManagedAgentService.ts:674`). The button is disabled with a tooltip pointing at chart history for those.
- **`FixedBrokenDiff` component**: semantic diff alongside `ChartDetails` / `BrokenDetails` in the sidebar:
    - **Dimensions / Metrics / Table calculations**: added (green) and removed (red strikethrough) field-pill chips, reusing the existing `fieldPill` style with new `fieldPillAdded` / `fieldPillRemoved` colour variants.
    - **Chart type**, **explore name**: before → after text rows when changed.
    - **Filters**: rule count delta only — no filter-tree rendering for v1 (intentional — filter trees get unreadable fast).
    - **Empty diff fallback**: if nothing surface-level changed, shows a "see chart history for details" message.
    - Always renders a **View full chart history** link as a punch-through to the existing version-history page.
- **Attribution fix** (`ManagedAgentService.ts`): `handleFixBrokenChart` and `restorePreviousChartVersion` previously passed `undefined` as the user to `savedChartModel.createVersion`, leaving `last_version_updated_by_user_uuid` NULL. The frontend rendered that as "Last modified by null null" (visible the moment we exposed it in the new sidebar). Auto-fixes now attribute to the human admin who enabled Autopilot (`getAutopilotActor`); reverts attribute to the human clicker.

## Out of scope

- Dashboard auto-fixes (the agent only fixes charts today via `fix_broken_chart`)
- Filter-rule-level diffing (count delta only)
- Rendered-output comparison (would require a query)
- Replacing the existing chart version-history page

## Regression analysis

Purely additive frontend change in EE plus a one-line attribution fix in the existing `fix_broken_chart` / revert flow:
- Banner + diff sections only render when `actionType === FIXED_BROKEN`. All other action types are unaffected.
- For users **without managed-agent enabled** — no impact (no managed-agent UI rendered at all).
- For users with managed-agent enabled but no FIXED_BROKEN actions — no impact (existing sidebar unchanged for SOFT_DELETED, FLAGGED_*, CREATED_CONTENT, INSIGHT).
- For existing FIXED_BROKEN actions in the wild: the menu-item Undo path is unchanged and still works. The new banner adds a more prominent affordance using the same mutation.
- Soft-deleted target case: when the auto-fixed chart was *also* later deleted, `useSavedQuery` 404s; the banner and diff hide gracefully and the existing deleted-target sidebar takes over.
- Attribution fix: previously every auto-fix produced a chart version with NULL user attribution (showed as "by null null"). New versions now attribute to the project's Autopilot-enabling admin; existing NULL-attributed versions in the DB are not mutated. No new endpoints, no schema changes.

## Test plan

- [ ] Trigger a Run-Now on a project with broken charts the agent can fix → open the resulting FIXED_BROKEN action: banner + diff visible, Revert works, "Last modified by" shows the admin's name (not "null null")
- [ ] Click Revert → chart reverts, banner replaced by "Undone" label, diff hides, "Last modified by" shows the clicker's name
- [ ] Force a fix that changes `chartConfig.type` → diff shows the before→after text row
- [ ] Drop a filter rule via fix → diff shows `Filters: N → N-1`
- [ ] Find a pre-`previousVersionUuid` legacy action → banner shows but Revert button disabled with tooltip
- [ ] Soft-delete a chart that has a FIXED_BROKEN action against it → sidebar falls through to deleted-target view (no banner, no diff)