### PR TITLE
fix: improve refresh token rotation error logging with structured metadata

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -996,6 +996,21 @@ export class ProjectService extends BaseService {
             : undefined;
     }
 
+    private static getRotationSourceUuid(
+        source: RefreshTokenRotationSource,
+    ): string {
+        switch (source.kind) {
+            case 'project':
+                return source.projectUuid;
+            case 'organization':
+                return source.organizationWarehouseCredentialsUuid;
+            case 'user':
+                return source.userWarehouseCredentialsUuid;
+            default:
+                return assertUnreachable(source, 'Unknown source kind');
+        }
+    }
+
     private async persistRefreshTokenRotation({
         source,
         oldRefreshToken,
@@ -1036,11 +1051,11 @@ export class ProjectService extends BaseService {
             }
         } catch (error) {
             // Don't fail the in-flight query: the freshly minted access token is still usable.
-            this.logger.error(
-                `Failed to persist rotated OAuth refresh token for ${
-                    source.kind
-                }: ${getErrorMessage(error)}`,
-            );
+            this.logger.error('Failed to persist rotated OAuth refresh token', {
+                sourceKind: source.kind,
+                sourceUuid: ProjectService.getRotationSourceUuid(source),
+                error: getErrorMessage(error),
+            });
         }
     }
 


### PR DESCRIPTION
Closes:

### Description:
Improves the error logging when persisting a rotated OAuth refresh token fails. Instead of interpolating the source kind into a plain string, the log now uses structured fields to include both the `sourceKind` and the resolved `sourceUuid` (project, organization warehouse credentials, or user warehouse credentials UUID). A new helper method `getRotationSourceUuid` extracts the appropriate UUID from the rotation source based on its kind.