### PR TITLE
fix(oauth): persist rotated Snowflake & Databricks refresh tokens (#22831)

### DIFF
--- a/packages/backend/src/models/OrganizationWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/OrganizationWarehouseCredentialsModel.ts
@@ -284,4 +284,55 @@ export class OrganizationWarehouseCredentialsModel {
             );
         }
     }
+
+    /** Compare-and-swap on the credential's stored refreshToken. Returns true on swap. */
+    async rotateRefreshToken(
+        organizationWarehouseCredentialsUuid: string,
+        expectedOldRefreshToken: string,
+        newRefreshToken: string,
+    ): Promise<boolean> {
+        return this.database.transaction(async (trx) => {
+            const row = await trx(OrganizationWarehouseCredentialsTableName)
+                .select('warehouse_connection')
+                .where(
+                    'organization_warehouse_credentials_uuid',
+                    organizationWarehouseCredentialsUuid,
+                )
+                .forUpdate()
+                .first();
+            if (!row) {
+                return false;
+            }
+
+            let credentials: CreateWarehouseCredentials;
+            try {
+                credentials = JSON.parse(
+                    this.encryptionUtil.decrypt(row.warehouse_connection),
+                ) as CreateWarehouseCredentials;
+            } catch {
+                return false;
+            }
+
+            const stored = (credentials as Partial<{ refreshToken: string }>)
+                .refreshToken;
+            if (stored !== expectedOldRefreshToken) {
+                return false;
+            }
+
+            (credentials as { refreshToken: string }).refreshToken =
+                newRefreshToken;
+            const encryptedCredentials = this.encryptionUtil.encrypt(
+                OrganizationWarehouseCredentialsModel.stringifyCredentials(
+                    credentials,
+                ),
+            );
+            await trx(OrganizationWarehouseCredentialsTableName)
+                .update({ warehouse_connection: encryptedCredentials })
+                .where(
+                    'organization_warehouse_credentials_uuid',
+                    organizationWarehouseCredentialsUuid,
+                );
+            return true;
+        });
+    }
 }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1907,6 +1907,65 @@ export class ProjectModel {
         }
     }
 
