### PR TITLE
fix(color-palette): skip palette resolver fetch in embedded dashboards

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -2138,10 +2138,14 @@ export const GenericDashboardChartTile: FC<
         (c) => c.dashboard?.uuid,
     );
     const chartUuid = dashboardChartReadyQuery?.chart.uuid;
-    const { data: resolvedPalette } = useProjectColorPalette(projectUuid, {
-        dashboardUuid: dashboardUuidFromContext,
-        chartUuid,
-    });
+    // Skip the resolver fetch when the parent already supplied a palette
+    // (embeds, screenshots, SDK minimal): the override always wins below,
+    // and the endpoint 403s for JWT/embed auth.
+    const { data: resolvedPalette } = useProjectColorPalette(
+        projectUuid,
+        { dashboardUuid: dashboardUuidFromContext, chartUuid },
+        { enabled: !colorPaletteOverride },
+    );
     const effectiveColorPaletteOverride =
         colorPaletteOverride ?? resolvedPalette?.colors;
     const effectiveDarkColorPaletteOverride =

--- a/packages/frontend/src/hooks/appearance/useProjectColorPalette.ts
+++ b/packages/frontend/src/hooks/appearance/useProjectColorPalette.ts
@@ -33,6 +33,7 @@ const getProjectColorPalette = (
 export const useProjectColorPalette = (
     projectUuid: string | undefined,
     context: ProjectColorPaletteContext = {},
+    options: { enabled?: boolean } = {},
 ) =>
     useQuery<ResolvedPalette, ApiError>({
         queryKey: [
@@ -44,5 +45,5 @@ export const useProjectColorPalette = (
             context.chartUuid ?? null,
         ],
         queryFn: () => getProjectColorPalette(projectUuid!, context),
-        enabled: Boolean(projectUuid),
+        enabled: Boolean(projectUuid) && options.enabled !== false,
     });


### PR DESCRIPTION
Closes: SPK-444

### Description:

PR #22794 added an unconditional call to \`useProjectColorPalette\` inside \`GenericDashboardChartTile\`. The endpoint it hits is gated by \`assertRegisteredAccount\`, so JWT/embed auth gets a 403 for every chart tile in every embedded dashboard (cosmetic — not render-breaking, but noisy in console/Sentry).

Embeds already receive a server-resolved palette via \`colorPaletteOverride\` (from \`EmbedService\`), and the override always wins in the existing \`colorPaletteOverride ?? resolvedPalette?.colors\` chain. This PR adds an \`enabled\` option to \`useProjectColorPalette\` and passes \`enabled: !colorPaletteOverride\` from the tile, so the fetch is skipped whenever the parent already supplied a palette (embeds, screenshots, SDK minimal).