### PR TITLE
fix(explorer): guard `runQuery` against undefined feature flag and return dispatch status

### DIFF
--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -114,6 +114,7 @@ describe('Explore', () => {
         cy.get('button').contains('Run query').click();
 
         // open chart
+        cy.findByTestId('Chart-card-expand').click();
 
         // wait for the chart to finish loading
         cy.contains('Loading chart').should('not.exist');

--- a/packages/frontend/src/hooks/useExplorerQuery.ts
+++ b/packages/frontend/src/hooks/useExplorerQuery.ts
@@ -28,8 +28,7 @@ import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
 export const useExplorerQuery = () => {
     // Get all state and runQuery from manager (single source of truth)
     const manager = useExplorerQueryManager();
-    const { queryResults, runQuery, validQueryArgs, unpivotedQueryResults } =
-        manager;
+    const { queryResults, validQueryArgs, unpivotedQueryResults } = manager;
 
     // Redux dispatch and query client for actions
     const dispatch = useExplorerDispatch();
@@ -63,8 +62,8 @@ export const useExplorerQuery = () => {
     // Action: Fetch results (force refresh - bypasses auto-fetch setting)
     const fetchResults = useCallback(() => {
         resetQueryResults();
-        runQuery();
-    }, [resetQueryResults, runQuery]);
+        dispatch(explorerActions.requestQueryExecution());
+    }, [resetQueryResults, dispatch]);
 
     // Action: Get download query UUID
     const getDownloadQueryUuid = useCallback(

--- a/packages/frontend/src/hooks/useExplorerQueryEffects.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryEffects.ts
@@ -219,8 +219,10 @@ export const useExplorerQueryEffects = ({
 
     useEffect(() => {
         if (pendingFetch) {
-            runQuery();
-            dispatch(explorerActions.clearPendingFetch());
+            const dispatched = runQuery();
+            if (dispatched) {
+                dispatch(explorerActions.clearPendingFetch());
+            }
         }
     }, [pendingFetch, runQuery, dispatch]);
 

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -153,8 +153,10 @@ export const useExplorerQueryManager = () => {
     const { query: unpivotedQuery, queryResults: unpivotedQueryResults } =
         unpivotedQueryExecutor;
 
-    // Function to prepare and set query arguments (single source of truth)
-    const runQuery = useCallback(() => {
+    const runQuery = useCallback((): boolean => {
+        if (useSqlPivotResults === undefined) {
+            return false;
+        }
         const mainQueryArgs = buildQueryArgs({
             activeFields,
             tableName,
@@ -173,13 +175,15 @@ export const useExplorerQueryManager = () => {
 
         if (mainQueryArgs) {
             dispatch(explorerActions.setValidQueryArgs(mainQueryArgs));
+            return true;
         }
+        return false;
     }, [
         activeFields,
         tableName,
         projectUuid,
         explore,
-        useSqlPivotResults?.enabled,
+        useSqlPivotResults,
         metricQuery,
         parameters,
         isEditMode,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- reference the related issue e.g. #150 -->

### Description:

When the Explorer loads, clicking "Run query" before the explore metadata and `UseSqlPivotResult` feature flag have finished loading silently no-ops. The user has to click again. In e2e tests, Cypress only clicks once, so the test hangs waiting for results that never come.

This surfaced as flaky app/explore.cy.ts tests (shards 2/5 and 3/5) and was bisected to #22776 (AI agents launcher) that PR didn't introduce the bug, but added requests to initial page load that widened the race window enough for Cypress to lose every time.

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->