### PR TITLE
chore: upgrade pgvector postgres image to pg18

### DIFF
--- a/docker/docker-compose.dev.instance.yml
+++ b/docker/docker-compose.dev.instance.yml
@@ -4,7 +4,7 @@ volumes:
 
 services:
     db-dev:
-        image: pgvector/pgvector:pg16
+        image: pgvector/pgvector:pg18
         container_name: ${LD_CONTAINER_PREFIX:-docker}-db-dev-1
         restart: always
         environment:
@@ -12,4 +12,4 @@ services:
         ports:
             - '${LD_PG_PORT:-5432}:5432'
         volumes:
-            - postgres_data:/var/lib/postgresql/data
+            - postgres_data:/var/lib/postgresql

--- a/docker/docker-compose.dev.mini.yml
+++ b/docker/docker-compose.dev.mini.yml
@@ -19,14 +19,14 @@ services:
         entrypoint: '/init-minio.sh'
 
     db-dev:
-        image: pgvector/pgvector:pg16
+        image: pgvector/pgvector:pg18
         restart: always
         environment:
             POSTGRES_PASSWORD: password
         ports:
             - '5432:5432'
         volumes:
-            - postgres_data:/var/lib/postgresql/data
+            - postgres_data:/var/lib/postgresql
 
     headless-browser:
         build:

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -1,3 +1,6 @@
+volumes:
+    postgres_data:
+
 services:
     minio:
         image: coollabsio/minio:latest
@@ -15,12 +18,14 @@ services:
             - MINIO_BROWSER=${MINIO_BROWSER:-off}
 
     db-dev:
-        image: pgvector/pgvector:pg16
+        image: pgvector/pgvector:pg18
         restart: always
         environment:
             POSTGRES_PASSWORD: password
         ports:
             - '5432:5432'
+        volumes:
+            - postgres_data:/var/lib/postgresql
 
     ssh-server:
         image: linuxserver/openssh-server:latest

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -9,7 +9,7 @@ endpoints:
 
 services:
     db-preview:
-        image: pgvector/pgvector:pg16
+        image: pgvector/pgvector:pg18
         restart: always
         environment:
             - POSTGRES_PASSWORD=${PGPASSWORD}


### PR DESCRIPTION
Closes:

### Description:
Upgrades the PostgreSQL database image from `pgvector/pgvector:pg16` to `pgvector/pgvector:pg18` across all Docker Compose configurations (dev instance, dev mini, infra, and preview environments).