### PR TITLE
fix(data-apps): use fully qualified e2b template name

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1547,7 +1547,8 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
             .filter(Boolean),
         s3,
         e2bApiKey: process.env.E2B_API_KEY || null,
-        e2bTemplateName: process.env.E2B_TEMPLATE_NAME || 'lightdash-data-app',
+        e2bTemplateName:
+            process.env.E2B_TEMPLATE_NAME || 'lightdash/lightdash-data-app',
         // Default to the running Lightdash version so prod always launches
         // sandboxes from the matching template build (the release workflow
         // guarantees this tag exists). Operators can override to roll back


### PR DESCRIPTION
### Description:
Self-hosters are currently either required to upload their own template or set the 
`E2B_TEMPLATE_NAME` to `lightdash/lightdash-data-app`.
To make it easier, I'm changing the default value to be the fully qualified name of our public template. Self-hosters can still opt to use their own, but the default value will work out-of-the-box with our template.