### PR TITLE
refactor: migrate viz config to mantine 8

### DIFF
--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.module.css
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.module.css
@@ -1,0 +1,12 @@
+.accordion {
+    border: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.controlPanel {
+    background-color: light-dark(white, transparent);
+}
+
+.panel {
+    background-color: light-dark(white, transparent);
+    border-radius: var(--mantine-radius-sm);
+}

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -14,7 +14,7 @@ import {
     Stack,
     Text,
     useMantineColorScheme,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useMemo } from 'react';
 import {
     useAppSelector,
@@ -26,6 +26,7 @@ import { Config } from '../../VisualizationConfigs/common/Config';
 import { type BarChartActionsType } from '../store/barChartSlice';
 import { type LineChartActionsType } from '../store/lineChartSlice';
 import { selectCurrentCartesianChartState } from '../store/selectors';
+import classes from './CartesianChartSeries.module.css';
 import { SingleSeriesConfiguration } from './SingleSeriesConfiguration';
 
 type ConfigurableSeries = {
@@ -159,7 +160,7 @@ export const CartesianChartSeries = ({
     };
 
     return (
-        <Stack mt="sm" spacing="xs">
+        <Stack mt="sm" gap="xs">
             {Object.keys(groupedSeries).length === 0 && (
                 <Text>No series found. Add a metric to create a series.</Text>
             )}
@@ -221,34 +222,17 @@ export const CartesianChartSeries = ({
                           <Accordion
                               key={referenceField}
                               variant="contained"
-                              sx={(theme) => ({
-                                  root: {
-                                      border: `1px solid ${theme.colors.ldGray[2]}`,
-                                  },
-                              })}
+                              className={classes.accordion}
                           >
                               <Accordion.Item value={referenceField} m={0}>
                                   <Accordion.Control
-                                      sx={(theme) => ({
-                                          backgroundColor:
-                                              theme.colorScheme === 'light'
-                                                  ? 'white'
-                                                  : 'transparent',
-                                      })}
+                                      className={classes.controlPanel}
                                   >
                                       <Config.Subheading>
                                           {friendlyName(referenceField)}
                                       </Config.Subheading>
                                   </Accordion.Control>
-                                  <Accordion.Panel
-                                      sx={(theme) => ({
-                                          backgroundColor:
-                                              theme.colorScheme === 'light'
-                                                  ? 'white'
-                                                  : 'transparent',
-                                          borderRadius: theme.radius.sm,
-                                      })}
-                                  >
+                                  <Accordion.Panel className={classes.panel}>
                                       {seriesArray.map((s, index) => (
                                           <SingleSeriesConfiguration
                                               key={`${s.reference}-${index}`}

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormatting.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { isBigNumberVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import accordionClasses from '../common/Accordion.module.css';
 import { AddButton } from '../common/AddButton';
 import { Config } from '../common/Config';
 import { BigNumberConditionalFormattingItem } from './BigNumberConditionalFormattingItem';
@@ -100,7 +101,13 @@ export const BigNumberConditionalFormatting: FC = () => {
                     <Config.Heading>Rules and Conditions</Config.Heading>
                     <AddButton onClick={handleAdd} />
                 </Config.Group>
-                <Accordion multiple variant="contained" radius="md">
+                <Accordion
+                    multiple
+                    variant="contained"
+                    chevronPosition="right"
+                    className={accordionClasses.containedList}
+                    transparentActiveItem
+                >
                     {activeConfigs.map((conditionalFormatting, index) => (
                         <BigNumberConditionalFormattingItem
                             key={configIdsRef.current[index] ?? index}

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingItem.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingItem.module.css
@@ -1,0 +1,23 @@
+.conditionsGroup {
+    --accordion-radius: var(--mantine-radius-md);
+    margin-inline: calc(var(--mantine-spacing-xs) * -1);
+    position: relative;
+}
+
+.conditionsGroup > * {
+    background-color: var(--item-filled-color);
+
+    &:not(:last-of-type)::after {
+        content: 'AND';
+        position: absolute;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        padding: 0 var(--mantine-spacing-xs);
+        background-color: var(--item-filled-color);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.6px;
+        color: var(--mantine-color-ldGray-6);
+        z-index: 1;
+    }
+}

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingItem.tsx
@@ -8,29 +8,21 @@ import {
 } from '@lightdash/common';
 import {
     Accordion,
-    ActionIcon,
-    Box,
     Button,
-    Divider,
+    Flex,
     Group,
-    Menu,
     Stack,
-    Text,
     useMantineColorScheme,
 } from '@mantine-8/core';
-import {
-    IconDots,
-    IconMoon,
-    IconPlus,
-    IconSun,
-    IconTrash,
-} from '@tabler/icons-react';
+import { IconMoon, IconPlus, IconSun } from '@tabler/icons-react';
 import { produce } from 'immer';
-import { Fragment, useCallback, useState, type FC } from 'react';
+import { useCallback, useState, type FC } from 'react';
 import FiltersProvider from '../../common/Filters/FiltersProvider';
 import MantineIcon from '../../common/MantineIcon';
 import ColorSelector from '../ColorSelector';
+import { AccordionControl } from '../common/AccordionControl';
 import { Config } from '../common/Config';
+import classes from './BigNumberConditionalFormattingItem.module.css';
 import BigNumberConditionalFormattingRule from './BigNumberConditionalFormattingRule';
 
 type Props = {
@@ -51,12 +43,15 @@ export const BigNumberConditionalFormattingItem: FC<Props> = ({
     onRemove,
 }) => {
     const { colorScheme } = useMantineColorScheme();
-    const [isAddingRule, setIsAddingRule] = useState(false);
+    const [openConditions, setOpenConditions] = useState<string[]>(() =>
+        isConditionalFormattingConfigWithSingleColor(value)
+            ? value.rules.map((_, i) => `${i}`)
+            : [],
+    );
 
     const handleAddRule = useCallback(() => {
-        setIsAddingRule(true);
-
         if (isConditionalFormattingConfigWithSingleColor(value)) {
+            const newIndex = value.rules.length;
             onChange(
                 produce(value, (draft) => {
                     draft.rules.push(
@@ -64,6 +59,7 @@ export const BigNumberConditionalFormattingItem: FC<Props> = ({
                     );
                 }),
             );
+            setOpenConditions((prev) => [...prev, `${newIndex}`]);
         }
     }, [onChange, value]);
 
@@ -74,6 +70,14 @@ export const BigNumberConditionalFormattingItem: FC<Props> = ({
                     produce(value, (draft) => {
                         draft.rules.splice(index, 1);
                     }),
+                );
+                setOpenConditions((prev) =>
+                    prev
+                        .filter((v) => v !== `${index}`)
+                        .map((v) => {
+                            const i = Number(v);
+                            return i > index ? `${i - 1}` : v;
+                        }),
                 );
             }
         },
@@ -148,42 +152,16 @@ export const BigNumberConditionalFormattingItem: FC<Props> = ({
 
     return (
         <Accordion.Item value={accordionValue}>
-            <Accordion.Control
-                icon={
+            <AccordionControl
+                label={controlLabel}
+                extraControlElements={
                     <ColorSelector
                         color={previewColor}
                         swatches={colorPalette}
                     />
                 }
-            >
-                <Group justify="space-between" wrap="nowrap">
-                    <Text fw={500} size="xs" truncate>
-                        {controlLabel}
-                    </Text>
-                    <Menu withArrow offset={-2}>
-                        <Menu.Target>
-                            <ActionIcon
-                                variant="transparent"
-                                color="gray"
-                                onClick={(e) => e.stopPropagation()}
-                            >
-                                <MantineIcon icon={IconDots} />
-                            </ActionIcon>
-                        </Menu.Target>
-                        <Menu.Dropdown>
-                            <Menu.Item
-                                leftSection={<MantineIcon icon={IconTrash} />}
-                                color="red"
-                                onClick={onRemove}
-                            >
-                                <Text fz="xs" fw={500}>
-                                    Delete
-                                </Text>
-                            </Menu.Item>
-                        </Menu.Dropdown>
-                    </Menu>
-                </Group>
-            </Accordion.Control>
+                onRemove={onRemove}
+            />
             <Accordion.Panel>
                 <Stack gap="xs">
                     <FiltersProvider>
@@ -212,21 +190,32 @@ export const BigNumberConditionalFormattingItem: FC<Props> = ({
                         </Group>
 
                         {isConditionalFormattingConfigWithSingleColor(value) ? (
-                            <Box
-                                p="xs"
-                                style={(theme) => ({
-                                    backgroundColor: theme.colors.ldGray[1],
-                                    border: `1px solid ${theme.colors.ldGray[4]}`,
-                                    borderRadius: theme.radius.md,
-                                })}
-                            >
-                                {value.rules.map((rule, ruleIndex) => (
-                                    <Fragment key={ruleIndex}>
+                            <>
+                                <Flex justify="space-between">
+                                    <Config.Label>Conditions</Config.Label>
+                                    <Button
+                                        size="compact-xs"
+                                        variant="subtle"
+                                        leftSection={
+                                            <MantineIcon icon={IconPlus} />
+                                        }
+                                        onClick={handleAddRule}
+                                    >
+                                        Add
+                                    </Button>
+                                </Flex>
+                                <Accordion
+                                    multiple
+                                    chevronPosition="right"
+                                    variant="contained"
+                                    className={classes.conditionsGroup}
+                                    value={openConditions}
+                                    onChange={setOpenConditions}
+                                >
+                                    {value.rules.map((rule, ruleIndex) => (
                                         <BigNumberConditionalFormattingRule
-                                            isDefaultOpen={
-                                                value.rules.length === 1 ||
-                                                isAddingRule
-                                            }
+                                            key={ruleIndex}
+                                            accordionValue={`${ruleIndex}`}
                                             hasRemove={value.rules.length > 1}
                                             ruleIndex={ruleIndex}
                                             rule={rule}
@@ -249,34 +238,9 @@ export const BigNumberConditionalFormattingItem: FC<Props> = ({
                                                 handleRemoveRule(ruleIndex)
                                             }
                                         />
-
-                                        {ruleIndex !==
-                                            value.rules.length - 1 && (
-                                            <Divider
-                                                mt="xs"
-                                                label={
-                                                    <Config.Label>
-                                                        AND
-                                                    </Config.Label>
-                                                }
-                                                labelPosition="center"
-                                            />
-                                        )}
-                                    </Fragment>
-                                ))}
-                            </Box>
-                        ) : null}
-
-                        {isConditionalFormattingConfigWithSingleColor(value) ? (
-                            <Button
-                                style={{ alignSelf: 'start' }}
-                                variant="subtle"
-                                size="compact-sm"
-                                leftSection={<MantineIcon icon={IconPlus} />}
-                                onClick={handleAddRule}
-                            >
-                                Add new condition
-                            </Button>
+                                    ))}
+                                </Accordion>
+                            </>
                         ) : null}
                     </FiltersProvider>
                 </Stack>

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingRule.tsx
@@ -7,19 +7,8 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
-import {
-    ActionIcon,
-    Collapse,
-    Group,
-    Select,
-    Stack,
-    Text,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
-import { useHover } from '@mantine/hooks';
-import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { Group, Select, Stack, TextInput, Accordion } from '@mantine-8/core';
+import { useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import FilterInputComponent from '../../common/Filters/FilterInputs';
 import {
@@ -27,10 +16,10 @@ import {
     getFilterOptions,
 } from '../../common/Filters/FilterInputs/utils';
 import FiltersProvider from '../../common/Filters/FiltersProvider';
-import MantineIcon from '../../common/MantineIcon';
+import { AccordionControl } from '../common/AccordionControl';
 
 interface Props {
-    isDefaultOpen?: boolean;
+    accordionValue: string;
     ruleIndex: number;
     rule: ConditionalFormattingWithFilterOperator;
     field: FilterableItem | undefined;
@@ -41,7 +30,7 @@ interface Props {
 }
 
 const BigNumberConditionalFormattingRule: FC<Props> = ({
-    isDefaultOpen = true,
+    accordionValue,
     ruleIndex,
     rule,
     field,
@@ -51,9 +40,6 @@ const BigNumberConditionalFormattingRule: FC<Props> = ({
     hasRemove,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-
-    const { ref, hovered } = useHover();
-    const [isOpen, setIsOpen] = useState(isDefaultOpen);
 
     const filterType: FilterType.NUMBER | FilterType.STRING | undefined =
         useMemo(() => {
@@ -97,38 +83,17 @@ const BigNumberConditionalFormattingRule: FC<Props> = ({
     );
 
     return (
-        <Stack spacing="xs" ref={ref}>
-            <Group noWrap position="apart">
-                <Group spacing="xs">
-                    <Text fw={500} fz="xs">
-                        Condition {ruleIndex + 1}
-                    </Text>
+        <Accordion.Item value={accordionValue}>
+            <AccordionControl
+                label={`Condition ${ruleIndex + 1}`}
+                onRemove={hasRemove ? onRemoveRule : undefined}
+            />
 
-                    {hasRemove && hovered && (
-                        <Tooltip
-                            variant="xs"
-                            label="Remove condition"
-                            position="left"
-                            withinPortal
-                        >
-                            <ActionIcon onClick={onRemoveRule}>
-                                <MantineIcon icon={IconTrash} />
-                            </ActionIcon>
-                        </Tooltip>
-                    )}
-                </Group>
-
-                <ActionIcon onClick={() => setIsOpen(!isOpen)} size="sm">
-                    <MantineIcon
-                        icon={isOpen ? IconChevronUp : IconChevronDown}
-                    />
-                </ActionIcon>
-            </Group>
-
-            <Collapse in={isOpen}>
-                <Stack spacing="xs">
-                    <Group noWrap spacing="xs">
+            <Accordion.Panel>
+                <Stack gap="xs">
+                    <Group wrap="nowrap" gap="xs" align="flex-start">
                         <Select
+                            size="xs"
                             value={rule.operator}
                             data={filterOperatorOptions}
                             onChange={(value) => {
@@ -140,6 +105,7 @@ const BigNumberConditionalFormattingRule: FC<Props> = ({
                         />
 
                         <Select
+                            size="xs"
                             display={field && filterType ? 'none' : 'block'}
                             placeholder="Value(s)"
                             data={[]}
@@ -159,6 +125,7 @@ const BigNumberConditionalFormattingRule: FC<Props> = ({
                                         />
                                     ) : (
                                         <TextInput
+                                            size="xs"
                                             disabled={true}
                                             placeholder="Values"
                                         />
@@ -167,8 +134,8 @@ const BigNumberConditionalFormattingRule: FC<Props> = ({
                             )}
                     </Group>
                 </Stack>
-            </Collapse>
-        </Stack>
+            </Accordion.Panel>
+        </Accordion.Item>
     );
 };
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.module.css
@@ -1,0 +1,3 @@
+.panelStack {
+    border-radius: var(--mantine-radius-sm);
+}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -350,6 +350,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
             <Accordion.Panel>
                 <Stack gap="xs" className={classes.panelStack}>
                     <FieldSelect
+                        size="xs"
                         label={<Config.Label>Field</Config.Label>}
                         item={selectedField}
                         items={fieldsInAxes}
@@ -369,6 +370,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                         <ReferenceLineValue
                             label={<Config.Label>Value</Config.Label>}
                             field={selectedField}
+                            size="xs"
                             startOfWeek={startOfWeek}
                             value={value}
                             disabled={useAverage && averageAvailable}
@@ -384,6 +386,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                         <TextInput
                             label={<Config.Label>Label</Config.Label>}
                             value={label}
+                            size="xs"
                             placeholder={
                                 useAverage && averageAvailable
                                     ? (value ?? 'Average')

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -23,7 +23,7 @@ import {
     Stack,
     Text,
     TextInput,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import {
     IconLayoutAlignLeft,
     IconLayoutAlignRight,
@@ -44,6 +44,7 @@ import { useVisualizationContext } from '../../../LightdashVisualization/useVisu
 import ColorSelector from '../../ColorSelector';
 import { AccordionControl } from '../../common/AccordionControl';
 import { Config } from '../../common/Config';
+import classes from './ReferenceLine.module.css';
 
 type UpdateReferenceLineProps = {
     value?: string;
@@ -339,12 +340,10 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
 
             <Accordion.Panel>
                 <Stack
-                    bg={'ldGray.0'}
-                    spacing="xs"
+                    bg="ldGray.0"
+                    gap="xs"
                     p="xs"
-                    sx={(theme) => ({
-                        borderRadius: theme.radius.sm,
-                    })}
+                    className={classes.panelStack}
                 >
                     <FieldSelect
                         label="Field"
@@ -362,7 +361,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                         hasGrouping
                     />
 
-                    <Group noWrap grow align="baseline">
+                    <Group wrap="nowrap" grow align="baseline">
                         <Box>
                             <Text fz="xs" fw={500}>
                                 Value
@@ -405,7 +404,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                             }}
                         />
                     </Group>
-                    <Group noWrap position="apart">
+                    <Group wrap="nowrap" justify="space-between">
                         <Checkbox
                             label="Use series average"
                             disabled={!averageAvailable}
@@ -422,15 +421,17 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                                 }
                             }}
                         />
-                        <Group noWrap>
+                        <Group wrap="nowrap">
                             <Config.Label>Position</Config.Label>
                             <SegmentedControl
                                 size="xs"
                                 id="label-position"
                                 value={labelPosition}
-                                onChange={(
-                                    newPosition: 'start' | 'middle' | 'end',
-                                ) => {
+                                onChange={(newValue) => {
+                                    const newPosition = newValue as
+                                        | 'start'
+                                        | 'middle'
+                                        | 'end';
                                     setLabelPosition(newPosition);
 
                                     updateReferenceLine({

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -16,13 +16,15 @@ import {
 } from '@lightdash/common';
 import {
     Accordion,
-    Box,
+    Center,
     Checkbox,
     Group,
+    type MantineRadius,
+    type MantineSize,
     SegmentedControl,
     Stack,
-    Text,
     TextInput,
+    type TextInputProps,
 } from '@mantine-8/core';
 import {
     IconLayoutAlignLeft,
@@ -80,6 +82,9 @@ type ReferenceLineValueProps = {
     startOfWeek: WeekDay | undefined;
     disabled?: boolean;
     onChange: (value: string) => void;
+    label?: TextInputProps['label'];
+    size?: MantineSize;
+    radius?: MantineRadius;
 };
 
 const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
@@ -88,7 +93,11 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
     startOfWeek,
     disabled,
     onChange,
+    label,
+    size,
+    radius = 'md',
 }) => {
+    const inputProps = { label, size, radius };
     if (isCustomDimension(field)) return <></>;
     if (isDateItem(field)) {
         if (isDimension(field) && field.timeInterval) {
@@ -101,8 +110,8 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                 case TimeFrames.WEEK:
                     return (
                         <FilterWeekPicker
+                            {...inputProps}
                             disabled={disabled}
-                            size="xs"
                             value={parsedDate}
                             firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                             onChange={(dateValue) => {
@@ -121,8 +130,8 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                 case TimeFrames.MONTH:
                     return (
                         <FilterMonthAndYearPicker
+                            {...inputProps}
                             disabled={disabled}
-                            size="xs"
                             value={parsedDate}
                             onChange={(dateValue: Date) => {
                                 onChange(
@@ -139,8 +148,8 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                 case TimeFrames.YEAR:
                     return (
                         <FilterYearPicker
+                            {...inputProps}
                             disabled={disabled}
-                            size="xs"
                             value={parsedDate}
                             onChange={(dateValue: Date) => {
                                 onChange(
@@ -157,8 +166,8 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
 
             return (
                 <FilterDatePicker
+                    {...inputProps}
                     disabled={disabled}
-                    size="xs"
                     value={parsedDate}
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     onChange={(newValue) => {
@@ -171,13 +180,13 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
 
     return (
         <TextInput
+            {...inputProps}
             disabled={
                 (!isNumericItem(field) &&
                     // We treat untyped table calculations as numeric
                     !(field && isTableCalculation(field) && !field.type)) ||
                 disabled
             }
-            size="xs"
             title={
                 isNumericItem(field)
                     ? ''
@@ -339,14 +348,9 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
             />
 
             <Accordion.Panel>
-                <Stack
-                    bg="ldGray.0"
-                    gap="xs"
-                    p="xs"
-                    className={classes.panelStack}
-                >
+                <Stack bg="ldGray.0" gap="xs" className={classes.panelStack}>
                     <FieldSelect
-                        label="Field"
+                        label={<Config.Label>Field</Config.Label>}
                         item={selectedField}
                         items={fieldsInAxes}
                         placeholder="Search field..."
@@ -361,30 +365,24 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                         hasGrouping
                     />
 
-                    <Group wrap="nowrap" grow align="baseline">
-                        <Box>
-                            <Text fz="xs" fw={500}>
-                                Value
-                            </Text>
-
-                            <ReferenceLineValue
-                                field={selectedField}
-                                startOfWeek={startOfWeek}
-                                value={value}
-                                disabled={useAverage && averageAvailable}
-                                onChange={(newValue: string) => {
-                                    setValue(newValue);
-                                    if (selectedField !== undefined)
-                                        updateReferenceLine({
-                                            ...currentLineConfig,
-                                            value: newValue,
-                                        });
-                                }}
-                            />
-                        </Box>
+                    <Group wrap="nowrap" grow align="baseline" gap="sm">
+                        <ReferenceLineValue
+                            label={<Config.Label>Value</Config.Label>}
+                            field={selectedField}
+                            startOfWeek={startOfWeek}
+                            value={value}
+                            disabled={useAverage && averageAvailable}
+                            onChange={(newValue: string) => {
+                                setValue(newValue);
+                                if (selectedField !== undefined)
+                                    updateReferenceLine({
+                                        ...currentLineConfig,
+                                        value: newValue,
+                                    });
+                            }}
+                        />
                         <TextInput
-                            label="Label"
-                            // disabled={!value}
+                            label={<Config.Label>Label</Config.Label>}
                             value={label}
                             placeholder={
                                 useAverage && averageAvailable
@@ -404,9 +402,13 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                             }}
                         />
                     </Group>
-                    <Group wrap="nowrap" justify="space-between">
+                    <Group wrap="nowrap">
                         <Checkbox
-                            label="Use series average"
+                            flex="1"
+                            size="xs"
+                            label={
+                                <Config.Label>Use series average</Config.Label>
+                            }
                             disabled={!averageAvailable}
                             checked={useAverage && averageAvailable}
                             onChange={(newState) => {
@@ -421,9 +423,12 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                                 }
                             }}
                         />
-                        <Group wrap="nowrap">
-                            <Config.Label>Position</Config.Label>
+                        <Group wrap="nowrap" flex="1" gap="sm">
+                            <Config.Label style={{ whiteSpace: 'nowrap' }}>
+                                Position
+                            </Config.Label>
                             <SegmentedControl
+                                w="100%"
                                 size="xs"
                                 id="label-position"
                                 value={labelPosition}
@@ -443,25 +448,31 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                                     {
                                         value: 'start',
                                         label: (
-                                            <MantineIcon
-                                                icon={IconLayoutAlignLeft}
-                                            />
+                                            <Center>
+                                                <MantineIcon
+                                                    icon={IconLayoutAlignLeft}
+                                                />
+                                            </Center>
                                         ),
                                     },
                                     {
                                         value: 'middle',
                                         label: (
-                                            <MantineIcon
-                                                icon={IconLayoutAlignTop}
-                                            />
+                                            <Center>
+                                                <MantineIcon
+                                                    icon={IconLayoutAlignTop}
+                                                />
+                                            </Center>
                                         ),
                                     },
                                     {
                                         value: 'end',
                                         label: (
-                                            <MantineIcon
-                                                icon={IconLayoutAlignRight}
-                                            />
+                                            <Center>
+                                                <MantineIcon
+                                                    icon={IconLayoutAlignRight}
+                                                />
+                                            </Center>
                                         ),
                                     },
                                 ]}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -348,7 +348,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
             />
 
             <Accordion.Panel>
-                <Stack bg="ldGray.0" gap="xs" className={classes.panelStack}>
+                <Stack gap="xs" className={classes.panelStack}>
                     <FieldSelect
                         label={<Config.Label>Field</Config.Label>}
                         item={selectedField}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -9,13 +9,14 @@ import {
     type Series,
     type TableCalculation,
 } from '@lightdash/common';
-import { Accordion } from '@mantine/core';
+import { Accordion } from '@mantine-8/core';
 import { useCallback, useMemo, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useProject } from '../../../../hooks/useProject';
 import { type ReferenceLineField } from '../../../common/ReferenceLine';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
+import accordionClasses from '../../common/Accordion.module.css';
 import { AddButton } from '../../common/AddButton';
 import { Config } from '../../common/Config';
 import { useControlledAccordion } from '../../common/hooks/useControlledAccordion';
@@ -206,17 +207,7 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                         variant="contained"
                         value={openItems}
                         onChange={handleAccordionChange}
-                        styles={(theme) => ({
-                            control: {
-                                padding: theme.spacing.xs,
-                            },
-                            label: {
-                                padding: 0,
-                            },
-                            panel: {
-                                padding: 0,
-                            },
-                        })}
+                        className={accordionClasses.containedList}
                     >
                         {referenceLines.map((line, index) => (
                             <ReferenceLine

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -205,6 +205,7 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                     <Accordion
                         multiple
                         variant="contained"
+                        transparentActiveItem
                         value={openItems}
                         onChange={handleAccordionChange}
                         className={accordionClasses.containedList}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
@@ -134,10 +134,12 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
                 <Config.Section>
                     <FieldSelect
                         disabled
+                        size="xs"
                         item={field}
                         items={field ? [field] : []}
                         onChange={() => undefined}
                         hasGrouping
+                        label={<Config.Label>Select Field</Config.Label>}
                     />
                     <Group gap="xs">
                         <Config.Label>Color</Config.Label>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
@@ -7,7 +7,7 @@ import {
     type FilterableItem,
     type FilterOperator,
 } from '@lightdash/common';
-import { Accordion, Divider, Group } from '@mantine/core';
+import { Accordion, Divider, Group } from '@mantine-8/core';
 import { produce } from 'immer';
 import {
     Fragment,
@@ -20,6 +20,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import FieldSelect from '../../../common/FieldSelect';
 import ColorSelector from '../../ColorSelector';
+import accordionClasses from '../../common/Accordion.module.css';
 import { AccordionControl } from '../../common/AccordionControl';
 import { AddButton } from '../../common/AddButton';
 import { Config } from '../../common/Config';
@@ -138,7 +139,7 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
                         onChange={() => undefined}
                         hasGrouping
                     />
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <Config.Label>Color</Config.Label>
                         <ColorSelector
                             color={config.color}
@@ -295,17 +296,7 @@ export const ChartConditionalFormatting: FC<Props> = ({
                 variant="contained"
                 value={openItems}
                 onChange={handleAccordionChange}
-                styles={(theme) => ({
-                    control: {
-                        padding: theme.spacing.xs,
-                    },
-                    label: {
-                        padding: 0,
-                    },
-                    panel: {
-                        padding: 0,
-                    },
-                })}
+                className={accordionClasses.containedList}
             >
                 {supportedConfigs.map((config, index) => (
                     <ChartConditionalFormattingItem

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSection.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSection.tsx
@@ -7,7 +7,7 @@ import {
     SegmentedControl,
     Stack,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { memo, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import { isGaugeVisualizationConfig } from '../../LightdashVisualization/types';
@@ -64,8 +64,8 @@ const GaugeSectionComponent: FC<Props> = memo(
                     }
                 />
                 <Accordion.Panel>
-                    <Stack spacing="md">
-                        <Group spacing="xs" align="flex-end">
+                    <Stack gap="md">
+                        <Group gap="xs" align="flex-end">
                             {minValueMode === GaugeValueMode.FIXED ? (
                                 <NumberInput
                                     label="Min value"
@@ -74,9 +74,8 @@ const GaugeSectionComponent: FC<Props> = memo(
                                     onChange={(value) =>
                                         onUpdate(index, { min: Number(value) })
                                     }
-                                    style={{ flex: 1 }}
-                                    precision={2}
-                                    removeTrailingZeros={true}
+                                    flex={1}
+                                    decimalScale={2}
                                 />
                             ) : (
                                 <FieldSelect
@@ -92,7 +91,7 @@ const GaugeSectionComponent: FC<Props> = memo(
                                         });
                                     }}
                                     hasGrouping
-                                    style={{ flex: 1 }}
+                                    flex={1}
                                 />
                             )}
                             <SegmentedControl
@@ -115,11 +114,7 @@ const GaugeSectionComponent: FC<Props> = memo(
                                 data={[
                                     {
                                         label: (
-                                            <Tooltip
-                                                label="Set the minimum value"
-                                                withinPortal
-                                                variant="xs"
-                                            >
+                                            <Tooltip label="Set the minimum value">
                                                 <Center>Value</Center>
                                             </Tooltip>
                                         ),
@@ -127,11 +122,7 @@ const GaugeSectionComponent: FC<Props> = memo(
                                     },
                                     {
                                         label: (
-                                            <Tooltip
-                                                label="Select a field to use as the maximum value"
-                                                withinPortal
-                                                variant="xs"
-                                            >
+                                            <Tooltip label="Select a field to use as the maximum value">
                                                 <Center>Field</Center>
                                             </Tooltip>
                                         ),
@@ -141,7 +132,7 @@ const GaugeSectionComponent: FC<Props> = memo(
                             />
                         </Group>
 
-                        <Group spacing="xs" align="flex-end">
+                        <Group gap="xs" align="flex-end">
                             {maxValueMode === GaugeValueMode.FIXED ? (
                                 <NumberInput
                                     label="Max value"
@@ -150,9 +141,8 @@ const GaugeSectionComponent: FC<Props> = memo(
                                     onChange={(value) =>
                                         onUpdate(index, { max: Number(value) })
                                     }
-                                    precision={2}
-                                    removeTrailingZeros={true}
-                                    style={{ flex: 1 }}
+                                    decimalScale={2}
+                                    flex={1}
                                 />
                             ) : (
                                 <FieldSelect
@@ -168,7 +158,7 @@ const GaugeSectionComponent: FC<Props> = memo(
                                         });
                                     }}
                                     hasGrouping
-                                    style={{ flex: 1 }}
+                                    flex={1}
                                 />
                             )}
                             <SegmentedControl
@@ -191,11 +181,7 @@ const GaugeSectionComponent: FC<Props> = memo(
                                 data={[
                                     {
                                         label: (
-                                            <Tooltip
-                                                label="Set the maximum value"
-                                                withinPortal
-                                                variant="xs"
-                                            >
+                                            <Tooltip label="Set the maximum value">
                                                 <Center>Value</Center>
                                             </Tooltip>
                                         ),
@@ -203,11 +189,7 @@ const GaugeSectionComponent: FC<Props> = memo(
                                     },
                                     {
                                         label: (
-                                            <Tooltip
-                                                label="Select a field to use as the maximum value"
-                                                withinPortal
-                                                variant="xs"
-                                            >
+                                            <Tooltip label="Select a field to use as the maximum value">
                                                 <Center>Field</Center>
                                             </Tooltip>
                                         ),

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSections.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSections.tsx
@@ -1,8 +1,9 @@
 import { type GaugeSection } from '@lightdash/common';
-import { Accordion, Stack } from '@mantine/core';
+import { Accordion, Stack } from '@mantine-8/core';
 import { memo, useCallback, type FC } from 'react';
 import { isGaugeVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import accordionClasses from '../common/Accordion.module.css';
 import { AddButton } from '../common/AddButton';
 import { Config } from '../common/Config';
 import { useControlledAccordion } from '../common/hooks/useControlledAccordion';
@@ -86,24 +87,14 @@ const GaugeSections: FC = memo(() => {
                     <AddButton onClick={addSection} />
                 </Config.Group>
 
-                <Stack spacing="md">
+                <Stack gap="md">
                     {sections.length > 0 && (
                         <Accordion
                             multiple
                             variant="contained"
                             value={openItems}
                             onChange={handleAccordionChange}
-                            styles={(theme) => ({
-                                control: {
-                                    padding: theme.spacing.xs,
-                                },
-                                label: {
-                                    padding: 0,
-                                },
-                                panel: {
-                                    padding: 0,
-                                },
-                            })}
+                            className={accordionClasses.containedList}
                         >
                             {sections.map((section, index) => (
                                 <GaugeSectionComponent

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.module.css
@@ -1,7 +1,3 @@
-.ruleItem.ruleItem {
-    background-color: transparent;
-}
-
 .conditionsGroup {
     --accordion-radius: var(--mantine-radius-md);
     margin-inline: calc(var(--mantine-spacing-xs) * -1);

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.module.css
@@ -1,58 +1,27 @@
-/*.rulesBox {
-    background-color: var(--mantine-color-ldGray-1);
-    border: 1px solid var(--mantine-color-ldGray-4);
-    border-radius: var(--mantine-radius-sm);
-}*/
-
 .ruleItem.ruleItem {
     background-color: transparent;
 }
 
-.ruleItem [data-cf-rule-delete] {
-    opacity: 0;
-    transition: opacity 120ms ease;
-    pointer-events: none;
-}
-
-.ruleItem:hover [data-cf-rule-delete] {
-    opacity: 1;
-    pointer-events: auto;
-}
-
 .conditionsGroup {
-    background-color: var(--item-filled-color);
-    border: 1px solid var(--item-border-color);
-    border-radius: var(--mantine-radius-md);
-    overflow: hidden;
+    --accordion-radius: var(--mantine-radius-md);
     margin-inline: calc(var(--mantine-spacing-xs) * -1);
-}
-
-.conditionItem {
-    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
-}
-
-.andDivider {
     position: relative;
-    height: 1px;
-    background-color: var(--mantine-color-ldGray-2);
 }
 
-.andChip {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    padding: 0 var(--mantine-spacing-xs);
-    background-color: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-6)
-    );
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.6px;
-    color: var(--mantine-color-ldGray-6);
-}
+.conditionsGroup > * {
+    background-color: var(--item-filled-color);
 
-.addRuleButton {
-    align-self: flex-start;
+    &:not(:last-of-type)::after {
+        content: 'AND';
+        position: absolute;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        padding: 0 var(--mantine-spacing-xs);
+        background-color: var(--item-filled-color);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.6px;
+        color: var(--mantine-color-ldGray-6);
+        z-index: 1;
+    }
 }

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.module.css
@@ -1,7 +1,56 @@
-.rulesBox {
+/*.rulesBox {
     background-color: var(--mantine-color-ldGray-1);
     border: 1px solid var(--mantine-color-ldGray-4);
     border-radius: var(--mantine-radius-sm);
+}*/
+
+.ruleItem.ruleItem {
+    background-color: transparent;
+}
+
+.ruleItem [data-cf-rule-delete] {
+    opacity: 0;
+    transition: opacity 120ms ease;
+    pointer-events: none;
+}
+
+.ruleItem:hover [data-cf-rule-delete] {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.conditionsGroup {
+    background-color: var(--item-filled-color);
+    border: 1px solid var(--item-border-color);
+    border-radius: var(--mantine-radius-md);
+    overflow: hidden;
+    margin-inline: calc(var(--mantine-spacing-xs) * -1);
+}
+
+.conditionItem {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+}
+
+.andDivider {
+    position: relative;
+    height: 1px;
+    background-color: var(--mantine-color-ldGray-2);
+}
+
+.andChip {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    padding: 0 var(--mantine-spacing-xs);
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-6)
+    );
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.6px;
+    color: var(--mantine-color-ldGray-6);
 }
 
 .addRuleButton {

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.module.css
@@ -1,0 +1,9 @@
+.rulesBox {
+    background-color: var(--mantine-color-ldGray-1);
+    border: 1px solid var(--mantine-color-ldGray-4);
+    border-radius: var(--mantine-radius-sm);
+}
+
+.addRuleButton {
+    align-self: flex-start;
+}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -27,7 +27,6 @@ import {
     Accordion,
     Box,
     Button,
-    Divider,
     Group,
     SegmentedControl,
     Stack,
@@ -342,7 +341,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
     );
 
     return (
-        <Accordion.Item value={accordionValue}>
+        <Accordion.Item value={accordionValue} className={classes.ruleItem}>
             <AccordionControl
                 label={
                     field ? getItemLabelWithoutTableName(field) : controlLabel
@@ -360,7 +359,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
                 onControlClick={onControlClick}
                 onRemove={handleRemove}
             />
-            <Accordion.Panel>
+            <Accordion.Panel className={classes.rulePanel}>
                 <Stack gap="xs">
                     <FiltersProvider>
                         <FieldSelect
@@ -372,10 +371,10 @@ export const ConditionalFormattingItem: FC<Props> = ({
                             hasGrouping
                         />
 
-                        <Group gap="xs">
-                            <Config.Label>Color</Config.Label>
-
+                        <Stack gap={4}>
+                            <Config.Label>Color mode</Config.Label>
                             <SegmentedControl
+                                fullWidth
                                 data={[
                                     {
                                         value: ConditionalFormattingConfigType.Single,
@@ -403,17 +402,20 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                     );
                                 }}
                             />
+                        </Stack>
 
-                            {isConditionalFormattingConfigWithSingleColor(
-                                config,
-                            ) ? (
+                        {isConditionalFormattingConfigWithSingleColor(
+                            config,
+                        ) ? (
+                            <Group gap="xs">
+                                <Config.Label>Color</Config.Label>
                                 <ColorSelector
                                     color={config.color}
                                     swatches={colorPalette}
                                     onColorChange={handleChangeSingleColor}
                                 />
-                            ) : null}
-                        </Group>
+                            </Group>
+                        ) : null}
 
                         <Group gap="xs">
                             <Config.Label>Apply to</Config.Label>
@@ -444,61 +446,87 @@ export const ConditionalFormattingItem: FC<Props> = ({
                         {isConditionalFormattingConfigWithSingleColor(
                             config,
                         ) ? (
-                            <Box p="xs" className={classes.rulesBox}>
-                                {config.rules.map((rule, ruleIndex) => (
-                                    <Fragment key={ruleIndex}>
-                                        <ConditionalFormattingRule
-                                            isDefaultOpen={
-                                                config.rules.length === 1 ||
-                                                isAddingRule
-                                            }
-                                            hasRemove={config.rules.length > 1}
-                                            ruleIndex={ruleIndex}
-                                            rule={rule}
-                                            field={field}
-                                            fields={fields}
-                                            onChangeRule={(newRule) =>
-                                                handleChangeRule(
-                                                    ruleIndex,
-                                                    newRule,
-                                                )
-                                            }
-                                            onChangeRuleOperator={(
-                                                newOperator,
-                                            ) =>
-                                                handleChangeRuleOperator(
-                                                    ruleIndex,
-                                                    newOperator,
-                                                )
-                                            }
-                                            onChangeRuleComparisonType={(
-                                                newComparisonType,
-                                            ) =>
-                                                handleChangeRuleComparisonType(
-                                                    ruleIndex,
-                                                    newComparisonType,
-                                                )
-                                            }
-                                            onRemoveRule={() =>
-                                                handleRemoveRule(ruleIndex)
-                                            }
-                                        />
-
-                                        {ruleIndex !==
-                                            config.rules.length - 1 && (
-                                            <Divider
-                                                mt="xs"
-                                                label={
-                                                    <Config.Label>
-                                                        AND
-                                                    </Config.Label>
+                            <Fragment>
+                                <Box className={classes.conditionsGroup}>
+                                    {config.rules.map((rule, ruleIndex) => (
+                                        <Fragment key={ruleIndex}>
+                                            <Box
+                                                className={
+                                                    classes.conditionItem
                                                 }
-                                                labelPosition="center"
-                                            />
-                                        )}
-                                    </Fragment>
-                                ))}
-                            </Box>
+                                            >
+                                                <ConditionalFormattingRule
+                                                    isDefaultOpen={
+                                                        config.rules.length ===
+                                                            1 || isAddingRule
+                                                    }
+                                                    hasRemove={
+                                                        config.rules.length > 1
+                                                    }
+                                                    ruleIndex={ruleIndex}
+                                                    rule={rule}
+                                                    field={field}
+                                                    fields={fields}
+                                                    onChangeRule={(newRule) =>
+                                                        handleChangeRule(
+                                                            ruleIndex,
+                                                            newRule,
+                                                        )
+                                                    }
+                                                    onChangeRuleOperator={(
+                                                        newOperator,
+                                                    ) =>
+                                                        handleChangeRuleOperator(
+                                                            ruleIndex,
+                                                            newOperator,
+                                                        )
+                                                    }
+                                                    onChangeRuleComparisonType={(
+                                                        newComparisonType,
+                                                    ) =>
+                                                        handleChangeRuleComparisonType(
+                                                            ruleIndex,
+                                                            newComparisonType,
+                                                        )
+                                                    }
+                                                    onRemoveRule={() =>
+                                                        handleRemoveRule(
+                                                            ruleIndex,
+                                                        )
+                                                    }
+                                                />
+                                            </Box>
+
+                                            {ruleIndex !==
+                                                config.rules.length - 1 && (
+                                                <div
+                                                    className={
+                                                        classes.andDivider
+                                                    }
+                                                >
+                                                    <span
+                                                        className={
+                                                            classes.andChip
+                                                        }
+                                                    >
+                                                        AND
+                                                    </span>
+                                                </div>
+                                            )}
+                                        </Fragment>
+                                    ))}
+                                </Box>
+                                <Button
+                                    className={classes.addRuleButton}
+                                    variant="subtle"
+                                    leftSection={
+                                        <MantineIcon icon={IconPlus} />
+                                    }
+                                    onClick={handleAddRule}
+                                >
+                                    Add new condition
+                                </Button>
+                            </Fragment>
                         ) : isConditionalFormattingConfigWithColorRange(
                               config,
                           ) ? (
@@ -512,19 +540,6 @@ export const ConditionalFormattingItem: FC<Props> = ({
                         ) : (
                             assertUnreachable(config, 'Unknown config type')
                         )}
-
-                        {isConditionalFormattingConfigWithSingleColor(
-                            config,
-                        ) ? (
-                            <Button
-                                className={classes.addRuleButton}
-                                variant="subtle"
-                                leftSection={<MantineIcon icon={IconPlus} />}
-                                onClick={handleAddRule}
-                            >
-                                Add new condition
-                            </Button>
-                        ) : null}
                     </FiltersProvider>
                 </Stack>
             </Accordion.Panel>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -31,7 +31,7 @@ import {
     Group,
     SegmentedControl,
     Stack,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { IconPlus } from '@tabler/icons-react';
 import { produce } from 'immer';
 import { Fragment, useCallback, useMemo, useState, type FC } from 'react';
@@ -42,6 +42,7 @@ import { useVisualizationContext } from '../../LightdashVisualization/useVisuali
 import ColorSelector from '../ColorSelector';
 import { AccordionControl } from '../common/AccordionControl';
 import { Config } from '../common/Config';
+import classes from './ConditionalFormattingItem.module.css';
 import ConditionalFormattingItemColorRange from './ConditionalFormattingItemColorRange';
 import ConditionalFormattingRule from './ConditionalFormattingRule';
 
@@ -360,7 +361,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
                 onRemove={handleRemove}
             />
             <Accordion.Panel>
-                <Stack spacing="xs">
+                <Stack gap="xs">
                     <FiltersProvider>
                         <FieldSelect
                             label="Select field"
@@ -371,7 +372,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
                             hasGrouping
                         />
 
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <Config.Label>Color</Config.Label>
 
                             <SegmentedControl
@@ -396,10 +397,10 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                 value={getConditionalFormattingConfigType(
                                     config,
                                 )}
-                                onChange={(
-                                    newConfigType: ConditionalFormattingConfigType,
-                                ) => {
-                                    handleConfigTypeChange(newConfigType);
+                                onChange={(value) => {
+                                    handleConfigTypeChange(
+                                        value as ConditionalFormattingConfigType,
+                                    );
                                 }}
                             />
 
@@ -414,7 +415,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
                             ) : null}
                         </Group>
 
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <Config.Label>Apply to</Config.Label>
 
                             <SegmentedControl
@@ -432,21 +433,18 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                     config.applyTo ??
                                     ConditionalFormattingColorApplyTo.CELL
                                 }
-                                onChange={handleChangeApplyTo}
+                                onChange={(value) =>
+                                    handleChangeApplyTo(
+                                        value as ConditionalFormattingColorApplyTo,
+                                    )
+                                }
                             />
                         </Group>
 
                         {isConditionalFormattingConfigWithSingleColor(
                             config,
                         ) ? (
-                            <Box
-                                p="xs"
-                                sx={(theme) => ({
-                                    backgroundColor: theme.colors.ldGray[1],
-                                    border: `1px solid ${theme.colors.ldGray[4]}`,
-                                    borderRadius: theme.radius.sm,
-                                })}
-                            >
+                            <Box p="xs" className={classes.rulesBox}>
                                 {config.rules.map((rule, ruleIndex) => (
                                     <Fragment key={ruleIndex}>
                                         <ConditionalFormattingRule
@@ -519,9 +517,9 @@ export const ConditionalFormattingItem: FC<Props> = ({
                             config,
                         ) ? (
                             <Button
-                                sx={{ alignSelf: 'start' }}
+                                className={classes.addRuleButton}
                                 variant="subtle"
-                                leftIcon={<MantineIcon icon={IconPlus} />}
+                                leftSection={<MantineIcon icon={IconPlus} />}
                                 onClick={handleAddRule}
                             >
                                 Add new condition

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -375,8 +375,9 @@ export const ConditionalFormattingItem: FC<Props> = ({
                 <Stack gap="xs">
                     <FiltersProvider>
                         <FieldSelect
-                            label="Select field"
+                            label={<Config.Label>Select field</Config.Label>}
                             clearable
+                            size="xs"
                             item={field}
                             items={fields}
                             onChange={handleChangeField}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -465,8 +465,17 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                     <Button
                                         size="compact-xs"
                                         variant="subtle"
+                                        disabled={!field}
+                                        title={
+                                            !field
+                                                ? 'Select a field first'
+                                                : undefined
+                                        }
                                         leftSection={
-                                            <MantineIcon icon={IconPlus} />
+                                            <MantineIcon
+                                                icon={IconPlus}
+                                                size="sm"
+                                            />
                                         }
                                         onClick={handleAddRule}
                                     >
@@ -478,7 +487,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                     chevronPosition="right"
                                     variant="contained"
                                     className={classes.conditionsGroup}
-                                    value={openConditions}
+                                    value={field ? openConditions : []}
                                     onChange={setOpenConditions}
                                 >
                                     {config.rules.map((rule, ruleIndex) => (
@@ -486,6 +495,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                             key={ruleIndex}
                                             accordionValue={`${ruleIndex}`}
                                             hasRemove={config.rules.length > 1}
+                                            disabled={!field}
                                             ruleIndex={ruleIndex}
                                             rule={rule}
                                             field={field}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -25,15 +25,15 @@ import {
 } from '@lightdash/common';
 import {
     Accordion,
-    Box,
     Button,
+    Flex,
     Group,
     SegmentedControl,
     Stack,
 } from '@mantine-8/core';
 import { IconPlus } from '@tabler/icons-react';
 import { produce } from 'immer';
-import { Fragment, useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, useState, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import FiltersProvider from '../../common/Filters/FiltersProvider';
 import MantineIcon from '../../common/MantineIcon';
@@ -73,8 +73,12 @@ export const ConditionalFormattingItem: FC<Props> = ({
     addNewItem,
     removeItem,
 }) => {
-    const [isAddingRule, setIsAddingRule] = useState(false);
     const [config, setConfig] = useState<ConditionalFormattingConfig>(value);
+    const [openConditions, setOpenConditions] = useState<string[]>(() =>
+        isConditionalFormattingConfigWithSingleColor(value)
+            ? value.rules.map((_, i) => `${i}`)
+            : [],
+    );
     const { itemsMap } = useVisualizationContext();
 
     const field = useMemo(
@@ -184,9 +188,8 @@ export const ConditionalFormattingItem: FC<Props> = ({
     );
 
     const handleAddRule = useCallback(() => {
-        setIsAddingRule(true);
-
         if (isConditionalFormattingConfigWithSingleColor(config)) {
+            const newIndex = config.rules.length;
             handleChange(
                 produce(config, (draft) => {
                     draft.rules.push(
@@ -194,6 +197,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
                     );
                 }),
             );
+            setOpenConditions((prev) => [...prev, `${newIndex}`]);
         }
     }, [handleChange, config]);
 
@@ -204,6 +208,14 @@ export const ConditionalFormattingItem: FC<Props> = ({
                     produce(config, (draft) => {
                         draft.rules.splice(index, 1);
                     }),
+                );
+                setOpenConditions((prev) =>
+                    prev
+                        .filter((v) => v !== `${index}`)
+                        .map((v) => {
+                            const i = Number(v);
+                            return i > index ? `${i - 1}` : v;
+                        }),
                 );
             }
         },
@@ -446,87 +458,66 @@ export const ConditionalFormattingItem: FC<Props> = ({
                         {isConditionalFormattingConfigWithSingleColor(
                             config,
                         ) ? (
-                            <Fragment>
-                                <Box className={classes.conditionsGroup}>
-                                    {config.rules.map((rule, ruleIndex) => (
-                                        <Fragment key={ruleIndex}>
-                                            <Box
-                                                className={
-                                                    classes.conditionItem
-                                                }
-                                            >
-                                                <ConditionalFormattingRule
-                                                    isDefaultOpen={
-                                                        config.rules.length ===
-                                                            1 || isAddingRule
-                                                    }
-                                                    hasRemove={
-                                                        config.rules.length > 1
-                                                    }
-                                                    ruleIndex={ruleIndex}
-                                                    rule={rule}
-                                                    field={field}
-                                                    fields={fields}
-                                                    onChangeRule={(newRule) =>
-                                                        handleChangeRule(
-                                                            ruleIndex,
-                                                            newRule,
-                                                        )
-                                                    }
-                                                    onChangeRuleOperator={(
-                                                        newOperator,
-                                                    ) =>
-                                                        handleChangeRuleOperator(
-                                                            ruleIndex,
-                                                            newOperator,
-                                                        )
-                                                    }
-                                                    onChangeRuleComparisonType={(
-                                                        newComparisonType,
-                                                    ) =>
-                                                        handleChangeRuleComparisonType(
-                                                            ruleIndex,
-                                                            newComparisonType,
-                                                        )
-                                                    }
-                                                    onRemoveRule={() =>
-                                                        handleRemoveRule(
-                                                            ruleIndex,
-                                                        )
-                                                    }
-                                                />
-                                            </Box>
-
-                                            {ruleIndex !==
-                                                config.rules.length - 1 && (
-                                                <div
-                                                    className={
-                                                        classes.andDivider
-                                                    }
-                                                >
-                                                    <span
-                                                        className={
-                                                            classes.andChip
-                                                        }
-                                                    >
-                                                        AND
-                                                    </span>
-                                                </div>
-                                            )}
-                                        </Fragment>
-                                    ))}
-                                </Box>
-                                <Button
-                                    className={classes.addRuleButton}
-                                    variant="subtle"
-                                    leftSection={
-                                        <MantineIcon icon={IconPlus} />
-                                    }
-                                    onClick={handleAddRule}
+                            <>
+                                <Flex justify="space-between">
+                                    <Config.Label>Conditions</Config.Label>
+                                    <Button
+                                        size="compact-xs"
+                                        variant="subtle"
+                                        leftSection={
+                                            <MantineIcon icon={IconPlus} />
+                                        }
+                                        onClick={handleAddRule}
+                                    >
+                                        Add
+                                    </Button>
+                                </Flex>
+                                <Accordion
+                                    multiple
+                                    chevronPosition="right"
+                                    variant="contained"
+                                    className={classes.conditionsGroup}
+                                    value={openConditions}
+                                    onChange={setOpenConditions}
                                 >
-                                    Add new condition
-                                </Button>
-                            </Fragment>
+                                    {config.rules.map((rule, ruleIndex) => (
+                                        <ConditionalFormattingRule
+                                            key={ruleIndex}
+                                            accordionValue={`${ruleIndex}`}
+                                            hasRemove={config.rules.length > 1}
+                                            ruleIndex={ruleIndex}
+                                            rule={rule}
+                                            field={field}
+                                            fields={fields}
+                                            onChangeRule={(newRule) =>
+                                                handleChangeRule(
+                                                    ruleIndex,
+                                                    newRule,
+                                                )
+                                            }
+                                            onChangeRuleOperator={(
+                                                newOperator,
+                                            ) =>
+                                                handleChangeRuleOperator(
+                                                    ruleIndex,
+                                                    newOperator,
+                                                )
+                                            }
+                                            onChangeRuleComparisonType={(
+                                                newComparisonType,
+                                            ) =>
+                                                handleChangeRuleComparisonType(
+                                                    ruleIndex,
+                                                    newComparisonType,
+                                                )
+                                            }
+                                            onRemoveRule={() =>
+                                                handleRemoveRule(ruleIndex)
+                                            }
+                                        />
+                                    ))}
+                                </Accordion>
+                            </>
                         ) : isConditionalFormattingConfigWithColorRange(
                               config,
                           ) ? (

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -7,12 +7,13 @@ import {
     type ConditionalFormattingConfig,
     type FilterableItem,
 } from '@lightdash/common';
-import { Accordion } from '@mantine/core';
+import { Accordion } from '@mantine-8/core';
 import { produce } from 'immer';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import accordionClasses from '../common/Accordion.module.css';
 import { AddButton } from '../common/AddButton';
 import { Config } from '../common/Config';
 import { useControlledAccordion } from '../common/hooks/useControlledAccordion';
@@ -134,17 +135,7 @@ const ConditionalFormattingList = ({}) => {
                     variant="contained"
                     value={openItems}
                     onChange={handleAccordionChange}
-                    styles={(theme) => ({
-                        control: {
-                            padding: theme.spacing.xs,
-                        },
-                        label: {
-                            padding: 0,
-                        },
-                        panel: {
-                            padding: 0,
-                        },
-                    })}
+                    className={accordionClasses.containedList}
                 >
                     {activeConfigs.map((conditionalFormatting, index) => (
                         <ConditionalFormattingItem

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -136,6 +136,7 @@ const ConditionalFormattingList = ({}) => {
                     value={openItems}
                     onChange={handleAccordionChange}
                     className={accordionClasses.containedList}
+                    transparentActiveItem
                 >
                     {activeConfigs.map((conditionalFormatting, index) => (
                         <ConditionalFormattingItem

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -22,7 +22,6 @@ import {
     TextInput,
     Tooltip,
 } from '@mantine/core';
-import { useHover } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
 import differenceBy from 'lodash/differenceBy';
 import { useCallback, useMemo, useState, type FC } from 'react';
@@ -65,7 +64,6 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
-    const { ref, hovered } = useHover();
     const [isOpen, setIsOpen] = useState(isDefaultOpen);
 
     const comparisonType = useMemo(() => {
@@ -213,20 +211,23 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
     }, [rule, compareField, field]);
 
     return (
-        <Stack spacing="xs" ref={ref}>
+        <Stack spacing="xs">
             <Group noWrap position="apart">
                 <Group spacing="xs">
                     <Text fw={500} fz="xs">
                         Condition {ruleIndex + 1}
                     </Text>
 
-                    {hasRemove && hovered && (
+                    {hasRemove && (
                         <Tooltip
                             label="Remove condition"
                             position="left"
                             withinPortal
                         >
-                            <ActionIcon onClick={onRemoveRule}>
+                            <ActionIcon
+                                data-cf-rule-delete
+                                onClick={onRemoveRule}
+                            >
                                 <MantineIcon icon={IconTrash} />
                             </ActionIcon>
                         </Tooltip>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -271,6 +271,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                                 items={availableCompareFields}
                                 onChange={handleChangeCompareField}
                                 hasGrouping
+                                size="xs"
                                 placeholder="Compare field"
                             />
                         )}
@@ -278,6 +279,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                         <Select
                             value={rule.operator}
                             data={filterOperatorOptions}
+                            size="xs"
                             onChange={(value) => {
                                 if (!value) return;
                                 onChangeRuleOperator(value as FilterOperator);
@@ -290,6 +292,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                             display={field && filterType ? 'none' : 'block'}
                             placeholder="Value(s)"
                             data={[]}
+                            size="xs"
                             disabled={!field || !filterType}
                         />
 
@@ -308,6 +311,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                                         <TextInput
                                             disabled={true}
                                             placeholder="Values"
+                                            size="xs"
                                         />
                                     )}
                                 </FiltersProvider>
@@ -315,6 +319,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                         {isConditionalFormattingWithCompareTarget(rule) &&
                             !isConditionalFormattingWithValues(rule) && (
                                 <FieldSelect
+                                    size="xs"
                                     clearable
                                     item={compareField}
                                     items={availableCompareFields}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -46,6 +46,7 @@ interface ConditionalFormattingRuleProps {
         comparisonType: ConditionalFormattingComparisonType,
     ) => void;
     onRemoveRule: () => void;
+    disabled?: boolean;
 }
 
 const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
@@ -59,6 +60,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
     onChangeRuleComparisonType,
     onRemoveRule,
     hasRemove,
+    disabled,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
@@ -210,6 +212,8 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
         <Accordion.Item value={accordionValue}>
             <AccordionControl
                 label={`Condition ${ruleIndex + 1}`}
+                disabled={disabled}
+                title={disabled ? 'Select a field first' : undefined}
                 onRemove={hasRemove ? onRemoveRule : undefined}
             />
 

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -10,10 +10,9 @@ import {
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
+import { Accordion } from '@mantine-8/core';
 import {
-    ActionIcon,
     Center,
-    Collapse,
     Group,
     SegmentedControl,
     Select,
@@ -22,9 +21,8 @@ import {
     TextInput,
     Tooltip,
 } from '@mantine/core';
-import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
 import differenceBy from 'lodash/differenceBy';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import FieldSelect from '../../common/FieldSelect';
 import FilterInputComponent from '../../common/Filters/FilterInputs';
@@ -33,10 +31,10 @@ import {
     getFilterOptions,
 } from '../../common/Filters/FilterInputs/utils';
 import FiltersProvider from '../../common/Filters/FiltersProvider';
-import MantineIcon from '../../common/MantineIcon';
+import { AccordionControl } from '../common/AccordionControl';
 
 interface ConditionalFormattingRuleProps {
-    isDefaultOpen?: boolean;
+    accordionValue: string;
     ruleIndex: number;
     rule: ConditionalFormattingWithFilterOperator;
     field: FilterableItem | undefined;
@@ -51,7 +49,7 @@ interface ConditionalFormattingRuleProps {
 }
 
 const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
-    isDefaultOpen = true,
+    accordionValue,
     ruleIndex,
     rule,
     field,
@@ -63,8 +61,6 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
     hasRemove,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-
-    const [isOpen, setIsOpen] = useState(isDefaultOpen);
 
     const comparisonType = useMemo(() => {
         if (
@@ -211,37 +207,13 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
     }, [rule, compareField, field]);
 
     return (
-        <Stack spacing="xs">
-            <Group noWrap position="apart">
-                <Group spacing="xs">
-                    <Text fw={500} fz="xs">
-                        Condition {ruleIndex + 1}
-                    </Text>
+        <Accordion.Item value={accordionValue}>
+            <AccordionControl
+                label={`Condition ${ruleIndex + 1}`}
+                onRemove={hasRemove ? onRemoveRule : undefined}
+            />
 
-                    {hasRemove && (
-                        <Tooltip
-                            label="Remove condition"
-                            position="left"
-                            withinPortal
-                        >
-                            <ActionIcon
-                                data-cf-rule-delete
-                                onClick={onRemoveRule}
-                            >
-                                <MantineIcon icon={IconTrash} />
-                            </ActionIcon>
-                        </Tooltip>
-                    )}
-                </Group>
-
-                <ActionIcon onClick={() => setIsOpen(!isOpen)} size="sm">
-                    <MantineIcon
-                        icon={isOpen ? IconChevronUp : IconChevronDown}
-                    />
-                </ActionIcon>
-            </Group>
-
-            <Collapse in={isOpen}>
+            <Accordion.Panel>
                 <Stack spacing="xs">
                     <Group noWrap spacing="xs">
                         <Text fw={500} fz="xs" c="dimmed">
@@ -289,7 +261,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                                     value: ConditionalFormattingComparisonType.TARGET_TO_VALUES,
                                 },
                             ]}
-                        ></SegmentedControl>
+                        />
                     </Group>
                     {isConditionalFormattingWithCompareTarget(rule) &&
                         isConditionalFormattingWithValues(rule) && (
@@ -353,8 +325,8 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                             )}
                     </Group>
                 </Stack>
-            </Collapse>
-        </Stack>
+            </Accordion.Panel>
+        </Accordion.Item>
     );
 };
 

--- a/packages/frontend/src/components/VisualizationConfigs/common/Accordion.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/common/Accordion.module.css
@@ -1,0 +1,34 @@
+.containedList {
+}
+
+.containedList :global(.mantine-Accordion-control) {
+    padding: var(--mantine-spacing-xs);
+}
+
+.containedList :global(.mantine-Accordion-label) {
+    padding: 0;
+}
+
+.containedList :global(.mantine-Accordion-panel) {
+    padding: 0;
+}
+
+.controlRow {
+    border-radius: var(--mantine-radius-sm);
+}
+
+.controlRow:hover {
+    background-color: var(--mantine-color-ldGray-0);
+
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-5);
+    }
+}
+
+.controlLabel {
+    flex: 1;
+}
+
+.controlButton {
+    flex: 0;
+}

--- a/packages/frontend/src/components/VisualizationConfigs/common/Accordion.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/common/Accordion.module.css
@@ -24,3 +24,14 @@
         background-color: transparent;
     }
 }
+
+.controlRow [data-cf-rule-delete] {
+    opacity: 0;
+    transition: opacity 120ms ease;
+    pointer-events: none;
+}
+
+.controlRow:hover [data-cf-rule-delete] {
+    opacity: 1;
+    pointer-events: auto;
+}

--- a/packages/frontend/src/components/VisualizationConfigs/common/Accordion.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/common/Accordion.module.css
@@ -1,4 +1,5 @@
 .containedList {
+    --accordion-radius: var(--mantine-radius-md);
 }
 
 .containedList :global(.mantine-Accordion-control) {
@@ -13,22 +14,13 @@
     padding: 0;
 }
 
-.controlRow {
-    border-radius: var(--mantine-radius-sm);
-}
-
-.controlRow:hover {
-    background-color: var(--mantine-color-ldGray-0);
-
-    @mixin dark {
-        background-color: var(--mantine-color-ldDark-5);
-    }
-}
-
 .controlLabel {
     flex: 1;
 }
 
 .controlButton {
     flex: 0;
+    &:hover {
+        background-color: transparent;
+    }
 }

--- a/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
@@ -4,12 +4,11 @@ import {
     Box,
     Flex,
     Group,
-    Menu,
     Text,
     Tooltip,
     type AccordionControlProps as MantineAccordionControlProps,
 } from '@mantine-8/core';
-import { IconDots, IconTrash } from '@tabler/icons-react';
+import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import classes from './Accordion.module.css';
@@ -32,7 +31,8 @@ export const AccordionControl: FC<Props> = ({
 }) => {
     return (
         <Flex
-            px="xs"
+            py="xs"
+            pl="sm"
             pos="relative"
             align="center"
             gap="xs"
@@ -56,29 +56,20 @@ export const AccordionControl: FC<Props> = ({
             >
                 {label}
             </Text>
-            <Group wrap="nowrap" ml="sm" gap="lg">
-                <Tooltip label={`Remove ${label}`} position="right">
-                    <Menu withArrow offset={-2}>
-                        <Menu.Target>
-                            <ActionIcon variant="transparent">
-                                <MantineIcon icon={IconDots} />
-                            </ActionIcon>
-                        </Menu.Target>
-                        <Menu.Dropdown>
-                            <Menu.Item
-                                leftSection={<MantineIcon icon={IconTrash} />}
-                                color="red"
-                                onClick={onRemove}
-                            >
-                                <Text fz="xs" fw={500}>
-                                    Delete
-                                </Text>
-                            </Menu.Item>
-                        </Menu.Dropdown>
-                    </Menu>
+            <Group wrap="nowrap" ml="sm" gap="xs">
+                <Tooltip label={`Remove ${label}`} position="left">
+                    <ActionIcon
+                        data-cf-rule-delete
+                        variant="transparent"
+                        color="red"
+                        onClick={onRemove}
+                    >
+                        <MantineIcon icon={IconTrash} />
+                    </ActionIcon>
                 </Tooltip>
                 <Accordion.Control
-                    w="sm"
+                    px="sm"
+                    variant="transparent"
                     className={classes.controlButton}
                     onClick={onControlClick}
                     {...props}

--- a/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
@@ -1,17 +1,16 @@
 import {
     Accordion,
-    ActionIcon,
     Box,
     Flex,
     Group,
     Text,
-    Tooltip,
     type AccordionControlProps as MantineAccordionControlProps,
 } from '@mantine-8/core';
 import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import classes from './Accordion.module.css';
+import { ConfirmDeleteButton } from './ConfirmDeleteButton';
 
 type Props = {
     label: string;
@@ -58,16 +57,13 @@ export const AccordionControl: FC<Props> = ({
             </Text>
             <Group wrap="nowrap" ml="sm" gap="xs">
                 {onRemove && (
-                    <Tooltip label={`Remove ${label}`} position="left">
-                        <ActionIcon
-                            data-cf-rule-delete
-                            variant="transparent"
-                            color="red"
-                            onClick={onRemove}
-                        >
-                            <MantineIcon icon={IconTrash} />
-                        </ActionIcon>
-                    </Tooltip>
+                    <ConfirmDeleteButton
+                        data-cf-rule-delete
+                        aria-label={`Remove ${label}`}
+                        onConfirm={onRemove}
+                    >
+                        <MantineIcon icon={IconTrash} />
+                    </ConfirmDeleteButton>
                 )}
                 <Accordion.Control
                     px="sm"

--- a/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
@@ -15,8 +15,8 @@ import classes from './Accordion.module.css';
 
 type Props = {
     label: string;
-    onControlClick: () => void;
-    onRemove: () => void;
+    onControlClick?: () => void;
+    onRemove?: () => void;
     extraControlElements?: React.ReactNode;
 } & MantineAccordionControlProps;
 
@@ -57,16 +57,18 @@ export const AccordionControl: FC<Props> = ({
                 {label}
             </Text>
             <Group wrap="nowrap" ml="sm" gap="xs">
-                <Tooltip label={`Remove ${label}`} position="left">
-                    <ActionIcon
-                        data-cf-rule-delete
-                        variant="transparent"
-                        color="red"
-                        onClick={onRemove}
-                    >
-                        <MantineIcon icon={IconTrash} />
-                    </ActionIcon>
-                </Tooltip>
+                {onRemove && (
+                    <Tooltip label={`Remove ${label}`} position="left">
+                        <ActionIcon
+                            data-cf-rule-delete
+                            variant="transparent"
+                            color="red"
+                            onClick={onRemove}
+                        >
+                            <MantineIcon icon={IconTrash} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
                 <Accordion.Control
                     px="sm"
                     variant="transparent"

--- a/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
@@ -17,6 +17,7 @@ type Props = {
     onControlClick?: () => void;
     onRemove?: () => void;
     extraControlElements?: React.ReactNode;
+    disabled?: boolean;
 } & MantineAccordionControlProps;
 
 // Custom Accordion.Control wrapper so interactive elements (color swatch, menu)

--- a/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AccordionControl.tsx
@@ -8,10 +8,11 @@ import {
     Text,
     Tooltip,
     type AccordionControlProps as MantineAccordionControlProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { IconDots, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
+import classes from './Accordion.module.css';
 
 type Props = {
     label: string;
@@ -20,7 +21,8 @@ type Props = {
     extraControlElements?: React.ReactNode;
 } & MantineAccordionControlProps;
 
-// NOTE: Custom Accordion.Control component so that we can add more interactive elements to the control without nesting them inside the Accordion.Control component
+// Custom Accordion.Control wrapper so interactive elements (color swatch, menu)
+// can sit alongside the toggle without being nested inside the click target.
 export const AccordionControl: FC<Props> = ({
     label,
     onControlClick,
@@ -34,12 +36,7 @@ export const AccordionControl: FC<Props> = ({
             pos="relative"
             align="center"
             gap="xs"
-            sx={(theme) => ({
-                borderRadius: theme.radius.sm,
-                '&:hover': {
-                    backgroundColor: theme.colors.ldGray[0],
-                },
-            })}
+            className={classes.controlRow}
         >
             {extraControlElements && (
                 <Box
@@ -54,18 +51,13 @@ export const AccordionControl: FC<Props> = ({
                 fw={500}
                 size="xs"
                 truncate
-                sx={{ flex: 1 }}
+                className={classes.controlLabel}
                 onClick={onControlClick}
             >
                 {label}
             </Text>
-            <Group noWrap ml="sm" spacing="lg">
-                <Tooltip
-                    variant="xs"
-                    label={`Remove ${label}`}
-                    position="right"
-                    withinPortal
-                >
+            <Group wrap="nowrap" ml="sm" gap="lg">
+                <Tooltip label={`Remove ${label}`} position="right">
                     <Menu withArrow offset={-2}>
                         <Menu.Target>
                             <ActionIcon variant="transparent">
@@ -74,7 +66,7 @@ export const AccordionControl: FC<Props> = ({
                         </Menu.Target>
                         <Menu.Dropdown>
                             <Menu.Item
-                                icon={<MantineIcon icon={IconTrash} />}
+                                leftSection={<MantineIcon icon={IconTrash} />}
                                 color="red"
                                 onClick={onRemove}
                             >
@@ -87,7 +79,7 @@ export const AccordionControl: FC<Props> = ({
                 </Tooltip>
                 <Accordion.Control
                     w="sm"
-                    sx={{ flex: 0 }}
+                    className={classes.controlButton}
                     onClick={onControlClick}
                     {...props}
                 />

--- a/packages/frontend/src/components/VisualizationConfigs/common/ConfirmDeleteButton.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/ConfirmDeleteButton.tsx
@@ -1,0 +1,85 @@
+import { ActionIcon, Tooltip, type ActionIconProps } from '@mantine-8/core';
+import { useTimeout } from '@mantine-8/hooks';
+import {
+    useCallback,
+    useEffect,
+    useState,
+    type FC,
+    type KeyboardEvent,
+    type MouseEvent,
+    type ReactNode,
+} from 'react';
+
+type Props = {
+    onConfirm: () => void;
+    children: ReactNode;
+    tooltip?: string;
+    /**
+     * Timeout in miliseconds that will auto-disarm after first click
+     */
+    timeoutMs?: number;
+    'aria-label': string;
+} & Omit<ActionIconProps, 'children' | 'onClick' | 'color' | 'variant'>;
+
+/**
+ * Two-click confirm delete button.
+ * First click arms (variant change + tooltip) and second click fires onConfirm
+ * Auto-disarms on mouse leave, blur, escape or after `timeoutMs`
+ */
+export const ConfirmDeleteButton: FC<Props> = ({
+    onConfirm,
+    children,
+    tooltip = 'Click again to delete',
+    timeoutMs = 3000,
+    'aria-label': ariaLabel,
+    ...actionIconProps
+}) => {
+    const [armed, setArmed] = useState(false);
+    const { start, clear } = useTimeout(() => setArmed(false), timeoutMs);
+
+    const disarm = useCallback(() => {
+        clear();
+        setArmed(false);
+    }, [clear]);
+
+    useEffect(() => clear, [clear]);
+
+    const handleClick = (e: MouseEvent) => {
+        e.stopPropagation();
+        if (armed) {
+            disarm();
+            onConfirm();
+            return;
+        }
+        setArmed(true);
+        start();
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') disarm();
+    };
+
+    return (
+        <Tooltip
+            label={tooltip}
+            opened={armed}
+            withArrow
+            position="top"
+            withinPortal
+        >
+            <ActionIcon
+                {...actionIconProps}
+                aria-label={ariaLabel}
+                aria-pressed={armed}
+                color={armed ? 'red' : 'gray'}
+                variant={armed ? 'filled' : 'subtle'}
+                onClick={handleClick}
+                onMouseLeave={disarm}
+                onBlur={disarm}
+                onKeyDown={handleKeyDown}
+            >
+                {children}
+            </ActionIcon>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -1,4 +1,5 @@
 import {
+    Accordion,
     Badge,
     Button,
     Card,
@@ -26,7 +27,16 @@ import { type ColorScheme } from '@mantine/styles';
 import { DotsLoader } from './ee/features/aiCopilot/components/ChatElements/DotsLoader/DotsLoader';
 import { getMantineThemeOverride as getMantine6ThemeOverride } from './mantineTheme';
 // eslint-disable-next-line css-modules/no-unused-class
+import accordionStyles from './styles/mantine-overrides/accordion.module.css';
+// eslint-disable-next-line css-modules/no-unused-class
 import styles from './styles/mantine-overrides/tooltip.module.css';
+
+declare module '@mantine-8/core' {
+    interface AccordionProps {
+        // When true, the active item won't get the variant's filled background.
+        transparentActiveItem?: boolean;
+    }
+}
 
 declare module '@mantine-8/core' {
     export interface ButtonProps {
@@ -108,6 +118,12 @@ export const getMantine8ThemeOverride = (
 
         components: {
             ...legacyComponentsTheme,
+            Accordion: Accordion.extend({
+                classNames: (_theme, props) =>
+                    props.transparentActiveItem
+                        ? { item: accordionStyles.transparentActiveItem }
+                        : {},
+            }),
             Badge: Badge.extend({
                 defaultProps: {
                     radius: 'sm',

--- a/packages/frontend/src/styles/mantine-overrides/accordion.module.css
+++ b/packages/frontend/src/styles/mantine-overrides/accordion.module.css
@@ -1,0 +1,3 @@
+.transparentActiveItem[data-active] {
+    background-color: transparent;
+}


### PR DESCRIPTION
### Description:

Migrated Accordion visualization config elements to Mantine 8, including Table conditional formatting, BigNumber conditional formatting, Reference Lines and Chart conditional formatting
(and some extra styling)



![CleanShot 2026-05-11 at 13.58.59.png](https://app.graphite.com/user-attachments/assets/27b1566a-578b-481f-8bf2-d29f65b26dfa.png)

