### PR TITLE
fix: coerce non-string filter values in case-insensitive string filters

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -1695,6 +1695,37 @@ describe('case sensitivity', () => {
   UPPER(${stringFilterDimension}) NOT LIKE UPPER('%Jerry%') OR (${stringFilterDimension}) IS NULL)`);
     });
 
+    test.each<[FilterOperator, string]>([
+        [FilterOperator.EQUALS, `(UPPER(${stringFilterDimension})) IN ('1')`],
+        [
+            FilterOperator.NOT_EQUALS,
+            `((UPPER(${stringFilterDimension})) NOT IN ('1') OR (${stringFilterDimension}) IS NULL)`,
+        ],
+        [
+            FilterOperator.STARTS_WITH,
+            `UPPER(${stringFilterDimension}) LIKE '1%'`,
+        ],
+        [FilterOperator.ENDS_WITH, `UPPER(${stringFilterDimension}) LIKE '%1'`],
+    ])(
+        'should coerce numeric values to strings when caseSensitive is false for %s',
+        (operator, expectedSql) => {
+            const filter: FilterRule = {
+                id: 'test',
+                target: { fieldId: 'test' },
+                operator,
+                values: [1],
+            };
+            expect(
+                renderStringFilterSql(
+                    stringFilterDimension,
+                    filter,
+                    "'",
+                    false, // caseSensitive = false
+                ),
+            ).toBe(expectedSql);
+        },
+    );
+
     test('should respect field-level caseSensitive over explore-level', () => {
         const field = {
             ...disabledFilterMock.field,

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -121,8 +121,8 @@ export const renderStringFilterSql = (
     // Apply UPPER() to both dimension and values when case insensitive (caseSensitive = false)
     const wrapDimension = (sql: string) =>
         !caseSensitive ? `UPPER(${sql})` : sql;
-    const wrapValue = (value: string) =>
-        !caseSensitive ? value.toUpperCase() : value;
+    const wrapValue = (value: unknown) =>
+        !caseSensitive ? String(value).toUpperCase() : value;
 
     switch (filter.operator) {
         case FilterOperator.EQUALS:


### PR DESCRIPTION
### Description:
Non-string values (e.g. integers) in `filter.values` crashed `renderStringFilterSql` with `value.toUpperCase is not a function` when `caseSensitive=false`. The case-sensitive branch was implicitly safe because it interpolated values through template literals; the new case-insensitive branch called `.toUpperCase()` directly. Coerce via `String(value)` so both paths produce equivalent SQL.

