### PR TITLE
fix: Enable handleExceptions and handleRejections on Winston Console transport

### DIFF
--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -124,6 +124,8 @@ if (lightdashConfig.logging.outputs.includes('console')) {
             level:
                 lightdashConfig.logging.consoleLevel ||
                 lightdashConfig.logging.level,
+            handleExceptions: true,
+            handleRejections: true,
         }),
     );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: [[Logging] Enable handleExceptions / handleRejections on Winston Console transport](https://github.com/lightdash/lightdash/issues/22824)

### Description:

The Winston Console transport was not configured with `handleExceptions: true` or `handleRejections: true`, so uncaught exceptions and unhandled promise rejections bypassed Winston entirely and wrote raw plain-text stack traces to stderr.

This means one unhandled exception produces 10-20 separate log events — each a single stack frame with no standalone diagnostic value — rather than a single structured JSON entry. For deployments using a log aggregator (e.g. Datadog), this creates significant noise and makes it difficult to identify real issues.

This PR adds `handleExceptions: true` and `handleRejections: true` to the Console transport so all errors are captured by Winston, formatted consistently with the rest of the log output, and emitted as a single structured entry.