### PR TITLE
feat(timezone): settings toggle for project-timezone filter inputs (GLITCH-327)

### DIFF
--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -10,6 +10,7 @@ import {
     Flex,
     LoadingOverlay,
     Stack,
+    Switch,
     Text,
     Title,
 } from '@mantine-8/core';
@@ -27,6 +28,7 @@ import TimeZonePicker from '../common/TimeZonePicker';
 
 const queryTimezoneSchema = z.object({
     timezone: z.string().nullable(),
+    useProjectTimezoneInFilters: z.boolean(),
 });
 
 type QueryTimezoneFormValues = z.infer<typeof queryTimezoneSchema>;
@@ -34,31 +36,56 @@ type QueryTimezoneFormValues = z.infer<typeof queryTimezoneSchema>;
 const QueryTimezoneForm: FC<{
     isLoading: boolean;
     project: Project;
+    showFilterInputsToggle: boolean;
     onSubmit: (data: QueryTimezoneFormValues) => void;
-}> = ({ isLoading, project, onSubmit }) => {
+}> = ({ isLoading, project, showFilterInputsToggle, onSubmit }) => {
     const form = useForm<QueryTimezoneFormValues>({
         validate: zodResolver(queryTimezoneSchema),
         initialValues: {
             timezone: project.queryTimezone ?? null,
+            useProjectTimezoneInFilters:
+                project.useProjectTimezoneInFilters === true,
         },
     });
 
     const hasChanged = useMemo(
-        () => form.values.timezone !== (project.queryTimezone ?? null),
-        [form.values.timezone, project.queryTimezone],
+        () =>
+            form.values.timezone !== (project.queryTimezone ?? null) ||
+            form.values.useProjectTimezoneInFilters !==
+                (project.useProjectTimezoneInFilters === true),
+        [
+            form.values.timezone,
+            form.values.useProjectTimezoneInFilters,
+            project.queryTimezone,
+            project.useProjectTimezoneInFilters,
+        ],
     );
+
+    const filterToggleDisabled = !form.values.timezone;
 
     return (
         <form onSubmit={form.onSubmit(onSubmit)}>
-            <TimeZonePicker
-                label="Default query time zone"
-                variant="default"
-                maw="100%"
-                searchable
-                clearable
-                placeholder="Server default (UTC)"
-                {...form.getInputProps('timezone')}
-            />
+            <Stack gap="md">
+                <TimeZonePicker
+                    label="Default time zone"
+                    variant="default"
+                    maw="100%"
+                    searchable
+                    clearable
+                    placeholder="Server default (UTC)"
+                    {...form.getInputProps('timezone')}
+                />
+                {showFilterInputsToggle && (
+                    <Switch
+                        label="Use project time zone in date filter inputs"
+                        description="When on, absolute date filter pickers interpret values in the project time zone instead of the viewer's browser time zone. Existing filter values are preserved."
+                        disabled={filterToggleDisabled}
+                        {...form.getInputProps('useProjectTimezoneInFilters', {
+                            type: 'checkbox',
+                        })}
+                    />
+                )}
+            </Stack>
             <Flex justify="flex-end" gap="sm" mt="sm">
                 <Button
                     type="submit"
@@ -90,19 +117,23 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
 
     const handleSubmit = useCallback(
         async (values: QueryTimezoneFormValues) => {
+            const queryTimezone = values.timezone ?? null;
             try {
                 await projectMutation.mutateAsync({
-                    queryTimezone: values.timezone ?? null,
+                    queryTimezone,
+                    useProjectTimezoneInFilters:
+                        queryTimezone !== null &&
+                        values.useProjectTimezoneInFilters,
                 });
                 showToastSuccess({
-                    title: `Successfully updated project's query timezone`,
+                    title: `Successfully updated project's time zone settings`,
                 });
             } catch (e) {
                 const errorMessage = isApiError(e)
                     ? e.error.message
                     : getErrorMessage(e);
                 showToastError({
-                    title: `Failed to update project's query timezone`,
+                    title: `Failed to update project's time zone settings`,
                     subtitle: errorMessage,
                 });
             }
@@ -115,13 +146,14 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
             <LoadingOverlay visible={isLoadingProject} />
             <SettingsGridCard>
                 <Stack gap="xs">
-                    <Title order={4}>Query time zone</Title>
+                    <Title order={4}>Project time zone</Title>
                     <Text c="ldGray.6" fz="sm">
                         {timezoneSupportEnabled ? (
                             <>
                                 The time zone used for date filters, time
                                 grouping, and how dates appear in charts and
-                                tables. This does not change your
+                                tables. Optionally also drives absolute date
+                                filter inputs. This does not change your
                                 database&apos;s session time zone.
                             </>
                         ) : (
@@ -153,6 +185,7 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
                         <QueryTimezoneForm
                             isLoading={projectMutation.isLoading}
                             project={project}
+                            showFilterInputsToggle={timezoneSupportEnabled}
                             onSubmit={handleSubmit}
                         />
                     )}

--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -43,8 +43,7 @@ const QueryTimezoneForm: FC<{
         validate: zodResolver(queryTimezoneSchema),
         initialValues: {
             timezone: project.queryTimezone ?? null,
-            useProjectTimezoneInFilters:
-                project.useProjectTimezoneInFilters === true,
+            useProjectTimezoneInFilters: project.useProjectTimezoneInFilters,
         },
     });
 
@@ -52,7 +51,7 @@ const QueryTimezoneForm: FC<{
         () =>
             form.values.timezone !== (project.queryTimezone ?? null) ||
             form.values.useProjectTimezoneInFilters !==
-                (project.useProjectTimezoneInFilters === true),
+                project.useProjectTimezoneInFilters,
         [
             form.values.timezone,
             form.values.useProjectTimezoneInFilters,

--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -77,7 +77,7 @@ const QueryTimezoneForm: FC<{
                 {showFilterInputsToggle && (
                     <Switch
                         label="Use project time zone in date filter inputs"
-                        description="When on, absolute date filter pickers interpret values in the project time zone instead of the viewer's browser time zone. Existing filter values are preserved."
+                        description="Use the project time zone for absolute date filters."
                         disabled={filterToggleDisabled}
                         {...form.getInputProps('useProjectTimezoneInFilters', {
                             type: 'checkbox',

--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -151,8 +151,7 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
                             <>
                                 The time zone used for date filters, time
                                 grouping, and how dates appear in charts and
-                                tables. Optionally also drives absolute date
-                                filter inputs. This does not change your
+                                tables. This does not change your
                                 database&apos;s session time zone.
                             </>
                         ) : (

--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -76,8 +76,8 @@ const QueryTimezoneForm: FC<{
                 />
                 {showFilterInputsToggle && (
                     <Switch
-                        label="Use project time zone in date filter inputs"
-                        description="Use the project time zone for absolute date filters."
+                        label="Project time zone in filter inputs"
+                        description="Interpret absolute dates in the project's time zone instead of the user's browser."
                         disabled={filterToggleDisabled}
                         {...form.getInputProps('useProjectTimezoneInFilters', {
                             type: 'checkbox',

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1024,7 +1024,7 @@ const Settings: FC = () => {
                                         })}
                                     >
                                         <RouterNavLink
-                                            label="Query time zone"
+                                            label="Project time zone"
                                             exact
                                             to={`/generalSettings/projectManagement/${project.projectUuid}/queryTimezone`}
                                             leftSection={


### PR DESCRIPTION
### Description

Adds a "Use project time zone in date filter inputs" \`Switch\` to project time zone settings, gated behind \`EnableTimezoneSupport\`. Renames the page from "Query time zone" to "Project time zone".

The toggle is disabled while no timezone is set, and submission also coerces it to \`false\` when timezone is null so the persisted state can never represent "use project TZ" with no project TZ to use.

Part 2 of 3 in the GLITCH-327 stack — the toggle persists but has no observable effect on filter inputs until #22830 lands.

relates to: https://linear.app/lightdash/issue/GLITCH-327/absolute-date-filter-inputs-have-the-option-to-display-using-project