### PR TITLE
fix: resolve short-form metric refs against outer metric's table to prevent same-named joined metric collision (PROD-7503)

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -3021,6 +3021,174 @@ export const METRIC_QUERY_NESTED_AGG_MIXED_RAW_NO_DIMS: CompiledMetricQuery = {
     compiledCustomDimensions: [],
 };
 
+// PROD-7503: base table has a hidden helper metric named `met_active_customers`
+// (type:number — raw column ref). A joined table has an aggregate metric with
+// the SAME name (type:average). The base table also has:
+//   - an outer mixed metric `met_active_customers_agg` whose SQL uses the short
+//     form `${met_active_customers}` to reference the base table's raw helper.
+//   - an outer pure-agg metric `met_active_customers_goal` whose SQL uses the
+//     qualified form `${joined_tbl.met_active_customers}` to reference the
+//     joined table's aggregate.
+// Selecting both triggers the nested_agg_mixed CTE with an aggregate inner dep
+// from the joined table whose name collides with the base helper's name.
+export const EXPLORE_NESTED_AGG_NAME_COLLISION: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'base_tbl',
+    label: 'base_tbl',
+    baseTable: 'base_tbl',
+    tags: [],
+    tables: {
+        base_tbl: {
+            name: 'base_tbl',
+            label: 'base_tbl',
+            database: 'db',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."base_tbl"',
+            primaryKey: ['id'],
+            lineageGraph: {},
+            dimensions: {
+                category: {
+                    type: DimensionType.STRING,
+                    name: 'category',
+                    label: 'category',
+                    table: 'base_tbl',
+                    tableLabel: 'base_tbl',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.category',
+                    compiledSql: '"base_tbl".category',
+                    tablesReferences: ['base_tbl'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                // Hidden helper: raw column ref. Same NAME as the joined
+                // table's aggregate metric — this is the collision.
+                met_active_customers: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'base_tbl',
+                    tableLabel: 'base_tbl',
+                    name: 'met_active_customers',
+                    label: 'met_active_customers',
+                    sql: '${TABLE}.active_customers',
+                    compiledSql: '"base_tbl".active_customers',
+                    tablesReferences: ['base_tbl'],
+                    hidden: true,
+                },
+                // Hidden helper: raw column ref (ordering column for MAX_BY).
+                met_updated_on: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'base_tbl',
+                    tableLabel: 'base_tbl',
+                    name: 'met_updated_on',
+                    label: 'met_updated_on',
+                    sql: '${TABLE}.updated_on',
+                    compiledSql: '"base_tbl".updated_on',
+                    tablesReferences: ['base_tbl'],
+                    hidden: true,
+                },
+                // Outer mixed metric: both inner deps are raw column helpers on
+                // base_tbl. The ${met_active_customers} short-form ref must
+                // resolve to base_tbl's helper, NOT the joined table's
+                // aggregate of the same name.
+                met_active_customers_agg: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'base_tbl',
+                    tableLabel: 'base_tbl',
+                    name: 'met_active_customers_agg',
+                    label: 'met_active_customers_agg',
+                    sql: 'MAX_BY(${met_active_customers}, ${met_updated_on})',
+                    compiledSql:
+                        'MAX_BY("base_tbl".active_customers, "base_tbl".updated_on)',
+                    tablesReferences: ['base_tbl'],
+                    hidden: false,
+                },
+                // Outer pure-agg metric: qualified ref to the joined table's
+                // aggregate. Forces joined_tbl.met_active_customers into
+                // aggregateInnerDeps for the nested_agg CTE.
+                met_active_customers_goal: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'base_tbl',
+                    tableLabel: 'base_tbl',
+                    name: 'met_active_customers_goal',
+                    label: 'met_active_customers_goal',
+                    sql: '${joined_tbl.met_active_customers}',
+                    compiledSql: 'AVG("joined_tbl".active_customers)',
+                    tablesReferences: ['base_tbl', 'joined_tbl'],
+                    hidden: false,
+                },
+            },
+        },
+        joined_tbl: {
+            name: 'joined_tbl',
+            label: 'joined_tbl',
+            database: 'db',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."joined_tbl"',
+            primaryKey: ['base_id'],
+            lineageGraph: {},
+            dimensions: {
+                joined_dim: {
+                    type: DimensionType.STRING,
+                    name: 'joined_dim',
+                    label: 'joined_dim',
+                    table: 'joined_tbl',
+                    tableLabel: 'joined_tbl',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.joined_dim',
+                    compiledSql: '"joined_tbl".joined_dim',
+                    tablesReferences: ['joined_tbl'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                // Aggregate metric with the SAME name as base_tbl's helper.
+                met_active_customers: {
+                    type: MetricType.AVERAGE,
+                    fieldType: FieldType.METRIC,
+                    table: 'joined_tbl',
+                    tableLabel: 'joined_tbl',
+                    name: 'met_active_customers',
+                    label: 'met_active_customers',
+                    sql: '${TABLE}.active_customers',
+                    compiledSql: 'AVG("joined_tbl".active_customers)',
+                    tablesReferences: ['joined_tbl'],
+                    hidden: false,
+                },
+            },
+        },
+    },
+    joinedTables: [
+        {
+            table: 'joined_tbl',
+            sqlOn: '${base_tbl.id} = ${joined_tbl.base_id}',
+            compiledSqlOn: '("base_tbl".id) = ("joined_tbl".base_id)',
+            type: 'left',
+            relationship: JoinRelationship.ONE_TO_ONE,
+            tablesReferences: ['base_tbl', 'joined_tbl'],
+        },
+    ],
+};
+
+export const METRIC_QUERY_NESTED_AGG_NAME_COLLISION: CompiledMetricQuery = {
+    exploreName: 'base_tbl',
+    dimensions: ['base_tbl_category'],
+    metrics: [
+        'base_tbl_met_active_customers_agg',
+        'base_tbl_met_active_customers_goal',
+    ],
+    filters: {},
+    sorts: [{ fieldId: 'base_tbl_met_active_customers_agg', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
 // --- cross-model type:number referencing sum_distinct fixtures ---
 
 export const EXPLORE_WITH_CROSS_MODEL_SUM_DISTINCT: Explore = {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -26,6 +26,7 @@ import {
 import {
     bigqueryClientMock,
     EXPLORE,
+    EXPLORE_NESTED_AGG_NAME_COLLISION,
     EXPLORE_WITH_AVERAGE_DISTINCT,
     EXPLORE_WITH_CROSS_MODEL_SUM_DISTINCT,
     EXPLORE_WITH_CROSS_TABLE_METRICS,
@@ -53,6 +54,7 @@ import {
     METRIC_QUERY_NESTED_AGG_MIXED_RAW,
     METRIC_QUERY_NESTED_AGG_MIXED_RAW_NO_DIMS,
     METRIC_QUERY_NESTED_AGG_MIXED_RAW_WITH_PURE,
+    METRIC_QUERY_NESTED_AGG_NAME_COLLISION,
     METRIC_QUERY_NESTED_AGG_NO_DIMS,
     METRIC_QUERY_NESTED_AGG_PRODUCT,
     METRIC_QUERY_NESTED_AGG_RAW_COL,
@@ -4942,6 +4944,40 @@ describe('Nested aggregate metrics', () => {
         expect(result.query.match(/AS "my_table_max_value"/g)).toHaveLength(1);
         // The outer metric should appear once via nested_agg_results
         expect(result.query.match(/AS "my_table_sum_of_max"/g)).toHaveLength(1);
+    });
+
+    test('should resolve short-form metric refs against the outer metric table when a joined table has a same-named aggregate (PROD-7503)', () => {
+        // Repro: base table has a hidden helper `met_active_customers`
+        // (raw column). Joined table has an aggregate metric with the SAME
+        // name. The outer mixed metric `met_active_customers_agg` on the
+        // base table uses `${met_active_customers}` (short form) which must
+        // resolve to the base table's raw helper — NOT the joined table's
+        // pre-computed AVG in the nested_agg CTE.
+        const result = buildQuery({
+            explore: EXPLORE_NESTED_AGG_NAME_COLLISION,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_NAME_COLLISION,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // The mixed CTE's MAX_BY must reference the base table's raw column,
+        // not the joined table's pre-aggregated value.
+        // (compileMetricReference wraps resolved refs in parens.)
+        expect(result.query).toContain(
+            'MAX_BY(("base_tbl".active_customers), ("base_tbl".updated_on))',
+        );
+        // Negative: the buggy SQL referenced the joined table's CTE column
+        // as the first argument to MAX_BY.
+        expect(result.query).not.toMatch(
+            /MAX_BY\(\s*nested_agg\."joined_tbl_met_active_customers"/,
+        );
+
+        // The pure-agg goal metric should still resolve correctly to the
+        // joined-table CTE column.
+        expect(result.query).toContain(
+            'nested_agg."joined_tbl_met_active_customers" AS "base_tbl_met_active_customers_goal"',
+        );
     });
 });
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -3176,33 +3176,29 @@ export class MetricQueryBuilder {
 
             if (hasRawDep) {
                 // Mixed metric: replace aggregate dep refs with CTE 1 column
-                // refs manually, then let compileMetricSql resolve raw refs
-                // and ${TABLE} refs against the base table (which is in scope
-                // in CTE 3).
-                let mixedSql = preSql;
-                for (const [depId, depMetric] of aggregateInnerDeps) {
-                    const escapedName = depMetric.name.replace(
-                        /[.*+?^${}()|[\]\\]/g,
-                        '\\$&',
-                    );
-                    const escapedTable = depMetric.table.replace(
-                        /[.*+?^${}()|[\]\\]/g,
-                        '\\$&',
-                    );
-                    const cteRef = `${naCteName}.${fieldQuoteChar}${depId}${fieldQuoteChar}`;
-                    mixedSql = mixedSql
-                        .replace(
-                            new RegExp(`\\$\\{${escapedName}\\}`, 'g'),
-                            cteRef,
-                        )
-                        .replace(
-                            new RegExp(
-                                `\\$\\{${escapedTable}\\.${escapedName}\\}`,
-                                'g',
-                            ),
-                            cteRef,
+                // refs, then let compileMetricSql resolve raw refs and
+                // ${TABLE} refs against the base table (which is in scope in
+                // CTE 3). Resolve each ${ref} via getParsedReference so the
+                // short form ${name} maps to the outer metric's own table —
+                // not to a same-named metric on a joined table (PROD-7503).
+                const mixedSql = preSql.replace(
+                    lightdashVariablePattern,
+                    (fullMatch, ref) => {
+                        if (ref === 'TABLE') return fullMatch;
+                        const { refTable, refName } = getParsedReference(
+                            ref,
+                            outerMetric.table,
                         );
-                }
+                        const refItemId = getItemId({
+                            table: refTable,
+                            name: refName,
+                        });
+                        if (aggregateInnerDeps.has(refItemId)) {
+                            return `${naCteName}.${fieldQuoteChar}${refItemId}${fieldQuoteChar}`;
+                        }
+                        return fullMatch;
+                    },
+                );
 
                 // Compile remaining refs (raw metric refs, ${TABLE}, dimensions)
                 // against the explore tables — they resolve to base table columns.


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7503/nested-aggregate-cte-resolves-metric-reference-to-wrong-table-when

### Description:

Fixes a bug where a short-form metric reference (e.g. `${met_active_customers}`) inside a mixed nested aggregate metric was incorrectly resolving to a same-named aggregate metric on a joined table instead of the raw column helper on the outer metric's own table.

The root cause was that the previous substitution logic matched `${name}` purely by metric name, without considering which table the reference belonged to. When a joined table had an aggregate metric with the same name as a base table's raw helper, the joined table's pre-aggregated CTE column would be substituted into the `MAX_BY` expression instead of the base table's raw column — producing incorrect SQL.

The fix replaces the name-only string substitution with a `getParsedReference`-based approach that resolves each `${ref}` token using the outer metric's own table as the default table context. This ensures short-form refs like `${met_active_customers}` correctly map to `base_tbl.met_active_customers`, while qualified refs like `${joined_tbl.met_active_customers}` still correctly resolve to the joined table's CTE column.

A new test fixture (`EXPLORE_NESTED_AGG_NAME_COLLISION` / `METRIC_QUERY_NESTED_AGG_NAME_COLLISION`) and corresponding test case are added to cover this scenario and prevent regressions.