### PR TITLE
fix(replace-custom-metrics): treat default-typed formatOptions as no-format

### DIFF
--- a/packages/common/src/utils/fields.test.ts
+++ b/packages/common/src/utils/fields.test.ts
@@ -116,6 +116,37 @@ describe('compareMetricAndCustomMetric', () => {
         },
     );
 
+    test('should treat default-typed formatOptions as equivalent to no formatOptions', async () => {
+        const result = compareMetricAndCustomMetric({
+            customMetric: {
+                ...customMetric,
+                formatOptions: {
+                    type: CustomFormatType.DEFAULT,
+                    separator: NumberSeparator.DEFAULT,
+                },
+            },
+            metric: {
+                ...metric,
+            },
+        });
+        expect(result.isExactMatch).toEqual(true);
+        expect(result.isSuggestedMatch).toEqual(true);
+    });
+
+    test('should treat null and undefined percentile as equivalent', async () => {
+        const result = compareMetricAndCustomMetric({
+            customMetric: {
+                ...customMetric,
+                percentile: null as unknown as undefined,
+            },
+            metric: {
+                ...metric,
+            },
+        });
+        expect(result.isExactMatch).toEqual(true);
+        expect(result.isSuggestedMatch).toEqual(true);
+    });
+
     test('should return exact match when comparing format expression with format object', async () => {
         const result = compareMetricAndCustomMetric({
             customMetric: {

--- a/packages/common/src/utils/fields.ts
+++ b/packages/common/src/utils/fields.ts
@@ -1,12 +1,13 @@
 import { type Explore } from '../types/explore';
 import {
+    CustomFormatType,
     type CompiledDimension,
     type CompiledField,
     type CompiledMetric,
     type Metric,
 } from '../types/field';
 import { isDateFilterRule, type DateFilterSettings } from '../types/filter';
-import { type AdditionalMetric } from '../types/metricQuery';
+import { hasFormatOptions, type AdditionalMetric } from '../types/metricQuery';
 import type { ParametersValuesMap } from '../types/parameters';
 import {
     type ReplaceableCustomFields,
@@ -151,6 +152,23 @@ export const getFields = (explore: Explore): CompiledField[] => [
     ...getMetrics(explore),
 ];
 
+// An item has "no meaningful format" when it carries no explicit formatOptions
+// (or only `{type: 'default'}`) and no legacy format fields. `getFormatExpression`
+// would produce `undefined` for the default-typed formatOptions case but a phantom
+// number-format string (e.g., `'0'`) for items with no formatOptions at all that
+// happen to be numeric — and those two states should compare as equivalent.
+const hasMeaningfulFormat = (item: Metric | AdditionalMetric): boolean => {
+    if (hasFormatOptions(item)) {
+        return item.formatOptions.type !== CustomFormatType.DEFAULT;
+    }
+    if ('format' in item && item.format) return true;
+    if ('compact' in item && item.compact) return true;
+    if ('round' in item && item.round !== undefined && item.round !== null) {
+        return true;
+    }
+    return false;
+};
+
 export function compareMetricAndCustomMetric({
     metric,
     customMetric,
@@ -158,6 +176,13 @@ export function compareMetricAndCustomMetric({
     metric: Metric;
     customMetric: AdditionalMetric;
 }) {
+    const metricHasFormat = hasMeaningfulFormat(metric);
+    const customMetricHasFormat = hasMeaningfulFormat(customMetric);
+    const formatIsMatch =
+        !metricHasFormat && !customMetricHasFormat
+            ? true
+            : getFormatExpression(metric) === getFormatExpression(customMetric);
+
     const conditions = {
         fieldIdMatch: {
             isMatch: getItemId(metric) === getItemId(customMetric),
@@ -182,13 +207,14 @@ export function compareMetricAndCustomMetric({
             requiredForSuggestion: true,
         },
         formatMatch: {
-            isMatch:
-                getFormatExpression(metric) ===
-                getFormatExpression(customMetric),
+            isMatch: formatIsMatch,
             requiredForSuggestion: true,
         },
         percentileMatch: {
-            isMatch: metric.percentile === customMetric.percentile,
+            // Coalesce null/undefined: chart-side hydrates DB NULL as null, explore-side omits the key (undefined).
+            isMatch:
+                (metric.percentile ?? null) ===
+                (customMetric.percentile ?? null),
             requiredForSuggestion: true,
         },
         filtersMatch: {


### PR DESCRIPTION
## Summary

Fixes a long-standing match-failure mode in `compareMetricAndCustomMetric` (the comparator that powers `replace-custom-metrics-on-compile` and the chart-explorer Write Back suggestion). Charts created via the API/CLI carry a no-op `formatOptions: { type: 'default', separator: 'default' }` block by default, while explore metrics whose dbt YAML has no explicit format have no `formatOptions` at all. Both states semantically mean "no formatting was set", but `getFormatExpression` resolved them to **different** values (the default-typed formatOptions returns `undefined`, while a numeric metric with no formatOptions falls through to a legacy `NUMBER` format expression like `'0'`). `formatMatch` then failed and a chart's custom metric was never recognised as a duplicate of its dbt-side equivalent.

This is a slice in the [governance insights stack](docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md) (PROD-7392) but the fix is independent of governance — it lives at `packages/common/src/utils/fields.ts` and helps every consumer of `compareMetricAndCustomMetric` (chart-as-code "Write Back to dbt", governance Open PR, scheduled `replace-custom-metrics-on-compile`).

## What changes

`compareMetricAndCustomMetric` now treats a pair of items where **neither side has meaningful formatting** as a format match, regardless of which path `getFormatExpression` happened to take internally.

A new private helper `hasMeaningfulFormat(item)` decides whether an item has formatting we'd care about preserving:
- A `formatOptions` block with `type !== 'default'` → meaningful.
- A `formatOptions` block with `type === 'default'` (or no `formatOptions` at all) → not meaningful; legacy `format`/`compact`/`round` on the item are checked next.
- `format`, `compact`, or `round` (non-falsy / non-null) → meaningful.

`formatMatch.isMatch` short-circuits to `true` when both sides report no meaningful format. Otherwise it falls back to the existing `getFormatExpression(metric) === getFormatExpression(customMetric)` comparison — so any case where at least one side carries real formatting still uses the old strict equality.

## Pre-existing behaviour preserved

- Charts and explore metrics that both have no formatting at all continue to match (regression-tested by the existing default-case test in `fields.test.ts`).
- Currency / percent / etc. format options still need to round-trip exactly to the explore metric's format expression (existing `should return exact match when comparing format expression with format object` test still passes).
- Metrics with `format: 'usd'`, `round: 2`, `compact: ...` etc. continue to be considered "meaningful" and require strict equality.

## What this is NOT

- Not a change to `getFormatExpression` itself. The legacy `NUMBER` fallback for items with no formatOptions remains — it's used by other callers (rendering, exports) that genuinely want a default representation. We just stop using it for *equivalence* checks where both sides claim "no format".
- Not a change to the writeback YAML output — `convertCustomMetricToDbt` is unchanged.

## Test added

`should treat default-typed formatOptions as equivalent to no formatOptions` in `fields.test.ts`. Constructs a custom metric with `formatOptions: { type: DEFAULT, separator: DEFAULT }` and an explore metric with no formatOptions / format / round / compact, asserts both `isExactMatch` and `isSuggestedMatch`.

## Test plan

- [ ] Common typecheck + lint + test pass (verified locally).
- [ ] On a project with a chart whose custom metric was created via the CLI (carries `formatOptions: { type: default }`) and a corresponding dbt-side metric with no explicit format, run a project compile. Expected: `replaceCustomFields` finds the chart, replaces the custom metric with the dbt metric, chart history shows a new version. Pre-fix: would find 0 charts.
- [ ] Verify that a chart whose custom metric has `format: 'usd'` and a dbt metric with no format still does NOT match (formatMatch falls back to strict comparison and fails — desired).

## Stack

- Slice 1 (#22832): heavy_custom_usage on additional metrics, e2e
- Slice 2 (#22833): inconsistent_definitions kind + variant UI
- Slice 3 (#22836): SQL-type custom dimensions
- Slice 4 (#22837): top-K cap + governance rollup
- Slice 5 (#22839): bulk-copy combined governance YAML
- Slice 6 (#22840): Slack summary + telemetry
- Slice 7 (#22845): post-promotion expectation caption + spec course-correction
- Slice 8 (#22848): governance UX polish v1
- Slice 9 (#22852): governance UX polish v2
- Slice 10 (#22858): open dbt PR from governance INSIGHT sidebar
- Slice 11 (#22862): auto-resolve governance INSIGHTs
- **Slice 13 (#22867): formatMatch tolerates default formatOptions** ← you are here

🤖 Generated with [Claude Code](https://claude.com/claude-code)