### PR TITLE
feat(timezone): filter pickers honor project timezone (GLITCH-327)

### DIFF
--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -319,6 +319,7 @@ const FiltersCard: FC = memo(() => {
                     }}
                     baseTable={data?.baseTable}
                     parameterValues={parameterValues}
+                    metricQueryTimezone={metricQuery.timezone ?? undefined}
                 >
                     <FiltersForm
                         isEditMode={isEditMode}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
@@ -1,3 +1,8 @@
+import {
+    FeatureFlags,
+    getTimezoneLabel,
+    isValidTimezone,
+} from '@lightdash/common';
 import { Group, Text } from '@mantine-8/core';
 import {
     DateTimePicker,
@@ -6,10 +11,21 @@ import {
 } from '@mantine/dates';
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
-import { type FC } from 'react';
+import utc from 'dayjs/plugin/utc';
+import { useCallback, useMemo, type FC } from 'react';
+import { useProject } from '../../../../hooks/useProject';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import useFiltersContext from '../useFiltersContext';
 import styles from './FilterDateTimePicker.module.css';
+import {
+    shiftToProjectTimezone,
+    unshiftFromProjectTimezone,
+} from './FilterDateTimePicker.utils';
 
+dayjs.extend(utc);
 dayjs.extend(timezone);
+
+const SUBTEXT_DATE_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss';
 
 interface Props extends Omit<
     DateTimePickerProps,
@@ -30,6 +46,54 @@ const FilterDateTimePicker: FC<Props> = ({
 }) => {
     const displayFormat = 'YYYY-MM-DD HH:mm:ss';
 
+    const { projectUuid, metricQueryTimezone } = useFiltersContext();
+    const { data: enableTimezoneSupportFlag } = useServerFeatureFlag(
+        FeatureFlags.EnableTimezoneSupport,
+    );
+    const { data: project } = useProject(projectUuid);
+
+    const candidateTimezone =
+        metricQueryTimezone ?? project?.queryTimezone ?? undefined;
+    const projectTimezone =
+        enableTimezoneSupportFlag?.enabled &&
+        project?.useProjectTimezoneInFilters === true &&
+        candidateTimezone &&
+        isValidTimezone(candidateTimezone)
+            ? candidateTimezone
+            : undefined;
+
+    const shiftedValue = useMemo(() => {
+        if (!projectTimezone || !value) return value;
+        return shiftToProjectTimezone(value, projectTimezone);
+    }, [value, projectTimezone]);
+
+    const handleChange = useCallback(
+        (date: Date | null) => {
+            if (!date) return;
+            if (!projectTimezone) {
+                onChange(date);
+                return;
+            }
+            onChange(unshiftFromProjectTimezone(date, projectTimezone));
+        },
+        [onChange, projectTimezone],
+    );
+
+    const browserTimezone = dayjs.tz.guess();
+    const subtext = useMemo(() => {
+        if (!value) return '';
+        if (projectTimezone) {
+            return `Local time (${browserTimezone}): ${dayjs(value)
+                .tz(browserTimezone)
+                .format(SUBTEXT_DATE_FORMAT)}`;
+        }
+        return `UTC time: ${dayjs(value).utc().format(SUBTEXT_DATE_FORMAT)}`;
+    }, [value, projectTimezone, browserTimezone]);
+
+    const sideLabel = projectTimezone
+        ? (getTimezoneLabel(projectTimezone) ?? projectTimezone)
+        : browserTimezone;
+
     return (
         <Group wrap="nowrap" gap="xs" align="start" w="100%">
             {/* // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
@@ -42,21 +106,18 @@ const FilterDateTimePicker: FC<Props> = ({
                 {...rest}
                 popoverProps={{ shadow: 'sm', ...rest.popoverProps }}
                 firstDayOfWeek={firstDayOfWeek}
-                value={value}
-                onChange={(date) => {
-                    if (!date) return;
-                    onChange(date);
-                }}
+                value={shiftedValue}
+                onChange={handleChange}
                 inputWrapperOrder={['input', 'description']}
                 description={
                     <Text ml="two" fz="xs" c="dimmed">
-                        UTC time: {value?.toUTCString().replace('GMT', '')}
+                        {subtext}
                     </Text>
                 }
             />
             {showTimezone && (
                 <Text fz="xs" c="dimmed" mt={7} className={styles.noWrap}>
-                    {dayjs.tz.guess()}
+                    {sideLabel}
                 </Text>
             )}
         </Group>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
@@ -79,7 +79,7 @@ const FilterDateTimePicker: FC<Props> = ({
         [onChange, projectTimezone],
     );
 
-    const browserTimezone = dayjs.tz.guess();
+    const browserTimezone = useMemo(() => dayjs.tz.guess(), []);
     const subtext = useMemo(() => {
         if (!value) return '';
         if (projectTimezone) {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
@@ -56,7 +56,7 @@ const FilterDateTimePicker: FC<Props> = ({
         metricQueryTimezone ?? project?.queryTimezone ?? undefined;
     const projectTimezone =
         enableTimezoneSupportFlag?.enabled &&
-        project?.useProjectTimezoneInFilters === true &&
+        project?.useProjectTimezoneInFilters &&
         candidateTimezone &&
         isValidTimezone(candidateTimezone)
             ? candidateTimezone

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.utils.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.utils.test.ts
@@ -1,0 +1,45 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+import { describe, expect, it } from 'vitest';
+import {
+    shiftToProjectTimezone,
+    unshiftFromProjectTimezone,
+} from './FilterDateTimePicker.utils';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const WALL_CLOCK = 'YYYY-MM-DDTHH:mm:ss';
+
+describe('FilterDateTimePicker timezone shift', () => {
+    it("shifts so the shifted Date's browser-local wall clock matches the project-TZ wall clock of the input", () => {
+        // 2024-06-15T10:30:00Z — outside DST transitions in both browser TZs and tested project TZs
+        const value = new Date(Date.UTC(2024, 5, 15, 10, 30, 0));
+        const projectTimezone = 'America/New_York';
+
+        const shifted = shiftToProjectTimezone(value, projectTimezone);
+
+        expect(dayjs(shifted).format(WALL_CLOCK)).toBe(
+            dayjs(value).tz(projectTimezone).format(WALL_CLOCK),
+        );
+    });
+
+    it.each([
+        ['America/New_York', new Date(Date.UTC(2024, 5, 15, 10, 30, 0))],
+        ['Europe/Helsinki', new Date(Date.UTC(2024, 5, 15, 22, 0, 0))],
+        ['Asia/Tokyo', new Date(Date.UTC(2024, 5, 15, 23, 30, 0))],
+        ['Pacific/Auckland', new Date(Date.UTC(2024, 5, 15, 0, 15, 0))],
+        ['UTC', new Date(Date.UTC(2024, 5, 15, 12, 0, 0))],
+    ])(
+        'round-trips unshift(shift(value)) === value for %s',
+        (projectTimezone, value) => {
+            const shifted = shiftToProjectTimezone(value, projectTimezone);
+            const restored = unshiftFromProjectTimezone(
+                shifted,
+                projectTimezone,
+            );
+            expect(restored.toISOString()).toBe(value.toISOString());
+        },
+    );
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.utils.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.utils.test.ts
@@ -1,30 +1,10 @@
-import dayjs from 'dayjs';
-import timezone from 'dayjs/plugin/timezone';
-import utc from 'dayjs/plugin/utc';
 import { describe, expect, it } from 'vitest';
 import {
     shiftToProjectTimezone,
     unshiftFromProjectTimezone,
 } from './FilterDateTimePicker.utils';
 
-dayjs.extend(utc);
-dayjs.extend(timezone);
-
-const WALL_CLOCK = 'YYYY-MM-DDTHH:mm:ss';
-
 describe('FilterDateTimePicker timezone shift', () => {
-    it("shifts so the shifted Date's browser-local wall clock matches the project-TZ wall clock of the input", () => {
-        // 2024-06-15T10:30:00Z — outside DST transitions in both browser TZs and tested project TZs
-        const value = new Date(Date.UTC(2024, 5, 15, 10, 30, 0));
-        const projectTimezone = 'America/New_York';
-
-        const shifted = shiftToProjectTimezone(value, projectTimezone);
-
-        expect(dayjs(shifted).format(WALL_CLOCK)).toBe(
-            dayjs(value).tz(projectTimezone).format(WALL_CLOCK),
-        );
-    });
-
     it.each([
         ['America/New_York', new Date(Date.UTC(2024, 5, 15, 10, 30, 0))],
         ['Europe/Helsinki', new Date(Date.UTC(2024, 5, 15, 22, 0, 0))],

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.utils.ts
@@ -1,0 +1,30 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const WALL_CLOCK_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
+// Mantine renders Date objects in the browser's local TZ. To display
+// project-TZ wall-clock, we shift the Date so its UTC instant matches the
+// wall-clock when interpreted by the browser. unshiftFromProjectTimezone
+// inverts the shift so the real UTC instant bubbles up to callers unchanged.
+export const shiftToProjectTimezone = (
+    value: Date,
+    projectTimezone: string,
+): Date => {
+    const wallClock = dayjs(value)
+        .tz(projectTimezone)
+        .format(WALL_CLOCK_FORMAT);
+    return dayjs(wallClock).toDate();
+};
+
+export const unshiftFromProjectTimezone = (
+    date: Date,
+    projectTimezone: string,
+): Date => {
+    const wallClock = dayjs(date).format(WALL_CLOCK_FORMAT);
+    return dayjs.tz(wallClock, projectTimezone).toDate();
+};

--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -23,6 +23,7 @@ type Props<T extends DefaultFieldsMap> = {
     popoverProps?: Omit<PopoverProps, 'children'>;
     parameterValues?: ParametersValuesMap;
     activeTabUuid?: string;
+    metricQueryTimezone?: string;
     children?: ReactNode;
 };
 
@@ -37,6 +38,7 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
     popoverProps,
     parameterValues,
     activeTabUuid,
+    metricQueryTimezone,
     children,
 }: Props<T>) => {
     const getField = useCallback(
@@ -77,6 +79,7 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
                 getAutocompleteFilterGroup: getAutocompleteFilterGroupCallback,
                 popoverProps,
                 parameterValues,
+                metricQueryTimezone,
             }}
         >
             {children}

--- a/packages/frontend/src/components/common/Filters/context.ts
+++ b/packages/frontend/src/components/common/Filters/context.ts
@@ -26,6 +26,7 @@ export type FiltersContext<T extends DefaultFieldsMap = DefaultFieldsMap> = {
     ) => AndFilterGroup | undefined;
     popoverProps?: Omit<PopoverProps, 'children'>;
     parameterValues?: ParametersValuesMap;
+    metricQueryTimezone?: string;
 };
 
 const Context = createContext<FiltersContext | undefined>(undefined);


### PR DESCRIPTION
### Description

When \`EnableTimezoneSupport\` is on and the project has opted in via the new toggle, \`FilterDateTimePicker\` shifts the rendered \`Date\` so Mantine displays the project-TZ wall clock, and inverts the shift on change so the underlying UTC instant bubbles up to callers unchanged. Subtext flips to a local-time translation; the side label shows the project TZ. Per-chart timezone overrides are honored via \`metricQuery.timezone\` when set.

Wall-clock shift/unshift helpers are extracted to a sibling module with a unit test covering the round-trip across 5 project timezones.

Part 3 of 3 in the GLITCH-327 stack.

closes: https://linear.app/lightdash/issue/GLITCH-327/absolute-date-filter-inputs-have-the-option-to-display-using-project