### PR TITLE
refactor(data-apps): remove unused cookie auth from preview router

### DIFF
--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -5,8 +5,6 @@ import { validate as isValidUuid } from 'uuid';
 import { type AppRuntimeConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';
 import {
-    PREVIEW_COOKIE_NAME,
-    PREVIEW_TOKEN_MAX_AGE_SECONDS,
     verifyPreviewToken,
     type PreviewTokenPayload,
 } from './appPreviewToken';
@@ -61,24 +59,8 @@ const isSafeFilename = (filename: string): boolean =>
     /^[a-zA-Z0-9._-]+$/.test(filename) && !filename.includes('..');
 
 /**
- * Extracts a named cookie value from the Cookie header.
- */
-const getCookieValue = (
-    cookieHeader: string | undefined,
-    name: string,
-): string | undefined => {
-    if (!cookieHeader) return undefined;
-    const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
-    return match ? match[1] : undefined;
-};
-
-/**
  * Rewrites Vite-generated asset references in HTML to include a token
- * query parameter so they authenticate without cookies.
- *
- * This is needed when the iframe sandbox omits `allow-same-origin` —
- * the browser won't store cookies for an opaque origin, so asset
- * requests must carry the token themselves.
+ * query parameter so asset requests authenticate themselves.
  *
  * Matches patterns like:
  *   src="./assets/index-BxK29f.js"
@@ -207,16 +189,8 @@ export const createAppPreviewRouter = (
 
     // -- Auth middleware ------------------------------------------------
 
-    /**
-     * Verifies a token and translates the result into an HTTP response.
-     * Shared by both middleware variants.
-     */
-    const handleTokenVerification = (
-        token: string | undefined,
-        req: express.Request,
-        res: express.Response,
-        next: express.NextFunction,
-    ): void => {
+    /** Verifies a JWT from the `?token` query param. */
+    const requireToken: express.RequestHandler = (req, res, next) => {
         const { appUuid, version } = req.params;
 
         if (!isValidUuid(appUuid)) {
@@ -235,6 +209,9 @@ export const createAppPreviewRouter = (
             });
             return;
         }
+
+        const token =
+            typeof req.query.token === 'string' ? req.query.token : undefined;
 
         const result = verifyPreviewToken(
             token,
@@ -255,42 +232,6 @@ export const createAppPreviewRouter = (
         next();
     };
 
-    /**
-     * Accepts a JWT from the `?token` query param, verifies it, and
-     * promotes it to a path-scoped HttpOnly cookie so subsequent asset
-     * requests are authenticated automatically by the browser.
-     */
-    const requireTokenAndSetCookie: express.RequestHandler = (
-        req,
-        res,
-        next,
-    ) => {
-        const token =
-            typeof req.query.token === 'string' ? req.query.token : undefined;
-
-        handleTokenVerification(token, req, res, () => {
-            const { appUuid, version } = req.params;
-            const cookiePath = `/api/apps/${appUuid}/versions/${version}/`;
-            res.cookie(PREVIEW_COOKIE_NAME, token!, {
-                path: cookiePath,
-                httpOnly: true,
-                secure: true,
-                sameSite: 'strict',
-                maxAge: PREVIEW_TOKEN_MAX_AGE_SECONDS * 1000,
-            });
-            next();
-        });
-    };
-
-    /** Accepts a JWT from a `?token` query param or the path-scoped cookie. */
-    const requireTokenOrCookie: express.RequestHandler = (req, res, next) => {
-        const token =
-            typeof req.query.token === 'string'
-                ? req.query.token
-                : getCookieValue(req.headers.cookie, PREVIEW_COOKIE_NAME);
-        handleTokenVerification(token, req, res, next);
-    };
-
     // -- Routes ---------------------------------------------------------
 
     // Redirect to trailing slash so relative asset paths resolve correctly.
@@ -305,11 +246,10 @@ export const createAppPreviewRouter = (
     });
 
     // Serve index.html for an app version.
-    // Rewrites asset URLs to include the token so they work without cookies
-    // (needed when the iframe sandbox omits allow-same-origin).
+    // Rewrites asset URLs to include the token so asset requests authenticate.
     router.get(
         '/:appUuid/versions/:version/',
-        requireTokenAndSetCookie,
+        requireToken,
         async (req, res) => {
             const { appUuid, version } = req.params;
             const s3Key = `apps/${appUuid}/versions/${version}/index.html`;
@@ -323,10 +263,7 @@ export const createAppPreviewRouter = (
                 return;
             }
 
-            const token =
-                typeof req.query.token === 'string'
-                    ? req.query.token
-                    : undefined;
+            const token = req.query.token as string;
 
             setSecurityHeaders(res);
             res.setHeader('Content-Type', 'text/html; charset=utf-8');
@@ -336,21 +273,15 @@ export const createAppPreviewRouter = (
                 res.locals.previewTokenPayload as PreviewTokenPayload,
             );
 
-            if (token) {
-                const html = await bufferS3Body(result.body);
-                res.send(injectTokenIntoAssetUrls(html, token));
-            } else {
-                result.body.pipe(res);
-            }
+            const html = await bufferS3Body(result.body);
+            res.send(injectTokenIntoAssetUrls(html, token));
         },
     );
 
-    // Serve static assets (JS, CSS, fonts).
-    // Accepts either a ?token query param (for sandboxed iframes without
-    // allow-same-origin) or the path-scoped cookie (for normal browsers).
+    // Serve static assets (JS, CSS, fonts). Authenticated via ?token query param.
     router.get(
         '/:appUuid/versions/:version/assets/:filename',
-        requireTokenOrCookie,
+        requireToken,
         async (req, res) => {
             const { filename } = req.params;
 

--- a/packages/backend/src/routers/appPreviewToken.ts
+++ b/packages/backend/src/routers/appPreviewToken.ts
@@ -6,10 +6,6 @@ const PREVIEW_TOKEN_MAX_AGE_SECONDS = 3600; // 1 hour
 const PREVIEW_TOKEN_ISSUER = 'lightdash';
 const PREVIEW_TOKEN_AUDIENCE = 'app-preview';
 
-/** Cookie name used to carry the preview token on asset requests. */
-export const PREVIEW_COOKIE_NAME = '__preview_token';
-export { PREVIEW_TOKEN_MAX_AGE_SECONDS };
-
 export type PreviewTokenPayload = {
     type: typeof PREVIEW_TOKEN_TYPE;
     appUuid: string;


### PR DESCRIPTION
### Description:
Preview asset requests already always carry the token via query param, so the cookie fallback path was dead code.

Gets also rid of this little console error:
<img width="1354" height="301" alt="Screenshot 2026-05-08 at 15 11 21" src="https://github.com/user-attachments/assets/f2e75093-8ea4-46f6-aa1d-a6806232161c" />

