### PR TITLE
feat(managed-agent): polish governance UX (header copy-all, collapsible charts, inline copy, honest caption)

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -4,6 +4,7 @@ import {
     type ContentVerificationInfo,
     countTotalFilterRules,
     type Dashboard,
+    FeatureFlags,
     getFixedBrokenMetadata,
     getGovernanceInsightMetadata,
     type GovernanceInsightMetadata,
@@ -87,6 +88,7 @@ import { useGetSlack } from '../../../hooks/slack/useSlack';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProject } from '../../../hooks/useProject';
 import { useChartVersion, useSavedQuery } from '../../../hooks/useSavedQuery';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentLatestRun } from './hooks/useManagedAgentLatestRun';
@@ -459,48 +461,66 @@ const SlowDetails: FC<{ metadata: Record<string, unknown> }> = ({
     );
 };
 
+const VARIANT_CHART_PREVIEW_LIMIT = 3;
+
 const GovernanceVariantBlock: FC<{
     projectUuid: string;
     variant: GovernanceInsightMetadata['variants'][number];
     showName: boolean;
-}> = ({ projectUuid, variant, showName }) => (
-    <Stack gap={4}>
-        <Group gap={6} align="center" wrap="nowrap">
-            {showName && (
-                <Text fz="xs" fw={500} ff="monospace">
-                    {variant.name}
-                </Text>
-            )}
-            <Text fz="xs" c="dimmed">
-                {variant.chartCount} chart
-                {variant.chartCount === 1 ? '' : 's'}
-            </Text>
-        </Group>
-        <Code block fz="xs">
-            {variant.sql}
-        </Code>
-        {variant.charts.length > 0 && (
-            <Stack gap={2} pl="sm">
-                {variant.charts.slice(0, 3).map((chart) => (
-                    <Anchor
-                        key={chart.savedQueryUuid}
-                        href={`/projects/${projectUuid}/saved/${chart.savedQueryUuid}`}
-                        target="_blank"
-                        rel="noreferrer"
-                        fz="xs"
-                    >
-                        {chart.savedQueryName}
-                    </Anchor>
-                ))}
-                {variant.charts.length > 3 && (
-                    <Text fz="xs" c="dimmed">
-                        + {variant.charts.length - 3} more
+}> = ({ projectUuid, variant, showName }) => {
+    const [expanded, setExpanded] = useState(false);
+    const visibleCharts = expanded
+        ? variant.charts
+        : variant.charts.slice(0, VARIANT_CHART_PREVIEW_LIMIT);
+    const hiddenCount = variant.charts.length - VARIANT_CHART_PREVIEW_LIMIT;
+
+    return (
+        <Stack gap={4}>
+            <Group gap={6} align="center" wrap="nowrap">
+                {showName && (
+                    <Text fz="xs" fw={500} ff="monospace">
+                        {variant.name}
                     </Text>
                 )}
-            </Stack>
-        )}
-    </Stack>
-);
+                <Text fz="xs" c="dimmed">
+                    {variant.chartCount} chart
+                    {variant.chartCount === 1 ? '' : 's'}
+                </Text>
+            </Group>
+            <Box style={{ position: 'relative' }}>
+                <Code block fz="xs">
+                    {variant.sql}
+                </Code>
+            </Box>
+            {variant.charts.length > 0 && (
+                <Stack gap={2} pl="sm">
+                    {visibleCharts.map((chart) => (
+                        <Anchor
+                            key={chart.savedQueryUuid}
+                            href={`/projects/${projectUuid}/saved/${chart.savedQueryUuid}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            fz="xs"
+                        >
+                            {chart.savedQueryName}
+                        </Anchor>
+                    ))}
+                    {hiddenCount > 0 && (
+                        <UnstyledButton
+                            onClick={() => setExpanded((prev) => !prev)}
+                        >
+                            <Text fz="xs" c="dimmed">
+                                {expanded
+                                    ? 'Show fewer'
+                                    : `+ ${hiddenCount} more`}
+                            </Text>
+                        </UnstyledButton>
+                    )}
+                </Stack>
+            )}
+        </Stack>
+    );
+};
 
 const GOVERNANCE_KIND_LABEL: Record<string, string> = {
     heavy_custom_usage: 'Heavy custom usage',
@@ -552,6 +572,10 @@ const GovernanceDetails: FC<{
     const showVariantNames = metadata.variants.some(
         (v, i) => i > 0 && v.name !== metadata.variants[0].name,
     );
+    const { data: replaceOnCompileFlag } = useServerFeatureFlag(
+        FeatureFlags.ReplaceCustomMetricsOnCompile,
+    );
+    const replaceOnCompileEnabled = !!replaceOnCompileFlag?.enabled;
 
     return (
         <Stack gap="md">
@@ -576,29 +600,38 @@ const GovernanceDetails: FC<{
 
             {suggestion?.yamlSnippet ? (
                 <Stack gap={4}>
-                    <Group justify="space-between" align="center">
-                        <MetadataLabel label="Proposed dbt YAML" />
+                    <MetadataLabel label="Proposed dbt YAML" />
+                    <Box style={{ position: 'relative' }}>
+                        <Code block fz="xs">
+                            {suggestion.yamlSnippet}
+                        </Code>
                         <CopyButton value={suggestion.yamlSnippet}>
                             {({ copied, copy }) => (
-                                <Button
-                                    size="compact-xs"
-                                    variant="default"
-                                    leftSection={
+                                <Tooltip
+                                    label={copied ? 'Copied' : 'Copy'}
+                                    withinPortal
+                                >
+                                    <ActionIcon
+                                        size="sm"
+                                        variant="subtle"
+                                        color="gray"
+                                        onClick={copy}
+                                        style={{
+                                            position: 'absolute',
+                                            top: 4,
+                                            right: 4,
+                                        }}
+                                        aria-label="Copy YAML"
+                                    >
                                         <MantineIcon
                                             icon={copied ? IconCheck : IconCopy}
-                                            size={12}
+                                            size={14}
                                         />
-                                    }
-                                    onClick={copy}
-                                >
-                                    {copied ? 'Copied' : 'Copy'}
-                                </Button>
+                                    </ActionIcon>
+                                </Tooltip>
                             )}
                         </CopyButton>
-                    </Group>
-                    <Code block fz="xs">
-                        {suggestion.yamlSnippet}
-                    </Code>
+                    </Box>
                     {suggestion.rationale && (
                         <Text fz="xs" c="dimmed" lh={1.6}>
                             {suggestion.rationale}
@@ -617,11 +650,12 @@ const GovernanceDetails: FC<{
                 )
             )}
 
-            {suggestion?.yamlSnippet && (
+            {suggestion?.yamlSnippet && replaceOnCompileEnabled && (
                 <Text fz="xs" c="dimmed" lh={1.6} fs="italic">
-                    Once this metric is added to dbt, the next project compile
-                    will automatically replace the affected charts&apos; custom
-                    metrics with the new dbt metric.
+                    Add this to dbt with the same name and SQL, then re-compile
+                    the project. Affected charts will be cleaned up
+                    automatically on the next compile if the new dbt metric is
+                    an exact match.
                 </Text>
             )}
         </Stack>
@@ -1695,70 +1729,67 @@ const buildCombinedGovernanceSnippet = (
     return sections.join('\n\n');
 };
 
-const GovernanceCopyAllRow: FC<{
-    actions: readonly ManagedAgentAction[];
-}> = ({ actions }) => {
-    const snippets = useMemo(() => {
-        const out: Array<{
-            targetModel: string | null;
-            yamlSnippet: string;
-        }> = [];
-        for (const action of actions) {
-            if (
-                action.actionType !== ManagedAgentActionType.INSIGHT ||
-                action.targetType !== 'project' ||
-                action.reversedAt
-            ) {
-                continue;
-            }
-            const parsed = getGovernanceInsightMetadata(action.metadata);
-            if (
-                !parsed ||
-                parsed.insightKind === GovernanceInsightKind.GOVERNANCE_ROLLUP
-            ) {
-                continue;
-            }
-            const suggestion = parsed.suggestion;
-            if (suggestion?.yamlSnippet) {
-                out.push({
-                    targetModel: suggestion.targetModel,
-                    yamlSnippet: suggestion.yamlSnippet,
-                });
-            }
+const collectGovernanceSnippets = (
+    actions: readonly ManagedAgentAction[] | undefined,
+): Array<{ targetModel: string | null; yamlSnippet: string }> => {
+    if (!actions) return [];
+    const out: Array<{ targetModel: string | null; yamlSnippet: string }> = [];
+    for (const action of actions) {
+        if (
+            action.actionType !== ManagedAgentActionType.INSIGHT ||
+            action.targetType !== 'project' ||
+            action.reversedAt
+        ) {
+            continue;
         }
-        return out;
-    }, [actions]);
+        const parsed = getGovernanceInsightMetadata(action.metadata);
+        if (
+            !parsed ||
+            parsed.insightKind === GovernanceInsightKind.GOVERNANCE_ROLLUP
+        ) {
+            continue;
+        }
+        const suggestion = parsed.suggestion;
+        if (suggestion?.yamlSnippet) {
+            out.push({
+                targetModel: suggestion.targetModel,
+                yamlSnippet: suggestion.yamlSnippet,
+            });
+        }
+    }
+    return out;
+};
 
+const GovernanceCopyAllButton: FC<{
+    snippets: Array<{ targetModel: string | null; yamlSnippet: string }>;
+}> = ({ snippets }) => {
     if (snippets.length < 2) return null;
-
     const combined = buildCombinedGovernanceSnippet(snippets);
-
     return (
-        <Table.Tr>
-            <Table.Td colSpan={3}>
-                <Group justify="flex-end" px="md" py={6}>
-                    <CopyButton value={combined}>
-                        {({ copied, copy }) => (
-                            <Button
-                                size="compact-xs"
-                                variant="default"
-                                leftSection={
-                                    <MantineIcon
-                                        icon={copied ? IconCheck : IconCopy}
-                                        size={12}
-                                    />
-                                }
-                                onClick={copy}
-                            >
-                                {copied
-                                    ? 'Copied'
-                                    : `Copy all governance YAML (${snippets.length})`}
-                            </Button>
-                        )}
-                    </CopyButton>
-                </Group>
-            </Table.Td>
-        </Table.Tr>
+        <CopyButton value={combined}>
+            {({ copied, copy }) => (
+                <Tooltip
+                    label={`Copy combined YAML for ${snippets.length} governance findings`}
+                    withinPortal
+                >
+                    <ActionIcon
+                        size="sm"
+                        variant="subtle"
+                        color="gray"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            copy();
+                        }}
+                        aria-label="Copy all governance YAML"
+                    >
+                        <MantineIcon
+                            icon={copied ? IconCheck : IconCopy}
+                            size={14}
+                        />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+        </CopyButton>
     );
 };
 
@@ -1858,7 +1889,11 @@ const RunHeaderRow: FC<{
     isOpen: boolean;
     expandable: boolean;
     onToggle: () => void;
-}> = ({ run, variant, isOpen, expandable, onToggle }) => (
+    governanceSnippets: Array<{
+        targetModel: string | null;
+        yamlSnippet: string;
+    }>;
+}> = ({ run, variant, isOpen, expandable, onToggle, governanceSnippets }) => (
     <Table.Tr
         className={classes.runHeaderRow}
         onClick={expandable ? onToggle : undefined}
@@ -1973,6 +2008,9 @@ const RunHeaderRow: FC<{
                                 {run.actionCount}{' '}
                                 {run.actionCount === 1 ? 'action' : 'actions'}
                             </Text>
+                            <GovernanceCopyAllButton
+                                snippets={governanceSnippets}
+                            />
                         </>
                     ) : null}
                 </Group>
@@ -1996,6 +2034,10 @@ const RunRow: FC<{
         fastPoll: isLive,
         runUuid: run.runUuid,
     });
+    const governanceSnippets = useMemo(
+        () => collectGovernanceSnippets(actions),
+        [actions],
+    );
     return (
         <Table.Tbody>
             <RunHeaderRow
@@ -2004,6 +2046,7 @@ const RunRow: FC<{
                 isOpen={isOpen}
                 expandable={expandable}
                 onToggle={onToggle}
+                governanceSnippets={governanceSnippets}
             />
             {variant === 'errored' && run.error && (
                 <Table.Tr>
@@ -2044,22 +2087,17 @@ const RunRow: FC<{
                                   </Table.Td>
                               </Table.Tr>
                           )
-                        : actions && (
-                              <>
-                                  <GovernanceCopyAllRow actions={actions} />
-                                  {actions.map((action) => (
-                                      <ActionRow
-                                          key={action.actionUuid}
-                                          action={action}
-                                          selected={
-                                              selectedActionUuid ===
-                                              action.actionUuid
-                                          }
-                                          onSelect={onSelectAction}
-                                      />
-                                  ))}
-                              </>
-                          )}
+                        : actions &&
+                          actions.map((action) => (
+                              <ActionRow
+                                  key={action.actionUuid}
+                                  action={action}
+                                  selected={
+                                      selectedActionUuid === action.actionUuid
+                                  }
+                                  onSelect={onSelectAction}
+                              />
+                          ))}
                 </>
             )}
         </Table.Tbody>


### PR DESCRIPTION
## Summary

Slice 8 of the [governance insights stack](docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md) (PROD-7392). Stacks on #22845.

UX polish based on first-run feedback. Four fixes, all frontend.

## What changes

### 1. "Copy all governance YAML" moved into the run header row

Slice 5 placed the bulk-copy button as a standalone table row above the action list. That row had no left-side content and the button floated awkwardly.

Now the bulk-copy is an `ActionIcon` (`subtle` variant, copy icon) sitting alongside the action-count chips inside `RunHeaderRow`. Standalone `<GovernanceCopyAllRow>` is gone; snippet collection moved to a pure helper `collectGovernanceSnippets` and `<GovernanceCopyAllButton>` is inline. Click stops propagation so it doesn't toggle the run open/closed.

### 2. Collapsible affected-charts list

`GovernanceVariantBlock` previously rendered up to 3 chart links + a non-interactive `+ N more` text. For groups with many charts (the test project has 6+ on `amount_sum_of_amount`) that text was a dead end.

Now: `+ N more` is a clickable `UnstyledButton` that toggles the rest of the list. Default still shows top 3; expanded shows all; toggle reads "Show fewer" when expanded. State is per-variant via local `useState`.

### 3. Inline copy on the YAML proposal

The "Copy" button was a separate Mantine `Button` with `compact-xs` size sitting above the `Code` block. Now it's an `ActionIcon` (`subtle`, gray, size `sm`) absolutely positioned at `top: 4, right: 4` inside a `position: relative` Box wrapping the code block. Tooltip toggles between "Copy" and "Copied".

This matches the affordance the user pointed at — Mantine's `ActionIcon`-style copy button living in the corner of the snippet rather than a labeled button above it.

### 4. Honest caption — and gated on the flag actually being on

Previous caption claimed:

> *Once this metric is added to dbt, the next project compile will automatically replace the affected charts' custom metrics with the new dbt metric.*

That was overclaiming. Auto-replace only fires when:
- `FeatureFlags.ReplaceCustomMetricsOnCompile` is enabled for the project, AND
- the new dbt metric matches the chart's custom metric exactly (name + SQL + filter conditions, per `compareMetricAndCustomMetric`).

Now the caption:
- Reads `useServerFeatureFlag(FeatureFlags.ReplaceCustomMetricsOnCompile)` and **only renders when the flag is enabled**. If the user's project doesn't have it on, the caption stays out of their way entirely (they fix charts manually via the links above; mentioning a feature they don't have just confuses).
- When rendered, copy is honest about the conditions: *"Add this to dbt with the same name and SQL, then re-compile the project. Affected charts will be cleaned up automatically on the next compile if the new dbt metric is an exact match."*

## Behaviour with feature flag OFF

Unchanged — no governance INSIGHTs to render, none of these UI changes are visible.

## Test plan

- [ ] Frontend typecheck + lint pass (verified locally).
- [ ] On a run with 2+ governance insights with non-null `yamlSnippet`, verify the copy-all icon appears next to the run's action-count chips. Click it and verify it copies the combined YAML without expanding/collapsing the run.
- [ ] On a run with 1 governance insight, verify NO copy-all icon appears.
- [ ] On a governance insight whose variant has 4+ affected charts, verify only 3 chart links show by default and `+ N more` toggles expand/collapse.
- [ ] On a governance insight, verify the YAML code block has a small Copy icon in its top-right corner. Hover shows tooltip "Copy" → click → "Copied" → reverts after 2s.
- [ ] With `replace-custom-metrics-on-compile` ENABLED, verify the auto-cleanup caption appears under the YAML.
- [ ] With `replace-custom-metrics-on-compile` DISABLED, verify NO auto-cleanup caption appears (the chart links above are the manual cleanup path).

## Stack

- Slice 1 (#22832): heavy_custom_usage on additional metrics, e2e
- Slice 2 (#22833): inconsistent_definitions kind + variant UI
- Slice 3 (#22836): SQL-type custom dimensions
- Slice 4 (#22837): top-K cap + governance rollup
- Slice 5 (#22839): bulk-copy combined governance YAML
- Slice 6 (#22840): Slack summary + telemetry
- Slice 7 (#22845): post-promotion expectation caption + spec course-correction
- **Slice 8 (#22848): governance UX polish** ← you are here

🤖 Generated with [Claude Code](https://claude.com/claude-code)