### PR TITLE
fix: use recursive CTE for chart origin resolver

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -568,7 +568,7 @@ export class SavedChartModel {
         const result: ResolverRow | undefined = await this.database
             .raw<{ rows: ResolverRow[] }>(
                 `
-                WITH chart_origin AS (
+                WITH RECURSIVE chart_origin AS (
                     SELECT
                         sq.saved_query_uuid AS chart_uuid,
                         sq.name AS chart_name,


### PR DESCRIPTION
Closes:

### Description:
Fixes a SQL query in `SavedChartModel` by converting the `chart_origin` CTE to a recursive CTE (`WITH RECURSIVE`), enabling the query to correctly traverse hierarchical or self-referencing chart relationships.