### PR TITLE
feat(managed-agent): show ✓ on resolved/dismissed action rows

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1883,6 +1883,33 @@ const ActionRow: FC<{
     const config = ACTION_CONFIG[action.actionType];
     const TargetIcon = getActionRowIcon(action);
     const isReversed = !!action.reversedAt;
+    const isActionAutoResolved =
+        isReversed &&
+        (action.metadata as Record<string, unknown> | undefined)
+            ?.autoResolved === true;
+    const reversedTooltip = isActionAutoResolved
+        ? 'Auto-resolved'
+        : getManagedAgentActionCategory(action.actionType) === 'undo'
+          ? 'Undone'
+          : 'Dismissed';
+    const pillTooltip = isReversed ? reversedTooltip : config.tooltip;
+    const pillContents = (
+        <span className={classes.actionPill}>
+            {isReversed ? (
+                <MantineIcon
+                    icon={IconCheck}
+                    size={10}
+                    color="var(--mantine-color-dimmed)"
+                />
+            ) : (
+                <Box
+                    className={classes.dot}
+                    style={{ backgroundColor: config.dotColor }}
+                />
+            )}
+            {config.label}
+        </span>
+    );
 
     return (
         <Table.Tr
@@ -1896,24 +1923,12 @@ const ActionRow: FC<{
             onClick={() => onSelect(action)}
         >
             <Table.Td w={100}>
-                {config.tooltip ? (
-                    <Tooltip label={config.tooltip} withinPortal>
-                        <span className={classes.actionPill}>
-                            <Box
-                                className={classes.dot}
-                                style={{ backgroundColor: config.dotColor }}
-                            />
-                            {config.label}
-                        </span>
+                {pillTooltip ? (
+                    <Tooltip label={pillTooltip} withinPortal>
+                        {pillContents}
                     </Tooltip>
                 ) : (
-                    <span className={classes.actionPill}>
-                        <Box
-                            className={classes.dot}
-                            style={{ backgroundColor: config.dotColor }}
-                        />
-                        {config.label}
-                    </span>
+                    pillContents
                 )}
             </Table.Td>
             <Table.Td w={250}>


### PR DESCRIPTION
## Summary

Slice 14 of the [governance insights stack](docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md) (PROD-7392). Stacks on #22867.

When an action row is reversed (any reason — user-dismissed, undone, auto-resolved by slice 11), the row now visually conveys it at a glance instead of requiring a click into the sidebar.

## What changes

In `ActionRow`, when `action.reversedAt !== null`:
- The colored category dot (purple for insight, teal for fixed, etc.) is replaced by a small ✓ `IconCheck` in a dimmed colour.
- The action label ("Insight", "Fixed", etc.) stays so the original category remains readable.
- A tooltip on the pill differentiates the resolution path:
  - "Auto-resolved" when `metadata.autoResolved === true` (slice 11's path)
  - "Undone" for action categories where revert means restore (`SOFT_DELETED`, `CREATED_CONTENT`, `FIXED_BROKEN`)
  - "Dismissed" otherwise (the user-dismissed path)
- The existing `classes.rowReversed` styling (the dimming) is unchanged — the tick complements it.

When the row isn't reversed, behaviour is unchanged (coloured dot, original tooltip, original styling).

## Why

Action lists tend to grow long. Without the row-level signal, users couldn't scan the list to see which insights they'd already actioned vs. ones still requiring attention — they'd have to click into each one. The tick is generic across action types so it benefits dismissals, undos, and auto-resolutions equally.

## Test plan

- [ ] Frontend typecheck + lint pass (verified locally).
- [ ] On a project with one `INSIGHT` action that's been auto-resolved (slice 11), verify the row shows ✓ and the pill tooltip reads "Auto-resolved".
- [ ] On a manually-dismissed `INSIGHT`, verify the tooltip reads "Dismissed".
- [ ] On an undone `FIXED_BROKEN` or `SOFT_DELETED` action, verify the tooltip reads "Undone".
- [ ] On an active (non-reversed) action, verify the coloured category dot still renders and the tooltip is the action's own (e.g., "Marked as broken. Future Autopilot runs...").

## Stack

- Slice 1 (#22832): heavy_custom_usage on additional metrics, e2e
- Slice 2 (#22833): inconsistent_definitions kind + variant UI
- Slice 3 (#22836): SQL-type custom dimensions
- Slice 4 (#22837): top-K cap + governance rollup
- Slice 5 (#22839): bulk-copy combined governance YAML
- Slice 6 (#22840): Slack summary + telemetry
- Slice 7 (#22845): post-promotion expectation caption + spec course-correction
- Slice 8 (#22848): governance UX polish v1
- Slice 9 (#22852): governance UX polish v2
- Slice 10 (#22858): open dbt PR from governance INSIGHT sidebar
- Slice 11 (#22862): auto-resolve governance INSIGHTs
- Slice 13 (#22867): formatMatch tolerates default formatOptions
- **Slice 14 (#22868): row-level ✓ on resolved/dismissed actions** ← you are here

🤖 Generated with [Claude Code](https://claude.com/claude-code)