### PR TITLE
fix(data-apps): avoid connecting to sandbox for pause/kill commands

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2990,10 +2990,9 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         // so no spurious failed analytics event fires on top of the cancel.
         if (app.sandbox_id) {
             try {
-                const sandbox = await Sandbox.connect(app.sandbox_id, {
+                await Sandbox.pause(app.sandbox_id, {
                     apiKey: this.getE2bApiKey(),
                 });
-                await sandbox.pause();
                 this.logger.info(
                     `App ${appUuid}: sandbox paused after cancel (sandboxId=${app.sandbox_id})`,
                 );
@@ -3418,10 +3417,9 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     ): Promise<void> {
         if (!sandboxId) return;
         try {
-            const sandbox = await Sandbox.connect(sandboxId, {
+            await Sandbox.pause(sandboxId, {
                 apiKey: this.getE2bApiKey(),
             });
-            await sandbox.pause();
             this.logger.info(
                 `App ${appUuid}: sandbox paused during delete (sandboxId=${sandboxId})`,
             );
@@ -3438,10 +3436,9 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     ): Promise<void> {
         if (!sandboxId) return;
         try {
-            const sandbox = await Sandbox.connect(sandboxId, {
+            await Sandbox.kill(sandboxId, {
                 apiKey: this.getE2bApiKey(),
             });
-            await sandbox.kill();
             this.logger.info(
                 `App ${appUuid}: sandbox killed during hard delete (sandboxId=${sandboxId})`,
             );


### PR DESCRIPTION
### Description:
A quick investigation as to why deletion of apps is slow, revealed that we connect first to the sandbox to the just pause (soft-delete) or kill (hard-delete) it.
Instead of waking it up we can just send the pause/kill command directly, saving a lot of time since most of the time the app will be already paused as we do so after each iteration.

From the docs:
> Pause and resume performance
> - Pausing a sandbox takes approximately 4 seconds per 1 GiB of RAM
> - Resuming a sandbox takes approximately 1 second

https://e2b.dev/docs/sandbox/persistence#limitations