### PR TITLE
feat(managed-agent): hide governance YAML/PR/caption when insight is reversed

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -594,7 +594,8 @@ const GovernanceRollupDetails: FC<{
 const GovernanceDetails: FC<{
     projectUuid: string;
     metadata: GovernanceInsightMetadata;
-}> = ({ projectUuid, metadata }) => {
+    isReversed: boolean;
+}> = ({ projectUuid, metadata, isReversed }) => {
     const suggestion = metadata.suggestion;
     const isInconsistent =
         metadata.insightKind === GovernanceInsightKind.INCONSISTENT_DEFINITIONS;
@@ -671,7 +672,7 @@ const GovernanceDetails: FC<{
                 ))}
             </Stack>
 
-            {suggestion?.yamlSnippet ? (
+            {!isReversed && suggestion?.yamlSnippet ? (
                 <Stack gap={4}>
                     <MetadataLabel label="Proposed dbt YAML" />
                     <Box style={{ position: 'relative' }}>
@@ -728,7 +729,9 @@ const GovernanceDetails: FC<{
                     )}
                 </Stack>
             ) : (
-                isInconsistent && (
+                !isReversed &&
+                isInconsistent &&
+                !suggestion?.yamlSnippet && (
                     <Stack gap={4}>
                         <MetadataLabel label="Proposed dbt YAML" />
                         <Text fz="xs" c="dimmed" lh={1.6}>
@@ -739,14 +742,16 @@ const GovernanceDetails: FC<{
                 )
             )}
 
-            {suggestion?.yamlSnippet && replaceOnCompileEnabled && (
-                <Text fz="xs" c="dimmed" lh={1.6} fs="italic">
-                    Add this to dbt with the same name and SQL, then re-compile
-                    the project. Affected charts will be cleaned up
-                    automatically on the next compile if the new dbt metric is
-                    an exact match.
-                </Text>
-            )}
+            {!isReversed &&
+                suggestion?.yamlSnippet &&
+                replaceOnCompileEnabled && (
+                    <Text fz="xs" c="dimmed" lh={1.6} fs="italic">
+                        Add this to dbt with the same name and SQL, then
+                        re-compile the project. Affected charts will be cleaned
+                        up automatically on the next compile if the new dbt
+                        metric is an exact match.
+                    </Text>
+                )}
         </Stack>
     );
 };
@@ -1467,6 +1472,7 @@ const DetailSidebar: FC<{
                     <GovernanceDetails
                         projectUuid={action.projectUuid}
                         metadata={governanceMetadata}
+                        isReversed={isReversed}
                     />
                 )}
                 {governanceRollupMetadata && (


### PR DESCRIPTION
## Summary

Slice 15 of the [governance insights stack](docs/superpowers/specs/2026-05-08-managed-agent-governance-insights-design.md) (PROD-7392). Stacks on #22868.

When a governance INSIGHT is reversed (auto-resolved by slice 11 OR user-dismissed), the sidebar's actionable affordances become misleading — the YAML proposal has already been applied, the "Open PR" button would create a duplicate PR, the "Add this to dbt…" caption is retroactive nonsense. This slice hides them when `liveAction.reversedAt !== null`.

## What changes

`GovernanceDetails` accepts a new `isReversed` prop (passed from `DetailSidebar` using the same `liveAction.reversedAt` flag that drives the existing reversed-banner). When `isReversed` is true:

- **Hidden**: "Proposed dbt YAML" section (Code block + ActionIcon copy + "Open pull request in dbt repo" button + suggestion rationale below).
- **Hidden**: the "pick a canonical" fallback caption that renders when `suggestion.canonicalSql` is null on inconsistent groups.
- **Hidden**: the italic "Add this to dbt with the same name and SQL…" caption.
- **Kept**: the section header (`Used in N charts` / `N distinct definitions across M charts`).
- **Kept**: the variant list with chart links — useful as a historical record of what the duplicate state looked like at the time.

When `isReversed` is false, behaviour is unchanged.

## Why kept the variants

Two reasons:
1. The chart links are a useful audit trail — "the agent flagged these specific charts at the time of resolution". Helps reviewers reconstruct what was fixed.
2. After auto-replace runs, the affected charts no longer reference the custom metric — but the historical fact that they did is still meaningful context. Hiding the variant list would make the resolved insight look anaemic.

## Test plan

- [ ] Frontend typecheck + lint pass (verified locally).
- [ ] On an active governance INSIGHT, the YAML preview, Copy icon, "Open pull request" button, and italic compile caption all render (unchanged behaviour).
- [ ] On the same insight after auto-resolution (slice 11) or user-dismissal: the YAML preview, Copy icon, "Open PR" button, and italic caption are all gone. Section header + variant list still visible.
- [ ] On a `governance_rollup` insight (which has no actionable bits to begin with), no behaviour change.
- [ ] On a tied-canonical inconsistent insight (suggestion.canonicalSql is null) that gets reversed, the "pick a canonical" fallback caption is also hidden.

## Stack

- Slice 1 (#22832) → Slice 14 (#22868)
- **Slice 15 (#22869): hide governance actionables when reversed** ← you are here

🤖 Generated with [Claude Code](https://claude.com/claude-code)