### PR TITLE
fix(writeback): omit format field when chart custom metric has none

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -171,7 +171,6 @@ models:
               label: New metric
               description: description
               type: average
-              format: "#,##0.###"
           additional_dimensions:
             id:
               label: Sql dimension

--- a/packages/common/src/utils/convertCustomMetricsToYaml.ts
+++ b/packages/common/src/utils/convertCustomMetricsToYaml.ts
@@ -2,17 +2,27 @@ import type { DbtColumnLightdashMetric } from '../types/dbt';
 import { friendlyName } from '../types/field';
 import { convertMetricFilterToDbt } from '../types/filterGrammarConversion';
 import { type AdditionalMetric } from '../types/metricQuery';
+import { hasMeaningfulFormat } from './fields';
 import { getFormatExpression } from './formatting';
 
 export function convertCustomMetricToDbt(
     field: AdditionalMetric,
 ): DbtColumnLightdashMetric {
     const filters = convertMetricFilterToDbt(field.filters);
+    // Only emit `format` when the chart has actually configured one. Calling
+    // `getFormatExpression` on a numeric field with no formatOptions falls
+    // through to a legacy NUMBER expression like `"#,##0.###"`, which would
+    // otherwise be baked into the dbt YAML and fail downstream
+    // `compareMetricAndCustomMetric` matching against an explore metric that
+    // has no format set.
+    const format = hasMeaningfulFormat(field)
+        ? getFormatExpression(field)
+        : undefined;
     return {
         label: field.label || friendlyName(field.name),
         description: field.description,
         type: field.type,
-        format: getFormatExpression(field),
+        format,
         percentile: field.percentile,
         filters,
     };

--- a/packages/common/src/utils/fields.ts
+++ b/packages/common/src/utils/fields.ts
@@ -157,7 +157,9 @@ export const getFields = (explore: Explore): CompiledField[] => [
 // would produce `undefined` for the default-typed formatOptions case but a phantom
 // number-format string (e.g., `'0'`) for items with no formatOptions at all that
 // happen to be numeric — and those two states should compare as equivalent.
-const hasMeaningfulFormat = (item: Metric | AdditionalMetric): boolean => {
+export const hasMeaningfulFormat = (
+    item: Metric | AdditionalMetric,
+): boolean => {
     if (hasFormatOptions(item)) {
         return item.formatOptions.type !== CustomFormatType.DEFAULT;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
