### PR TITLE
feat(managed-agent): track run started, run completed, and action created

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1398,11 +1398,57 @@ export type ManagedAgentActionReversedEvent = BaseTrack & {
     };
 };
 
+export type ManagedAgentRunStartedEvent = BaseTrack & {
+    event: 'managed_agent.run_started';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        runUuid: string;
+        triggeredBy: 'cron' | 'manual' | 'on_enable';
+        schedule: string;
+        hasSlackChannel: boolean;
+    };
+};
+
+export type ManagedAgentRunCompletedEvent = BaseTrack & {
+    event: 'managed_agent.run_completed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        runUuid: string;
+        triggeredBy: 'cron' | 'manual' | 'on_enable';
+        status: 'completed' | 'error';
+        durationMs: number;
+        actionCount: number;
+        actionCountsByType: Record<string, number>;
+        slackPosted: boolean;
+        error: string | null;
+    };
+};
+
+export type ManagedAgentActionCreatedEvent = BaseTrack & {
+    event: 'managed_agent.action_created';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        runUuid: string | null;
+        sessionId: string;
+        actionType: string;
+        targetType: string;
+    };
+};
+
 export type ManagedAgentEvent =
     | ManagedAgentSettingsCreatedEvent
     | ManagedAgentSettingsUpdatedEvent
     | ManagedAgentRunNowTriggeredEvent
