### PR TITLE
fix(managed-agent): refresh runs and latest-run caches after revert

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -790,6 +790,12 @@ const DetailSidebar: FC<{
             void queryClient.invalidateQueries({
                 queryKey: ['managed-agent-actions', action.projectUuid],
             });
+            void queryClient.invalidateQueries({
+                queryKey: ['managed-agent-runs', action.projectUuid],
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['managed-agent-latest-run', action.projectUuid],
+            });
         },
         onError: ({ error }) => {
             const isHardDeleted =


### PR DESCRIPTION
Follow-up to #22815.

The action-sidebar's revert mutation only invalidated the `managed-agent-actions` cache, leaving the `managed-agent-runs` and `managed-agent-latest-run` caches stale. After clicking **Undo** or **Dismiss**, the action row in the run-grouped table didn't update (no dimming, no strikethrough) until the user manually refreshed the page, because `RunGroup` also reads from the runs list (action counts, trigger badges) which never re-fetched.

Every other mutation in `ManagedAgentActivityPage.tsx` already invalidates all three caches (run-now at lines 1789-1793, settings at lines 1883-1891) — the revert path was the only outlier. This PR brings it into line.

## Regression analysis

Purely additive — adds two more `invalidateQueries` calls in the existing `revertMutation.onSuccess` handler:
- For users without managed-agent enabled — never executed, no impact.
- For users with managed-agent who never click revert — never executed, no impact.
- For users clicking revert — they now also pay one tick of refetch on the runs list and latest-run query (both already polling on a 30s/3s interval anyway). No new endpoints, no schema changes.

## Test plan

- [ ] Open the Autopilot activity page, expand a run, click an action → click **Undo** (or **Dismiss** for FLAGGED_*/INSIGHT) → action row dims with strikethrough immediately, no manual refresh required
- [ ] Run-row counts/dots reflect the post-revert state without refresh