### PR TITLE
docs(skills): document rowLimit and columnLimit in chart references

### DIFF
--- a/skills/developing-in-lightdash/resources/cartesian-chart-reference.md
+++ b/skills/developing-in-lightdash/resources/cartesian-chart-reference.md
@@ -88,6 +88,27 @@ Optional properties:
 - **`areaStyle`**: Presence indicates area chart
 - **`markLine`**: Reference line configuration
 
+### Limiting Displayed Rows
+
+Use `rowLimit` to trim the rendered chart to the first or last N rows of data without changing the underlying query. This is client-side slicing on already-fetched rows — useful for "show me the top 5" or "hide the totals row" while keeping the full dataset available for exports and tooltips.
+
+```yaml
+chartConfig:
+  config:
+    rowLimit:
+      mode: show          # "show" or "hide"
+      direction: first    # "first" or "last"
+      count: 10
+```
+
+| User intent | Config |
+|---|---|
+| "Show only the top 10 partners" | `{ mode: show, direction: first, count: 10 }` |
+| "Hide the last row (a totals row)" | `{ mode: hide, direction: last, count: 1 }` |
+| "Show the bottom 5 underperformers" (assumes ascending sort) | `{ mode: show, direction: last, count: 5 }` |
+
+**`metricQuery.limit` vs `rowLimit`**: `metricQuery.limit` constrains how many rows are *fetched* from the warehouse. `rowLimit` only trims what is *displayed* from the already-fetched rows. If the user wants to scan fewer rows in the database, use `metricQuery.limit`. Use `rowLimit` when the full dataset should remain queryable but only a subset should appear in the chart.
+
 ## Examples
 
 ### Bar Chart

--- a/skills/developing-in-lightdash/resources/table-chart-reference.md
+++ b/skills/developing-in-lightdash/resources/table-chart-reference.md
@@ -47,6 +47,8 @@ version: 1
 | `showResultsTotal` | boolean | Show total count of results |
 | `showSubtotals` | boolean | Show subtotal rows for grouped data |
 | `metricsAsRows` | boolean | Display metrics as rows instead of columns (pivoted view) |
+| `rowLimit` | object | Show or hide the first/last N rows client-side (see below) |
+| `columnLimit` | number | Maximum number of pivot groups to display as columns (pivoted tables only) |
 
 ### Column Configuration
 
@@ -80,6 +82,43 @@ Conditional formatting highlights cells based on their values. Each rule consist
 - **Numeric**: `lessThan`, `lessThanOrEqual`, `greaterThan`, `greaterThanOrEqual`
 - **Range**: `inBetween`, `notInBetween`
 - **Date**: `inThePast`, `notInThePast`, `inTheNext`, `inTheCurrent`, `notInTheCurrent`
+
+### Limiting Displayed Rows
+
+Use `rowLimit` to trim the rendered table to the first or last N rows without changing the underlying query. This is client-side slicing on already-fetched rows.
+
+```yaml
+chartConfig:
+  config:
+    rowLimit:
+      mode: show          # "show" or "hide"
+      direction: first    # "first" or "last"
+      count: 10
+```
+
+| User intent | Config |
+|---|---|
+| "Show only the top 10 rows" | `{ mode: show, direction: first, count: 10 }` |
+| "Hide the last row (a totals row)" | `{ mode: hide, direction: last, count: 1 }` |
+| "Show the bottom 5" (assumes ascending sort) | `{ mode: show, direction: last, count: 5 }` |
+
+**`metricQuery.limit` vs `rowLimit`**: `metricQuery.limit` constrains how many rows are fetched from the warehouse. `rowLimit` only trims what is displayed. Use `metricQuery.limit` to fetch fewer rows; use `rowLimit` when the full dataset should remain queryable (e.g. for exports) but only a subset should appear.
+
+### Limiting Pivot Columns
+
+For pivoted tables, use `columnLimit` to cap how many pivot groups appear as columns. The limit applies to **distinct pivot dimension values**, not raw column count — so `columnLimit: 5` on a table pivoted by region keeps the first 5 regions, each potentially expanding into multiple metric columns.
+
+```yaml
+chartConfig:
+  config:
+    columnLimit: 10
+  type: "table"
+pivotConfig:
+  columns:
+    - orders_product_category
+```
+
+`columnLimit` is only meaningful when `pivotConfig.columns` is set. Omitting it (or setting `0`) means no limit. For non-pivoted tables, hide individual columns via `columns.<fieldId>.visible: false` instead.
 
 ## Example: Full-Featured Table
 


### PR DESCRIPTION
## Summary

Adds coverage of two recently-released chart features to the `developing-in-lightdash` agent skill so AI coding assistants (Claude / Cursor / Codex) and the cloud Managed Agent generate idiomatic chart-as-code:

- **`rowLimit`** on cartesian and table charts — client-side trimming to first/last N rows with a `show`/`hide` mode
- **`columnLimit`** on table charts — caps how many distinct pivot groups appear as columns

The JSON schema (`chart-as-code-1.0.json`) already exposes both fields because it is regenerated from the TSOA OpenAPI output. The prose references were the gap — without them, the AI knew the shape was valid but did not proactively reach for it when a user said things like "show me the top 10."

Each new section includes:
- The minimal YAML shape
- A user-intent-to-config mapping table (e.g. *"Hide the last row (a totals row)"* → `{ mode: hide, direction: last, count: 1 }`)
- A `metricQuery.limit` (server-side) vs `rowLimit` (client-side) callout to prevent wasteful queries when a user just wants a smaller chart

## Test plan

- [ ] Visual review of the rendered markdown in `skills/developing-in-lightdash/resources/cartesian-chart-reference.md` and `table-chart-reference.md`
- [ ] No schema regeneration needed — confirmed `chart-as-code-1.0.json` already contains `RowLimit` and `columnLimit` definitions
- [ ] Spot-check with an AI assistant: prompt with "show only the top 10 partners on this bar chart" against the updated skill and confirm `rowLimit` is suggested