-    | ManagedAgentActionReversedEvent;
+    | ManagedAgentActionReversedEvent
+    | ManagedAgentRunStartedEvent
+    | ManagedAgentRunCompletedEvent
+    | ManagedAgentActionCreatedEvent;
 
 export const parseAnalyticsLimit = (
     limit: 'table' | 'all' | number | null | undefined,

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -570,6 +570,28 @@ export class ManagedAgentModel {
         return result ? Number(result.count) : 0;
     }
 
+    async getActionCountsByTypeForRun(
+        runUuid: string,
+    ): Promise<Record<string, number>> {
+        const rows = await this.database(ManagedAgentActionsTableName)
+            .where({ managed_agent_run_uuid: runUuid })
+            .groupBy('action_type')
+            .select<{ action_type: string; count: string }[]>(
+                'action_type',
+                this.database.raw('COUNT(*) AS count'),
+            );
+        return Object.fromEntries(
+            rows.map(({ action_type, count }) => [action_type, Number(count)]),
+        );
+    }
+
+    async getRun(runUuid: string): Promise<ManagedAgentRun | null> {
+        const row = await this.database(ManagedAgentRunsTableName)
+            .where({ managed_agent_run_uuid: runUuid })
+            .first();
+        return row ? ManagedAgentModel.mapDbRun(row) : null;
+    }
+
     async getLatestRun(projectUuid: string): Promise<ManagedAgentRun | null> {
         const row = await this.database(ManagedAgentRunsTableName)
             .where({ project_uuid: projectUuid })

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -50,6 +50,16 @@ import type { ServiceAccountModel } from '../../models/ServiceAccountModel';
 
 type RunsCursor = { startedAt: Date; runUuid: string };
 
+type HeartbeatContext = {
+    runUuid: string;
+    projectUuid: string;
+    organizationUuid: string;
+    settings: ManagedAgentSettings | null;
+    triggeredBy: ManagedAgentRunTriggeredBy;
+    startedAtMs: number;
+    analyticsUserId: string | null;
+};
+
 const encodeRunsCursor = (cursor: RunsCursor | null): string | null => {
     if (!cursor) return null;
     return Buffer.from(
@@ -1153,20 +1163,23 @@ export class ManagedAgentService extends BaseService {
     // --- Heartbeat ---
 
     async runHeartbeat(projectUuid: string, runUuid: string): Promise<void> {
-        const settings = await this.managedAgentModel.getSettings(projectUuid);
-        if (!settings?.enabled) {
-            await this.failRunSafely(runUuid, 'Autopilot disabled');
+        const ctx = await this.loadHeartbeatContext(projectUuid, runUuid);
+        if (!ctx) return;
+
+        this.trackRunStarted(ctx);
+
+        if (!ctx.settings?.enabled) {
+            await this.failRunSafely(ctx, 'Autopilot disabled');
             return;
         }
 
-        // Get the auto-created PAT for MCP auth
         const serviceAccountToken =
             await this.managedAgentModel.getServiceAccountToken(projectUuid);
         if (!serviceAccountToken) {
             this.logger.warn(
                 `No service account token for project ${projectUuid}, skipping heartbeat`,
             );
-            await this.failRunSafely(runUuid, 'No service account token');
+            await this.failRunSafely(ctx, 'No service account token');
             return;
         }
 
@@ -1221,9 +1234,13 @@ export class ManagedAgentService extends BaseService {
             );
             runError = error instanceof Error ? error.message : 'Unknown';
         } finally {
-            const actionCount = await this.managedAgentModel
-                .countActionsForRun(runUuid)
-                .catch(() => 0);
+            const actionCountsByType = await this.managedAgentModel
+                .getActionCountsByTypeForRun(runUuid)
+                .catch(() => ({}) as Record<string, number>);
+            const actionCount = Object.values(actionCountsByType).reduce(
+                (sum, n) => sum + n,
+                0,
+            );
             await this.managedAgentModel
                 .finishRun(runUuid, {
                     status: runError
@@ -1243,23 +1260,159 @@ export class ManagedAgentService extends BaseService {
 
             // Post summary to Slack even if the session errored — actions
             // recorded via custom tools before the crash are still valuable.
-            this.logger.info(
-                `Slack notification check: slackChannelId=${settings.slackChannelId ?? 'null'}, sessionId=${sessionId || 'empty'}`,
+            const slackPosted = await this.maybePostHeartbeatSlackSummary(
+                ctx,
+                sessionId,
+                agentSummary,
             );
-            if (settings.slackChannelId && sessionId) {
-                await this.postHeartbeatSummaryToSlack(
-                    projectUuid,
-                    sessionId,
-                    settings.slackChannelId,
-                    agentSummary,
-                );
-            }
+
+            this.trackRunCompleted(ctx, {
+                status: runError ? 'error' : 'completed',
+                actionCount,
+                actionCountsByType,
+                slackPosted,
+                error: runError,
+            });
         }
     }
 
-    private async failRunSafely(runUuid: string, error: string): Promise<void> {
+    private async loadHeartbeatContext(
+        projectUuid: string,
+        runUuid: string,
+    ): Promise<HeartbeatContext | null> {
+        const run = await this.managedAgentModel.getRun(runUuid);
+        if (!run) {
+            this.logger.error(`Run ${runUuid} not found, aborting heartbeat`);
+            return null;
+        }
+        const settings = await this.managedAgentModel.getSettings(projectUuid);
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        return {
+            runUuid,
+            projectUuid,
+            organizationUuid,
+            settings,
+            triggeredBy: run.triggeredBy,
+            startedAtMs: run.startedAt.getTime(),
+            analyticsUserId: settings?.enabledByUserUuid ?? null,
+        };
+    }
+
+    private trackRunStarted(ctx: HeartbeatContext): void {
+        if (!ctx.analyticsUserId) {
+            this.logger.warn(
+                `Skipping run_started analytics — no enabledByUserUuid for run ${ctx.runUuid}`,
+            );
+            return;
+        }
+        this.analytics.track({
+            event: 'managed_agent.run_started',
+            userId: ctx.analyticsUserId,
+            properties: {
+                organizationId: ctx.organizationUuid,
+                projectId: ctx.projectUuid,
+                runUuid: ctx.runUuid,
+                triggeredBy: ctx.triggeredBy,
+                schedule: ctx.settings?.schedule ?? 'unknown',
+                hasSlackChannel: !!ctx.settings?.slackChannelId,
+            },
+        });
+    }
+
+    private trackActionCreated(
+        actor: SessionUser,
+        runUuid: string,
+        action: ManagedAgentAction,
+    ): void {
+        if (!actor.userUuid || !actor.organizationUuid) {
+            this.logger.warn(
+                `Skipping action_created analytics — actor missing userUuid or organizationUuid (action ${action.actionUuid})`,
+            );
+            return;
+        }
+        this.analytics.track({
+            event: 'managed_agent.action_created',
+            userId: actor.userUuid,
+            properties: {
+                organizationId: actor.organizationUuid,
+                projectId: action.projectUuid,
+                runUuid,
+                sessionId: action.sessionId,
+                actionType: action.actionType,
+                targetType: action.targetType,
+            },
+        });
+    }
+
+    private trackRunCompleted(
+        ctx: HeartbeatContext,
+        outcome: {
+            status: 'completed' | 'error';
+            actionCount: number;
+            actionCountsByType: Record<string, number>;
+            slackPosted: boolean;
+            error: string | null;
+        },
+    ): void {
+        if (!ctx.analyticsUserId) {
+            this.logger.warn(
+                `Skipping run_completed analytics — no enabledByUserUuid for run ${ctx.runUuid}`,
+            );
+            return;
+        }
+        this.analytics.track({
+            event: 'managed_agent.run_completed',
+            userId: ctx.analyticsUserId,
+            properties: {
+                organizationId: ctx.organizationUuid,
+                projectId: ctx.projectUuid,
+                runUuid: ctx.runUuid,
+                triggeredBy: ctx.triggeredBy,
+                status: outcome.status,
+                durationMs: Date.now() - ctx.startedAtMs,
+                actionCount: outcome.actionCount,
+                actionCountsByType: outcome.actionCountsByType,
+                slackPosted: outcome.slackPosted,
+                error: outcome.error ? outcome.error.slice(0, 500) : null,
+            },
+        });
+    }
+
+    private async maybePostHeartbeatSlackSummary(
+        ctx: HeartbeatContext,
+        sessionId: string,
+        agentSummary: string,
+    ): Promise<boolean> {
+        const slackChannelId = ctx.settings?.slackChannelId;
+        this.logger.info(
+            `Slack notification check: slackChannelId=${slackChannelId ?? 'null'}, sessionId=${sessionId || 'empty'}`,
+        );
+        if (!slackChannelId || !sessionId) return false;
+        try {
+            await this.postHeartbeatSummaryToSlack(
+                ctx.projectUuid,
+                sessionId,
+                slackChannelId,
+                agentSummary,
+            );
+            return true;
+        } catch (e) {
+            this.logger.error(
+                `Failed to post Slack heartbeat summary for ${ctx.projectUuid}: ${
+                    e instanceof Error ? e.message : 'Unknown'
+                }`,
+            );
+            return false;
+        }
+    }
+
+    private async failRunSafely(
+        ctx: HeartbeatContext,
+        error: string,
+    ): Promise<void> {
         await this.managedAgentModel
-            .finishRun(runUuid, {
+            .finishRun(ctx.runUuid, {
                 status: ManagedAgentRunStatus.ERROR,
                 actionCount: 0,
                 summary: null,
@@ -1267,11 +1420,18 @@ export class ManagedAgentService extends BaseService {
             })
             .catch((e) =>
                 this.logger.error(
-                    `Failed to fail run ${runUuid}: ${
+                    `Failed to fail run ${ctx.runUuid}: ${
                         e instanceof Error ? e.message : 'Unknown'
                     }`,
                 ),
             );
+        this.trackRunCompleted(ctx, {
+            status: 'error',
+            actionCount: 0,
+            actionCountsByType: {},
+            slackPosted: false,
+            error,
+        });
     }
 
     async startHeartbeat(
@@ -1943,6 +2103,7 @@ chartConfig:
             description,
             metadata: { previousVersionUuid },
         });
+        this.trackActionCreated(actor, runUuid, action);
 
         return JSON.stringify({
             action_uuid: action.actionUuid,
@@ -2138,6 +2299,7 @@ chartConfig:
             description,
             metadata: { chart_as_code: chartAsCode },
         });
+        this.trackActionCreated(actor, runUuid, action);
 
         return JSON.stringify({
             action_uuid: action.actionUuid,
@@ -2222,6 +2384,7 @@ chartConfig:
             description,
             metadata: (input.metadata as Record<string, unknown>) ?? {},
         });
+        this.trackActionCreated(actor, runUuid, action);
         return JSON.stringify({ action_uuid: action.actionUuid });
     }
 
@@ -2319,6 +2482,7 @@ chartConfig:
             description,
             metadata: (input.metadata as Record<string, unknown>) ?? {},
         });
+        this.trackActionCreated(actor, runUuid, action);
         return JSON.stringify({
             action_uuid: action.actionUuid,
             recoverable: true,
@@ -2370,6 +2534,7 @@ chartConfig:
             description,
             metadata: (input.metadata as Record<string, unknown>) ?? {},
         });
+        this.trackActionCreated(actor, runUuid, action);
         return JSON.stringify({ action_uuid: action.actionUuid });
     }
 


### PR DESCRIPTION
Adds three new analytics events to fill the run-cycle gap. Existing events only covered settings changes, manual run-now triggers, and reverts — nothing fired when a run actually **started**, **finished**, or recorded an **agent action**.

## New events

| Event | Fires | Key properties |
|---|---|---|
| `managed_agent.run_started` | top of `runHeartbeat` | `triggeredBy` (cron/manual/on_enable), `schedule`, `hasSlackChannel` |
| `managed_agent.run_completed` | both `failRunSafely` (config errors) and the main heartbeat `finally` (runtime errors + success) | `status`, `durationMs`, `actionCount`, `actionCountsByType`, `slackPosted`, `error` |
| `managed_agent.action_created` | after every successful `managedAgentModel.createAction` (5 call sites) | `actionType`, `targetType`, `runUuid`, `sessionId` |

Tool-call-level events were intentionally skipped — too high cardinality and the tool-name list shifts with prompt iterations. Run-level + action-level is the right resolution.

## What this unlocks

- **Adoption** — orgs/projects with active runs.
- **Activity** — runs per project per day, by trigger type.
- **Effectiveness** — actions per run, action-type distribution, what tool the agent leans on.
- **Reliability** — error rate, run duration distribution.
- **Engagement loop** — pair `action_created` with the existing `action_reversed` event to compute "human override rate" per `actionType`.

## Refactor

- Extracted a `HeartbeatContext` type + four small private helpers from `runHeartbeat`: `loadHeartbeatContext`, `trackRunStarted`, `trackRunCompleted`, `maybePostHeartbeatSlackSummary`. The heartbeat function now reads as a clean orchestration — load context, fire started, run, finalise (track completed inside `finally`).
- `failRunSafely` now also threads through `trackRunCompleted`, so config errors produce the same event shape as runtime errors (with `actionCount: 0` and the relevant error string).
- Slack post wrapped in `try/catch` so a Slack failure can never swallow the finally-block analytics or `finishRun` — the `slackPosted` field on `run_completed` reflects actual delivery.
- New model methods: `getRun(runUuid)` for the run row, and `getActionCountsByTypeForRun(runUuid)`. The latter replaces the old `countActionsForRun` call inside heartbeat (sum of values gives the total, no extra query).

## Regression analysis

Backend-only, additive analytics work in EE:
- For users **without managed-agent enabled** — `runHeartbeat` is never called, no impact.
- For users with managed-agent enabled — every run already paid the cost of `getSettings`, `getSummary`, `countActionsForRun`, `finishRun`. We add one extra `getRun(runUuid)` (single-row indexed read) at the top of heartbeat. `countActionsForRun` is replaced by `getActionCountsByTypeForRun` (one DB query instead of one — same network cost).
- Behavioural change to runHeartbeat is limited to: (a) Slack-post failures no longer abort the finally block, and (b) `failRunSafely` now also emits `run_completed`. Both desirable.
- `analyticsUserId = settings?.enabledByUserUuid ?? ''` — empty string fallback exists for the edge case where `getSettings` returns null. In practice, settings always exist when a run row exists; the fallback is purely a TypeScript guard.

## Test plan

- [ ] Trigger a Run-Now → `run_started` fires immediately, `run_completed` fires when the agent finishes (or after the 5 min `MANAGED_AGENT_SESSION_TIMEOUT_MS`)
- [ ] Disable Autopilot mid-flight → next cron tick fires `run_started` then `run_completed` with `status:'error'`, `error:'Autopilot disabled'`, `actionCount:0`
- [ ] Project with no service-account token → `run_started` then `run_completed` with `error:'No service account token'`
- [ ] During a run, every action the agent takes (flag, fix, soft-delete, create, insight) emits `action_created` with the right `actionType` / `targetType`
- [ ] Slack-enabled project → `run_completed.slackPosted` is `true` on success, `false` on Slack-post failure (and the failure does NOT prevent the rest of the finally block)