### PR TITLE
feat(managed-agent): set chart-cleanup expectation via existing replace-on-compile

### DIFF
--- a/docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md
+++ b/docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md
@@ -26,23 +26,46 @@ Customers like Wise are hitting governance debt at scale and asking us to surfac
 - High-views-but-unverified detection (PROD-7392 capability #1).
 - Optimisation suggestions: pre-aggregates, joins, indexes, default filters (PROD-7392 capability #5).
 - Customer-defined guidelines as free-form policy (PROD-7392 capability #2).
-- Auto-applying chart fixes after canonical metric appears in dbt (Step 3). Day-1 ships proposal-with-confirm; auto-apply is a phase-2 follow-up gated on telemetry.
+- **Auto-applying chart fixes after the canonical metric appears in dbt.** This is already implemented by the existing `replace-custom-metrics-on-compile` system — see "What already works" below. Earlier drafts of this spec proposed building a Step 3 here; that's redundant and has been removed.
 - Chat-on-demand invocation. Tool is called by the scheduled autopilot run only.
 - Per-project threshold configuration. N=3 is fixed for v1.
-- Feature flag. Autopilot itself is opt-in; re-gating inside is redundant.
 
 ## What already works (don't rebuild)
+
+### Existing primitives we plug into
 
 - `ManagedAgentActionType.INSIGHT` exists (`packages/common/src/ee/types/managedAgent.ts:10`).
 - `ManagedAgentTargetType.PROJECT` is already a valid target (`managedAgent.ts:17`).
 - `handleLogInsight` accepts arbitrary `target_type` + opaque `metadata` and creates the action via `managedAgentModel.createAction` (`ManagedAgentService.ts:2492`). No new persistence path needed.
 - Custom definitions live in dedicated tables — no JSONB scan required:
   - `saved_queries_version_additional_metrics`
-  - `saved_queries_version_custom_dimensions`
+  - `saved_queries_version_custom_sql_dimensions`
   - `saved_queries_version_table_calculations` (out of scope here)
 - `DbtSchemaEditor` already knows how to write `additional_metrics` and SQL-type `custom_dimensions` into dbt YAML (`DbtSchemaEditor.ts:270`).
 - `trackActionCreated` exists and fires on every `createAction` call.
 - The reversal flow (`reversed_at` / `reversed_by_user_uuid`) doubles as dismissal for `INSIGHT` actions per `getManagedAgentActionCategory`.
+
+### The post-promotion cleanup loop already exists
+
+`FeatureFlags.ReplaceCustomMetricsOnCompile` gates a scheduler task that fires after every dbt project compile (`SchedulerTask.ts:1748`):
+
+1. `findReplaceableCustomFields` (`ProjectService.ts:7875`) scans every chart in the project and looks for custom metrics whose name + SQL + filter conditions exactly match a real metric in the explore. Match logic in `findReplaceableCustomMetrics` (`fields.ts:250`) → `compareMetricAndCustomMetric`.
+2. `replaceCustomFields` (`ProjectService.ts:7915`) calls `maybeReplaceFieldsInChartVersion` to remove the now-redundant custom metric from each chart's `metricQuery.additionalMetrics`. Has a `skipChartsUpdatedAfter` freshness check.
+3. Tracks `custom_fields.replaced` analytics.
+
+**This is the post-promotion cleanup phase.** Once a customer takes the YAML our governance INSIGHT proposes and adds it to their dbt project, the next compile fires this task and the affected charts auto-clean themselves. We do not need to re-implement this — the governance INSIGHT system completes the loop:
+
+```
+governance INSIGHT (this spec)        — surfaces "this should be in dbt"
+       ↓
+user copies YAML into dbt repo        — manual or PR (phase-2)
+       ↓
+dbt compile                            — existing infra
+       ↓
+replace-custom-metrics-on-compile     — existing scheduler task auto-cleans charts
+```
+
+**Implication for the UI:** The action sidebar's governance INSIGHT should set this expectation explicitly, so users understand they don't need to manually edit each affected chart. See "Frontend → Sidebar — INSIGHT" below for the "What happens next" caption.
 
 ## Data model
 
@@ -256,14 +279,11 @@ Handler:
 
 The existing flag-suggestion spec's apply endpoint stays separate — different action type, different suggestion shape, different validation.
 
-### Phase-2 Step 3 (chart-fix proposals after dbt sync)
+### Post-promotion chart cleanup — already exists
 
-Out of day-1 scope. Sketch:
+Removed from this spec. The post-promotion step ("once the canonical metric is in dbt, clean up the affected charts") is implemented today by `replace-custom-metrics-on-compile` (see "What already works" above). Customers with that flag enabled get the cleanup automatically on the next dbt compile after they merge the YAML.
 
-1. On each autopilot run, look up active (non-reversed) INSIGHT actions with `metadata.suggestion.kind === 'promote_to_dbt'` and non-null `canonicalSql` + `targetModel`.
-2. For each, check the catalog: does `targetModel` now expose a metric/dimension whose SQL normalises to `canonicalSql` and whose name slug matches `proposedMetricName`?
-3. If yes: for each `variants[*].charts[*]`, log a `INSIGHT` with `targetType: CHART` and `metadata.suggestion = { kind: 'replace_field', metricQuery, chartConfig, confidence: 'high' }` proposing the swap. Apply path reuses the chart-version write helper (extract from `applyFlagSuggestion` at this point — see Decisions §3).
-4. The original PROJECT-targeted INSIGHT is **not** mutated; the new chart-targeted INSIGHTs are children of the same `runUuid`. The audit trail links them via `metadata.parentInsightActionUuid`.
+Customers without that flag get a one-time manual cleanup pass: open each affected chart, switch the custom metric for the new dbt metric, save. The governance INSIGHT's variant list links directly to the affected charts to make this fast. The "What happens next" caption (see Frontend) sets the right expectation depending on flag state.
 
 ## Frontend
 
@@ -288,10 +308,13 @@ Render branch keyed on `action.actionType === INSIGHT && action.targetType === P
 4. **No-canonical state** (when `suggestion.canonicalSql === null`):
    - Banner: `Multiple variants are equally common — pick a canonical to generate a YAML proposal`.
    - Day-1: read-only — caption only, no picker. Phase-2 wires up the picker.
-5. **Multi-select checkbox** at the top of each insight card (day-1 — combined-snippet path):
+5. **What happens next caption** — below the suggestion, a small `c="dimmed"` paragraph that sets the right expectation for chart cleanup:
+   - "Once you add this metric to your dbt project, the next compile will automatically replace the affected charts' custom metrics with the new dbt metric (via `replace-custom-metrics-on-compile`)."
+   - This is the only place in the UI that references the existing scheduler task by name. Day-1 is unconditional copy; phase-2 could read the project's flag state and adjust copy ("…if `replace-custom-metrics-on-compile` is enabled for this project") but that's overkill for v1.
+6. **Multi-select checkbox** at the top of each insight card (day-1 — combined-snippet path):
    - Sidebar gains a "Copy combined snippet" CTA at the top when ≥1 insight is selected.
    - Concatenates selected `yamlSnippet`s, grouping by `targetModel` with one heading per model.
-6. **Reversal** stays in the dots menu. Add an alias label "Mark as applied" alongside "Dismiss" — same backend action, different copy.
+7. **Reversal** stays in the dots menu. Add an alias label "Mark as applied" alongside "Dismiss" — same backend action, different copy.
 
 ### Sidebar — `governance_rollup`
 

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -616,6 +616,14 @@ const GovernanceDetails: FC<{
                     </Stack>
                 )
             )}
+
+            {suggestion?.yamlSnippet && (
+                <Text fz="xs" c="dimmed" lh={1.6} fs="italic">
+                    Once this metric is added to dbt, the next project compile
+                    will automatically replace the affected charts&apos; custom
+                    metrics with the new dbt metric.
+                </Text>
+            )}
         </Stack>
     );
 };


### PR DESCRIPTION
## Summary

Slice 7 of the [governance insights stack](docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md) (PROD-7392). Stacks on #22840.

Course-correction PR. Spelled out the relationship between the new governance insights and the existing `replace-custom-metrics-on-compile` system, and dropped the planned phase-2 Step 3 from the spec since it would have re-implemented that existing behaviour.

## Background

A colleague pointed out that `FeatureFlags.ReplaceCustomMetricsOnCompile` already exists and wires a scheduler task that, after every dbt project compile, walks all charts and removes custom metrics whose name + SQL exactly match a real metric in the explore (`SchedulerTask.ts:1748` → `ProjectService.replaceCustomFields:7915` → `findReplaceableCustomMetrics` in `common/src/utils/fields.ts`). I missed this when writing the original spec and earlier proposed building a "phase-2 Step 3" that would have done essentially the same thing.

## What changes

### Spec doc

- Removed the "Phase-2 Step 3" section. Replaced with a "Post-promotion chart cleanup — already exists" note pointing at the existing scheduler task.
- Added a "What already works → The post-promotion cleanup loop already exists" subsection that walks through `replace-custom-metrics-on-compile` end-to-end and shows how governance INSIGHTs compose with it:

  ```
  governance INSIGHT (this spec)        — surfaces "this should be in dbt"
         ↓
  user copies YAML into dbt repo        — manual or PR (phase-2)
         ↓
  dbt compile                            — existing infra
         ↓
  replace-custom-metrics-on-compile     — existing scheduler task auto-cleans charts
  ```

- Updated "Out of scope" to call out that auto-applying chart fixes is **not in scope and not needed** because the existing system handles it.
- Removed the "Feature flag" line from "Out of scope" since slice 1 ships with one (delivery-only).
- Fixed `saved_queries_version_custom_dimensions` → `saved_queries_version_custom_sql_dimensions` (the actual table name).

### Frontend

Adds a small italic `c="dimmed"` caption beneath the YAML proposal in `GovernanceDetails`:

> *Once this metric is added to dbt, the next project compile will automatically replace the affected charts' custom metrics with the new dbt metric.*

The caption only renders when `suggestion.yamlSnippet` is non-null (i.e. there's a real promotion proposal to act on). Sets the right user expectation so they don't go hunting for a per-chart fix UI that doesn't exist (and doesn't need to).

## What this is NOT

- Not a new code path. Doesn't add or modify the existing `replace-custom-metrics-on-compile` scheduler.
- Not a UI gating change. Caption is unconditional — doesn't read the project's flag state. Customers without `replace-custom-metrics-on-compile` enabled will see the same caption; for them the cleanup is manual via the chart links in the variant list. Phase-2 could conditionally adjust the copy, but that's overkill for v1.

## Behaviour with feature flag OFF

Unchanged — there are no governance INSIGHTs to render, so the new caption never appears.

## Test plan

- [ ] Frontend typecheck + lint pass (verified locally).
- [ ] On a governance INSIGHT with a non-null `yamlSnippet`, verify the new italic caption appears below the YAML + Copy button.
- [ ] On a governance INSIGHT with `yamlSnippet === null` (canonical-tied case), verify the caption does NOT appear (no promotion proposal yet).
- [ ] On the `governance_rollup` insight, verify the caption does NOT appear (no individual snippet).
- [ ] On `heavy_custom_usage` insights, verify the caption appears.

## Stack — final

- Slice 1 (#22832): heavy_custom_usage on additional metrics, e2e
- Slice 2 (#22833): inconsistent_definitions kind + variant UI
- Slice 3 (#22836): SQL-type custom dimensions
- Slice 4 (#22837): top-K cap + governance rollup
- Slice 5 (#22839): bulk-copy combined governance YAML
- Slice 6 (#22840): Slack summary + telemetry
- **Slice 7 (#22845): post-promotion expectation caption + spec course-correction** ← you are here

🤖 Generated with [Claude Code](https://claude.com/claude-code)