+    /** Compare-and-swap on the credential's stored refreshToken. Invalidates the warehouse credentials cache on swap. */
+    async rotateRefreshToken(
+        projectUuid: string,
+        expectedOldRefreshToken: string,
+        newRefreshToken: string,
+    ): Promise<boolean> {
+        const swapped = await this.database.transaction(async (trx) => {
+            const row = await trx('warehouse_credentials')
+                .innerJoin(
+                    'projects',
+                    'warehouse_credentials.project_id',
+                    'projects.project_id',
+                )
+                .where('projects.project_uuid', projectUuid)
+                .select<
+                    { project_id: number; encrypted_credentials: Buffer }[]
+                >([
+                    'warehouse_credentials.project_id',
+                    'warehouse_credentials.encrypted_credentials',
+                ])
+                .forUpdate()
+                .first();
+            if (!row) {
+                return false;
+            }
+
+            let credentials: CreateWarehouseCredentials;
+            try {
+                credentials = JSON.parse(
+                    this.encryptionUtil.decrypt(row.encrypted_credentials),
+                ) as CreateWarehouseCredentials;
+            } catch {
+                return false;
+            }
+
+            const stored = (credentials as Partial<{ refreshToken: string }>)
+                .refreshToken;
+            if (stored !== expectedOldRefreshToken) {
+                return false;
+            }
+
+            (credentials as { refreshToken: string }).refreshToken =
+                newRefreshToken;
+            const encryptedCredentials = this.encryptionUtil.encrypt(
+                JSON.stringify(credentials),
+            );
+            await trx('warehouse_credentials')
+                .update({ encrypted_credentials: encryptedCredentials })
+                .where('project_id', row.project_id);
+            return true;
+        });
+
+        if (swapped) {
+            warehouseCredentialsCache?.del(projectUuid);
+        }
+
+        return swapped;
+    }
+
     async duplicateContent(
         projectUuid: string,
         previewProjectUuid: string,

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    CreateWarehouseCredentials,
     DatabricksAuthenticationType,
     databricksOauthU2mUserCredentialsSchema,
     DatabricksTokenError,
@@ -487,5 +488,59 @@ export class UserWarehouseCredentialsModel {
             .delete()
             .where('user_uuid', userUuid)
             .andWhere('warehouse_type', warehouseType);
+    }
+
+    /** Compare-and-swap on the credential's stored refreshToken. Returns true on swap. */
+    async rotateRefreshToken(
+        userWarehouseCredentialsUuid: string,
+        expectedOldRefreshToken: string,
+        newRefreshToken: string,
+    ): Promise<boolean> {
+        return this.database.transaction(async (trx) => {
+            const row = await trx(UserWarehouseCredentialsTableName)
+                .select('name', 'warehouse_type', 'encrypted_credentials')
+                .where(
+                    'user_warehouse_credentials_uuid',
+                    userWarehouseCredentialsUuid,
+                )
+                .forUpdate()
+                .first();
+            if (!row) {
+                return false;
+            }
+
+            let credentials: CreateWarehouseCredentials;
+            try {
+                credentials = JSON.parse(
+                    this.encryptionUtil.decrypt(row.encrypted_credentials),
+                ) as CreateWarehouseCredentials;
+            } catch {
+                return false;
+            }
+
+            const stored = (credentials as Partial<{ refreshToken: string }>)
+                .refreshToken;
+            if (stored !== expectedOldRefreshToken) {
+                return false;
+            }
+
+            (credentials as { refreshToken: string }).refreshToken =
+                newRefreshToken;
+            const encryptedCredentials = this.encryptionUtil.encrypt(
+                JSON.stringify(credentials),
+            );
+            await trx(UserWarehouseCredentialsTableName)
+                .update({
+                    name: row.name,
+                    warehouse_type: row.warehouse_type,
+                    encrypted_credentials: encryptedCredentials,
+                    updated_at: new Date(),
+                })
+                .where(
+                    'user_warehouse_credentials_uuid',
+                    userWarehouseCredentialsUuid,
+                );
+            return true;
+        });
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -436,7 +436,10 @@ describe('ProjectService', () => {
             jest.spyOn(
                 UserService,
                 'generateSnowflakeAccessToken',
-            ).mockResolvedValue('mocked-access-token');
+            ).mockResolvedValue({
+                accessToken: 'mocked-access-token',
+                refreshToken: 'mocked-refresh-token',
+            });
 
             // Project credentials with Snowflake SSO that has a refreshToken
             // The project's refreshToken should be cleared and NOT used
@@ -512,7 +515,10 @@ describe('ProjectService', () => {
             jest.spyOn(
                 UserService,
                 'generateSnowflakeAccessToken',
-            ).mockResolvedValue('mocked-access-token');
+            ).mockResolvedValue({
+                accessToken: 'mocked-access-token',
+                refreshToken: 'mocked-refresh-token',
+            });
 
             // Project credentials with Snowflake SSO
             const projectSnowflakeCredentials = {
@@ -580,7 +586,10 @@ describe('ProjectService', () => {
             jest.spyOn(
                 UserService,
                 'generateSnowflakeAccessToken',
-            ).mockResolvedValue('mocked-access-token');
+            ).mockResolvedValue({
+                accessToken: 'mocked-access-token',
+                refreshToken: 'mocked-refresh-token',
+            });
 
             // Mock project credentials with Snowflake SSO - requireUserCredentials is false
             // so the project's credentials should be used directly
@@ -634,6 +643,324 @@ describe('ProjectService', () => {
 
             // User credentials should NOT have been fetched
             expect(findForProjectWithSecretsMock).not.toHaveBeenCalled();
+        });
+
+        test('should persist rotated Snowflake refresh token to user_warehouse_credentials when Snowflake rotates it', async () => {
+            // clear in memory cache so new mock is applied
+            service.warehouseClients = {};
+
+            jest.spyOn(
+                UserService,
+                'generateSnowflakeAccessToken',
+            ).mockResolvedValue({
+                accessToken: 'mocked-access-token',
+                refreshToken: 'rotated-refresh-token',
+            });
+
+            const projectSnowflakeCredentials = {
+                type: WarehouseTypes.SNOWFLAKE,
+                account: 'test-account',
+                warehouse: 'test-warehouse',
+                database: 'test-db',
+                schema: 'test-schema',
+                authenticationType: 'sso',
+                refreshToken: 'project-refresh-token',
+                requireUserCredentials: true,
+            };
+            (
+                projectModel.getWarehouseCredentialsForProject as jest.Mock
+            ).mockImplementation(async () => projectSnowflakeCredentials);
+
+            const userCredentials = {
+                uuid: 'user-creds-uuid',
+                credentials: {
+                    type: WarehouseTypes.SNOWFLAKE,
+                    authenticationType: 'sso',
+                    refreshToken: 'user-refresh-token',
+                },
+            };
+
+            const findForProjectWithSecretsMock = jest.fn(
+                async () => userCredentials,
+            );
+            const rotateRefreshTokenMock = jest.fn(async () => true);
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: jest.Mock;
+                        rotateRefreshToken: jest.Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.findForProjectWithSecrets =
+                findForProjectWithSecretsMock;
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: jest.Mock;
+                        rotateRefreshToken: jest.Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.rotateRefreshToken =
+                rotateRefreshTokenMock;
+
+            (
+                projectModel.getWarehouseClientFromCredentials as jest.Mock
+            ).mockImplementation((creds: Record<string, unknown>) => ({
+                ...warehouseClientMock,
+                credentials: creds,
+                runQuery: jest.fn(async () => resultsWith1Row),
+            }));
+
+            await service.runExploreQuery(
+                sessionAccount,
+                metricQueryMock,
+                projectUuid,
+                'valid_explore',
+                null,
+            );
+
+            expect(rotateRefreshTokenMock).toHaveBeenCalledTimes(1);
+            expect(rotateRefreshTokenMock).toHaveBeenCalledWith(
+                'user-creds-uuid',
+                'user-refresh-token',
+                'rotated-refresh-token',
+            );
+        });
+
+        test('should not call rotateRefreshToken when Snowflake returns the same refresh token', async () => {
+            // clear in memory cache so new mock is applied
+            service.warehouseClients = {};
+
+            jest.spyOn(
+                UserService,
+                'generateSnowflakeAccessToken',
+            ).mockResolvedValue({
+                accessToken: 'mocked-access-token',
+                refreshToken: 'user-refresh-token',
+            });
+
+            const projectSnowflakeCredentials = {
+                type: WarehouseTypes.SNOWFLAKE,
+                account: 'test-account',
+                warehouse: 'test-warehouse',
+                database: 'test-db',
+                schema: 'test-schema',
+                authenticationType: 'sso',
+                refreshToken: 'project-refresh-token',
+                requireUserCredentials: true,
+            };
+            (
+                projectModel.getWarehouseCredentialsForProject as jest.Mock
+            ).mockImplementation(async () => projectSnowflakeCredentials);
+
+            const userCredentials = {
+                uuid: 'user-creds-uuid',
+                credentials: {
+                    type: WarehouseTypes.SNOWFLAKE,
+                    authenticationType: 'sso',
+                    refreshToken: 'user-refresh-token',
+                },
+            };
+
+            const findForProjectWithSecretsMock = jest.fn(
+                async () => userCredentials,
+            );
+            const rotateRefreshTokenMock = jest.fn(async () => true);
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: jest.Mock;
+                        rotateRefreshToken: jest.Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.findForProjectWithSecrets =
+                findForProjectWithSecretsMock;
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: jest.Mock;
+                        rotateRefreshToken: jest.Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.rotateRefreshToken =
+                rotateRefreshTokenMock;
+
+            (
+                projectModel.getWarehouseClientFromCredentials as jest.Mock
+            ).mockImplementation((creds: Record<string, unknown>) => ({
+                ...warehouseClientMock,
+                credentials: creds,
+                runQuery: jest.fn(async () => resultsWith1Row),
+            }));
+
+            await service.runExploreQuery(
+                sessionAccount,
+                metricQueryMock,
+                projectUuid,
+                'valid_explore',
+                null,
+            );
+
+            expect(rotateRefreshTokenMock).not.toHaveBeenCalled();
+        });
+
+        test('should persist rotated Databricks OAuth U2M refresh token to user_warehouse_credentials when Databricks rotates it', async () => {
+            // clear in memory cache so new mock is applied
+            service.warehouseClients = {};
+
+            const { refreshDatabricksOAuthToken } = jest.requireMock(
+                '@lightdash/warehouses',
+            );
+            (refreshDatabricksOAuthToken as jest.Mock).mockResolvedValue({
+                accessToken: 'fresh-u2m-access-token',
+                refreshToken: 'rotated-u2m-refresh-token',
+            });
+
+            const projectDatabricksCredentials = {
+                type: WarehouseTypes.DATABRICKS,
+                authenticationType: 'oauth_u2m',
+                serverHostName: 'test.databricks.com',
+                httpPath: '/sql/test',
+                database: 'test_db',
+                requireUserCredentials: true,
+            };
+            (
+                projectModel.getWarehouseCredentialsForProject as jest.Mock
+            ).mockImplementation(async () => projectDatabricksCredentials);
+
+            const userCredentials = {
+                uuid: 'user-creds-uuid',
+                credentials: {
+                    type: WarehouseTypes.DATABRICKS,
+                    authenticationType: 'oauth_u2m',
+                    serverHostName: 'test.databricks.com',
+                    refreshToken: 'user-u2m-refresh-token',
+                    oauthClientId: 'user-client-id',
+                },
+            };
+
+            const findForProjectWithSecretsMock = jest.fn(
+                async () => userCredentials,
+            );
+            const rotateRefreshTokenMock = jest.fn(async () => true);
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: jest.Mock;
+                        rotateRefreshToken: jest.Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.findForProjectWithSecrets =
+                findForProjectWithSecretsMock;
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: jest.Mock;
+                        rotateRefreshToken: jest.Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.rotateRefreshToken =
+                rotateRefreshTokenMock;
+
+            (
+                projectModel.getWarehouseClientFromCredentials as jest.Mock
+            ).mockImplementation((creds: Record<string, unknown>) => ({
+                ...warehouseClientMock,
+                credentials: creds,
+                runQuery: jest.fn(async () => resultsWith1Row),
+            }));
+
+            await service.runExploreQuery(
+                sessionAccount,
+                metricQueryMock,
+                projectUuid,
+                'valid_explore',
+                null,
+            );
+
+            expect(rotateRefreshTokenMock).toHaveBeenCalledTimes(1);
+            expect(rotateRefreshTokenMock).toHaveBeenCalledWith(
+                'user-creds-uuid',
+                'user-u2m-refresh-token',
+                'rotated-u2m-refresh-token',
+            );
+        });
+
+        test('should not call rotateRefreshToken when Databricks returns the same refresh token', async () => {
+            // clear in memory cache so new mock is applied
+            service.warehouseClients = {};
+
+            const { refreshDatabricksOAuthToken } = jest.requireMock(
+                '@lightdash/warehouses',
+            );
+            (refreshDatabricksOAuthToken as jest.Mock).mockResolvedValue({
+                accessToken: 'fresh-u2m-access-token',
+                refreshToken: 'user-u2m-refresh-token',
+            });
+
+            const projectDatabricksCredentials = {
+                type: WarehouseTypes.DATABRICKS,
+                authenticationType: 'oauth_u2m',
+                serverHostName: 'test.databricks.com',
+                httpPath: '/sql/test',
+                database: 'test_db',
+                requireUserCredentials: true,
+            };
+            (
+                projectModel.getWarehouseCredentialsForProject as jest.Mock
+            ).mockImplementation(async () => projectDatabricksCredentials);
+
+            const userCredentials = {
+                uuid: 'user-creds-uuid',
+                credentials: {
+                    type: WarehouseTypes.DATABRICKS,
+                    authenticationType: 'oauth_u2m',
+                    serverHostName: 'test.databricks.com',
+                    refreshToken: 'user-u2m-refresh-token',
+                    oauthClientId: 'user-client-id',
+                },
+            };
+
+            const findForProjectWithSecretsMock = jest.fn(
+                async () => userCredentials,
+            );
+            const rotateRefreshTokenMock = jest.fn(async () => true);
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: jest.Mock;
+                        rotateRefreshToken: jest.Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.findForProjectWithSecrets =
+                findForProjectWithSecretsMock;
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: jest.Mock;
+                        rotateRefreshToken: jest.Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.rotateRefreshToken =
+                rotateRefreshTokenMock;
+
+            (
+                projectModel.getWarehouseClientFromCredentials as jest.Mock
+            ).mockImplementation((creds: Record<string, unknown>) => ({
+                ...warehouseClientMock,
+                credentials: creds,
+                runQuery: jest.fn(async () => resultsWith1Row),
+            }));
+
+            await service.runExploreQuery(
+                sessionAccount,
+                metricQueryMock,
+                projectUuid,
+                'valid_explore',
+                null,
+            );
+
+            expect(rotateRefreshTokenMock).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -996,6 +996,21 @@ export class ProjectService extends BaseService {
             : undefined;
     }
 
+    private static getRotationSourceUuid(
+        source: RefreshTokenRotationSource,
+    ): string {
+        switch (source.kind) {
+            case 'project':
+                return source.projectUuid;
+            case 'organization':
+                return source.organizationWarehouseCredentialsUuid;
+            case 'user':
+                return source.userWarehouseCredentialsUuid;
+            default:
+                return assertUnreachable(source, 'Unknown source kind');
+        }
+    }
+
     private async persistRefreshTokenRotation({
         source,
         oldRefreshToken,
@@ -1036,11 +1051,11 @@ export class ProjectService extends BaseService {
             }
         } catch (error) {
             // Don't fail the in-flight query: the freshly minted access token is still usable.
-            this.logger.error(
-                `Failed to persist rotated OAuth refresh token for ${
-                    source.kind
-                }: ${getErrorMessage(error)}`,
-            );
+            this.logger.error('Failed to persist rotated OAuth refresh token', {
+                sourceKind: source.kind,
+                sourceUuid: ProjectService.getRotationSourceUuid(source),
+                error: getErrorMessage(error),
+            });
         }
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -270,6 +270,14 @@ import { UserService } from '../UserService';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
 import { getAvailableParameterDefinitions } from './parameters';
 
+type RefreshTokenRotationSource =
+    | { kind: 'project'; projectUuid: string }
+    | {
+          kind: 'organization';
+          organizationWarehouseCredentialsUuid: string;
+      }
+    | { kind: 'user'; userWarehouseCredentialsUuid: string };
+
 export type ProjectServiceArguments = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
@@ -768,7 +776,7 @@ export class ProjectService extends BaseService {
                 );
                 // If we try to generate access token from token instead of refreshToken
                 // it will throw an error: The request was invalid.
-                const accessToken =
+                const { accessToken, refreshToken: newRefreshToken } =
                     await UserService.generateSnowflakeAccessToken(
                         refreshToken,
                     );
@@ -776,6 +784,7 @@ export class ProjectService extends BaseService {
                     ...args,
                     authenticationType: SnowflakeAuthenticationType.SSO,
                     token: accessToken,
+                    refreshToken: newRefreshToken,
                 };
             } catch (e: unknown) {
                 if (e instanceof LightdashError) {
@@ -946,6 +955,93 @@ export class ProjectService extends BaseService {
         }
 
         return args;
+    }
+
+    private async refreshCredentialsAndPersistRotation<
+        T extends CreateWarehouseCredentials,
+    >(
+        args: T,
+        userUuid: string,
+        source: RefreshTokenRotationSource,
+    ): Promise<T> {
+        const oldRefreshToken = ProjectService.getCredentialsRefreshToken(args);
+
+        const refreshed = await this.refreshCredentials(args, userUuid);
+
+        const newRefreshToken =
+            ProjectService.getCredentialsRefreshToken(refreshed);
+
+        if (
+            oldRefreshToken &&
+            newRefreshToken &&
+            newRefreshToken !== oldRefreshToken
+        ) {
+            await this.persistRefreshTokenRotation({
+                source,
+                oldRefreshToken,
+                newRefreshToken,
+            });
+        }
+
+        return refreshed;
+    }
+
+    private static getCredentialsRefreshToken(
+        creds: CreateWarehouseCredentials,
+    ): string | undefined {
+        const candidate = (creds as Partial<{ refreshToken: string }>)
+            .refreshToken;
+        return typeof candidate === 'string' && candidate.length > 0
+            ? candidate
+            : undefined;
+    }
+
+    private async persistRefreshTokenRotation({
+        source,
+        oldRefreshToken,
+        newRefreshToken,
+    }: {
+        source: RefreshTokenRotationSource;
+        oldRefreshToken: string;
+        newRefreshToken: string;
+    }): Promise<void> {
+        try {
+            switch (source.kind) {
+                case 'project':
+                    await this.projectModel.rotateRefreshToken(
+                        source.projectUuid,
+                        oldRefreshToken,
+                        newRefreshToken,
+                    );
+                    break;
+                case 'organization':
+                    await this.organizationWarehouseCredentialsModel.rotateRefreshToken(
+                        source.organizationWarehouseCredentialsUuid,
+                        oldRefreshToken,
+                        newRefreshToken,
+                    );
+                    break;
+                case 'user':
+                    await this.userWarehouseCredentialsModel.rotateRefreshToken(
+                        source.userWarehouseCredentialsUuid,
+                        oldRefreshToken,
+                        newRefreshToken,
+                    );
+                    break;
+                default:
+                    assertUnreachable(
+                        source,
+                        'Unknown OAuth refresh token rotation source',
+                    );
+            }
+        } catch (error) {
+            // Don't fail the in-flight query: the freshly minted access token is still usable.
+            this.logger.error(
+                `Failed to persist rotated OAuth refresh token for ${
+                    source.kind
+                }: ${getErrorMessage(error)}`,
+            );
+        }
     }
 
     /*
@@ -1289,9 +1385,13 @@ export class ProjectService extends BaseService {
             this.logger.debug(
                 `Refreshing warehouse credentials from organization credentials`,
             );
-            credentials = await this.refreshCredentials(
+            credentials = await this.refreshCredentialsAndPersistRotation(
                 credentials, // This credentials are already loaded from organization
                 userId,
+                {
+                    kind: 'organization',
+                    organizationWarehouseCredentialsUuid,
+                },
             );
         }
 
@@ -1348,9 +1448,14 @@ export class ProjectService extends BaseService {
                 this.logger.debug(
                     `Using user warehouse credentials for user ${userId}`,
                 );
-                credentials = await this.refreshCredentials(
+                credentials = await this.refreshCredentialsAndPersistRotation(
                     credentials,
                     userId,
+                    {
+                        kind: 'user',
+                        userWarehouseCredentialsUuid:
+                            userWarehouseCredentials.uuid,
+                    },
                 );
                 userWarehouseCredentialsUuid = userWarehouseCredentials.uuid;
             } else if (credentials.requireUserCredentials) {
@@ -1365,9 +1470,10 @@ export class ProjectService extends BaseService {
                 this.logger.debug(
                     `Refreshing warehouse credentials for session user ${userId}`,
                 );
-                credentials = await this.refreshCredentials(
+                credentials = await this.refreshCredentialsAndPersistRotation(
                     credentials,
                     userId,
+                    { kind: 'project', projectUuid },
                 );
             }
         } else if (credentials.requireUserCredentials) {
@@ -1382,7 +1488,11 @@ export class ProjectService extends BaseService {
             this.logger.debug(
                 `Refreshing warehouse credentials for embed user ${userId}`,
             );
-            credentials = await this.refreshCredentials(credentials, userId);
+            credentials = await this.refreshCredentialsAndPersistRotation(
+                credentials,
+                userId,
+                { kind: 'project', projectUuid },
+            );
         }
 
         return {
@@ -2873,10 +2983,18 @@ export class ProjectService extends BaseService {
             this.logger.debug(
                 `Refreshing snowflake warehouse credentials from refresh token on buildAdapter`,
             );
-            const accessToken = await UserService.generateSnowflakeAccessToken(
-                project.warehouseConnection.refreshToken,
-            );
+            const oldRefreshToken = project.warehouseConnection.refreshToken;
+            const { accessToken, refreshToken: newRefreshToken } =
+                await UserService.generateSnowflakeAccessToken(oldRefreshToken);
             project.warehouseConnection.token = accessToken;
+            project.warehouseConnection.refreshToken = newRefreshToken;
+            if (newRefreshToken !== oldRefreshToken) {
+                await this.persistRefreshTokenRotation({
+                    source: { kind: 'project', projectUuid },
+                    oldRefreshToken,
+                    newRefreshToken,
+                });
+            }
         }
 
         if (

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2044,7 +2044,7 @@ export class UserService extends BaseService {
                 user.userUuid,
                 OpenIdIdentityIssuerType.SNOWFLAKE,
             );
-            const accessToken =
+            const { accessToken } =
                 await UserService.generateSnowflakeAccessToken(refreshToken);
             return accessToken;
         }
@@ -2076,17 +2076,24 @@ export class UserService extends BaseService {
 
     static async generateSnowflakeAccessToken(
         refreshToken: string,
-    ): Promise<string> {
+    ): Promise<{ accessToken: string; refreshToken: string }> {
         return new Promise((resolve, reject) => {
             refresh.requestNewAccessToken(
                 'snowflake',
                 refreshToken,
-                (err: AnyType, accessToken: string, _refreshToken, result) => {
+                (
+                    err: AnyType,
+                    accessToken: string,
+                    newRefreshToken: string | undefined,
+                ) => {
                     if (err || !accessToken) {
                         reject(err);
                         return;
                     }
-                    resolve(accessToken);
+                    resolve({
+                        accessToken,
+                        refreshToken: newRefreshToken || refreshToken,
+                    });
                 },
             );
         });


### PR DESCRIPTION
## Summary

- Capture the rotated OAuth refresh token returned by warehouse providers (currently discarded for Snowflake; for Databricks it was kept in memory but never written back) and persist it back to whichever row sourced it — `user_warehouse_credentials`, `warehouse_credentials` (project), or `organization_warehouse_credentials`.
- Single generic `rotateRefreshToken(uuid, oldToken, newToken)` method on each of the three credential models, with `forUpdate()` row lock + compare-and-swap so concurrent refreshes don't overwrite each other; cache invalidation on the project path.
- Covers Snowflake SSO and Databricks OAuth U2M / M2M with the same code path.
- Closes #22831.

## Why

Snowflake's OAuth integration can rotate refresh tokens — the previous token is invalidated as soon as a new one is issued. Two common scenarios:

- **Snowflake OAuth (custom client) with `OAUTH_SINGLE_USE_REFRESH_TOKENS_REQUIRED = TRUE`** — every refresh rotates, every refresh invalidates the prior token.
- **Snowflake OAuth (custom client) with `OAUTH_SINGLE_USE_REFRESH_TOKENS_REQUIRED = FALSE` (default)** — refresh tokens are reusable across refreshes, but a new refresh token is issued on user re-authorization, which can also invalidate the prior token depending on integration semantics.
- **External OAuth (federated through Okta / AzureAD)** — the IdP controls rotation; many IdPs rotate by default.

Lightdash was discarding the new token in all of these cases, so the next refresh hit `invalid_grant`. Symptom: scheduled jobs (Google Sheets / Slack / email syncs) fail shortly after the owner uses Lightdash interactively. Detailed root-cause analysis in #22831.

Databricks OAuth U2M/M2M has the same rotation behavior (depending on workspace config) and the same latent persistence gap — the `refreshDatabricksOAuthToken` callers correctly captured the rotated `refreshToken` in memory but never wrote it back to the credentials store. Now folded into the same fix.

## What changed

| File | Change |
|---|---|
| `services/UserService.ts` | `generateSnowflakeAccessToken` now returns `{ accessToken, refreshToken }` instead of only the access token. |
| `services/ProjectService/ProjectService.ts` | `refreshCredentials` Snowflake SSO branch propagates the rotated `refreshToken` on the returned credentials (mirrors the Databricks pattern). New helpers `refreshCredentialsAndPersistRotation` + `persistRefreshTokenRotation` write the rotated token back to the source row via the appropriate model — generic over warehouse type, picks up Snowflake SSO and Databricks U2M/M2M structurally. `getWarehouseCredentials` (org / user / project / embed branches) and `buildAdapter` use the new helper. Persistence failures log structured context (`sourceKind`, `sourceUuid`) without failing the in-flight query. |
| `models/UserWarehouseCredentialsModel.ts` | New generic `rotateRefreshToken(uuid, oldToken, newToken)` — `forUpdate()` row lock + compare-and-swap on the stored `refreshToken` field. |
| `models/OrganizationWarehouseCredentialsModel.ts` | Same generic method on `warehouse_connection`. |
| `models/ProjectModel/ProjectModel.ts` | Same generic method on `warehouse_credentials.encrypted_credentials`; also invalidates `warehouseCredentialsCache` after a successful swap so the next reader picks up the rotated token. |
| `services/ProjectService/ProjectService.test.ts` | Existing mocks updated for the new return shape; four new tests cover (a) Snowflake rotation persisted via the user model, (b) Snowflake no-op when the same token is returned, (c) Databricks U2M rotation persisted via the user model, (d) Databricks U2M no-op when the same token is returned. |

The CAS guard on the stored `refreshToken` value is what protects against credential type changes (the old token won't match) and concurrent rotations (whoever wins the lock + CAS check writes). No warehouse-specific branching in the model methods — they're structural.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint` on touched files
- [x] `pnpm -F backend test -- ProjectService.test` — 49/49 (includes 4 new tests for rotated-token persistence + no-op)
- [ ] Manual: configure a Snowflake OAuth integration with `OAUTH_SINGLE_USE_REFRESH_TOKENS_REQUIRED = TRUE`, log in, run a query, wait for access-token TTL, run another query — should succeed instead of failing with `invalid_grant`.
- [ ] Manual: same scenario for Databricks OAuth U2M with rotation enabled at the workspace.

## Out of scope / follow-ups

- Initial Databricks OAUTH_M2M token issuance from `oauthClientId + oauthClientSecret` (when no refresh token has been saved yet) is still re-exchanged on every request rather than persisted. The new helper only persists rotations of an existing refresh token. Worth a separate optimization PR.
- `openid_identities.refresh_token` is not rotated by this change; it's only used by `UserService.getAccessToken('snowflake')` for the EE `/snowflake/sso/is-authenticated` check, which is not on the query path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)