### PR TITLE
feat(analytics): add download activity log endpoint

### DIFF
--- a/packages/backend/src/controllers/userActivityController.ts
+++ b/packages/backend/src/controllers/userActivityController.ts
@@ -1,5 +1,6 @@
 import {
     AnyType,
+    ApiDownloadActivity,
     ApiErrorPayload,
     ApiJobScheduledResponse,
     ApiUserActivity,
@@ -49,7 +50,7 @@ export class UserActivityController extends BaseController {
     @SuccessResponse('200', 'Success')
     @Get('/{projectUuid}')
     @OperationId('getUserActivity')
-    async get(
+    async getUserActivity(
         @Request() req: express.Request,
         @Path() projectUuid: string,
     ): Promise<ApiUserActivity> {
@@ -75,7 +76,7 @@ export class UserActivityController extends BaseController {
     @SuccessResponse('200', 'Success')
     @Post('/{projectUuid}/download')
     @OperationId('downloadUserActivityCsv')
-    async post(
+    async exportUserActivityCsv(
         @Request() req: express.Request,
         @Path() projectUuid: string,
     ): Promise<ApiUserActivityDownloadCsv> {
@@ -86,6 +87,37 @@ export class UserActivityController extends BaseController {
         return {
             status: 'ok',
             results: userActivity,
+        };
+    }
+
+    /**
+     * Get download activity log for a project, ordered by most recent first.
+     * Pagination is required — both `page` and `pageSize` must be provided.
+     * @summary Get download activity log
+     * @param page page number (1-indexed)
+     * @param pageSize number of items per page
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Get('/{projectUuid}/download-activity')
+    @OperationId('getDownloadActivity')
+    async getDownloadActivity(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Query() page: number,
+        @Query() pageSize: number,
+    ): Promise<ApiDownloadActivity> {
+        this.setStatus(200);
+        const results = await req.services
+            .getAnalyticsService()
+            .getDownloadActivity(projectUuid, req.account!, { page, pageSize });
+        return {
+            status: 'ok',
+            results,
         };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5324,6 +5324,11 @@ const models: TsoaRoute.Models = {
         enums: ['scatter', 'area', 'heatmap', 'hexbin'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MapHexbinSizingMode: {
+        dataType: 'refEnum',
+        enums: ['dynamic', 'fixed'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MapTileBackground: {
         dataType: 'refEnum',
         enums: [
@@ -5372,7 +5377,11 @@ const models: TsoaRoute.Models = {
                 dataLayerOpacity: { dataType: 'double' },
                 hexbinConfig: {
                     dataType: 'nestedObjectLiteral',
-                    nestedProperties: { opacity: { dataType: 'double' } },
+                    nestedProperties: {
+                        fixedResolution: { dataType: 'double' },
+                        sizingMode: { ref: 'MapHexbinSizingMode' },
+                        opacity: { dataType: 'double' },
+                    },
                 },
                 heatmapConfig: {
                     dataType: 'nestedObjectLiteral',
@@ -9510,11 +9519,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9529,11 +9538,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9548,11 +9557,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9629,12 +9638,6 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -9646,6 +9649,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9674,7 +9683,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9682,7 +9691,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9697,7 +9710,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -9705,11 +9718,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -9761,11 +9770,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9887,12 +9896,6 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
-                                                                                                        },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -9904,6 +9907,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9935,11 +9944,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9954,11 +9963,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15954,6 +15963,89 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 status: { dataType: 'enum', enums: ['ok'], required: true },
                 results: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DownloadAuditEntry: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                originalQueryContext: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                downloadedAt: { dataType: 'datetime', required: true },
+                fileType: { dataType: 'string', required: true },
+                userLastName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                userFirstName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                userUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                queryUuid: { dataType: 'string', required: true },
+                downloadUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DownloadActivityResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pagination: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        totalResults: { dataType: 'double', required: true },
+                        totalPageCount: { dataType: 'double', required: true },
+                        pageSize: { dataType: 'double', required: true },
+                        page: { dataType: 'double', required: true },
+                    },
+                    required: true,
+                },
+                data: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'DownloadAuditEntry' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDownloadActivity: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'DownloadActivityResults', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
         },
@@ -41220,7 +41312,7 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsUserActivityController_get: Record<
+    const argsUserActivityController_getUserActivity: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
@@ -41236,10 +41328,10 @@ export function RegisterRoutes(app: Router) {
         '/api/v1/analytics/user-activity/:projectUuid',
         ...fetchMiddlewares<RequestHandler>(UserActivityController),
         ...fetchMiddlewares<RequestHandler>(
-            UserActivityController.prototype.get,
+            UserActivityController.prototype.getUserActivity,
         ),
 
-        async function UserActivityController_get(
+        async function UserActivityController_getUserActivity(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -41249,7 +41341,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsUserActivityController_get,
+                    args: argsUserActivityController_getUserActivity,
                     request,
                     response,
                 });
@@ -41268,7 +41360,7 @@ export function RegisterRoutes(app: Router) {
                 }
 
                 await templateService.apiHandler({
-                    methodName: 'get',
+                    methodName: 'getUserActivity',
                     controller,
                     response,
                     next,
@@ -41281,7 +41373,7 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsUserActivityController_post: Record<
+    const argsUserActivityController_exportUserActivityCsv: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
@@ -41297,10 +41389,10 @@ export function RegisterRoutes(app: Router) {
         '/api/v1/analytics/user-activity/:projectUuid/download',
         ...fetchMiddlewares<RequestHandler>(UserActivityController),
         ...fetchMiddlewares<RequestHandler>(
-            UserActivityController.prototype.post,
+            UserActivityController.prototype.exportUserActivityCsv,
         ),
 
-        async function UserActivityController_post(
+        async function UserActivityController_exportUserActivityCsv(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -41310,7 +41402,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsUserActivityController_post,
+                    args: argsUserActivityController_exportUserActivityCsv,
                     request,
                     response,
                 });
@@ -41329,7 +41421,75 @@ export function RegisterRoutes(app: Router) {
                 }
 
                 await templateService.apiHandler({
-                    methodName: 'post',
+                    methodName: 'exportUserActivityCsv',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsUserActivityController_getDownloadActivity: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        page: { in: 'query', name: 'page', required: true, dataType: 'double' },
+        pageSize: {
+            in: 'query',
+            name: 'pageSize',
+            required: true,
+            dataType: 'double',
+        },
+    };
+    app.get(
+        '/api/v1/analytics/user-activity/:projectUuid/download-activity',
+        ...fetchMiddlewares<RequestHandler>(UserActivityController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserActivityController.prototype.getDownloadActivity,
+        ),
+
+        async function UserActivityController_getDownloadActivity(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsUserActivityController_getDownloadActivity,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<UserActivityController>(
+                        UserActivityController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getDownloadActivity',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6212,6 +6212,10 @@
                 "enum": ["scatter", "area", "heatmap", "hexbin"],
                 "type": "string"
             },
+            "MapHexbinSizingMode": {
+                "enum": ["dynamic", "fixed"],
+                "type": "string"
+            },
             "MapTileBackground": {
                 "enum": [
                     "none",
@@ -6277,6 +6281,15 @@
                     },
                     "hexbinConfig": {
                         "properties": {
+                            "fixedResolution": {
+                                "type": "number",
+                                "format": "double",
+                                "description": "H3 resolution (0-15) used when sizingMode is FIXED. Ignored otherwise."
+                            },
+                            "sizingMode": {
+                                "$ref": "#/components/schemas/MapHexbinSizingMode",
+                                "description": "How bin size is determined. Defaults to DYNAMIC if unset."
+                            },
                             "opacity": {
                                 "type": "number",
                                 "format": "double",
@@ -10956,6 +10969,19 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
@@ -10971,13 +10997,13 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -10985,9 +11011,9 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10997,16 +11023,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -11036,8 +11062,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -11091,13 +11117,13 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "label": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "fieldType": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -11105,9 +11131,9 @@
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
+                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -11135,8 +11161,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16891,6 +16917,103 @@
                     }
                 },
                 "required": ["status", "results"],
+                "type": "object"
+            },
+            "DownloadAuditEntry": {
+                "properties": {
+                    "originalQueryContext": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "downloadedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "fileType": {
+                        "type": "string"
+                    },
+                    "userLastName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "userFirstName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "userUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "queryUuid": {
+                        "type": "string"
+                    },
+                    "downloadUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "originalQueryContext",
+                    "downloadedAt",
+                    "fileType",
+                    "userLastName",
+                    "userFirstName",
+                    "userUuid",
+                    "queryUuid",
+                    "downloadUuid"
+                ],
+                "type": "object"
+            },
+            "DownloadActivityResults": {
+                "properties": {
+                    "pagination": {
+                        "properties": {
+                            "totalResults": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "totalPageCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "pageSize": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "page": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": [
+                            "totalResults",
+                            "totalPageCount",
+                            "pageSize",
+                            "page"
+                        ],
+                        "type": "object"
+                    },
+                    "data": {
+                        "items": {
+                            "$ref": "#/components/schemas/DownloadAuditEntry"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["pagination", "data"],
+                "type": "object"
+            },
+            "ApiDownloadActivity": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/DownloadActivityResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
                 "type": "object"
             },
             "Pick_SshKeyPair.publicKey_": {
@@ -32076,7 +32199,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2903.4",
+        "version": "0.2904.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -35880,6 +36003,67 @@
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/analytics/user-activity/{projectUuid}/download-activity": {
+            "get": {
+                "operationId": "getDownloadActivity",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDownloadActivity"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get download activity log for a project, ordered by most recent first.\nPagination is required — both `page` and `pageSize` must be provided.",
+                "summary": "Get download activity log",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "page number (1-indexed)",
+                        "in": "query",
+                        "name": "page",
+                        "required": true,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "description": "number of items per page",
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": true,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
                         }
                     }
                 ]

--- a/packages/backend/src/models/DownloadAuditModel.ts
+++ b/packages/backend/src/models/DownloadAuditModel.ts
@@ -1,5 +1,12 @@
+import {
+    DownloadAuditEntry,
+    KnexPaginateArgs,
+    KnexPaginatedData,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 import { DownloadAuditTableName } from '../database/entities/downloadAudit';
+import { UserTableName } from '../database/entities/users';
+import KnexPaginate from '../database/pagination';
 
 type DownloadAuditModelArguments = {
     database: Knex;
@@ -37,5 +44,68 @@ export class DownloadAuditModel {
             file_type: fileType,
             original_query_context: originalQueryContext,
         });
+    }
+
+    async getDownloads(
+        organizationUuid: string,
+        projectUuid: string,
+        paginateArgs: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<DownloadAuditEntry[]>> {
+        // Note: offset-based pagination is susceptible to drift when new rows
+        // are inserted between page fetches — rows near page boundaries may be
+        // duplicated or skipped. A future improvement would be cursor-based
+        // pagination using (downloaded_at, download_uuid) as the stable cursor.
+        const baseQuery = this.database(DownloadAuditTableName)
+            .select<
+                {
+                    download_uuid: string;
+                    query_uuid: string;
+                    user_uuid: string | null;
+                    first_name: string | null;
+                    last_name: string | null;
+                    file_type: string;
+                    downloaded_at: Date;
+                    original_query_context: string | null;
+                }[]
+            >(
+                `${DownloadAuditTableName}.download_uuid`,
+                `${DownloadAuditTableName}.query_uuid`,
+                `${DownloadAuditTableName}.user_uuid`,
+                `${UserTableName}.first_name`,
+                `${UserTableName}.last_name`,
+                `${DownloadAuditTableName}.file_type`,
+                `${DownloadAuditTableName}.downloaded_at`,
+                `${DownloadAuditTableName}.original_query_context`,
+            )
+            .leftJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${DownloadAuditTableName}.user_uuid`,
+            )
+            .where(
+                `${DownloadAuditTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .andWhere(`${DownloadAuditTableName}.project_uuid`, projectUuid)
+            .orderBy(`${DownloadAuditTableName}.downloaded_at`, 'desc');
+
+        const { data, pagination } = await KnexPaginate.paginate(
+            baseQuery,
+            paginateArgs,
+        );
+
+        return {
+            data: data.map((row) => ({
+                downloadUuid: row.download_uuid,
+                queryUuid: row.query_uuid,
+                userUuid: row.user_uuid,
+                userFirstName: row.first_name,
+                userLastName: row.last_name,
+                fileType: row.file_type,
+                downloadedAt: row.downloaded_at,
+                originalQueryContext: row.original_query_context,
+            })),
+            pagination,
+        };
     }
 }

--- a/packages/backend/src/services/AnalyticsService/AnalyticsService.test.ts
+++ b/packages/backend/src/services/AnalyticsService/AnalyticsService.test.ts
@@ -1,0 +1,237 @@
+import { Ability } from '@casl/ability';
+import {
+    DownloadAuditEntry,
+    ForbiddenError,
+    KnexPaginateArgs,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    type Account,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import type { AnalyticsModel } from '../../models/AnalyticsModel';
+import type { DownloadAuditModel } from '../../models/DownloadAuditModel';
+import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import type { CsvService } from '../CsvService/CsvService';
+import { AnalyticsService } from './AnalyticsService';
+
+const projectUuid = 'project-uuid';
+const organizationUuid = 'org-uuid';
+const projectName = 'Test Project';
+
+const projectModel = {
+    get: jest.fn(async () => ({
+        organizationUuid,
+        name: projectName,
+        projectUuid,
+    })),
+} as unknown as ProjectModel;
+
+const analyticsModel = {} as unknown as AnalyticsModel;
+const csvService = {} as unknown as CsvService;
+
+const sampleEntry: DownloadAuditEntry = {
+    downloadUuid: 'dl-uuid',
+    queryUuid: 'q-uuid',
+    userUuid: 'user-uuid',
+    userFirstName: 'Alice',
+    userLastName: 'Smith',
+    fileType: 'csv',
+    downloadedAt: new Date('2024-01-01T00:00:00Z'),
+    originalQueryContext: null,
+};
+
+const defaultPaginateArgs: KnexPaginateArgs = { page: 1, pageSize: 50 };
+
+const makePagination = (overrides?: Partial<KnexPaginateArgs>) => ({
+    page: overrides?.page ?? 1,
+    pageSize: overrides?.pageSize ?? 50,
+    totalPageCount: 1,
+    totalResults: 1,
+});
+
+const makeDownloadAuditModel = (
+    data: DownloadAuditEntry[] = [sampleEntry],
+    pagination = makePagination(),
+) =>
+    ({
+        getDownloads: jest.fn(async () => ({ data, pagination })),
+    }) as unknown as DownloadAuditModel;
+
+const makeAccount = (canViewAnalytics: boolean): Account =>
+    ({
+        user: {
+            id: 'user-id',
+            type: 'registered',
+            role: OrganizationMemberRole.ADMIN,
+            ability: new Ability<PossibleAbilities>(
+                canViewAnalytics
+                    ? [{ subject: 'Analytics', action: 'view' }]
+                    : [],
+            ),
+            abilityRules: [],
+        },
+        organization: {
+            organizationUuid,
+            name: 'Test Org',
+            createdAt: new Date(),
+        },
+        authentication: { type: 'session' },
+        isSessionUser: () => true,
+        isRegisteredUser: () => true,
+        isJwtUser: () => false,
+        isAnonymousUser: () => false,
+        isServiceAccount: () => false,
+        isPatUser: () => false,
+        isOauthUser: () => false,
+        isAuthenticated: () => true,
+    }) as unknown as Account;
+
+const allowedAccount = makeAccount(true);
+const forbiddenAccount = makeAccount(false);
+
+describe('AnalyticsService.getDownloadActivity', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('throws ForbiddenError when account lacks Analytics view permission', async () => {
+        const downloadAuditModel = makeDownloadAuditModel();
+        const service = new AnalyticsService({
+            analytics: analyticsMock,
+            analyticsModel,
+            downloadAuditModel,
+            projectModel,
+            csvService,
+        });
+
+        await expect(
+            service.getDownloadActivity(
+                projectUuid,
+                forbiddenAccount,
+                defaultPaginateArgs,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+
+        expect(downloadAuditModel.getDownloads).not.toHaveBeenCalled();
+    });
+
+    it('returns paginated download entries with pagination metadata', async () => {
+        const pagination = makePagination();
+        const downloadAuditModel = makeDownloadAuditModel(
+            [sampleEntry],
+            pagination,
+        );
+        const service = new AnalyticsService({
+            analytics: analyticsMock,
+            analyticsModel,
+            downloadAuditModel,
+            projectModel,
+            csvService,
+        });
+
+        const result = await service.getDownloadActivity(
+            projectUuid,
+            allowedAccount,
+            defaultPaginateArgs,
+        );
+
+        expect(result.data).toEqual([sampleEntry]);
+        expect(result.pagination).toEqual(pagination);
+        expect(downloadAuditModel.getDownloads).toHaveBeenCalledWith(
+            organizationUuid,
+            projectUuid,
+            defaultPaginateArgs,
+        );
+    });
+
+    it('passes paginateArgs to model and returns correct page metadata', async () => {
+        const paginateArgs: KnexPaginateArgs = { page: 2, pageSize: 10 };
+        const pagination = {
+            page: 2,
+            pageSize: 10,
+            totalPageCount: 5,
+            totalResults: 50,
+        };
+        const downloadAuditModel = makeDownloadAuditModel(
+            [sampleEntry],
+            pagination,
+        );
+        const service = new AnalyticsService({
+            analytics: analyticsMock,
+            analyticsModel,
+            downloadAuditModel,
+            projectModel,
+            csvService,
+        });
+
+        const result = await service.getDownloadActivity(
+            projectUuid,
+            allowedAccount,
+            paginateArgs,
+        );
+
+        expect(result.data).toEqual([sampleEntry]);
+        expect(result.pagination).toEqual(pagination);
+        expect(downloadAuditModel.getDownloads).toHaveBeenCalledWith(
+            organizationUuid,
+            projectUuid,
+            paginateArgs,
+        );
+    });
+
+    it('returns empty data array when there are no downloads', async () => {
+        const pagination = {
+            page: 1,
+            pageSize: 50,
+            totalPageCount: 0,
+            totalResults: 0,
+        };
+        const downloadAuditModel = makeDownloadAuditModel([], pagination);
+        const service = new AnalyticsService({
+            analytics: analyticsMock,
+            analyticsModel,
+            downloadAuditModel,
+            projectModel,
+            csvService,
+        });
+
+        const result = await service.getDownloadActivity(
+            projectUuid,
+            allowedAccount,
+            defaultPaginateArgs,
+        );
+
+        expect(result.data).toEqual([]);
+        expect(result.pagination).toEqual(pagination);
+    });
+
+    it('tracks download_activity_viewed analytics event', async () => {
+        const downloadAuditModel = makeDownloadAuditModel();
+        const service = new AnalyticsService({
+            analytics: analyticsMock,
+            analyticsModel,
+            downloadAuditModel,
+            projectModel,
+            csvService,
+        });
+
+        const trackSpy = jest.spyOn(analyticsMock, 'track');
+
+        await service.getDownloadActivity(
+            projectUuid,
+            allowedAccount,
+            defaultPaginateArgs,
+        );
+
+        expect(trackSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'usage_analytics.download_activity_viewed',
+                userId: allowedAccount.user.id,
+                properties: expect.objectContaining({
+                    projectId: projectUuid,
+                    organizationId: organizationUuid,
+                }),
+            }),
+        );
+    });
+});

--- a/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
+++ b/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
@@ -2,7 +2,9 @@ import { subject } from '@casl/ability';
 import {
     AnyType,
     assertIsAccountWithOrg,
+    DownloadActivityResults,
     ForbiddenError,
+    KnexPaginateArgs,
     NotFoundError,
     SchedulerJobStatus,
     UserActivity,
@@ -12,6 +14,7 @@ import { stringify } from 'csv-stringify/sync';
 import { nanoid } from 'nanoid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { DownloadAuditModel } from '../../models/DownloadAuditModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../BaseService';
 import { CsvService } from '../CsvService/CsvService';
@@ -19,6 +22,7 @@ import { CsvService } from '../CsvService/CsvService';
 type AnalyticsServiceArguments = {
     analytics: LightdashAnalytics;
     analyticsModel: AnalyticsModel;
+    downloadAuditModel: DownloadAuditModel;
     projectModel: ProjectModel;
     csvService: CsvService;
 };
@@ -27,6 +31,8 @@ export class AnalyticsService extends BaseService {
     private readonly analytics: LightdashAnalytics;
 
     private readonly analyticsModel: AnalyticsModel;
+
+    private readonly downloadAuditModel: DownloadAuditModel;
 
     private readonly projectModel: ProjectModel;
 
@@ -37,6 +43,7 @@ export class AnalyticsService extends BaseService {
         this.analytics = args.analytics;
         this.projectModel = args.projectModel;
         this.analyticsModel = args.analyticsModel;
+        this.downloadAuditModel = args.downloadAuditModel;
         this.csvService = args.csvService;
     }
 
@@ -134,5 +141,45 @@ export class AnalyticsService extends BaseService {
             createdByUserUuid: account.user.id,
         });
         return upload.path;
+    }
+
+    async getDownloadActivity(
+        projectUuid: string,
+        account: Account,
+        paginateArgs: KnexPaginateArgs,
+    ): Promise<DownloadActivityResults> {
+        assertIsAccountWithOrg(account);
+        const { organizationUuid, name: projectName } =
+            await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Analytics', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { projectUuid, projectName },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        this.analytics.track({
+            event: 'usage_analytics.download_activity_viewed',
+            userId: account.user.id,
+            properties: {
+                projectId: projectUuid,
+                organizationId: account.organization.organizationUuid,
+            },
+        });
+
+        const { data, pagination } = await this.downloadAuditModel.getDownloads(
+            organizationUuid,
+            projectUuid,
+            paginateArgs,
+        );
+
+        return { data, pagination: pagination! };
     }
 }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -302,6 +302,7 @@ export class ServiceRepository
                 new AnalyticsService({
                     analytics: this.context.lightdashAnalytics,
                     analyticsModel: this.models.getAnalyticsModel(),
+                    downloadAuditModel: this.models.getDownloadAuditModel(),
                     projectModel: this.models.getProjectModel(),
                     csvService: this.getCsvService(),
                 }),

--- a/packages/common/src/types/analytics.ts
+++ b/packages/common/src/types/analytics.ts
@@ -70,6 +70,32 @@ export type ViewStatistics = {
     firstViewedAt: Date | string | null;
 };
 
+export type DownloadAuditEntry = {
+    downloadUuid: string;
+    queryUuid: string;
+    userUuid: string | null;
+    userFirstName: string | null;
+    userLastName: string | null;
+    fileType: string;
+    downloadedAt: Date;
+    originalQueryContext: string | null;
+};
+
+export type DownloadActivityResults = {
+    data: DownloadAuditEntry[];
+    pagination: {
+        page: number;
+        pageSize: number;
+        totalPageCount: number;
+        totalResults: number;
+    };
+};
+
+export type ApiDownloadActivity = {
+    status: 'ok';
+    results: DownloadActivityResults;
+};
+
 export enum QueryExecutionContext {
     DASHBOARD = 'dashboardView',
     AUTOREFRESHED_DASHBOARD = 'autorefreshedDashboard',


### PR DESCRIPTION
## Summary

The `download_audit` table has been recording every file export (CSV, XLSX, JSON) since #17553, but there was no read API to surface that data. This PR closes that gap.

- Adds `GET /api/v1/analytics/user-activity/{projectUuid}/download-activity` — returns file download events enriched with user details, ordered by most recent first
- **Pagination is required** — both `page` and `pageSize` must be provided; omitting either returns `422`. This avoids silent data truncation and gives callers a clean contract from day one
- Reuses the existing `Analytics` CASL subject for authorization — no new permission scopes needed
- Follows the `KnexPaginate.paginate()` pattern established in `ProjectCompileLogModel` and `GroupsModel`

## Known limitations

**Offset pagination drift** — if new download events are inserted between page fetches, rows near page boundaries may be duplicated or skipped, and `totalResults` can change between requests. This is a known limitation shared by all `KnexPaginate`-based endpoints in the codebase (`GroupsModel`, `ProjectCompileLogModel`, etc.). For an admin-facing audit log with low write frequency, the impact is minimal. A future improvement would be cursor-based pagination using `(downloaded_at, download_uuid)` as a stable cursor.

## Files changed

| File | Change |
|---|---|
| `packages/common/src/types/analytics.ts` | Add `DownloadAuditEntry`, `DownloadActivityResults`, `ApiDownloadActivity` |
| `packages/backend/src/models/DownloadAuditModel.ts` | Add `getDownloads()` read method |
| `packages/backend/src/services/AnalyticsService/AnalyticsService.ts` | Add `DownloadAuditModel` dependency and `getDownloadActivity()` with auth + tracking |
| `packages/backend/src/services/ServiceRepository.ts` | Wire `downloadAuditModel` into `AnalyticsService` |
| `packages/backend/src/controllers/userActivityController.ts` | Add `GET /{projectUuid}/download-activity` endpoint; rename `get` → `getUserActivity` and `post` → `exportUserActivityCsv` to match the descriptive naming convention used across all other controllers |
| `packages/backend/src/services/AnalyticsService/AnalyticsService.test.ts` | New — 5 unit tests covering auth, pagination, empty data, tracking event |
| `packages/backend/src/generated/routes.ts` + `swagger.json` | Auto-generated by `pnpm generate-api` |

## Unit test results

```
PASS packages/backend/src/services/AnalyticsService/AnalyticsService.test.ts

  AnalyticsService.getDownloadActivity
    ✓ throws ForbiddenError when account lacks Analytics view permission (16 ms)
    ✓ returns paginated download entries with pagination metadata (3 ms)
    ✓ passes paginateArgs to model and returns correct page metadata (2 ms)
    ✓ returns empty data array when there are no downloads (2 ms)
    ✓ tracks download_activity_viewed analytics event (2 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

## API test results

### TEST 1 — No pagination params → `422`
```
GET /download-activity
```
```json
{
    "status": "error",
    "error": {
        "statusCode": 422,
        "name": "ValidateError",
        "message": "page: 'page' is required, pageSize: 'pageSize' is required",
        "data": {
            "page": { "message": "'page' is required" },
            "pageSize": { "message": "'pageSize' is required" }
        }
    }
}
```

---

### TEST 2 — Only one pagination param → `422`
```
GET /download-activity?page=1
```
```json
{
    "status": "error",
    "error": {
        "statusCode": 422,
        "name": "ValidateError",
        "message": "pageSize: 'pageSize' is required",
        "data": {
            "pageSize": { "message": "'pageSize' is required" }
        }
    }
}
```

---

### TEST 3 — Valid pagination → `200`
```
GET /download-activity?page=1&pageSize=10
```
```json
{
    "status": "ok",
    "results": {
        "data": [
            {
                "downloadUuid": "e4426011-f7f3-482b-96d8-3811c992b16c",
                "queryUuid": "58333df1-be9c-46e6-b93d-6a99f284cea3",
                "userUuid": "b264d83a-9000-426a-85ec-3f9c20f368ce",
                "userFirstName": "David",
                "userLastName": "Attenborough",
                "fileType": "csv",
                "downloadedAt": "2026-05-09T01:27:51.558Z",
                "originalQueryContext": "exploreView"
            },
            {
                "downloadUuid": "c1b49a41-ee7d-41da-bf91-6c7d96496b75",
                "queryUuid": "dc3edc07-9424-4d47-bfb0-a6e6f0104af9",
                "userUuid": "b264d83a-9000-426a-85ec-3f9c20f368ce",
                "userFirstName": "David",
                "userLastName": "Attenborough",
                "fileType": "xlsx",
                "downloadedAt": "2026-05-09T01:27:51.558Z",
                "originalQueryContext": "dashboardView"
            }
        ],
        "pagination": {
            "page": 1,
            "pageSize": 10,
            "totalPageCount": 1,
            "totalResults": 2
        }
    }
}
```

---

### TEST 4 — Page 2 with pageSize=1 → `200`
```
GET /download-activity?page=2&pageSize=1
```
```json
{
    "status": "ok",
    "results": {
        "data": [
            {
                "downloadUuid": "c1b49a41-ee7d-41da-bf91-6c7d96496b75",
                "queryUuid": "dc3edc07-9424-4d47-bfb0-a6e6f0104af9",
                "userUuid": "b264d83a-9000-426a-85ec-3f9c20f368ce",
                "userFirstName": "David",
                "userLastName": "Attenborough",
                "fileType": "xlsx",
                "downloadedAt": "2026-05-09T01:27:51.558Z",
                "originalQueryContext": "dashboardView"
            }
        ],
        "pagination": {
            "page": 2,
            "pageSize": 1,
            "totalPageCount": 2,
            "totalResults": 2
        }
    }
}
```

---

### TEST 5 — Page out of range → `200` with empty data
```
GET /download-activity?page=99&pageSize=10
```
```json
{
    "status": "ok",
    "results": {
        "data": [],
        "pagination": {
            "page": 99,
            "pageSize": 10,
            "totalPageCount": 1,
            "totalResults": 2
        }
    }
}
```

---

### TEST 6 — Unauthenticated → `401`
```
GET /download-activity?page=1&pageSize=10  (no API key)
```
```
HTTP/1.1 401 Unauthorized
```

---

### TEST 7 — Invalid project UUID → `404`
```
GET /{invalidProjectUuid}/download-activity?page=1&pageSize=10
```
```json
{
    "status": "error",
    "error": {
        "statusCode": 404,
        "name": "NotFoundError",
        "message": "Cannot find project with id: 00000000-0000-0000-0000-000000000000",
        "data": {}
    }
}
```

## Test plan

- [x] Unit tests pass — 5 tests covering auth, pagination, empty data, tracking event
- [x] TypeScript typechecks clean for both `common` and `backend`
- [x] Lint and format clean (`pnpm -F backend lint`, `pnpm -F backend format --check`)
- [x] `pnpm generate-api` regenerated successfully
- [x] All 7 API scenarios tested live against local dev instance (see above)