### PR TITLE
feat: add `getDownloadPivotOptions` to normalize pivot export config

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -523,6 +523,8 @@ export class QueryController extends BaseController {
         >
     > {
         this.setStatus(200);
+        const downloadPivotConfig =
+            body.exportPivotedData === false ? undefined : body.pivotConfig;
 
         const results = await this.services.getAsyncQueryService().download({
             account: req.account!,
@@ -534,8 +536,7 @@ export class QueryController extends BaseController {
             customLabels: body.customLabels,
             columnOrder: body.columnOrder,
             hiddenFields: body.hiddenFields,
-            pivotConfig: body.pivotConfig,
-            exportPivotedData: body.exportPivotedData,
+            pivotConfig: downloadPivotConfig,
             attachmentDownloadName: body.attachmentDownloadName,
         });
 
@@ -561,6 +562,8 @@ export class QueryController extends BaseController {
         @Body() body: Omit<DownloadAsyncQueryResultsRequestParams, 'queryUuid'>,
     ): Promise<ApiJobScheduledResponse> {
         this.setStatus(200);
+        const downloadPivotConfig =
+            body.exportPivotedData === false ? undefined : body.pivotConfig;
 
         const jobId = await this.services
             .getAsyncQueryService()
@@ -574,7 +577,7 @@ export class QueryController extends BaseController {
                 customLabels: body.customLabels,
                 columnOrder: body.columnOrder,
                 hiddenFields: body.hiddenFields,
-                pivotConfig: body.pivotConfig,
+                pivotConfig: downloadPivotConfig,
                 exportPivotedData: body.exportPivotedData,
                 attachmentDownloadName: body.attachmentDownloadName,
             });

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2341,7 +2341,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                hidden: { dataType: 'boolean', required: true },
                 order: { dataType: 'double', required: true },
                 name: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
@@ -9674,7 +9673,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9682,7 +9681,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9697,7 +9700,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9705,11 +9708,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2449,9 +2449,6 @@
             },
             "DashboardTab": {
                 "properties": {
-                    "hidden": {
-                        "type": "boolean"
-                    },
                     "order": {
                         "type": "number",
                         "format": "double"
@@ -2463,7 +2460,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["hidden", "order", "name", "uuid"],
+                "required": ["order", "name", "uuid"],
                 "type": "object"
             },
             "SpaceMemberRole": {
@@ -10974,9 +10971,6 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
@@ -11000,16 +10994,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -11093,9 +11087,6 @@
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
-                                                                                    },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
                                                                                     },
                                                                                     "fieldType": {
                                                                                         "type": "string"
@@ -32088,7 +32079,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2903.4",
+        "version": "0.2904.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -23,6 +23,7 @@ import {
     getCustomLabelsFromTableConfig,
     getCustomLabelsFromVizTableConfig,
     getDownloadPivotConfig,
+    getDownloadPivotOptions,
     getErrorMessage,
     getHiddenFieldsFromVizTableConfig,
     getHiddenTableFields,
@@ -563,11 +564,10 @@ export default class SchedulerTask {
                             await this.schedulerService.savedChartModel.get(
                                 savedChartUuid,
                             );
-                        const downloadPivotConfig = getDownloadPivotConfig(
-                            chart,
-                            exportPivotedData,
-                        );
-                        const shouldPivotResults = !!downloadPivotConfig;
+                        const {
+                            pivotConfig: downloadPivotConfig,
+                            shouldPivotResults,
+                        } = getDownloadPivotOptions(chart, exportPivotedData);
                         const query =
                             await this.asyncQueryService.executeAsyncSavedChartQuery(
                                 {
@@ -599,7 +599,6 @@ export default class SchedulerTask {
                                         chart.chartConfig,
                                     ),
                                     pivotConfig: downloadPivotConfig,
-                                    exportPivotedData,
                                     columnOrder: chart.tableConfig.columnOrder,
                                     expirationSecondsOverride,
                                 },
@@ -705,13 +704,13 @@ export default class SchedulerTask {
                                     await this.schedulerService.savedChartModel.get(
                                         chartUuid,
                                     );
-                                const downloadPivotConfig =
-                                    getDownloadPivotConfig(
-                                        chart,
-                                        exportPivotedData,
-                                    );
-                                const shouldPivotResults =
-                                    !!downloadPivotConfig;
+                                const {
+                                    pivotConfig: downloadPivotConfig,
+                                    shouldPivotResults,
+                                } = getDownloadPivotOptions(
+                                    chart,
+                                    exportPivotedData,
+                                );
                                 const query =
                                     await this.asyncQueryService.executeAsyncDashboardChartQuery(
                                         {
@@ -749,7 +748,6 @@ export default class SchedulerTask {
                                                 chart.chartConfig,
                                             ),
                                             pivotConfig: downloadPivotConfig,
-                                            exportPivotedData,
                                             columnOrder:
                                                 chart.tableConfig.columnOrder,
                                             expirationSecondsOverride,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1132,7 +1132,6 @@ export class AsyncQueryService extends ProjectService {
         columnOrder = [],
         hiddenFields = [],
         pivotConfig,
-        exportPivotedData = true,
         attachmentDownloadName,
         expirationSecondsOverride,
     }: DownloadAsyncQueryResultsArgs): Promise<DownloadAsyncQueryResultsInternal> {
@@ -1264,12 +1263,11 @@ export class AsyncQueryService extends ProjectService {
                       ),
                   )
                 : fields;
-        const downloadPivotConfig = exportPivotedData ? pivotConfig : undefined;
 
         switch (type) {
             case DownloadFileType.CSV:
                 // Check if this is a pivot table download
-                if (downloadPivotConfig && queryHistory.metricQuery) {
+                if (pivotConfig && queryHistory.metricQuery) {
                     return this.pivotTableService.downloadAsyncPivotTableCsv({
                         resultsFileName,
                         fields,
@@ -1286,7 +1284,7 @@ export class AsyncQueryService extends ProjectService {
                             customLabels,
                             columnOrder: validColumnOrder,
                             hiddenFields,
-                            pivotConfig: downloadPivotConfig,
+                            pivotConfig,
                             attachmentDownloadName,
                         },
                         organizationUuid,
@@ -1311,7 +1309,7 @@ export class AsyncQueryService extends ProjectService {
                         customLabels,
                         columnOrder: validColumnOrder,
                         hiddenFields,
-                        pivotConfig: downloadPivotConfig,
+                        pivotConfig,
                     },
                     attachmentDownloadName,
                     {
@@ -1328,7 +1326,7 @@ export class AsyncQueryService extends ProjectService {
             case DownloadFileType.XLSX: {
                 // Check if this is a pivot table download
                 const xlsxResult =
-                    downloadPivotConfig && queryHistory.metricQuery
+                    pivotConfig && queryHistory.metricQuery
                         ? await ExcelService.downloadAsyncPivotTableXlsx({
                               resultsFileName,
                               fields,
@@ -1346,7 +1344,7 @@ export class AsyncQueryService extends ProjectService {
                                   customLabels,
                                   columnOrder: validColumnOrder,
                                   hiddenFields,
-                                  pivotConfig: downloadPivotConfig,
+                                  pivotConfig,
                                   attachmentDownloadName,
                               },
                               timezone: displayTimezone ?? undefined,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -51,7 +51,6 @@ export type DownloadAsyncQueryResultsArgs = Omit<
     columnOrder?: string[];
     hiddenFields?: string[];
     pivotConfig?: PivotConfig;
-    exportPivotedData?: boolean;
     attachmentDownloadName?: string;
     expirationSecondsOverride?: number;
 };

--- a/packages/common/src/pivot/pivotConfig.test.ts
+++ b/packages/common/src/pivot/pivotConfig.test.ts
@@ -1,5 +1,5 @@
 import { ChartType } from '../types/savedCharts';
-import { getPivotConfig } from './pivotConfig';
+import { getDownloadPivotOptions, getPivotConfig } from './pivotConfig';
 
 describe('getPivotConfig', () => {
     describe('Cartesian chart pivot config', () => {
@@ -59,5 +59,47 @@ describe('getPivotConfig', () => {
             expect(result).toBeDefined();
             expect(result?.visibleMetricFieldIds).toBeUndefined();
         });
+    });
+});
+
+describe('getDownloadPivotOptions', () => {
+    it('disables pivoting for flat cartesian downloads', () => {
+        const result = getDownloadPivotOptions(
+            {
+                chartConfig: {
+                    type: ChartType.CARTESIAN,
+                    config: {
+                        layout: {
+                            xField: 'dim_a',
+                            yField: ['metric_a'],
+                        },
+                        eChartsConfig: { series: [] },
+                    },
+                },
+                pivotConfig: { columns: ['dim_b'] },
+                tableConfig: { columnOrder: [] },
+            },
+            false,
+        );
+
+        expect(result.pivotConfig).toBeUndefined();
+        expect(result.shouldPivotResults).toBe(false);
+    });
+
+    it('keeps pivoting enabled for table downloads', () => {
+        const result = getDownloadPivotOptions(
+            {
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {},
+                },
+                pivotConfig: { columns: ['dim_b'] },
+                tableConfig: { columnOrder: [] },
+            },
+            false,
+        );
+
+        expect(result.pivotConfig).toBeDefined();
+        expect(result.shouldPivotResults).toBe(true);
     });
 });

--- a/packages/common/src/pivot/pivotConfig.ts
+++ b/packages/common/src/pivot/pivotConfig.ts
@@ -75,3 +75,21 @@ export const getDownloadPivotConfig = (
             return undefined;
     }
 };
+
+export const getDownloadPivotOptions = (
+    savedChart: Pick<
+        CreateSavedChartVersion,
+        'chartConfig' | 'pivotConfig' | 'tableConfig'
+    >,
+    exportPivotedData: boolean = true,
+): {
+    pivotConfig: PivotConfig | undefined;
+    shouldPivotResults: boolean;
+} => {
+    const pivotConfig = getDownloadPivotConfig(savedChart, exportPivotedData);
+
+    return {
+        pivotConfig,
+        shouldPivotResults: !!pivotConfig,
+    };
+};

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1780,6 +1780,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                     )}
                     hiddenFields={getHiddenTableFields(chart.chartConfig)}
                     pivotConfig={downloadPivotConfig}
+                    canExportUnpivotedData={
+                        chart.chartConfig.type === ChartType.CARTESIAN
+                    }
                 />
                 <ExportImageModal
                     echartRef={echartRef}
@@ -2078,6 +2081,9 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     )}
                     hiddenFields={getHiddenTableFields(chart.chartConfig)}
                     pivotConfig={downloadPivotConfig}
+                    canExportUnpivotedData={
+                        chart.chartConfig.type === ChartType.CARTESIAN
+                    }
                 />
             )}
             {canExportImages && (

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -62,6 +62,7 @@ export type ExportResultsProps = {
     showTableNames?: boolean;
     chartName?: string;
     pivotConfig?: PivotConfig;
+    canExportUnpivotedData?: boolean;
     hideLimitSelection?: boolean;
     forceShowLimitSelection?: boolean;
     renderDialogActions?: (renderProps: ExportCsvRenderProps) => ReactNode;
@@ -80,6 +81,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         showTableNames,
         chartName,
         pivotConfig,
+        canExportUnpivotedData = false,
         hideLimitSelection = false,
         forceShowLimitSelection = false,
         renderDialogActions,
@@ -96,6 +98,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         const [fileType, setFileType] = useState<DownloadFileType>(
             DownloadFileType.CSV,
         );
+        const downloadPivotConfig = exportPivotedData ? pivotConfig : undefined;
 
         const { isLoading: isExporting, mutateAsync: exportMutation } =
             useMutation(
@@ -118,9 +121,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         customLabels,
                         hiddenFields,
                         showTableNames,
-                        pivotConfig: exportPivotedData
-                            ? pivotConfig
-                            : undefined,
+                        pivotConfig: downloadPivotConfig,
                         exportPivotedData,
                         attachmentDownloadName: chartName
                             ? `${chartName}_${formatDate(new Date())}`
@@ -192,7 +193,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
 
         const csvCellsLimit = health.data?.query?.csvCellsLimit || 100000;
         const maxColumnLimit = health.data?.pivotTable?.maxColumnLimit || 60;
-        const isPivotTable = exportPivotedData && !!pivotConfig;
+        const isPivotTable = !!downloadPivotConfig;
         const isDialog = !!renderDialogActions;
         const showLimitNote =
             isPivotTable ||
@@ -237,60 +238,61 @@ const ExportResults: FC<ExportResultsProps> = memo(
             </Stack>
         );
 
-        const layoutSelection = pivotConfig ? (
-            <Stack gap="sm">
-                <Stack gap={4}>
-                    <Group gap={4}>
-                        <Text fw={600} fz="sm">
-                            Layout
+        const layoutSelection =
+            pivotConfig && canExportUnpivotedData ? (
+                <Stack gap="sm">
+                    <Stack gap={4}>
+                        <Group gap={4}>
+                            <Text fw={600} fz="sm">
+                                Layout
+                            </Text>
+                            <Tooltip
+                                withinPortal
+                                maw={300}
+                                multiline
+                                label="Grouped keeps the chart's pivoted columns. Flat exports the raw rows behind the chart."
+                                position="top"
+                            >
+                                <div>
+                                    <MantineIcon
+                                        icon={IconHelpCircle}
+                                        size="sm"
+                                        color="gray"
+                                    />
+                                </div>
+                            </Tooltip>
+                        </Group>
+                        <Text fz="xs" c="dimmed">
+                            Choose whether to export the chart&apos;s grouped
+                            layout or the underlying flat rows.
                         </Text>
-                        <Tooltip
-                            withinPortal
-                            maw={300}
-                            multiline
-                            label="Grouped keeps the chart's pivoted columns. Flat exports the raw rows behind the chart."
-                            position="top"
-                        >
-                            <div>
-                                <MantineIcon
-                                    icon={IconHelpCircle}
-                                    size="sm"
-                                    color="gray"
-                                />
-                            </div>
-                        </Tooltip>
-                    </Group>
-                    <Text fz="xs" c="dimmed">
-                        Choose whether to export the chart&apos;s grouped layout
-                        or the underlying flat rows.
-                    </Text>
+                    </Stack>
+                    <SegmentedControl
+                        size="sm"
+                        fullWidth
+                        value={
+                            exportPivotedData
+                                ? EXPORT_DATA_LAYOUT.PIVOTED
+                                : EXPORT_DATA_LAYOUT.UNPIVOTED
+                        }
+                        onChange={(value) =>
+                            setExportPivotedData(
+                                value === EXPORT_DATA_LAYOUT.PIVOTED,
+                            )
+                        }
+                        data={[
+                            {
+                                label: 'Grouped',
+                                value: EXPORT_DATA_LAYOUT.PIVOTED,
+                            },
+                            {
+                                label: 'Flat',
+                                value: EXPORT_DATA_LAYOUT.UNPIVOTED,
+                            },
+                        ]}
+                    />
                 </Stack>
-                <SegmentedControl
-                    size="sm"
-                    fullWidth
-                    value={
-                        exportPivotedData
-                            ? EXPORT_DATA_LAYOUT.PIVOTED
-                            : EXPORT_DATA_LAYOUT.UNPIVOTED
-                    }
-                    onChange={(value) =>
-                        setExportPivotedData(
-                            value === EXPORT_DATA_LAYOUT.PIVOTED,
-                        )
-                    }
-                    data={[
-                        {
-                            label: 'Grouped',
-                            value: EXPORT_DATA_LAYOUT.PIVOTED,
-                        },
-                        {
-                            label: 'Flat',
-                            value: EXPORT_DATA_LAYOUT.UNPIVOTED,
-                        },
-                    ]}
-                />
-            </Stack>
-        ) : null;
+            ) : null;
 
         return (
             <Stack gap="md" miw="20rem">

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -147,6 +147,9 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                             }
                             chartName={chartName}
                             pivotConfig={pivotConfig}
+                            canExportUnpivotedData={
+                                chartConfig.type === ChartType.CARTESIAN
+                            }
                             getGsheetLink={
                                 getGsheetLink === undefined
                                     ? undefined


### PR DESCRIPTION
Closes:

### Description:

Introduces `getDownloadPivotOptions` as a replacement for direct calls to `getDownloadPivotConfig` in the scheduler. This new helper returns both the `pivotConfig` and an effective `exportPivotedData` value, ensuring that non-Cartesian chart types always export pivoted data (defaulting `exportPivotedData` to `true`) regardless of the value passed in. The scheduler now uses this effective value when constructing download requests, fixing cases where non-Cartesian charts may have incorrectly respected the `exportPivotedData` flag.