### PR TITLE
feat(managed-agent): add bulk-copy combined governance YAML snippet

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1661,6 +1661,99 @@ const SettingsSidebar: FC<{
     );
 };
 
+// --- Governance combined-snippet copy ---
+
+const buildCombinedGovernanceSnippet = (
+    snippets: Array<{ targetModel: string | null; yamlSnippet: string }>,
+): string => {
+    const grouped = new Map<string, string[]>();
+    for (const s of snippets) {
+        const key = s.targetModel ?? '__unspecified__';
+        const list = grouped.get(key);
+        if (list) {
+            list.push(s.yamlSnippet);
+        } else {
+            grouped.set(key, [s.yamlSnippet]);
+        }
+    }
+    const sections: string[] = [];
+    for (const [model, blocks] of grouped) {
+        const heading =
+            model === '__unspecified__'
+                ? '# (model not inferred — review before pasting)'
+                : `# ${model}.yml — additions`;
+        sections.push(`${heading}\n${blocks.join('\n')}`);
+    }
+    return sections.join('\n\n');
+};
+
+const GovernanceCopyAllRow: FC<{
+    actions: readonly ManagedAgentAction[];
+}> = ({ actions }) => {
+    const snippets = useMemo(() => {
+        const out: Array<{
+            targetModel: string | null;
+            yamlSnippet: string;
+        }> = [];
+        for (const action of actions) {
+            if (
+                action.actionType !== ManagedAgentActionType.INSIGHT ||
+                action.targetType !== 'project' ||
+                action.reversedAt
+            ) {
+                continue;
+            }
+            const parsed = getGovernanceInsightMetadata(action.metadata);
+            if (
+                !parsed ||
+                parsed.insightKind === GovernanceInsightKind.GOVERNANCE_ROLLUP
+            ) {
+                continue;
+            }
+            const suggestion = parsed.suggestion;
+            if (suggestion?.yamlSnippet) {
+                out.push({
+                    targetModel: suggestion.targetModel,
+                    yamlSnippet: suggestion.yamlSnippet,
+                });
+            }
+        }
+        return out;
+    }, [actions]);
+
+    if (snippets.length < 2) return null;
+
+    const combined = buildCombinedGovernanceSnippet(snippets);
+
+    return (
+        <Table.Tr>
+            <Table.Td colSpan={3}>
+                <Group justify="flex-end" px="md" py={6}>
+                    <CopyButton value={combined}>
+                        {({ copied, copy }) => (
+                            <Button
+                                size="compact-xs"
+                                variant="default"
+                                leftSection={
+                                    <MantineIcon
+                                        icon={copied ? IconCheck : IconCopy}
+                                        size={12}
+                                    />
+                                }
+                                onClick={copy}
+                            >
+                                {copied
+                                    ? 'Copied'
+                                    : `Copy all governance YAML (${snippets.length})`}
+                            </Button>
+                        )}
+                    </CopyButton>
+                </Group>
+            </Table.Td>
+        </Table.Tr>
+    );
+};
+
 // --- Table Row ---
 
 const ActionRow: FC<{
@@ -1943,16 +2036,22 @@ const RunRow: FC<{
                                   </Table.Td>
                               </Table.Tr>
                           )
-                        : actions.map((action) => (
-                              <ActionRow
-                                  key={action.actionUuid}
-                                  action={action}
-                                  selected={
-                                      selectedActionUuid === action.actionUuid
-                                  }
-                                  onSelect={onSelectAction}
-                              />
-                          ))}
+                        : actions && (
+                              <>
+                                  <GovernanceCopyAllRow actions={actions} />
+                                  {actions.map((action) => (
+                                      <ActionRow
+                                          key={action.actionUuid}
+                                          action={action}
+                                          selected={
+                                              selectedActionUuid ===
+                                              action.actionUuid
+                                          }
+                                          onSelect={onSelectAction}
+                                      />
+                                  ))}
+                              </>
+                          )}
                 </>
             )}
         </Table.Tbody>


### PR DESCRIPTION
## Summary

Slice 5 of the [governance insights stack](docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md) (PROD-7392). Stacks on #22837.

Adds a "Copy all governance YAML" CTA on each run's action list. When a run produced ≥2 governance insights with non-null `yamlSnippet`, a single button concatenates them into one YAML block (grouped by `targetModel`) and copies to clipboard.

## What changes

Frontend-only.

- New `buildCombinedGovernanceSnippet` helper groups snippets by `targetModel` and emits one section per model with a `# <model>.yml — additions` heading. Snippets without a model land under a `# (model not inferred — review before pasting)` heading.
- New `GovernanceCopyAllRow` table row:
  - Filters the run's actions to non-reversed `INSIGHT` actions with `targetType: 'project'` and a non-null `metadata.suggestion.yamlSnippet`.
  - Skips rollup-kind insights (no snippet).
  - Renders nothing when fewer than 2 snippets are present (single insight already has its own per-action Copy button).
  - Otherwise renders an aligned-right `Copy all governance YAML (N)` button using the existing `CopyButton` pattern.

The button lives at the top of the action list inside the run's expanded section — out of the way for runs without governance findings, immediately visible when a run produced multiple actionable proposals.

## Why design-wise

Spec §10 calls for "multi-select + combined-snippet copy". The simplest UX that delivers the value is a per-run "copy everything actionable from this run" button, no checkboxes, no selection state. If a user wants finer-grained selection (e.g. "copy only these 3 of 7"), the per-action Copy button on each insight still works.

Phase-2 PR-creation ([spec §11](docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md)) can promote this same button to "Open PR" once the GitHub-app-to-dbt-repo path is wired.

## Behaviour with feature flag OFF

Unchanged — there are no governance insights to copy, so the row never renders.

## Test plan

- [ ] Frontend typecheck + lint pass (verified locally).
- [ ] On a run with 1 governance insight, verify NO "Copy all" button appears.
- [ ] On a run with 3+ governance insights with non-null `yamlSnippet`, verify the "Copy all governance YAML (3)" button appears at the top of the action list.
- [ ] Click the button, paste the clipboard contents — verify the YAML is well-formed, grouped by `# <model>.yml — additions` sections, and contains all 3 snippets.
- [ ] On a run with insights from two different `targetModel`s (e.g. `orders` and `customers`), verify the combined snippet has two sections.
- [ ] Reverse one insight (mark dismissed) and verify it's excluded from the combined snippet.
- [ ] Verify governance_rollup insights are NOT included in the combined snippet (they have no yamlSnippet).

## Stack

- Slice 1 (#22832): heavy_custom_usage on additional metrics, e2e
- Slice 2 (#22833): inconsistent_definitions kind + variant UI
- Slice 3 (#22836): SQL-type custom dimensions
- Slice 4 (#22837): top-K cap + governance rollup
- **Slice 5 (#22839): bulk-copy combined governance YAML** ← you are here
- Slice 6: Slack rollup line + telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)