### PR TITLE
feat(managed-agent): open dbt PR from governance INSIGHT sidebar

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -11,6 +11,7 @@ import {
     type GovernanceInsightMetadata,
     GovernanceInsightKind,
     type GovernanceRollupMetadata,
+    isCustomSqlDimension,
     getManagedAgentActionCategory,
     type ManagedAgentAction,
     ManagedAgentActionType,
@@ -57,6 +58,7 @@ import {
     IconExternalLink,
     IconEye,
     IconFolder,
+    IconGitPullRequest,
     IconHash,
     IconLayoutDashboard,
     IconMathFunction,
@@ -87,6 +89,11 @@ import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
 import InfoRow from '../../../components/common/PageHeader/InfoRow';
 import { SlackChannelSelect } from '../../../components/common/SlackChannelSelect';
 import TruncatedText from '../../../components/common/TruncatedText';
+import {
+    useIsGitProject,
+    useWriteBackCustomDimensions,
+    useWriteBackCustomMetrics,
+} from '../../../components/Explorer/WriteBackModal/hooks';
 import ForbiddenPanel from '../../../components/ForbiddenPanel';
 import { useChartViewStats } from '../../../hooks/chart/useChartViewStats';
 import { useDashboardQuery } from '../../../hooks/dashboard/useDashboard';
@@ -602,6 +609,53 @@ const GovernanceDetails: FC<{
     );
     const replaceOnCompileEnabled = !!replaceOnCompileFlag?.enabled;
 
+    const isGitProject = useIsGitProject(projectUuid);
+    const canonicalVariant = metadata.variants[0];
+    const canonicalChartUuid = canonicalVariant?.charts[0]?.savedQueryUuid;
+    const isMetricKind =
+        metadata.definitionType === GovernanceDefinitionType.METRIC;
+    const isSqlDimensionKind =
+        metadata.definitionType === GovernanceDefinitionType.SQL_DIMENSION;
+    const canOpenPr = isGitProject && !!suggestion?.canonicalSql;
+    const { data: canonicalChart } = useSavedQuery({
+        uuidOrSlug: canOpenPr ? canonicalChartUuid : undefined,
+        projectUuid,
+    });
+    const canonicalAdditionalMetric = useMemo(() => {
+        if (!canOpenPr || !isMetricKind || !canonicalChart) return null;
+        return (
+            canonicalChart.metricQuery.additionalMetrics?.find(
+                (m) =>
+                    m.name === canonicalVariant.name &&
+                    m.sql === canonicalVariant.sql,
+            ) ?? null
+        );
+    }, [canOpenPr, isMetricKind, canonicalChart, canonicalVariant]);
+    const canonicalCustomDimension = useMemo(() => {
+        if (!canOpenPr || !isSqlDimensionKind || !canonicalChart) return null;
+        return (
+            canonicalChart.metricQuery.customDimensions?.find(
+                (d) =>
+                    d.name === canonicalVariant.name &&
+                    isCustomSqlDimension(d) &&
+                    d.sql === canonicalVariant.sql,
+            ) ?? null
+        );
+    }, [canOpenPr, isSqlDimensionKind, canonicalChart, canonicalVariant]);
+    const writeBackMetric = useWriteBackCustomMetrics(projectUuid);
+    const writeBackDimension = useWriteBackCustomDimensions(projectUuid);
+    const writeBackLoading =
+        writeBackMetric.isLoading || writeBackDimension.isLoading;
+    const handleOpenPr = () => {
+        if (canonicalAdditionalMetric) {
+            writeBackMetric.mutate([canonicalAdditionalMetric]);
+        } else if (canonicalCustomDimension) {
+            writeBackDimension.mutate([canonicalCustomDimension]);
+        }
+    };
+    const prButtonAvailable =
+        canOpenPr && (canonicalAdditionalMetric || canonicalCustomDimension);
+
     return (
         <Stack gap="md">
             <Stack gap="sm">
@@ -651,6 +705,22 @@ const GovernanceDetails: FC<{
                             )}
                         </CopyButton>
                     </Box>
+                    {prButtonAvailable && (
+                        <Button
+                            size="compact-sm"
+                            variant="default"
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconGitPullRequest}
+                                    size={14}
+                                />
+                            }
+                            loading={writeBackLoading}
+                            onClick={handleOpenPr}
+                        >
+                            Open pull request in dbt repo
+                        </Button>
+                    )}
                     {suggestion.rationale && (
                         <Text fz="xs" c="dimmed" lh={1.6}>
                             {suggestion.rationale}


### PR DESCRIPTION
## Summary

Slice 10 of the [governance insights stack](docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md) (PROD-7392). Stacks on #22852.

Wires the existing dbt write-back PR flow into the governance INSIGHT sidebar. When the project has GitHub/GitLab connected and the canonical variant maps to a real `AdditionalMetric` / `CustomDimension` we can locate, an "Open pull request in dbt repo" button appears next to the YAML proposal. Clicking it hits the existing `/projects/:projectUuid/git-integration/pull-requests/{custom-metrics,custom-dimensions}` endpoint and the existing toast handler opens the resulting PR URL in a new tab.

No backend, no new endpoints — this is purely a UI glue layer over `WriteBackModal`'s hooks.

## What changes

### Frontend (`ManagedAgentActivityPage.tsx`)

In `GovernanceDetails`:

- Reuse `useIsGitProject`, `useWriteBackCustomMetrics`, `useWriteBackCustomDimensions` from `components/Explorer/WriteBackModal/hooks`.
- Pull the canonical variant's `savedQueryUuid` from `metadata.variants[0].charts[0]` and fetch that chart via the existing `useSavedQuery`.
- Find the matching `AdditionalMetric` (for `definitionType: metric`) or `CustomDimension` of `type: sql` (for `definitionType: sql_dimension`) in the chart's `metricQuery`.
- Render a `Button` with `IconGitPullRequest` next to the YAML preview. Disabled (and hidden) when:
  - The project isn't Git-connected, or
  - There's no canonical SQL (the inconsistent-tied case), or
  - We couldn't locate the source `AdditionalMetric` / `CustomDimension` in the canonical chart.
- Click → invokes the matching write-back mutation. Loading state on the button. Success toast (with PR-URL link) is provided by the existing hooks.

### Why it works without an extra endpoint

`useWriteBackCustomMetrics` POSTs `{ customMetrics: AdditionalMetric[] }` to `/projects/:projectUuid/git-integration/pull-requests/custom-metrics`. The endpoint uses `convertCustomMetricToDbt` to build the YAML server-side (slightly different from the agent's hand-crafted `yamlSnippet` shown in the sidebar — the server's version is the authoritative one that lands in the PR). Same for dimensions via `convertCustomSqlDimensionToDbt`.

The sidebar's YAML preview stays in place as a quick-view; the button is the path that actually creates a PR.

## Behaviour with feature flag OFF

Unchanged — no governance INSIGHTs to render the button on.

## Behaviour without GitHub integration

Button hidden; user falls back to the Copy YAML icon and manual PR creation in their dbt repo. No regression vs. slice 9.

## Test plan

- [ ] Frontend typecheck + lint pass (verified locally).
- [ ] On a Git-connected project with a `heavy_custom_usage` insight, verify the button appears under the YAML preview.
- [ ] Click the button → button shows loading state → on success, browser opens a PR on the dbt repo with the YAML applied to the appropriate model.
- [ ] On a non-Git project, verify the button does NOT appear (Copy YAML icon still does).
- [ ] On a `governance_rollup` insight, verify the button does NOT appear.
- [ ] On an `inconsistent_definitions` insight where canonicalSql is null (variants tied), verify the button does NOT appear and the existing "pick a canonical" caption renders.
- [ ] On a `sql_dimension` finding, verify the button calls the dimensions endpoint (PR contains a `meta.dimension` block, not a `metrics:` block).

## Stack

- Slice 1 (#22832): heavy_custom_usage on additional metrics, e2e
- Slice 2 (#22833): inconsistent_definitions kind + variant UI
- Slice 3 (#22836): SQL-type custom dimensions
- Slice 4 (#22837): top-K cap + governance rollup
- Slice 5 (#22839): bulk-copy combined governance YAML
- Slice 6 (#22840): Slack summary + telemetry
- Slice 7 (#22845): post-promotion expectation caption + spec course-correction
- Slice 8 (#22848): governance UX polish (copy-all moved to header, collapsible charts, inline copy, honest+gated caption)
- Slice 9 (#22852): governance UX polish v2 (drop copy-all, definition icons, label-aware names, markdown messages, consolidated sidebar)
- **Slice 10 (#22858): open dbt PR from governance INSIGHT sidebar** ← you are here

🤖 Generated with [Claude Code](https://claude.com/claude-code)