### PR TITLE
fix(echarts): snap category date axis in project timezone

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1481,6 +1481,7 @@ export const getCategoryDateAxisConfig = (
     rows?: ResultRow[],
     axisType?: string,
     series?: Series[],
+    resolvedTimezone?: string,
 ): CategoryDateAxisConfig => {
     if (!axisId || !rows || !axisField || axisType !== 'category') return {};
     if (!('timeInterval' in axisField)) return {};
@@ -1500,14 +1501,20 @@ export const getCategoryDateAxisConfig = (
     );
     const boundaryGap = hasBarSeries;
 
+    // Row values are aligned to project-TZ midnights — snap boundaries in
+    // the same zone so category strings match.
+    const tz = resolvedTimezone ?? 'UTC';
+    const inTz = (v: string | number) => dayjs.tz(dayjs.utc(v).toDate(), tz);
+
     if (timeInterval === TimeFrames.WEEK) {
         const continuousRange: string[] = [];
-        let nextDate = dayjs.utc(minX);
-        while (nextDate.isBefore(dayjs(maxX))) {
-            continuousRange.push(nextDate.format());
+        let nextDate = inTz(minX);
+        const endDate = inTz(maxX);
+        while (nextDate.isBefore(endDate)) {
+            continuousRange.push(nextDate.utc().format());
             nextDate = nextDate.add(1, 'week');
         }
-        continuousRange.push(dayjs.utc(maxX).format());
+        continuousRange.push(endDate.utc().format());
         return {
             data: continuousRange,
             axisTick: { alignWithLabel: true, interval: 0 },
@@ -1517,10 +1524,10 @@ export const getCategoryDateAxisConfig = (
 
     if (timeInterval === TimeFrames.YEAR) {
         const continuousRange: string[] = [];
-        let nextDate = dayjs.utc(minX).startOf('year');
-        const endDate = dayjs.utc(maxX).startOf('year');
+        let nextDate = inTz(minX).startOf('year');
+        const endDate = inTz(maxX).startOf('year');
         while (!nextDate.isAfter(endDate)) {
-            continuousRange.push(nextDate.format());
+            continuousRange.push(nextDate.utc().format());
             nextDate = nextDate.add(1, 'year');
         }
         return {
@@ -1532,10 +1539,10 @@ export const getCategoryDateAxisConfig = (
 
     if (timeInterval === TimeFrames.QUARTER) {
         const continuousRange: string[] = [];
-        let nextDate = dayjs.utc(minX).startOf('quarter');
-        const endDate = dayjs.utc(maxX).startOf('quarter');
+        let nextDate = inTz(minX).startOf('quarter');
+        const endDate = inTz(maxX).startOf('quarter');
         while (!nextDate.isAfter(endDate)) {
-            continuousRange.push(nextDate.format());
+            continuousRange.push(nextDate.utc().format());
             // dayjs requires quarterOfYear plugin for .add(1, 'quarter')
             nextDate = nextDate.add(3, 'months');
         }
@@ -1548,10 +1555,10 @@ export const getCategoryDateAxisConfig = (
 
     if (timeInterval === TimeFrames.MONTH) {
         const continuousRange: string[] = [];
-        let nextDate = dayjs.utc(minX).startOf('month');
-        const endDate = dayjs.utc(maxX).startOf('month');
+        let nextDate = inTz(minX).startOf('month');
+        const endDate = inTz(maxX).startOf('month');
         while (!nextDate.isAfter(endDate)) {
-            continuousRange.push(nextDate.format());
+            continuousRange.push(nextDate.utc().format());
             nextDate = nextDate.add(1, 'month');
         }
         return {
@@ -1760,6 +1767,7 @@ const getEchartAxes = ({
         axisRows,
         bottomAxisType,
         eChartsSeries,
+        resolvedTimezone,
     );
     const topAxisExtraConfig = getCategoryDateAxisConfig(
         topAxisXId,
@@ -1767,6 +1775,7 @@ const getEchartAxes = ({
         axisRows,
         topAxisType,
         eChartsSeries,
+        resolvedTimezone,
     );
     const rightAxisExtraConfig = getCategoryDateAxisConfig(
         rightAxisYId,
@@ -1774,6 +1783,7 @@ const getEchartAxes = ({
         axisRows,
         rightAxisType,
         eChartsSeries,
+        resolvedTimezone,
     );
     const leftAxisExtraConfig = getCategoryDateAxisConfig(
         leftAxisYId,
@@ -1781,6 +1791,7 @@ const getEchartAxes = ({
         axisRows,
         leftAxisType,
         eChartsSeries,
+        resolvedTimezone,
     );
 
     const axisLabelFontSize =


### PR DESCRIPTION
Bar charts using WEEK / MONTH / QUARTER / YEAR category axes render no bars on non-UTC project timezones.

After #22207, truncated intervals come back as UTC instants aligned to project-TZ midnights (e.g. Pago_Pago Nov 1 → `2024-11-01T11:00:00Z`). `getCategoryDateAxisConfig` still snapped axis boundaries to UTC midnights → string mismatch → ECharts category mapping drops every row.

Fix: snap WEEK / MONTH / QUARTER / YEAR boundaries in `resolvedTimezone`, then format back to UTC ISO so the strings match. Falls back to UTC when the flag is off — pre-#22207 behavior unchanged.

**Before**
<img width="2124" height="1177" alt="CleanShot 2026-05-11 at 09 27 03" src="https://github.com/user-attachments/assets/85fd6474-03f0-428b-b7ad-4b3da4c4c475" />

**After**
<img width="2132" height="1197" alt="after_fix" src="https://github.com/user-attachments/assets/8af9f433-4842-4870-8736-11ce1f09d972" />


Closes [GLITCH-428](https://linear.app/lightdash/issue/GLITCH-428/category-axis-time-dimensions-render-no-bars-on-non-utc-project)