### PR TITLE
chore: allow showing empty hexbin layers on maps

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -303,6 +303,12 @@ export type MapChart = {
         sizingMode?: MapHexbinSizingMode;
         /** H3 resolution (0-15) used when sizingMode is FIXED. Ignored otherwise. */
         fixedResolution?: number;
+        /** Render outlined empty cells across the visible map area, so the user
+         *  can see "where there is no data" relative to the hex grid. */
+        showEmptyBins?: boolean;
+        /** Fill color for empty bins. Hex6 (#rrggbb) = solid fill, hex8
+         *  (#rrggbbaa) = fill with alpha, null/undefined = outline only. */
+        emptyBinColor?: string | null;
     };
     /** Data layer opacity (0.1 to 1) */
     dataLayerOpacity?: number;

--- a/packages/frontend/src/components/SimpleMap/hexbin/HexbinLayer.tsx
+++ b/packages/frontend/src/components/SimpleMap/hexbin/HexbinLayer.tsx
@@ -1,9 +1,15 @@
 import { MapHexbinSizingMode } from '@lightdash/common';
 import { scaleLinear } from 'd3-scale';
+import type * as L from 'leaflet';
 import { useEffect, useMemo, useState } from 'react';
 import { Polygon, Tooltip, useMap, useMapEvents } from 'react-leaflet';
 import type { ScatterPoint } from '../../../hooks/leaflet/useLeafletMapConfig';
