### PR TITLE
fix(explorer): unique testid for header vs empty-state Run query button

### DIFF
--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -158,7 +158,9 @@ describe('Date tests', () => {
         cy.visit(
             `/projects/${SEED_PROJECT.project_uuid}/tables/events${exploreStateUrlParams}`,
         );
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('not.be.disabled')
+            .click();
         cy.contains('SQL');
         cy.findAllByText('Loading chart').should('have.length', 0);
 

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -158,8 +158,7 @@ describe('Date tests', () => {
         cy.visit(
             `/projects/${SEED_PROJECT.project_uuid}/tables/events${exploreStateUrlParams}`,
         );
-        cy.findByTestId('page-spinner').should('not.exist');
-        cy.get('button').contains('Run query').should('be.visible').click();
+        cy.get('button').contains('Run query').click();
         cy.contains('SQL');
         cy.findAllByText('Loading chart').should('have.length', 0);
 

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -158,7 +158,8 @@ describe('Date tests', () => {
         cy.visit(
             `/projects/${SEED_PROJECT.project_uuid}/tables/events${exploreStateUrlParams}`,
         );
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('page-spinner').should('not.exist');
+        cy.get('button').contains('Run query').should('be.visible').click();
         cy.contains('SQL');
         cy.findAllByText('Loading chart').should('have.length', 0);
 

--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -175,7 +175,9 @@ describe('Download CSV on Explore', () => {
         cy.findByText('Unique order count').click();
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('not.be.disabled')
+            .click();
 
         // wait for the chart to finish loading
         cy.findByText('Loading chart').should('not.exist');
@@ -310,7 +312,9 @@ describe('Download CSV on Explore', () => {
         cy.findByText('Unique order count').click();
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('not.be.disabled')
+            .click();
 
         // wait for chart to be expanded and configure button to be available, then change chart type to Table
         cy.get('body').then(($body) => {

--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -114,6 +114,7 @@ describe('Explore', () => {
         cy.get('button').contains('Run query').click();
 
         // open chart
+        cy.findByTestId('Chart-card-expand').click();
 
         // wait for the chart to finish loading
         cy.contains('Loading chart').should('not.exist');

--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -551,7 +551,9 @@ describe('Explore', () => {
         cy.findByText('Create').click();
 
         // Run query
-        cy.findAllByTestId('RefreshButton/RunQueryButton').first().click();
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('not.be.disabled')
+            .click();
 
         // Wait for query to finish loading
         cy.findByText('Loading results').should('not.exist');

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -104,7 +104,9 @@ const runPivotChart = (
     cy.intercept('GET', '**/api/v2/projects/*/query/*').as('pivotQueryResults');
 
     cy.visit(buildExploreUrl(chartState));
-    cy.get('button').contains('Run query').should('not.be.disabled').click();
+    cy.findByTestId('RefreshButton/RunQueryButton')
+        .should('not.be.disabled')
+        .click();
 
     cy.wait('@runPivotQuery', { timeout: 60000 }).then((interception) => {
         const body = getRequestBody(interception.request.body);
@@ -342,8 +344,7 @@ describe('Pivot Tables', () => {
         );
 
         // run query
-        cy.get('button')
-            .contains('Run query')
+        cy.findByTestId('RefreshButton/RunQueryButton')
             .should('not.be.disabled')
             .click();
 
@@ -362,8 +363,7 @@ describe('Pivot Tables', () => {
         );
 
         // run query
-        cy.get('button')
-            .contains('Run query')
+        cy.findByTestId('RefreshButton/RunQueryButton')
             .should('not.be.disabled')
             .click();
 

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -104,7 +104,10 @@ const runPivotChart = (
     cy.intercept('GET', '**/api/v2/projects/*/query/*').as('pivotQueryResults');
 
     cy.visit(buildExploreUrl(chartState));
-    cy.get('button').contains('Run query').click();
+    cy.findByTestId('page-spinner').should('not.exist');
+    cy.findByTestId('RefreshButton/RunQueryButton')
+        .should('be.visible')
+        .click();
 
     cy.wait('@runPivotQuery', { timeout: 60000 }).then((interception) => {
         const body = getRequestBody(interception.request.body);
@@ -342,7 +345,10 @@ describe('Pivot Tables', () => {
         );
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('page-spinner').should('not.exist');
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('be.visible')
+            .click();
 
         // Create a pivot table
         cy.contains('placed');
@@ -359,7 +365,10 @@ describe('Pivot Tables', () => {
         );
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('page-spinner').should('not.exist');
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('be.visible')
+            .click();
 
         cy.contains('Tables').should('be.visible'); // Ensure the sidebar has loaded before clicking configure below
         cy.contains('Configure').click();

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -104,10 +104,7 @@ const runPivotChart = (
     cy.intercept('GET', '**/api/v2/projects/*/query/*').as('pivotQueryResults');
 
     cy.visit(buildExploreUrl(chartState));
-    cy.findByTestId('page-spinner').should('not.exist');
-    cy.findByTestId('RefreshButton/RunQueryButton')
-        .should('be.visible')
-        .click();
+    cy.get('button').contains('Run query').click();
 
     cy.wait('@runPivotQuery', { timeout: 60000 }).then((interception) => {
         const body = getRequestBody(interception.request.body);
@@ -345,10 +342,7 @@ describe('Pivot Tables', () => {
         );
 
         // run query
-        cy.findByTestId('page-spinner').should('not.exist');
-        cy.findByTestId('RefreshButton/RunQueryButton')
-            .should('be.visible')
-            .click();
+        cy.get('button').contains('Run query').click();
 
         // Create a pivot table
         cy.contains('placed');
@@ -365,10 +359,7 @@ describe('Pivot Tables', () => {
         );
 
         // run query
-        cy.findByTestId('page-spinner').should('not.exist');
-        cy.findByTestId('RefreshButton/RunQueryButton')
-            .should('be.visible')
-            .click();
+        cy.get('button').contains('Run query').click();
 
         cy.contains('Tables').should('be.visible'); // Ensure the sidebar has loaded before clicking configure below
         cy.contains('Configure').click();

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -104,7 +104,7 @@ const runPivotChart = (
     cy.intercept('GET', '**/api/v2/projects/*/query/*').as('pivotQueryResults');
 
     cy.visit(buildExploreUrl(chartState));
-    cy.get('button').contains('Run query').click();
+    cy.get('button').contains('Run query').should('not.be.disabled').click();
 
     cy.wait('@runPivotQuery', { timeout: 60000 }).then((interception) => {
         const body = getRequestBody(interception.request.body);
@@ -342,7 +342,10 @@ describe('Pivot Tables', () => {
         );
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.get('button')
+            .contains('Run query')
+            .should('not.be.disabled')
+            .click();
 
         // Create a pivot table
         cy.contains('placed');
@@ -359,7 +362,10 @@ describe('Pivot Tables', () => {
         );
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.get('button')
+            .contains('Run query')
+            .should('not.be.disabled')
+            .click();
 
         cy.contains('Tables').should('be.visible'); // Ensure the sidebar has loaded before clicking configure below
         cy.contains('Configure').click();

--- a/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
+++ b/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
@@ -30,7 +30,9 @@ describe('User attributes sql_filter', () => {
         cy.findByText('First name').click();
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('not.be.disabled')
+            .click();
 
         cy.contains('Error loading results');
 
@@ -61,7 +63,9 @@ describe('User attributes sql_filter', () => {
         cy.findByText('First name').click();
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('not.be.disabled')
+            .click();
         cy.contains('Anna');
     });
 
@@ -82,7 +86,9 @@ describe('User attributes sql_filter', () => {
         cy.findByText('First name').click();
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('not.be.disabled')
+            .click();
         cy.contains('Christina', { timeout: 30000 });
     });
 });
@@ -156,7 +162,9 @@ describe('User attributes dimension required_attribute', () => {
         cy.findByText('Last name').click();
 
         // run query
-        cy.get('button').contains('Run query').click();
+        cy.findByTestId('RefreshButton/RunQueryButton')
+            .should('not.be.disabled')
+            .click();
         cy.contains('W.', { timeout: 30000 });
     });
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
@@ -118,7 +118,10 @@ export const EmptyStateNoTableData: FC<{ description: React.ReactNode }> = ({
                 </>
             }
         >
-            <RefreshButton size={'xs'} />
+            <RefreshButton
+                size={'xs'}
+                testId="RefreshButton/EmptyStateRunQueryButton"
+            />
         </EmptyState>
     </TrackSection>
 );

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -16,10 +16,12 @@ import {
     selectIsValidQuery,
     selectPreAggVisible,
     selectQueryLimit,
+    selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../features/explorer/store';
 import useHealth from '../hooks/health/useHealth';
+import { useExplore } from '../hooks/useExplore';
 import { useExplorerQuery } from '../hooks/useExplorerQuery';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
@@ -37,11 +39,18 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     // Get state and actions from Redux
     const limit = useExplorerSelector(selectQueryLimit);
     const isValidQuery = useExplorerSelector(selectIsValidQuery);
+    const tableName = useExplorerSelector(selectTableName);
     const dispatch = useExplorerDispatch();
     const preAggVisible = useExplorerSelector(selectPreAggVisible);
 
     // Get query state and actions from hooks
     const { isLoading, fetchResults, cancelQuery } = useExplorerQuery();
+
+    // buildQueryArgs returns null without explore — disable until loaded.
+    const { data: explore } = useExplore(tableName, {
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+    });
 
     const setRowLimit = useCallback(
         (newLimit: number) => {
@@ -50,7 +59,7 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
         [dispatch],
     );
 
-    const canRunQuery = isValidQuery;
+    const canRunQuery = isValidQuery && !!explore;
 
     const { track } = useTracking();
 
@@ -81,12 +90,12 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
                     position="bottom"
                     withArrow
                     withinPortal
-                    disabled={isLoading || !isValidQuery}
+                    disabled={isLoading || !canRunQuery}
                 >
                     <Button
                         size={size}
                         pr={limit ? 'xs' : undefined}
-                        disabled={!isValidQuery}
+                        disabled={!canRunQuery}
                         leftSection={<MantineIcon icon={IconPlayerPlay} />}
                         loading={isLoading}
                         onClick={onClick}

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -27,7 +27,10 @@ import MantineIcon from './common/MantineIcon';
 import PreAggregateStatusBadge from './PreAggregateStatusBadge';
 import RunQuerySettings from './RunQuerySettings';
 
-export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
+export const RefreshButton: FC<{
+    size?: MantineSize;
+    testId?: string;
+}> = memo(({ size, testId = 'RefreshButton/RunQueryButton' }) => {
     const [, startTransition] = useTransition();
     const health = useHealth();
     const maxLimit = health.data?.query.maxLimit ?? 5000;
@@ -100,7 +103,7 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
                             borderTopRightRadius: 0,
                             borderBottomRightRadius: 0,
                         })}
-                        data-testid="RefreshButton/RunQueryButton"
+                        data-testid={testId}
                     >
                         Run query ({limit})
                     </Button>

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -16,12 +16,10 @@ import {
     selectIsValidQuery,
     selectPreAggVisible,
     selectQueryLimit,
-    selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../features/explorer/store';
 import useHealth from '../hooks/health/useHealth';
-import { useExplore } from '../hooks/useExplore';
 import { useExplorerQuery } from '../hooks/useExplorerQuery';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
@@ -39,18 +37,12 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     // Get state and actions from Redux
     const limit = useExplorerSelector(selectQueryLimit);
     const isValidQuery = useExplorerSelector(selectIsValidQuery);
-    const tableName = useExplorerSelector(selectTableName);
     const dispatch = useExplorerDispatch();
     const preAggVisible = useExplorerSelector(selectPreAggVisible);
 
     // Get query state and actions from hooks
-    const { isLoading, fetchResults, cancelQuery } = useExplorerQuery();
-
-    // buildQueryArgs returns null without explore — disable until loaded.
-    const { data: explore } = useExplore(tableName, {
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-    });
+    const { isLoading, fetchResults, cancelQuery, explore } =
+        useExplorerQuery();
 
     const setRowLimit = useCallback(
         (newLimit: number) => {
@@ -59,6 +51,7 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
         [dispatch],
     );
 
+    // buildQueryArgs returns null without explore — disable until loaded.
     const canRunQuery = isValidQuery && !!explore;
 
     const { track } = useTracking();


### PR DESCRIPTION
### Description

\`RefreshButton\` is rendered in two places — \`ExplorerHeader\` and the \`ExplorerResults\` empty-state — and both emitted the same \`data-testid=\"RefreshButton/RunQueryButton\"\`. Generic e2e selectors like \`cy.get('button').contains('Run query')\` and \`findByTestId('RefreshButton/RunQueryButton')\` were ambiguously matching either button (or sometimes both, causing \"multiple elements\" errors), which manifested as flaky test failures where the click appeared to do nothing.

### Fix

- \`RefreshButton\` accepts a \`testId\` prop (defaults to \`RefreshButton/RunQueryButton\`).
- The empty-state instance passes \`testId=\"RefreshButton/EmptyStateRunQueryButton\"\` so the two buttons are independently targetable.
- Updated e2e tests in \`dates.cy.ts\`, \`explore.cy.ts\`, and \`pivotTables.cy.ts\` to use the unique header testid with \`should('not.be.disabled')\` for explicit readiness checks.

Also keeps the small UX improvement from earlier in the branch: \`canRunQuery = isValidQuery && !!explore\` — disables the button while \`/explores/:tableId\` is loading so a click before explore metadata arrives isn't a silent no-op.