### PR TITLE
feat(table): add gradient swatch support for color range conditional formatting

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingItem.tsx
@@ -144,7 +144,16 @@ export const BigNumberConditionalFormattingItem: FC<Props> = ({
     const darkColor = isConditionalFormattingConfigWithSingleColor(value)
         ? (value.darkColor ?? value.color)
         : colorPalette[0];
-    const previewColor = colorScheme === 'dark' ? darkColor : lightColor;
+    const previewColor = isConditionalFormattingConfigWithSingleColor(value)
+        ? colorScheme === 'dark'
+            ? darkColor
+            : lightColor
+        : value.color.start;
+    const previewSecondaryColor = !isConditionalFormattingConfigWithSingleColor(
+        value,
+    )
+        ? value.color.end
+        : undefined;
 
     return (
         <Accordion.Item value={accordionValue}>
@@ -152,6 +161,7 @@ export const BigNumberConditionalFormattingItem: FC<Props> = ({
                 icon={
                     <ColorSelector
                         color={previewColor}
+                        secondaryColor={previewSecondaryColor}
                         swatches={colorPalette}
                     />
                 }

--- a/packages/frontend/src/components/VisualizationConfigs/ColorSelector.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/ColorSelector.module.css
@@ -1,0 +1,16 @@
+.swatchInteractive {
+    cursor: pointer;
+    transition: opacity 100ms ease;
+}
+
+.swatchInteractive:hover {
+    opacity: 0.8;
+}
+
+.swatchStatic {
+    cursor: default;
+}
+
+.colorOverlayGradient {
+    background: var(--cs-gradient);
+}

--- a/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
@@ -6,14 +6,17 @@ import {
     Stack,
     TextInput,
     type ColorSwatchProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { clsx } from '@mantine/core';
 import { IconHash } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { type CSSProperties, type FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
+import classes from './ColorSelector.module.css';
 
 interface Props {
     color?: string;
     defaultColor?: string;
+    secondaryColor?: string;
     swatches: string[];
     onColorChange?: (newColor: string) => void;
     readOnly?: boolean;
@@ -24,6 +27,7 @@ interface Props {
 const ColorSelector: FC<Props> = ({
     color,
     defaultColor = 'rgba(0,0,0,.1)',
+    secondaryColor,
     swatches,
     onColorChange,
     readOnly = false,
@@ -32,6 +36,13 @@ const ColorSelector: FC<Props> = ({
 }) => {
     const isValidHexColor = color && isHexCodeColor(color);
     const isInteractive = Boolean(onColorChange) && !readOnly;
+    const primarySwatchColor = isValidHexColor ? color : defaultColor;
+    const showGradient = !isInteractive && Boolean(secondaryColor);
+    const gradientStyle = showGradient
+        ? ({
+              '--cs-gradient': `linear-gradient(135deg, ${primarySwatchColor} 0%, ${primarySwatchColor} 50%, ${secondaryColor} 50%, ${secondaryColor} 100%)`,
+          } as CSSProperties)
+        : undefined;
 
     return isInteractive ? (
         <Popover withinPortal shadow="md" withArrow>
@@ -40,20 +51,15 @@ const ColorSelector: FC<Props> = ({
                     size={20}
                     color={isValidHexColor ? color : defaultColor}
                     {...colorSwatchProps}
-                    sx={{
-                        cursor: 'pointer',
-                        transition: 'opacity 100ms ease',
-                        '&:hover': { opacity: 0.8 },
-                        ...(typeof colorSwatchProps?.sx === 'object' &&
-                        !Array.isArray(colorSwatchProps.sx)
-                            ? colorSwatchProps.sx
-                            : {}),
-                    }}
+                    className={clsx(
+                        classes.swatchInteractive,
+                        colorSwatchProps?.className,
+                    )}
                 />
             </Popover.Target>
 
             <Popover.Dropdown p="xs">
-                <Stack spacing="xs">
+                <Stack gap="xs">
                     <MantineColorPicker
                         size="sm"
                         format={withAlpha ? 'hexa' : 'hex'}
@@ -63,7 +69,6 @@ const ColorSelector: FC<Props> = ({
                         onChange={(newColor) => {
                             if (!onColorChange) return;
 
-                            // Only append alpha if the color has <1 opacity
                             if (withAlpha && newColor.endsWith('ff')) {
                                 onColorChange(newColor.slice(0, 7));
                             } else {
@@ -74,7 +79,7 @@ const ColorSelector: FC<Props> = ({
 
                     <TextInput
                         size="xs"
-                        icon={<MantineIcon icon={IconHash} />}
+                        leftSection={<MantineIcon icon={IconHash} />}
                         placeholder={`Type in a custom ${
                             withAlpha ? 'HEXA' : 'HEX'
                         }  color`}
@@ -99,13 +104,19 @@ const ColorSelector: FC<Props> = ({
     ) : (
         <ColorSwatch
             size={20}
-            color={isValidHexColor ? color : defaultColor}
+            color={primarySwatchColor}
             {...colorSwatchProps}
-            sx={{
-                cursor: 'default',
-                ...(typeof colorSwatchProps?.sx === 'object' &&
-                !Array.isArray(colorSwatchProps.sx)
-                    ? colorSwatchProps.sx
+            className={clsx(classes.swatchStatic, colorSwatchProps?.className)}
+            classNames={
+                showGradient
+                    ? { colorOverlay: classes.colorOverlayGradient }
+                    : undefined
+            }
+            style={{
+                ...gradientStyle,
+                ...(typeof colorSwatchProps?.style === 'object' &&
+                colorSwatchProps?.style !== null
+                    ? colorSwatchProps.style
                     : {}),
             }}
         />

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -340,6 +340,9 @@ export const ConditionalFormattingItem: FC<Props> = ({
         [isOpen, removeItem, addNewItem, accordionValue],
     );
 
+    const colorSelected = isConditionalFormattingConfigWithSingleColor(config)
+        ? { color: config.color }
+        : { color: config.color.start, secondaryColor: config.color.end };
     return (
         <Accordion.Item value={accordionValue}>
             <AccordionControl
@@ -347,14 +350,7 @@ export const ConditionalFormattingItem: FC<Props> = ({
                     field ? getItemLabelWithoutTableName(field) : controlLabel
                 }
                 extraControlElements={
-                    <ColorSelector
-                        color={
-                            isConditionalFormattingConfigWithSingleColor(config)
-                                ? config.color
-                                : config.color.start
-                        }
-                        swatches={colorPalette}
-                    />
+                    <ColorSelector {...colorSelected} swatches={colorPalette} />
                 }
                 onControlClick={onControlClick}
                 onRemove={handleRemove}


### PR DESCRIPTION
### Description:
Migrated ColorSelector component to mantine 8 + introduce two color swatcher preview
<img width="370" height="320" alt="CleanShot 2026-05-11 at 13 43 34" src="https://github.com/user-attachments/assets/7b086426-3a1d-43f0-b1c9-35974b7abc0d" />