-import { computeHexbinsWithMeta, type HexBin } from './hexbinUtils';
+import {
+    computeHexbinsWithMeta,
+    computeViewportEmptyBins,
+    type HexBin,
+    type ViewportBounds,
+} from './hexbinUtils';
 import { zoomToResolution } from './zoomToResolution';
 
 type Props = {
@@ -14,8 +20,32 @@ type Props = {
     sizingMode: MapHexbinSizingMode;
     /** Used when sizingMode === FIXED. */
     fixedResolution: number;
+    showEmptyBins: boolean;
+    /** Empty-bin fill color, hex6 or hex8, or null = outline-only. */
+    emptyBinColor: string | null;
     onTruncated?: (info: { totalPoints: number } | null) => void;
 };
+
+const EMPTY_BIN_STROKE = '#6c757d';
+
+/** Split a hex6 or hex8 color into a Leaflet-friendly {hex6, alpha} pair. */
+const parseHexColor = (
+    color: string,
+): { hex: string; alpha: number } | null => {
+    if (color.length === 9) {
+        const alpha = parseInt(color.slice(7, 9), 16) / 255;
+        return { hex: color.slice(0, 7), alpha };
+    }
+    if (color.length === 7) return { hex: color, alpha: 1 };
+    return null;
+};
+
+const boundsToViewport = (bounds: L.LatLngBounds): ViewportBounds => ({
+    south: bounds.getSouth(),
+    west: bounds.getWest(),
+    north: bounds.getNorth(),
+    east: bounds.getEast(),
+});
 
 const HexbinLayer = ({
     points,
@@ -24,40 +54,69 @@ const HexbinLayer = ({
     valueFieldLabel,
     sizingMode,
     fixedResolution,
+    showEmptyBins,
+    emptyBinColor,
     onTruncated,
 }: Props) => {
+    const emptyFill = emptyBinColor ? parseHexColor(emptyBinColor) : null;
     const map = useMap();
     const [zoom, setZoom] = useState<number>(map.getZoom());
+    const [viewport, setViewport] = useState<ViewportBounds>(() =>
+        boundsToViewport(map.getBounds()),
+    );
 
+    // moveend covers both pan and zoom — fires once per gesture, no debouncing needed.
     useMapEvents({
-        zoomend: () => setZoom(map.getZoom()),
+        moveend: () => {
+            setZoom(map.getZoom());
+            setViewport(boundsToViewport(map.getBounds()));
+        },
     });
 
-    const result = useMemo(() => {
-        const resolution =
+    const resolution = useMemo(
+        () =>
             sizingMode === MapHexbinSizingMode.FIXED
                 ? fixedResolution
-                : zoomToResolution(zoom);
-        return computeHexbinsWithMeta(points, resolution);
-    }, [points, zoom, sizingMode, fixedResolution]);
+                : zoomToResolution(zoom),
+        [sizingMode, fixedResolution, zoom],
+    );
+
+    // Populated bins are the expensive part (one h3 lookup per point), so we
+    // memoize them independently of viewport changes. Pan doesn't recompute
+    // them — only resolution or input data changes do.
+    const populatedResult = useMemo(
+        () => computeHexbinsWithMeta(points, resolution),
+        [points, resolution],
+    );
+    const populatedBins = populatedResult.bins;
+
+    const populatedSet = useMemo(
+        () => new Set(populatedBins.map((b) => b.h3Index)),
+        [populatedBins],
+    );
+
+    const emptyBins = useMemo(() => {
+        if (!showEmptyBins) return [];
+        return computeViewportEmptyBins(viewport, resolution, populatedSet);
+    }, [showEmptyBins, viewport, resolution, populatedSet]);
 
     useEffect(() => {
-        if (result.truncated) {
-            onTruncated?.({ totalPoints: result.totalPoints });
+        if (populatedResult.truncated) {
+            onTruncated?.({ totalPoints: populatedResult.totalPoints });
         } else {
             onTruncated?.(null);
         }
-    }, [result.truncated, result.totalPoints, onTruncated]);
+    }, [populatedResult.truncated, populatedResult.totalPoints, onTruncated]);
 
-    // Color by sum if any bin has a numeric sum, else fall back to count.
+    // Color by sum if any populated bin has a numeric sum, else fall back to count.
     const colorBy: 'sum' | 'count' = useMemo(
-        () => (result.bins.some((b) => b.sum !== null) ? 'sum' : 'count'),
-        [result.bins],
+        () => (populatedBins.some((b) => b.sum !== null) ? 'sum' : 'count'),
+        [populatedBins],
     );
 
     const scale = useMemo(() => {
-        if (result.bins.length === 0) return null;
-        const values = result.bins.map((b) =>
+        if (populatedBins.length === 0) return null;
+        const values = populatedBins.map((b) =>
             colorBy === 'sum' ? (b.sum ?? 0) : b.count,
         );
         const min = Math.min(...values);
@@ -70,13 +129,29 @@ const HexbinLayer = ({
             .domain(domain)
             .range(colorScale)
             .clamp(true);
-    }, [result.bins, colorScale, colorBy]);
+    }, [populatedBins, colorScale, colorBy]);
 
-    if (!scale || result.bins.length === 0) return null;
+    if (!scale || populatedBins.length === 0) return null;
 
     return (
         <>
-            {result.bins.flatMap((bin: HexBin) => {
+            {emptyBins.flatMap((bin: HexBin) =>
+                bin.rings.map((ring, ringIdx) => (
+                    <Polygon
+                        key={`empty-${bin.h3Index}-${ringIdx}`}
+                        positions={ring}
+                        pathOptions={{
+                            color: EMPTY_BIN_STROKE,
+                            fillColor: emptyFill?.hex,
+                            fillOpacity: emptyFill?.alpha ?? 0,
+                            weight: 1,
+                            opacity: 0.7,
+                            interactive: false,
+                        }}
+                    />
+                )),
+            )}
+            {populatedBins.flatMap((bin: HexBin) => {
                 const metric = colorBy === 'sum' ? (bin.sum ?? 0) : bin.count;
                 const color = scale(metric);
                 return bin.rings.map((ring, ringIdx) => (

--- a/packages/frontend/src/components/SimpleMap/hexbin/hexbinUtils.test.ts
+++ b/packages/frontend/src/components/SimpleMap/hexbin/hexbinUtils.test.ts
@@ -1,6 +1,8 @@
 import type { ScatterPoint } from '../../../hooks/leaflet/useLeafletMapConfig';
 import {
     computeHexbins,
+    computeHexbinsWithMeta,
+    computeViewportEmptyBins,
     MAX_HEXBIN_POINTS,
     splitAntimeridianRing,
     type LatLng,
@@ -85,6 +87,27 @@ describe('computeHexbins', () => {
         expect(typeof bins[0].centroid[1]).toBe('number');
     });
 
+    it('adds k=1 neighbor cells as count-0 bins when includeEmptyNeighbors is set', () => {
+        // One isolated point at res 7 should yield 1 populated bin + 6 empty
+        // neighbor bins (h3 cells have 6 neighbors at non-pentagon locations).
+        const { bins } = computeHexbinsWithMeta(
+            [mkPoint(40.7128, -74.006)],
+            7,
+            { includeEmptyNeighbors: true },
+        );
+        const populated = bins.filter((b) => b.count > 0);
+        const empty = bins.filter((b) => b.count === 0);
+        expect(populated).toHaveLength(1);
+        expect(empty).toHaveLength(6);
+        expect(empty.every((b) => b.sum === null)).toBe(true);
+    });
+
+    it('does not include neighbors when includeEmptyNeighbors is unset', () => {
+        const { bins } = computeHexbinsWithMeta([mkPoint(40.7128, -74.006)], 7);
+        expect(bins).toHaveLength(1);
+        expect(bins[0].count).toBe(1);
+    });
+
     it('truncates input above MAX_HEXBIN_POINTS', () => {
         const points = Array.from({ length: MAX_HEXBIN_POINTS + 100 }, (_, i) =>
             mkPoint(40 + i * 0.0001, -74),
@@ -92,6 +115,51 @@ describe('computeHexbins', () => {
         const bins = computeHexbins(points, 9);
         const total = bins.reduce((acc, b) => acc + b.count, 0);
         expect(total).toBe(MAX_HEXBIN_POINTS);
+    });
+});
+
+describe('computeViewportEmptyBins', () => {
+    const populated = new Set<string>();
+
+    it('returns cells covering the viewport, excluding populated', () => {
+        const empties = computeViewportEmptyBins(
+            { south: 40, west: -75, north: 41, east: -73 },
+            5,
+            populated,
+        );
+        expect(empties.length).toBeGreaterThan(0);
+        const ids = new Set(empties.map((b) => b.h3Index));
+        expect(ids.size).toBe(empties.length);
+    });
+
+    it('omits a populated cell from the empties', () => {
+        const sample = computeViewportEmptyBins(
+            { south: 40, west: -75, north: 41, east: -73 },
+            5,
+            new Set(),
+        );
+        const populatedOne = new Set([sample[0].h3Index]);
+        const filtered = computeViewportEmptyBins(
+            { south: 40, west: -75, north: 41, east: -73 },
+            5,
+            populatedOne,
+        );
+        expect(
+            filtered.find((b) => b.h3Index === sample[0].h3Index),
+        ).toBeUndefined();
+        expect(filtered.length).toBe(sample.length - 1);
+    });
+
+    it('handles near-world viewports without inverting the polygon', () => {
+        // Polygons spanning > 180° of longitude trip an h3-js bug where it
+        // returns cells outside the polygon. cellsInViewport must split.
+        const empties = computeViewportEmptyBins(
+            { south: 5, west: -65, north: 85, east: 155 },
+            1,
+            new Set(),
+        );
+        // At res 1 there are 842 cells globally; this viewport covers ~⅓.
+        expect(empties.length).toBeGreaterThan(50);
     });
 });
 

--- a/packages/frontend/src/components/SimpleMap/hexbin/hexbinUtils.ts
+++ b/packages/frontend/src/components/SimpleMap/hexbin/hexbinUtils.ts
@@ -1,5 +1,19 @@
-import { cellToBoundary, cellToLatLng, latLngToCell } from 'h3-js';
+import {
+    cellToBoundary,
+    cellToLatLng,
+    gridDisk,
+    latLngToCell,
+    polygonToCells,
+} from 'h3-js';
 import type { ScatterPoint } from '../../../hooks/leaflet/useLeafletMapConfig';
+
+/**
+ * Hard cap on how many empty cells we render in a single viewport. polygonToCells
+ * is fast, but rendering tens of thousands of <Polygon>s in Leaflet's SVG renderer
+ * is not. We pick 10k so the world view at h3 resolution 2 (~5,900 cells) fits
+ * comfortably; finer resolutions over a global viewport bail rather than freeze.
+ */
+const MAX_EMPTY_CELLS_PER_VIEWPORT = 10_000;
 
 export const MAX_HEXBIN_POINTS = 50_000;
 
@@ -69,9 +83,16 @@ export type HexbinResult = {
     totalPoints: number;
 };
 
+export type ComputeHexbinsOptions = {
+    /** When true, also include the k=1 hex neighborhood around each populated
+     *  bin as zero-count "empty" bins. Useful for giving sparse data context. */
+    includeEmptyNeighbors?: boolean;
+};
+
 export const computeHexbinsWithMeta = (
     points: ScatterPoint[],
     resolution: number,
+    options: ComputeHexbinsOptions = {},
 ): HexbinResult => {
     const truncated = points.length > MAX_HEXBIN_POINTS;
     const usedPoints = truncated ? points.slice(0, MAX_HEXBIN_POINTS) : points;
@@ -112,7 +133,145 @@ export const computeHexbinsWithMeta = (
         });
     }
 
+    if (options.includeEmptyNeighbors) {
+        bins.push(...computeEmptyNeighbors(bins));
+    }
+
     return { bins, truncated, totalPoints: points.length };
+};
+
+/**
+ * Given a set of populated bins, return one empty bin per cell in their k=1
+ * neighborhood that isn't itself populated. Kept exported (no longer used by
+ * HexbinLayer, which uses viewport fill instead) — useful as a fallback if
+ * viewport fill ever proves too expensive.
+ */
+const computeEmptyNeighbors = (populatedBins: HexBin[]): HexBin[] => {
+    const populated = new Set(populatedBins.map((b) => b.h3Index));
+    const seenEmpty = new Set<string>();
+    const empties: HexBin[] = [];
+    for (const h3Index of populated) {
+        for (const neighbor of gridDisk(h3Index, 1)) {
+            if (populated.has(neighbor) || seenEmpty.has(neighbor)) continue;
+            seenEmpty.add(neighbor);
+            const rawBoundary = cellToBoundary(neighbor) as LatLng[];
+            empties.push({
+                h3Index: neighbor,
+                count: 0,
+                sum: null,
+                rings: splitAntimeridianRing(rawBoundary),
+                centroid: cellToLatLng(neighbor) as LatLng,
+            });
+        }
+    }
+    return empties;
+};
+
+// ─── Viewport-based empty-cell fill ────────────────────────────────────────
+
+export type ViewportBounds = {
+    /** South latitude */
+    south: number;
+    /** West longitude */
+    west: number;
+    /** North latitude */
+    north: number;
+    /** East longitude */
+    east: number;
+};
+
+/** Build a HexBin entry for an empty (count=0) cell. */
+const emptyBinFor = (h3Index: string): HexBin => ({
+    h3Index,
+    count: 0,
+    sum: null,
+    rings: splitAntimeridianRing(cellToBoundary(h3Index) as LatLng[]),
+    centroid: cellToLatLng(h3Index) as LatLng,
+});
+
+/**
+ * Build a closed lat/lng rectangle ring suitable for h3-js polygonToCells
+ * (isGeoJson=false). Order is counter-clockwise.
+ */
+const rectRing = (
+    south: number,
+    west: number,
+    north: number,
+    east: number,
+): LatLng[] => [
+    [south, west],
+    [south, east],
+    [north, east],
+    [north, west],
+    [south, west],
+];
+
+/**
+ * Enumerate H3 cells inside a rectangular viewport. Splits polygons that span
+ * more than 180° of longitude — h3-js polygonToCells flips its interior/exterior
+ * interpretation on near-world polygons and returns ~0 cells, which produces a
+ * weirdly empty map at low zoom. Splitting into ≤180° halves sidesteps this
+ * entirely (cells along the seam are deduplicated via the returned Set).
+ */
+const cellsInViewport = (
+    south: number,
+    west: number,
+    north: number,
+    east: number,
+    resolution: number,
+): string[] => {
+    const lngSpan = east - west;
+    if (lngSpan <= 180) {
+        return polygonToCells(rectRing(south, west, north, east), resolution);
+    }
+    const mid = west + lngSpan / 2;
+    const a = polygonToCells(rectRing(south, west, north, mid), resolution);
+    const b = polygonToCells(rectRing(south, mid, north, east), resolution);
+    return Array.from(new Set([...a, ...b]));
+};
+
+/**
+ * Compute empty bins covering the visible map area at the given resolution.
+ * Excludes any cell that's already populated. Returns an empty array if the
+ * cell count would exceed MAX_EMPTY_CELLS_PER_VIEWPORT — bigger sets cause
+ * Leaflet rendering to grind.
+ */
+export const computeViewportEmptyBins = (
+    bounds: ViewportBounds,
+    resolution: number,
+    populated: ReadonlySet<string>,
+): HexBin[] => {
+    // Clamp to the world. At very low zoom Leaflet's getBounds can extend
+    // beyond ±180° / ±90° — passing those to polygonToCells produces a
+    // self-overlapping polygon that returns cells inconsistently along the
+    // dateline. Clamping keeps the input well-formed.
+    const south = Math.max(bounds.south, -85);
+    const north = Math.min(bounds.north, 85);
+    const west = Math.max(bounds.west, -180);
+    const east = Math.min(bounds.east, 180);
+    if (south >= north || west >= east) return [];
+
+    const baseCells = cellsInViewport(south, west, north, east, resolution);
+    if (baseCells.length > MAX_EMPTY_CELLS_PER_VIEWPORT) {
+        return [];
+    }
+
+    // Expand by one ring of neighbors so cells whose centroid sits just past
+    // the viewport edge still render — without this you get visible gaps at
+    // the screen border where partial hexes should be visible.
+    const expanded = new Set<string>(baseCells);
+    for (const cell of baseCells) {
+        for (const neighbor of gridDisk(cell, 1)) {
+            expanded.add(neighbor);
+        }
+    }
+
+    const empties: HexBin[] = [];
+    for (const cell of expanded) {
+        if (populated.has(cell)) continue;
+        empties.push(emptyBinFor(cell));
+    }
+    return empties;
 };
 
 /** Convenience wrapper for tests / call sites that don't need truncation metadata. */

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -1040,6 +1040,12 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                                     fixedResolution={
                                         mapConfig.hexbinConfig.fixedResolution
                                     }
+                                    showEmptyBins={
+                                        mapConfig.hexbinConfig.showEmptyBins
+                                    }
+                                    emptyBinColor={
+                                        mapConfig.hexbinConfig.emptyBinColor
+                                    }
                                     onTruncated={setHexbinTruncated}
                                 />
                             </Suspense>

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
@@ -671,8 +671,58 @@ export const Display: FC = memo(() => {
                             ]}
                             mb="md"
                         />
+                        <Config.Group>
+                            <Config.Label>Show empty bins</Config.Label>
+                            <Switch
+                                checked={
+                                    validConfig.hexbinConfig?.showEmptyBins ??
+                                    false
+                                }
+                                onChange={(e) =>
+                                    setHexbinConfig({
+                                        showEmptyBins: e.currentTarget.checked,
+                                    })
+                                }
+                            />
+                        </Config.Group>
+                        {(validConfig.hexbinConfig?.showEmptyBins ?? false) && (
+                            <Group my="xs">
+                                <ColorSelector
+                                    // The "no fill" state is the transparent
+                                    // gray swatch — Mantine renders it with
+                                    // the checkered transparency pattern, so
+                                    // it visually reads as no-fill without
+                                    // any separate toggle. Other swatches
+                                    // emit hex6; users can drag the alpha
+                                    // slider in the picker for partial fill.
+                                    color={
+                                        validConfig.hexbinConfig
+                                            ?.emptyBinColor ?? '#adb5bd00'
+                                    }
+                                    swatches={[
+                                        '#adb5bd00',
+                                        ...ECHARTS_DEFAULT_COLORS,
+                                    ]}
+                                    withAlpha
+                                    onColorChange={(c) => {
+                                        // alpha=00 → no fill (null).
+                                        // Otherwise store as picked (hex6 or
+                                        // hex8); HexbinLayer parses alpha.
+                                        const isTransparent =
+                                            c.length === 9 && c.endsWith('00');
+                                        setHexbinConfig({
+                                            emptyBinColor: isTransparent
+                                                ? null
+                                                : c,
+                                        });
+                                    }}
+                                />
+                                <Config.Label>Empty bin fill</Config.Label>
+                            </Group>
+                        )}
                         <Text size="xs" c="dimmed" mt="xs">
-                            Bins are computed from up to 50,000 points;
+                            Empty bins fill the visible area at the current
+                            zoom. Bins are computed from up to 50,000 points;
                             additional points are ignored.
                         </Text>
                     </Config.Section>

--- a/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
+++ b/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
@@ -82,6 +82,9 @@ export type LeafletMapConfig = {
         sizingMode: MapHexbinSizingMode;
         /** Resolution to use when sizingMode === FIXED. */
         fixedResolution: number;
+        showEmptyBins: boolean;
+        /** Hex6 or hex8 color string for empty-bin fill, or null = outline only. */
+        emptyBinColor: string | null;
     };
     tile: TileConfig;
     tileBackground: MapTileBackground;
@@ -599,6 +602,8 @@ const useLeafletMapConfig = ({
                 sizingMode:
                     hexbinConfig?.sizingMode ?? MapHexbinSizingMode.DYNAMIC,
                 fixedResolution: hexbinConfig?.fixedResolution ?? 4,
+                showEmptyBins: hexbinConfig?.showEmptyBins ?? false,
+                emptyBinColor: hexbinConfig?.emptyBinColor ?? null,
             },
             tile: getTileConfig(
                 colorScheme === 'dark'


### PR DESCRIPTION
### Description:

Allows showing extra bins on maps
