### PR TITLE
feat: add per-org Azure AD SSO configuration with DB storage, CRUD API, and settings UI

### DIFF
--- a/docs/azure-ad-sso.md
+++ b/docs/azure-ad-sso.md
@@ -1,0 +1,193 @@
+# Azure AD SSO
+
+Two parallel paths exist for Azure Active Directory single sign-on:
+
+1. **Instance-wide (env-based)** — a single Azure tenant configured via
+   environment variables. Applies to every user on the instance. This is the
+   original implementation and works the same as before.
+2. **Per-organization (DB-stored)** — each organization on a shared multi-org
+   instance configures its own Azure tenant via the *Settings → Single
+   Sign-On* admin panel. Added for shared deployments where every customer
+   needs their own tenant.
+
+Both paths coexist. Per-org config takes precedence over env-based config
+when both apply to a user's email domain.
+
+## When to use which
+
+| Scenario | Path |
+|---|---|
+| Self-hosted / on-prem single-org instance | Env-based — set `AUTH_AZURE_AD_OAUTH_*` env vars. No DB rows needed. |
+| Single-tenant dedicated cloud instance (one customer) | Env-based, same as on-prem. |
+| Shared multi-org cloud instance (`app.lightdash.cloud`) | Per-org DB config, one row per customer. Env vars left unset. |
+| Migrating a customer from instance Google to org-specific Azure | Per-org DB config — overrides instance Google for that customer's domain. |
+
+## Env-based path (unchanged)
+
+`AUTH_AZURE_AD_OAUTH_CLIENT_ID`, `AUTH_AZURE_AD_OAUTH_CLIENT_SECRET`,
+`AUTH_AZURE_AD_OAUTH_TENANT_ID` (and the cert-based variants for
+`private_key_jwt` flow) are read at startup in `parseConfig.ts`. If the
+client ID is set, `App.ts` registers a passport strategy under the name
+`'azuread'` via `createAzureAdPassportStrategy` in
+`packages/backend/src/controllers/authentication/strategies/azureStrategy.ts`.
+
+The `/api/v1/login/azuread` and `/api/v1/oauth/redirect/azuread` routes in
+`apiV1Router.ts` invoke `passport.authenticate('azuread', …)` against this
+startup-registered strategy.
+
+## Per-org path
+
+### Storage
+
+Table `organization_sso_configurations`
+([migration](../packages/backend/src/database/migrations/20260511105509_add_organization_sso_configurations.ts),
+[extension](../packages/backend/src/database/migrations/20260511120638_extend_organization_sso_configurations.ts)).
+
+One row per `(organization_uuid, provider)` — `provider` is currently always
+`'azuread'`. Columns:
+
+| Column | Purpose |
+|---|---|
+| `config` | Encrypted JSON blob with `oauth2ClientId`, `oauth2ClientSecret`, `oauth2TenantId`. Encrypted at rest via `EncryptionUtil` (AES-256-GCM, key derived from `LIGHTDASH_SECRET`). |
+| `enabled` | Master on/off switch for this method. Off → not offered to anyone. |
+| `override_email_domains` | If true, the row's own `email_domains` list governs discovery. If false, the org's existing `organization_allowed_email_domains` list is used. |
+| `email_domains` | Strict whitelist (only consulted when `override_email_domains = true`). Empty list + override on = method invisible to discovery. |
+| `allow_password` | If true, users matched by this method can also use email/password sign-in. If false, password input is hidden and only Azure is offered for matched users. |
+
+### Discovery flow
+
+When a user enters their email at the 2-step login precheck:
+
+1. `UserService.getLoginOptions(email)` calls
+   `OrganizationSsoModel.findEnabledMethodsForEmailDomain(domain)`.
+2. The model returns all `enabled = true` rows whose effective whitelist
+   contains the email's domain — either via `email_domains` (when override
+   is on) or via the org's `allowed_email_domains` (when override is off).
+3. The matching rows replace instance-level SSO providers in
+   `showOptions` — per-org SSO **suppresses** env-based SSO for matched
+   users. Example: a customer's domain matched by their per-org Azure
+   config no longer sees instance-level Google.
+4. Password input visibility follows a lenient rule: if **any** matching
+   method has `allow_password = true`, password is shown. Otherwise hidden.
+
+### Cross-org filter
+
+If the email belongs to an existing Lightdash user, the matching SSO methods
+are filtered down to orgs that user already belongs to. Discovery is scoped
+to the user's own organizations.
+
+```text
+existing user @ example.com on org A
+  + per-org Azure config on org B that lists `example.com`
+  → discovery returns []
+  → user sees instance-default precheck, no Azure button
+```
+
+Brand-new users (no Lightdash account yet) still get the full discovery,
+gated by the feature flag below.
+
+### Login route (`/api/v1/login/azuread`)
+
+The route reads `?login_hint=<email>` from the query and calls
+`resolveAzureAdStrategyName(req)` in
+[`apiV1Router.ts`](../packages/backend/src/routers/apiV1Router.ts). The
+resolver:
+
+1. Calls `findEnabledAzureAdMethodForEmail(email)` to find the matching
+   per-org config.
+2. If found, dynamically registers a passport strategy named
+   `azuread:<orgUuid>` with that org's config and returns the strategy
+   name. The strategy is cached for 10 minutes (TTL) and re-registered on
+   each request so config changes (e.g. rotated secrets) take effect.
+3. If no per-org match, falls back to the env-based `'azuread'` strategy
+   when configured at startup. If neither is available, returns 404.
+4. Stores the resolved strategy name on `req.session.oauth.azureAdStrategyName`.
+5. Forwards `login_hint` to Microsoft so Azure surfaces the right account
+   (prevents the wrong-account auto-pick when a browser has a stale
+   Microsoft session for another user).
+
+The callback route (`/oauth/redirect/azuread`) reads the strategy name back
+from session, re-registers if the cache was evicted (e.g. server restart),
+then runs `passport.authenticate`.
+
+### Settings panel
+
+`packages/frontend/src/components/UserSettings/OrganizationSsoPanel/`
+exposes the four flags + credential form to org admins. Gated behind:
+
+- `manage Organization` CASL ability (org admins only)
+- Feature flag `sso-organization-settings` (see "Rollout" below)
+
+The panel UI lets the admin:
+
+- Enter Azure Application (client) ID, Directory (tenant) ID, and the
+  client secret value
+- Toggle the master `enabled` switch
+- Tick "Override organization's allowed email domains" and edit a domain
+  whitelist — when unticked, the org's existing allowed domains apply
+- Tick "Allow password sign-in for users matching this method" to permit
+  email/password login alongside Azure for that domain
+
+## Login UX scenarios
+
+For an instance with env Google + per-org Azure on `acme.com`:
+
+| Email entered | `showOptions` | UI |
+|---|---|---|
+| *(no email)* | `[email, google]` | Instance defaults — email input + Google button |
+| `someone@unrelated.com` | `[email, google]` | Instance defaults |
+| `existing@acme.com` (member of Acme, has password) | `[email, azuread]` | Password input + Azure button. **Google is suppressed.** |
+| `newcomer@acme.com` (no account, domain matches) | `[azuread]` + `forceRedirect=true` | Auto-redirect to Azure. Single option, no password fallback. |
+| `someone@acme.com` (existing user, but in a *different* org from the Azure config) | `[email]` | Cross-org filter scopes Azure to the user's own org. Falls back to instance options. |
+
+## Rollout
+
+`sso-organization-settings` is a server-side feature flag
+(`packages/common/src/types/featureFlags.ts`). Off by default.
+
+**Per-org enablement (shared cloud)** — ops inserts a row into
+`feature_flag_overrides` for the customer's org:
+
+```sql
+INSERT INTO feature_flags (flag_id, default_enabled)
+VALUES ('sso-organization-settings', false)
+ON CONFLICT (flag_id) DO NOTHING;
+
+INSERT INTO feature_flag_overrides (flag_id, organization_uuid, enabled)
+VALUES ('sso-organization-settings', '<org-uuid>', true)
+ON CONFLICT (flag_id, organization_uuid)
+WHERE organization_uuid IS NOT NULL AND user_uuid IS NULL
+DO UPDATE SET enabled = true, updated_at = now();
+```
+
+After this, the customer's org admin sees the "Single Sign-On" entry under
+*Organization settings*.
+
+**Instance-wide enablement (self-hosted)** — set the env var:
+
+```bash
+ENABLED_FEATURE_FLAGS=sso-organization-settings
+```
+
+This makes the panel available to every org admin on the instance. On a
+self-hosted single-customer deployment, no further gating is needed.
+
+## File map
+
+| Path | Purpose |
+|---|---|
+| `packages/common/src/types/organizationSso.ts` | Common types (`OrganizationSsoProvider`, `AzureAdSsoConfig`, summary/upsert shapes) |
+| `packages/common/src/types/featureFlags.ts` | `SsoOrganizationSettings` flag enum |
+| `packages/backend/src/database/entities/organizationSsoConfigurations.ts` | Knex table type |
+| `packages/backend/src/database/migrations/20260511105509_add_organization_sso_configurations.ts` | Table creation |
+| `packages/backend/src/database/migrations/20260511120638_extend_organization_sso_configurations.ts` | Adds `enabled`, `override_email_domains`, `email_domains`, `allow_password` |
+| `packages/backend/src/models/OrganizationSsoModel.ts` | CRUD + discovery query |
+| `packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts` | Admin gating, validation, cross-org filter |
+| `packages/backend/src/ee/controllers/OrganizationSsoController.ts` | `/api/v1/org/sso/azuread` endpoints |
+| `packages/backend/src/controllers/authentication/strategies/azureStrategy.ts` | `createAzureAdOidcStrategyForConfig` |
+| `packages/backend/src/routers/apiV1Router.ts` | Dynamic `azuread:<orgUuid>` strategy registration, `login_hint` forwarding |
+| `packages/backend/src/services/UserService.ts` | `getLoginOptions` rewrite for discovery + cross-org filter |
+| `packages/frontend/src/components/UserSettings/OrganizationSsoPanel/` | Admin UI |
+| `packages/frontend/src/hooks/organization/useOrganizationSso.ts` | Frontend hooks for CRUD |
+| `packages/frontend/src/pages/Settings.tsx` | Route + nav link, gated by flag |
+| `packages/frontend/src/features/users/components/LoginLanding.tsx` | Forwards `preCheckEmail` as `loginHint` to SSO buttons |

--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -11,6 +11,7 @@ declare module 'express-session' {
             databricks?: {
                 projectUuid?: string | undefined;
             };
+            azureAdStrategyName?: string | undefined;
         };
         slack: {
             teamId?: string | undefined;

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -138,6 +138,10 @@ import {
     OrganizationAllowedEmailDomainsTableName,
 } from '../database/entities/organizationsAllowedEmailDomains';
 import {
+    OrganizationSsoConfigurationsTable,
+    OrganizationSsoConfigurationsTableName,
+} from '../database/entities/organizationSsoConfigurations';
+import {
     OrganizationWarehouseCredentialsTable,
     OrganizationWarehouseCredentialsTableName,
 } from '../database/entities/organizationWarehouseCredentials';
@@ -442,6 +446,7 @@ declare module 'knex/types/tables' {
         [SchedulerLogTableName]: SchedulerLogTable;
         [OrganizationAllowedEmailDomainsTableName]: OrganizationAllowedEmailDomainsTable;
         [OrganizationAllowedEmailDomainProjectsTableName]: OrganizationAllowedEmailDomainProjectsTable;
+        [OrganizationSsoConfigurationsTableName]: OrganizationSsoConfigurationsTable;
         [ValidationTableName]: ValidationTable;
         [GroupTableName]: GroupTable;
         [GroupMembershipTableName]: GroupMembershipTable;

--- a/packages/backend/src/controllers/authentication/strategies/azureStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/azureStrategy.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../@types/passport-openidconnect.d.ts" />
 /// <reference path="../../../@types/express-session.d.ts" />
-import { OpenIdIdentityIssuerType } from '@lightdash/common';
+import { AzureAdSsoConfig, OpenIdIdentityIssuerType } from '@lightdash/common';
 import {
     BaseClient,
     Issuer,
@@ -19,6 +19,9 @@ import { genericOidcHandler } from './oidcStrategy';
  * token authentication, using openid-client.
  *
  * Requires its own strategy since this method is not supported by OpenIdConnect.
+ *
+ * Only available via the env-based config — per-org SSO config uses the
+ * standard clientId/clientSecret/tenantId flow.
  */
 const azureAdPrivateKeyJksStrategy = async (): Promise<
     OpenIdClientStrategy<unknown, BaseClient>
@@ -99,7 +102,34 @@ const azureAdPrivateKeyJksStrategy = async (): Promise<
 };
 
 /**
- * Creates the appropriate AzureAd passport strategy based on the available configuration.
+ * Builds a passport strategy from a clientId/clientSecret/tenantId config
+ * (the path used by per-org DB-stored config and by the env-based standard
+ * flow).
+ */
+export const createAzureAdOidcStrategyForConfig = (
+    config: AzureAdSsoConfig,
+): OpenIDConnectStrategy =>
+    new OpenIDConnectStrategy(
+        {
+            issuer: `https://login.microsoftonline.com/${config.oauth2TenantId}/v2.0`,
+            authorizationURL: `https://login.microsoftonline.com/${config.oauth2TenantId}/oauth2/v2.0/authorize`,
+            tokenURL: `https://login.microsoftonline.com/${config.oauth2TenantId}/oauth2/v2.0/token`,
+            userInfoURL: 'https://graph.microsoft.com/oidc/userinfo',
+            clientID: config.oauth2ClientId,
+            clientSecret: config.oauth2ClientSecret,
+            callbackURL: new URL(
+                `/api/v1${lightdashConfig.auth.azuread.callbackPath}`,
+                lightdashConfig.siteUrl,
+            ).href,
+            passReqToCallback: true,
+        },
+        genericOidcHandler(OpenIdIdentityIssuerType.AZUREAD),
+    );
+
+/**
+ * Creates the appropriate AzureAd passport strategy based on the available env
+ * configuration. Kept for backwards compatibility with single-tenant
+ * env-driven instances.
  */
 export const createAzureAdPassportStrategy = () => {
     const { azuread } = lightdashConfig.auth;
@@ -113,22 +143,11 @@ export const createAzureAdPassportStrategy = () => {
         azuread.oauth2ClientSecret &&
         azuread.oauth2TenantId
     ) {
-        return new OpenIDConnectStrategy(
-            {
-                issuer: `https://login.microsoftonline.com/${azuread.oauth2TenantId}/v2.0`,
-                authorizationURL: `https://login.microsoftonline.com/${azuread.oauth2TenantId}/oauth2/v2.0/authorize`,
-                tokenURL: `https://login.microsoftonline.com/${azuread.oauth2TenantId}/oauth2/v2.0/token`,
-                userInfoURL: 'https://graph.microsoft.com/oidc/userinfo',
-                clientID: azuread.oauth2ClientId,
-                clientSecret: azuread.oauth2ClientSecret,
-                callbackURL: new URL(
-                    `/api/v1${azuread.callbackPath}`,
-                    lightdashConfig.siteUrl,
-                ).href,
-                passReqToCallback: true,
-            },
-            genericOidcHandler(OpenIdIdentityIssuerType.AZUREAD),
-        );
+        return createAzureAdOidcStrategyForConfig({
+            oauth2ClientId: azuread.oauth2ClientId,
+            oauth2ClientSecret: azuread.oauth2ClientSecret,
+            oauth2TenantId: azuread.oauth2TenantId,
+        });
     }
 
     if (

--- a/packages/backend/src/database/entities/organizationSsoConfigurations.ts
+++ b/packages/backend/src/database/entities/organizationSsoConfigurations.ts
@@ -1,0 +1,56 @@
+import { Knex } from 'knex';
+
+export const OrganizationSsoConfigurationsTableName =
+    'organization_sso_configurations';
+
+export type DbOrganizationSsoConfiguration = {
+    organization_sso_configuration_uuid: string;
+    organization_uuid: string;
+    provider: string;
+    config: Buffer;
+    enabled: boolean;
+    override_email_domains: boolean;
+    email_domains: string[];
+    allow_password: boolean;
+    created_at: Date;
+    updated_at: Date;
+    created_by_user_uuid: string | null;
+    updated_by_user_uuid: string | null;
+};
+
+type DbOrganizationSsoConfigurationInsert = Omit<
+    DbOrganizationSsoConfiguration,
+    | 'organization_sso_configuration_uuid'
+    | 'created_at'
+    | 'updated_at'
+    | 'enabled'
+    | 'override_email_domains'
+    | 'email_domains'
+    | 'allow_password'
+> &
+    Partial<
+        Pick<
+            DbOrganizationSsoConfiguration,
+            | 'enabled'
+            | 'override_email_domains'
+            | 'email_domains'
+            | 'allow_password'
+        >
+    >;
+
+export type OrganizationSsoConfigurationsTable = Knex.CompositeTableType<
+    DbOrganizationSsoConfiguration,
+    DbOrganizationSsoConfigurationInsert,
+    Partial<
+        Pick<
+            DbOrganizationSsoConfiguration,
+            | 'config'
+            | 'enabled'
+            | 'override_email_domains'
+            | 'email_domains'
+            | 'allow_password'
+            | 'updated_at'
+            | 'updated_by_user_uuid'
+        >
+    >
+>;

--- a/packages/backend/src/database/migrations/20260511105509_add_organization_sso_configurations.ts
+++ b/packages/backend/src/database/migrations/20260511105509_add_organization_sso_configurations.ts
@@ -1,0 +1,61 @@
+import { Knex } from 'knex';
+
+const ORGANIZATION_SSO_CONFIGURATIONS_TABLE = 'organization_sso_configurations';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(
+        ORGANIZATION_SSO_CONFIGURATIONS_TABLE,
+        (table) => {
+            table
+                .uuid('organization_sso_configuration_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('organization_uuid')
+                .notNullable()
+                .references('organization_uuid')
+                .inTable('organizations')
+                .onDelete('CASCADE');
+            table.string('provider').notNullable();
+            table.binary('config').notNullable(); // encrypted JSON
+            table.boolean('enabled').notNullable().defaultTo(true);
+            table
+                .boolean('override_email_domains')
+                .notNullable()
+                .defaultTo(false);
+            table
+                .specificType('email_domains', 'text[]')
+                .notNullable()
+                .defaultTo('{}');
+            table.boolean('allow_password').notNullable().defaultTo(true);
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .timestamp('updated_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .uuid('created_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .index();
+            table
+                .uuid('updated_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .index();
+
+            table.unique(['organization_uuid', 'provider']);
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(ORGANIZATION_SSO_CONFIGURATIONS_TABLE);
+}

--- a/packages/backend/src/ee/controllers/OrganizationSsoController.ts
+++ b/packages/backend/src/ee/controllers/OrganizationSsoController.ts
@@ -1,0 +1,98 @@
+import {
+    ApiAzureAdSsoConfigResponse,
+    ApiErrorPayload,
+    ApiSuccessEmpty,
+    ApiUpsertAzureAdSsoConfigResponse,
+    assertRegisteredAccount,
+    UpsertAzureAdSsoConfig,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Put,
+    Request,
+    Response,
+    Route,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+
+@Route('/api/v1/org/sso')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Organizations')
+export class OrganizationSsoController extends BaseController {
+    /**
+     * Returns the current organization's Azure AD SSO configuration (sensitive
+     * fields are not included).
+     * @summary Get Azure AD SSO configuration
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/azuread')
+    @OperationId('GetAzureAdSsoConfig')
+    async getAzureAdConfig(
+        @Request() req: express.Request,
+    ): Promise<ApiAzureAdSsoConfigResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationSsoService()
+            .getAzureAdConfig(req.account);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Creates or updates the current organization's Azure AD SSO configuration.
+     * Omit `oauth2ClientSecret` to preserve the previously stored secret on
+     * updates.
+     * @summary Upsert Azure AD SSO configuration
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Put('/azuread')
+    @OperationId('UpsertAzureAdSsoConfig')
+    async upsertAzureAdConfig(
+        @Request() req: express.Request,
+        @Body() body: UpsertAzureAdSsoConfig,
+    ): Promise<ApiUpsertAzureAdSsoConfigResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationSsoService()
+            .upsertAzureAdConfig(req.account, body);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Removes the current organization's Azure AD SSO configuration.
+     * @summary Delete Azure AD SSO configuration
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Delete('/azuread')
+    @OperationId('DeleteAzureAdSsoConfig')
+    async deleteAzureAdConfig(
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getOrganizationSsoService()
+            .deleteAzureAdConfig(req.account);
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -133,6 +133,8 @@ import { EmbedController } from './../ee/controllers/embedController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ManagedAgentController } from './../ee/controllers/managedAgentController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { OrganizationSsoController } from './../ee/controllers/OrganizationSsoController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationWarehouseCredentialsController } from './../ee/controllers/OrganizationWarehouseCredentialsController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { PreAggregateController } from './../ee/controllers/PreAggregateController';
@@ -5329,6 +5331,16 @@ const models: TsoaRoute.Models = {
         enums: ['dynamic', 'fixed'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MapHexbinValueBasis: {
+        dataType: 'refEnum',
+        enums: ['count', 'field'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MapHexbinAggregation: {
+        dataType: 'refEnum',
+        enums: ['sum', 'avg', 'min', 'max'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MapTileBackground: {
         dataType: 'refEnum',
         enums: [
@@ -5378,6 +5390,16 @@ const models: TsoaRoute.Models = {
                 hexbinConfig: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        emptyBinColor: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
+                        showEmptyBins: { dataType: 'boolean' },
+                        aggregation: { ref: 'MapHexbinAggregation' },
+                        valueBasis: { ref: 'MapHexbinValueBasis' },
                         fixedResolution: { dataType: 'double' },
                         sizingMode: { ref: 'MapHexbinSizingMode' },
                         opacity: { dataType: 'double' },
@@ -13662,6 +13684,147 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AzureAdSsoConfig.oauth2ClientId-or-oauth2TenantId_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                oauth2ClientId: { dataType: 'string', required: true },
+                oauth2TenantId: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    OrganizationSsoMethodFlags: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                allowPassword: { dataType: 'boolean', required: true },
+                emailDomains: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                overrideEmailDomains: { dataType: 'boolean', required: true },
+                enabled: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AzureAdSsoConfigSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_AzureAdSsoConfig.oauth2ClientId-or-oauth2TenantId_',
+                },
+                { ref: 'OrganizationSsoMethodFlags' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        hasClientSecret: {
+                            dataType: 'boolean',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAzureAdSsoConfigResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AzureAdSsoConfigSummary' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpsertAzureAdSsoConfigResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AzureAdSsoConfigSummary', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Partial_OrganizationSsoMethodFlags_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                enabled: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                overrideEmailDomains: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                emailDomains: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                allowPassword: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpsertAzureAdSsoConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        oauth2TenantId: { dataType: 'string', required: true },
+                        oauth2ClientSecret: { dataType: 'string' },
+                        oauth2ClientId: { dataType: 'string', required: true },
+                    },
+                },
+                { ref: 'Partial_OrganizationSsoMethodFlags_' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Role: {
         dataType: 'refAlias',
         type: {
@@ -18177,6 +18340,7 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    enabled: { dataType: 'boolean', required: true },
                     message: {
                         dataType: 'union',
                         subSchemas: [
@@ -18213,7 +18377,6 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
-                    enabled: { dataType: 'boolean', required: true },
                     notificationFrequency: {
                         dataType: 'union',
                         subSchemas: [
@@ -21827,7 +21990,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21837,7 +22000,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21847,7 +22010,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21860,7 +22023,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -38938,6 +39101,177 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'delete',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSsoController_getAzureAdConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/org/sso/azuread',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSsoController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSsoController.prototype.getAzureAdConfig,
+        ),
+
+        async function OrganizationSsoController_getAzureAdConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSsoController_getAzureAdConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSsoController>(
+                        OrganizationSsoController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAzureAdConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSsoController_upsertAzureAdConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpsertAzureAdSsoConfig',
+        },
+    };
+    app.put(
+        '/api/v1/org/sso/azuread',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSsoController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSsoController.prototype.upsertAzureAdConfig,
+        ),
+
+        async function OrganizationSsoController_upsertAzureAdConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSsoController_upsertAzureAdConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSsoController>(
+                        OrganizationSsoController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertAzureAdConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSsoController_deleteAzureAdConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.delete(
+        '/api/v1/org/sso/azuread',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSsoController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSsoController.prototype.deleteAzureAdConfig,
+        ),
+
+        async function OrganizationSsoController_deleteAzureAdConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSsoController_deleteAzureAdConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSsoController>(
+                        OrganizationSsoController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteAzureAdConfig',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6216,6 +6216,14 @@
                 "enum": ["dynamic", "fixed"],
                 "type": "string"
             },
+            "MapHexbinValueBasis": {
+                "enum": ["count", "field"],
+                "type": "string"
+            },
+            "MapHexbinAggregation": {
+                "enum": ["sum", "avg", "min", "max"],
+                "type": "string"
+            },
             "MapTileBackground": {
                 "enum": [
                     "none",
@@ -6281,6 +6289,23 @@
                     },
                     "hexbinConfig": {
                         "properties": {
+                            "emptyBinColor": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Fill color for empty bins. Hex6 (#rrggbb) = solid fill, hex8\n(#rrggbbaa) = fill with alpha, null/undefined = outline only."
+                            },
+                            "showEmptyBins": {
+                                "type": "boolean",
+                                "description": "Render outlined empty cells across the visible map area, so the user\ncan see \"where there is no data\" relative to the hex grid."
+                            },
+                            "aggregation": {
+                                "$ref": "#/components/schemas/MapHexbinAggregation",
+                                "description": "Aggregation applied when valueBasis = FIELD. Defaults to SUM."
+                            },
+                            "valueBasis": {
+                                "$ref": "#/components/schemas/MapHexbinValueBasis",
+                                "description": "What drives cell color: count of points (default) or an aggregation\nover a chosen value field (controlled via the chart's `valueFieldId`)."
+                            },
                             "fixedResolution": {
                                 "type": "number",
                                 "format": "double",
@@ -14615,6 +14640,150 @@
                 },
                 "type": "object"
             },
+            "Pick_AzureAdSsoConfig.oauth2ClientId-or-oauth2TenantId_": {
+                "properties": {
+                    "oauth2ClientId": {
+                        "type": "string"
+                    },
+                    "oauth2TenantId": {
+                        "type": "string"
+                    }
+                },
+                "required": ["oauth2ClientId", "oauth2TenantId"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "OrganizationSsoMethodFlags": {
+                "properties": {
+                    "allowPassword": {
+                        "type": "boolean",
+                        "description": "Controls whether email+password sign-in is shown alongside this method\nwhen it matches a user. When multiple matching SSO methods disagree,\nlenient rule applies (ANY method that allows → show password)."
+                    },
+                    "emailDomains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Strict whitelist (only consulted when `overrideEmailDomains` is true)."
+                    },
+                    "overrideEmailDomains": {
+                        "type": "boolean",
+                        "description": "When true, the method's own `emailDomains` list governs discovery.\nWhen false, the org's `allowed_email_domains` is used instead."
+                    },
+                    "enabled": {
+                        "type": "boolean",
+                        "description": "When false the method is hidden from precheck even if discovery would match."
+                    }
+                },
+                "required": [
+                    "allowPassword",
+                    "emailDomains",
+                    "overrideEmailDomains",
+                    "enabled"
+                ],
+                "type": "object",
+                "description": "Per-row flags shared by every SSO method configured at the org level.\nStored as plain columns alongside the encrypted provider-specific config."
+            },
+            "AzureAdSsoConfigSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_AzureAdSsoConfig.oauth2ClientId-or-oauth2TenantId_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OrganizationSsoMethodFlags"
+                    },
+                    {
+                        "properties": {
+                            "hasClientSecret": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["hasClientSecret"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiAzureAdSsoConfigResponse": {
+                "properties": {
+                    "results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AzureAdSsoConfigSummary"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiUpsertAzureAdSsoConfigResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AzureAdSsoConfigSummary"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Partial_OrganizationSsoMethodFlags_": {
+                "properties": {
+                    "enabled": {
+                        "type": "boolean",
+                        "description": "When false the method is hidden from precheck even if discovery would match."
+                    },
+                    "overrideEmailDomains": {
+                        "type": "boolean",
+                        "description": "When true, the method's own `emailDomains` list governs discovery.\nWhen false, the org's `allowed_email_domains` is used instead."
+                    },
+                    "emailDomains": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Strict whitelist (only consulted when `overrideEmailDomains` is true)."
+                    },
+                    "allowPassword": {
+                        "type": "boolean",
+                        "description": "Controls whether email+password sign-in is shown alongside this method\nwhen it matches a user. When multiple matching SSO methods disagree,\nlenient rule applies (ANY method that allows → show password)."
+                    }
+                },
+                "type": "object",
+                "description": "Make all properties in T optional"
+            },
+            "UpsertAzureAdSsoConfig": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "oauth2TenantId": {
+                                "type": "string"
+                            },
+                            "oauth2ClientSecret": {
+                                "type": "string",
+                                "description": "When omitted on update, the stored secret is preserved. Required on create."
+                            },
+                            "oauth2ClientId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["oauth2TenantId", "oauth2ClientId"],
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Partial_OrganizationSsoMethodFlags_"
+                    }
+                ]
+            },
             "Role": {
                 "properties": {
                     "updatedAt": {
@@ -19312,6 +19481,9 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "enabled": {
+                        "type": "boolean"
+                    },
                     "message": {
                         "type": "string"
                     },
@@ -19333,9 +19505,6 @@
                         },
                         "type": "array"
                     },
-                    "enabled": {
-                        "type": "boolean"
-                    },
                     "notificationFrequency": {
                         "$ref": "#/components/schemas/NotificationFrequency"
                     },
@@ -19356,9 +19525,9 @@
                 "required": [
                     "name",
                     "cron",
+                    "enabled",
                     "format",
                     "options",
-                    "enabled",
                     "includeLinks",
                     "targets"
                 ],
@@ -23197,22 +23366,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -32094,7 +32263,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2904.3",
+        "version": "0.2904.4",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -33967,6 +34136,108 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/org/sso/azuread": {
+            "get": {
+                "operationId": "GetAzureAdSsoConfig",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAzureAdSsoConfigResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Returns the current organization's Azure AD SSO configuration (sensitive\nfields are not included).",
+                "summary": "Get Azure AD SSO configuration",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            },
+            "put": {
+                "operationId": "UpsertAzureAdSsoConfig",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUpsertAzureAdSsoConfigResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Creates or updates the current organization's Azure AD SSO configuration.\nOmit `oauth2ClientSecret` to preserve the previously stored secret on\nupdates.",
+                "summary": "Upsert Azure AD SSO configuration",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpsertAzureAdSsoConfig"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "DeleteAzureAdSsoConfig",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Removes the current organization's Azure AD SSO configuration.",
+                "summary": "Delete Azure AD SSO configuration",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
             }
         },
         "/api/v2/orgs/{orgUuid}/roles": {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -31,6 +31,7 @@ import { OpenIdIdentityModel } from './OpenIdIdentitiesModel';
 import { OrganizationAllowedEmailDomainsModel } from './OrganizationAllowedEmailDomainsModel';
 import { OrganizationMemberProfileModel } from './OrganizationMemberProfileModel';
 import { OrganizationModel } from './OrganizationModel';
+import { OrganizationSsoModel } from './OrganizationSsoModel';
 import { OrganizationWarehouseCredentialsModel } from './OrganizationWarehouseCredentialsModel';
 import { PasswordResetLinkModel } from './PasswordResetLinkModel';
 import { PersistentDownloadFileModel } from './PersistentDownloadFileModel';
@@ -90,6 +91,7 @@ export type ModelManifest = {
     organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
     organizationModel: OrganizationModel;
+    organizationSsoModel: OrganizationSsoModel;
     organizationWarehouseCredentialsModel: OrganizationWarehouseCredentialsModel;
     passwordResetLinkModel: PasswordResetLinkModel;
     personalAccessTokenModel: PersonalAccessTokenModel;
@@ -423,6 +425,17 @@ export class ModelRepository
             'organizationWarehouseCredentialsModel',
             () =>
                 new OrganizationWarehouseCredentialsModel({
+                    database: this.database,
+                    encryptionUtil: this.utils.getEncryptionUtil(),
+                }),
+        );
+    }
+
+    public getOrganizationSsoModel(): OrganizationSsoModel {
+        return this.getModel(
+            'organizationSsoModel',
+            () =>
+                new OrganizationSsoModel({
                     database: this.database,
                     encryptionUtil: this.utils.getEncryptionUtil(),
                 }),

--- a/packages/backend/src/models/OrganizationSsoModel.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.ts
@@ -1,0 +1,195 @@
+import {
+    AzureAdSsoConfig,
+    OrganizationSsoMethodFlags,
+    OrganizationSsoProvider,
+    UnexpectedServerError,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { OrganizationSsoConfigurationsTableName } from '../database/entities/organizationSsoConfigurations';
+import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
+
+type OrganizationSsoModelArguments = {
+    database: Knex;
+    encryptionUtil: EncryptionUtil;
+};
+
+type ProviderConfigTypeMap = {
+    [OrganizationSsoProvider.AZUREAD]: AzureAdSsoConfig;
+};
+
+export type OrganizationSsoMethod<P extends OrganizationSsoProvider> = {
+    organizationUuid: string;
+    provider: P;
+    config: ProviderConfigTypeMap[P];
+} & OrganizationSsoMethodFlags;
+
+const ALLOWED_EMAIL_DOMAINS_TABLE = 'organization_allowed_email_domains';
+
+export class OrganizationSsoModel {
+    private readonly database: Knex;
+
+    private readonly encryptionUtil: EncryptionUtil;
+
+    constructor(args: OrganizationSsoModelArguments) {
+        this.database = args.database;
+        this.encryptionUtil = args.encryptionUtil;
+    }
+
+    private encryptConfig(config: object): Buffer {
+        return this.encryptionUtil.encrypt(JSON.stringify(config));
+    }
+
+    private decryptConfig<P extends OrganizationSsoProvider>(
+        buffer: Buffer,
+    ): ProviderConfigTypeMap[P] {
+        try {
+            return JSON.parse(
+                this.encryptionUtil.decrypt(buffer),
+            ) as ProviderConfigTypeMap[P];
+        } catch (e) {
+            throw new UnexpectedServerError(
+                'Failed to decrypt organization SSO configuration',
+            );
+        }
+    }
+
+    async findMethod<P extends OrganizationSsoProvider>(
+        organizationUuid: string,
+        provider: P,
+    ): Promise<OrganizationSsoMethod<P> | undefined> {
+        const row = await this.database(OrganizationSsoConfigurationsTableName)
+            .where('organization_uuid', organizationUuid)
+            .where('provider', provider)
+            .first();
+        if (!row) return undefined;
+        return {
+            organizationUuid: row.organization_uuid,
+            provider: row.provider as P,
+            config: this.decryptConfig<P>(row.config),
+            enabled: row.enabled,
+            overrideEmailDomains: row.override_email_domains,
+            emailDomains: row.email_domains ?? [],
+            allowPassword: row.allow_password,
+        };
+    }
+
+    /**
+     * Finds all enabled SSO methods whose effective whitelist includes the
+     * email's domain. The "effective whitelist" is the row's own
+     * `email_domains` when `override_email_domains = true`, else the org's
+     * `allowed_email_domains` list.
+     */
+    async findEnabledMethodsForEmailDomain(
+        emailDomain: string,
+    ): Promise<OrganizationSsoMethod<OrganizationSsoProvider>[]> {
+        const normalized = emailDomain.toLowerCase();
+        const rows = await this.database(OrganizationSsoConfigurationsTableName)
+            .leftJoin(
+                ALLOWED_EMAIL_DOMAINS_TABLE,
+                `${OrganizationSsoConfigurationsTableName}.organization_uuid`,
+                `${ALLOWED_EMAIL_DOMAINS_TABLE}.organization_uuid`,
+            )
+            .where(`${OrganizationSsoConfigurationsTableName}.enabled`, true)
+            .andWhere((builder) => {
+                void builder
+                    .where((subOverride) => {
+                        void subOverride
+                            .where(
+                                `${OrganizationSsoConfigurationsTableName}.override_email_domains`,
+                                true,
+                            )
+                            .whereRaw(
+                                `? = ANY (${OrganizationSsoConfigurationsTableName}.email_domains)`,
+                                [normalized],
+                            );
+                    })
+                    .orWhere((subInherit) => {
+                        void subInherit
+                            .where(
+                                `${OrganizationSsoConfigurationsTableName}.override_email_domains`,
+                                false,
+                            )
+                            .whereRaw(
+                                `? = ANY (${ALLOWED_EMAIL_DOMAINS_TABLE}.email_domains)`,
+                                [normalized],
+                            );
+                    });
+            })
+            .select(`${OrganizationSsoConfigurationsTableName}.*`);
+
+        return rows.map((row) => ({
+            organizationUuid: row.organization_uuid,
+            provider: row.provider as OrganizationSsoProvider,
+            config: this.decryptConfig(row.config),
+            enabled: row.enabled,
+            overrideEmailDomains: row.override_email_domains,
+            emailDomains: row.email_domains ?? [],
+            allowPassword: row.allow_password,
+        }));
+    }
+
+    async upsert<P extends OrganizationSsoProvider>(
+        organizationUuid: string,
+        provider: P,
+        config: ProviderConfigTypeMap[P],
+        flags: Partial<OrganizationSsoMethodFlags>,
+        userUuid: string | null,
+    ): Promise<void> {
+        const encrypted = this.encryptConfig(config);
+        const insert = {
+            organization_uuid: organizationUuid,
+            provider,
+            config: encrypted,
+            ...(flags.enabled !== undefined ? { enabled: flags.enabled } : {}),
+            ...(flags.overrideEmailDomains !== undefined
+                ? { override_email_domains: flags.overrideEmailDomains }
+                : {}),
+            ...(flags.emailDomains !== undefined
+                ? {
+                      email_domains: flags.emailDomains.map((d) =>
+                          d.toLowerCase(),
+                      ),
+                  }
+                : {}),
+            ...(flags.allowPassword !== undefined
+                ? { allow_password: flags.allowPassword }
+                : {}),
+            created_by_user_uuid: userUuid,
+            updated_by_user_uuid: userUuid,
+        };
+        await this.database(OrganizationSsoConfigurationsTableName)
+            .insert(insert)
+            .onConflict(['organization_uuid', 'provider'])
+            .merge({
+                config: encrypted,
+                ...(flags.enabled !== undefined
+                    ? { enabled: flags.enabled }
+                    : {}),
+                ...(flags.overrideEmailDomains !== undefined
+                    ? { override_email_domains: flags.overrideEmailDomains }
+                    : {}),
+                ...(flags.emailDomains !== undefined
+                    ? {
+                          email_domains: flags.emailDomains.map((d) =>
+                              d.toLowerCase(),
+                          ),
+                      }
+                    : {}),
+                ...(flags.allowPassword !== undefined
+                    ? { allow_password: flags.allowPassword }
+                    : {}),
+                updated_at: new Date(),
+                updated_by_user_uuid: userUuid,
+            });
+    }
+
+    async delete(
+        organizationUuid: string,
+        provider: OrganizationSsoProvider,
+    ): Promise<void> {
+        await this.database(OrganizationSsoConfigurationsTableName)
+            .where('organization_uuid', organizationUuid)
+            .where('provider', provider)
+            .delete();
+    }
+}

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -15,6 +15,10 @@ import {
     storeSlackContext,
 } from '../controllers/authentication';
 import {
+    createAzureAdOidcStrategyForConfig,
+    isAzureAdPassportStrategyAvailableToUse,
+} from '../controllers/authentication/strategies/azureStrategy';
+import {
     createDatabricksStrategy,
     databricksPassportStrategy,
     getDatabricksOidcEndpointsFromHost,
@@ -149,6 +153,62 @@ const getOrCreateDatabricksStrategy = (
     return strategyName;
 };
 
+// Cache dynamic Azure AD strategies to avoid leaking memory by registering a
+// new passport strategy on every request. Strategies are evicted after 10
+// minutes so rotated client secrets are eventually picked up.
+const AZURE_AD_STRATEGY_TTL_MS = 10 * 60 * 1000;
+const azureAdStrategyCache = new Map<
+    string,
+    { timer: ReturnType<typeof setTimeout> }
+>();
+
+const registerAzureAdStrategyForOrg = (
+    organizationUuid: string,
+    config: import('@lightdash/common').AzureAdSsoConfig,
+): string => {
+    const strategyName = `azuread:${organizationUuid}`;
+    const existing = azureAdStrategyCache.get(strategyName);
+    // Always re-register so config changes (e.g. rotated secret) take effect.
+    passport.use(strategyName, createAzureAdOidcStrategyForConfig(config));
+    if (existing) {
+        clearTimeout(existing.timer);
+    }
+    const timer = setTimeout(() => {
+        azureAdStrategyCache.delete(strategyName);
+        passport.unuse(strategyName);
+    }, AZURE_AD_STRATEGY_TTL_MS);
+    azureAdStrategyCache.set(strategyName, { timer });
+    return strategyName;
+};
+
+/**
+ * Resolves the right Azure AD strategy name for this request and registers
+ * the strategy dynamically. Returns undefined if no Azure config is available
+ * (neither per-org DB config matching the email domain nor an env-based
+ * fallback).
+ */
+const resolveAzureAdStrategyName = async (
+    req: express.Request,
+): Promise<string | undefined> => {
+    const ssoService = req.services.getOrganizationSsoService();
+    const email = getLoginHint(req);
+
+    if (email) {
+        const method = await ssoService.findEnabledAzureAdMethodForEmail(email);
+        if (method) {
+            return registerAzureAdStrategyForOrg(
+                method.organizationUuid,
+                method.config,
+            );
+        }
+    }
+    // Fall back to the env-based strategy registered at startup, if available.
+    if (isAzureAdPassportStrategyAvailableToUse) {
+        return 'azuread';
+    }
+    return undefined;
+};
+
 const authenticateDatabricks = (
     getAuthenticateOptions?: (
         req: express.Request,
@@ -255,17 +315,75 @@ apiV1Router.get(lightdashConfig.auth.okta.callbackPath, (req, res, next) =>
 apiV1Router.get(
     lightdashConfig.auth.azuread.loginPath,
     storeOIDCRedirect,
-    passport.authenticate('azuread', {
-        scope: ['openid', 'profile', 'email'].join(' '),
-    }),
+    async (req, res, next) => {
+        try {
+            const strategyName = await resolveAzureAdStrategyName(req);
+            if (!strategyName) {
+                res.status(404).json({
+                    status: 'error',
+                    message: 'Azure AD SSO is not configured',
+                });
+                return;
+            }
+            req.session.oauth = req.session.oauth || {};
+            req.session.oauth.azureAdStrategyName = strategyName;
+            const loginHint = getLoginHint(req);
+            passport.authenticate(strategyName, {
+                scope: ['openid', 'profile', 'email'].join(' '),
+                // Forward the user's email to Azure as login_hint so Microsoft
+                // surfaces the right account (and re-prompts when its session
+                // cookie holds a different one).
+                ...(loginHint
+                    ? ({ loginHint } as Record<string, unknown>)
+                    : {}),
+            } as passport.AuthenticateOptions)(req, res, next);
+        } catch (error) {
+            next(error);
+        }
+    },
 );
 
-apiV1Router.get(lightdashConfig.auth.azuread.callbackPath, (req, res, next) =>
-    passport.authenticate('azuread', {
-        failureRedirect: getOidcRedirectURL(false)(req),
-        successRedirect: getOidcRedirectURL(true)(req),
-        failureFlash: true,
-    })(req, res, next),
+apiV1Router.get(
+    lightdashConfig.auth.azuread.callbackPath,
+    async (req, res, next) => {
+        try {
+            // Prefer the strategy name stored on the session when login was
+            // initiated; falls back to dynamic resolution (or env) for
+            // resilience against expired sessions.
+            const sessionStrategyName = req.session.oauth?.azureAdStrategyName;
+            const strategyName =
+                sessionStrategyName ?? (await resolveAzureAdStrategyName(req));
+            if (!strategyName) {
+                res.status(404).json({
+                    status: 'error',
+                    message: 'Azure AD SSO is not configured',
+                });
+                return;
+            }
+            // If the strategy name encodes an org but the strategy isn't
+            // currently registered (e.g. server restart between login and
+            // callback), re-register it from the DB config.
+            if (
+                strategyName.startsWith('azuread:') &&
+                !azureAdStrategyCache.has(strategyName)
+            ) {
+                const orgUuid = strategyName.slice('azuread:'.length);
+                const config = await req.services
+                    .getOrganizationSsoService()
+                    .getAzureAdConfigForOrganization(orgUuid);
+                if (config) {
+                    registerAzureAdStrategyForOrg(orgUuid, config);
+                }
+            }
+            passport.authenticate(strategyName, {
+                failureRedirect: getOidcRedirectURL(false)(req),
+                successRedirect: getOidcRedirectURL(true)(req),
+                failureFlash: true,
+            })(req, res, next);
+        } catch (error) {
+            next(error);
+        }
+    },
 );
 
 apiV1Router.get(

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
@@ -1,0 +1,299 @@
+import { subject } from '@casl/ability';
+import {
+    AzureAdSsoConfig,
+    AzureAdSsoConfigSummary,
+    FeatureFlags,
+    ForbiddenError,
+    NotFoundError,
+    OrganizationSsoMethodFlags,
+    OrganizationSsoProvider,
+    ParameterError,
+    UpsertAzureAdSsoConfig,
+    type RegisteredAccount,
+} from '@lightdash/common';
+import { LightdashConfig } from '../../config/parseConfig';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
+import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
+import {
+    OrganizationSsoMethod,
+    OrganizationSsoModel,
+} from '../../models/OrganizationSsoModel';
+import { UserModel } from '../../models/UserModel';
+import { BaseService } from '../BaseService';
+
+type OrganizationSsoServiceArguments = {
+    lightdashConfig: LightdashConfig;
+    organizationSsoModel: OrganizationSsoModel;
+    organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
+    featureFlagModel: FeatureFlagModel;
+    userModel: UserModel;
+};
+
+const toSummary = (
+    method: OrganizationSsoMethod<OrganizationSsoProvider.AZUREAD>,
+): AzureAdSsoConfigSummary => ({
+    oauth2ClientId: method.config.oauth2ClientId,
+    oauth2TenantId: method.config.oauth2TenantId,
+    hasClientSecret: !!method.config.oauth2ClientSecret,
+    enabled: method.enabled,
+    overrideEmailDomains: method.overrideEmailDomains,
+    emailDomains: method.emailDomains,
+    allowPassword: method.allowPassword,
+});
+
+export class OrganizationSsoService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly organizationSsoModel: OrganizationSsoModel;
+
+    private readonly organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
+
+    private readonly featureFlagModel: FeatureFlagModel;
+
+    private readonly userModel: UserModel;
+
+    constructor({
+        lightdashConfig,
+        organizationSsoModel,
+        organizationAllowedEmailDomainsModel,
+        featureFlagModel,
+        userModel,
+    }: OrganizationSsoServiceArguments) {
+        super({ serviceName: 'OrganizationSsoService' });
+        this.lightdashConfig = lightdashConfig;
+        this.organizationSsoModel = organizationSsoModel;
+        this.organizationAllowedEmailDomainsModel =
+            organizationAllowedEmailDomainsModel;
+        this.featureFlagModel = featureFlagModel;
+        this.userModel = userModel;
+    }
+
+    private async assertFeatureEnabled(
+        account: RegisteredAccount,
+    ): Promise<void> {
+        const flag = await this.featureFlagModel.get({
+            user: {
+                userUuid: account.user.userUuid,
+                organizationUuid: account.organization?.organizationUuid,
+                organizationName: account.organization?.name,
+            },
+            featureFlagId: FeatureFlags.SsoOrganizationSettings,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError(
+                'Per-organization SSO settings are not enabled for this organization',
+            );
+        }
+    }
+
+    /**
+     * Domains no single organization should ever be able to claim.
+     * Not exhaustive — covers the obvious public providers and corporate
+     * domains we know can't legitimately belong to a single Lightdash org.
+     */
+    private static readonly DISALLOWED_DOMAINS = new Set([
+        'gmail.com',
+        'googlemail.com',
+        'google.com',
+        'microsoft.com',
+        'onmicrosoft.com',
+        'outlook.com',
+        'hotmail.com',
+        'live.com',
+        'yahoo.com',
+        'icloud.com',
+    ]);
+
+    private static validateEmailDomains(domains: string[]): void {
+        const normalized = domains.map((d) => d.trim().toLowerCase());
+
+        // Basic shape check — protects against typos like trailing dots or
+        // whitespace inside the domain.
+        const invalid = normalized.filter(
+            (d) =>
+                !/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(
+                    d,
+                ),
+        );
+        if (invalid.length > 0) {
+            throw new ParameterError(
+                `Invalid email domain format: ${invalid.join(', ')}`,
+            );
+        }
+
+        const disallowed = normalized.filter((d) =>
+            OrganizationSsoService.DISALLOWED_DOMAINS.has(d),
+        );
+        if (disallowed.length > 0) {
+            throw new ParameterError(
+                `These domains can't be claimed: ${disallowed.join(
+                    ', ',
+                )}. Use a domain or subdomain that identifies your organization.`,
+            );
+        }
+    }
+
+    private assertCanManageSso(account: RegisteredAccount): string {
+        const organizationUuid = account.organization?.organizationUuid;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return organizationUuid;
+    }
+
+    async getAzureAdConfig(
+        account: RegisteredAccount,
+    ): Promise<AzureAdSsoConfigSummary | null> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageSso(account);
+        const method = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.AZUREAD,
+        );
+        return method ? toSummary(method) : null;
+    }
+
+    async upsertAzureAdConfig(
+        account: RegisteredAccount,
+        data: UpsertAzureAdSsoConfig,
+    ): Promise<AzureAdSsoConfigSummary> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageSso(account);
+
+        if (!data.oauth2ClientId?.trim() || !data.oauth2TenantId?.trim()) {
+            throw new ParameterError(
+                'oauth2ClientId and oauth2TenantId are required',
+            );
+        }
+
+        if (data.emailDomains && data.emailDomains.length > 0) {
+            OrganizationSsoService.validateEmailDomains(data.emailDomains);
+        }
+
+        const existing = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.AZUREAD,
+        );
+
+        const clientSecret =
+            data.oauth2ClientSecret?.trim() ||
+            existing?.config.oauth2ClientSecret;
+        if (!clientSecret) {
+            throw new ParameterError('oauth2ClientSecret is required');
+        }
+
+        const config: AzureAdSsoConfig = {
+            oauth2ClientId: data.oauth2ClientId.trim(),
+            oauth2ClientSecret: clientSecret,
+            oauth2TenantId: data.oauth2TenantId.trim(),
+        };
+
+        const flags: Partial<OrganizationSsoMethodFlags> = {
+            enabled: data.enabled,
+            overrideEmailDomains: data.overrideEmailDomains,
+            emailDomains: data.emailDomains,
+            allowPassword: data.allowPassword,
+        };
+
+        await this.organizationSsoModel.upsert(
+            organizationUuid,
+            OrganizationSsoProvider.AZUREAD,
+            config,
+            flags,
+            account.user.userUuid,
+        );
+
+        const refreshed = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.AZUREAD,
+        );
+        if (!refreshed) {
+            throw new Error('Failed to read back upserted SSO configuration');
+        }
+        return toSummary(refreshed);
+    }
+
+    async deleteAzureAdConfig(account: RegisteredAccount): Promise<void> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageSso(account);
+        const existing = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.AZUREAD,
+        );
+        if (!existing) {
+            throw new NotFoundError('No Azure AD SSO configuration found');
+        }
+        await this.organizationSsoModel.delete(
+            organizationUuid,
+            OrganizationSsoProvider.AZUREAD,
+        );
+    }
+
+    /**
+     * Returns enabled SSO methods (DB-stored, per-org) whose effective
+     * whitelist matches the given email's domain.
+     *
+     * Security: when the email belongs to an existing Lightdash user, the
+     * returned set is filtered to orgs the user already belongs to —
+     * preventing a malicious admin of another org from re-routing the
+     * user's login flow to their tenant via a hijacked domain claim.
+     */
+    async findEnabledMethodsForEmail(
+        email: string,
+    ): Promise<OrganizationSsoMethod<OrganizationSsoProvider>[]> {
+        const domain = email.split('@')[1]?.toLowerCase();
+        if (!domain) return [];
+        const matches =
+            await this.organizationSsoModel.findEnabledMethodsForEmailDomain(
+                domain,
+            );
+        if (matches.length === 0) return matches;
+
+        const existingUser = await this.userModel.findUserByEmail(email);
+        if (!existingUser) return matches; // brand-new user → see all matches
+
+        const userOrgs = await this.userModel.getOrganizationsForUser(
+            existingUser.userUuid,
+        );
+        const userOrgUuids = new Set(userOrgs.map((o) => o.organizationUuid));
+        return matches.filter((m) => userOrgUuids.has(m.organizationUuid));
+    }
+
+    /**
+     * Returns the full Azure AD config for a specific org (DB only, no fallback).
+     */
+    async getAzureAdConfigForOrganization(
+        organizationUuid: string,
+    ): Promise<AzureAdSsoConfig | undefined> {
+        const method = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.AZUREAD,
+        );
+        return method?.config;
+    }
+
+    /**
+     * Returns the first enabled per-org Azure AD method whose whitelist
+     * matches the email's domain. Used by the login/callback routes.
+     */
+    async findEnabledAzureAdMethodForEmail(
+        email: string,
+    ): Promise<
+        OrganizationSsoMethod<OrganizationSsoProvider.AZUREAD> | undefined
+    > {
+        const matches = await this.findEnabledMethodsForEmail(email);
+        return matches.find(
+            (m): m is OrganizationSsoMethod<OrganizationSsoProvider.AZUREAD> =>
+                m.provider === OrganizationSsoProvider.AZUREAD,
+        );
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -36,6 +36,7 @@ import { MetricsExplorerService } from './MetricsExplorerService/MetricsExplorer
 import { NotificationsService } from './NotificationsService/NotificationsService';
 import { OAuthService } from './OAuthService/OAuthService';
 import { OrganizationService } from './OrganizationService/OrganizationService';
+import { OrganizationSsoService } from './OrganizationSsoService/OrganizationSsoService';
 import { PermissionsService } from './PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from './PersistentDownloadFileService/PersistentDownloadFileService';
 import { PersonalAccessTokenService } from './PersonalAccessTokenService';
@@ -86,6 +87,7 @@ interface ServiceManifest {
     oauthService: OAuthService;
 
     organizationService: OrganizationService;
+    organizationSsoService: OrganizationSsoService;
     preAggregateMaterializationService: PreAggregateMaterializationService;
     persistentDownloadFileService: PersistentDownloadFileService;
     personalAccessTokenService: PersonalAccessTokenService;
@@ -526,6 +528,21 @@ export class ServiceRepository
         );
     }
 
+    public getOrganizationSsoService(): OrganizationSsoService {
+        return this.getService(
+            'organizationSsoService',
+            () =>
+                new OrganizationSsoService({
+                    lightdashConfig: this.context.lightdashConfig,
+                    organizationSsoModel: this.models.getOrganizationSsoModel(),
+                    organizationAllowedEmailDomainsModel:
+                        this.models.getOrganizationAllowedEmailDomainsModel(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
+                    userModel: this.models.getUserModel(),
+                }),
+        );
+    }
+
     public getPermissionsService(): PermissionsService {
         return this.getService(
             'permissionsService',
@@ -913,6 +930,7 @@ export class ServiceRepository
                         this.models.getPersonalAccessTokenModel(),
                     organizationAllowedEmailDomainsModel:
                         this.models.getOrganizationAllowedEmailDomainsModel(),
+                    organizationSsoModel: this.models.getOrganizationSsoModel(),
                     userWarehouseCredentialsModel:
                         this.models.getUserWarehouseCredentialsModel(),
                     warehouseAvailableTablesModel:

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -20,6 +20,7 @@ import { OpenIdIdentityModel } from '../models/OpenIdIdentitiesModel';
 import { OrganizationAllowedEmailDomainsModel } from '../models/OrganizationAllowedEmailDomainsModel';
 import { OrganizationMemberProfileModel } from '../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../models/OrganizationModel';
+import { OrganizationSsoModel } from '../models/OrganizationSsoModel';
 import { PasswordResetLinkModel } from '../models/PasswordResetLinkModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
 import { SessionModel } from '../models/SessionModel';
@@ -96,6 +97,10 @@ const projectModel = {
     ensureDefaultUserSpace: jest.fn(async () => undefined),
 };
 
+const organizationSsoModel = {
+    findEnabledMethodsForEmailDomain: jest.fn(async () => []),
+};
+
 const createUserService = (lightdashConfig: LightdashConfig) =>
     new UserService({
         analytics: analyticsMock,
@@ -114,6 +119,8 @@ const createUserService = (lightdashConfig: LightdashConfig) =>
         personalAccessTokenModel: {} as PersonalAccessTokenModel,
         organizationAllowedEmailDomainsModel:
             {} as OrganizationAllowedEmailDomainsModel,
+        organizationSsoModel:
+            organizationSsoModel as unknown as OrganizationSsoModel,
         userWarehouseCredentialsModel: {} as UserWarehouseCredentialsModel,
         warehouseAvailableTablesModel: {} as WarehouseAvailableTablesModel,
         projectModel: projectModel as unknown as ProjectModel,
@@ -320,6 +327,273 @@ describe('UserService', () => {
             forceRedirect: false,
             redirectUri: undefined,
             showOptions: ['google', 'azuread', 'oneLogin', 'okta'],
+        });
+    });
+
+    describe('getLoginOptions per-org SSO discovery', () => {
+        const azureMethod = {
+            organizationUuid: 'org-1',
+            provider: OpenIdIdentityIssuerType.AZUREAD as unknown as never,
+            config: {
+                oauth2ClientId: 'cid',
+                oauth2ClientSecret: 'sec',
+                oauth2TenantId: 'tid',
+            },
+            enabled: true,
+            overrideEmailDomains: false,
+            emailDomains: [],
+            allowPassword: true,
+        };
+        const googleMethod = {
+            ...azureMethod,
+            provider: OpenIdIdentityIssuerType.GOOGLE as unknown as never,
+        };
+
+        const configWithGoogleEnv: LightdashConfig = {
+            ...lightdashConfigMock,
+            auth: {
+                ...lightdashConfigMock.auth,
+                google: {
+                    ...lightdashConfigMock.auth.google,
+                    enabled: true,
+                    loginPath: '/login/google',
+                },
+                azuread: {
+                    ...lightdashConfigMock.auth.azuread,
+                    loginPath: '/login/azuread',
+                },
+            },
+        };
+
+        test('no per-org match → instance defaults shown', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([]);
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('user@unknown.com')).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                showOptions: ['email', 'google'],
+            });
+        });
+
+        test('per-org Azure match suppresses instance Google (returning user with password)', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([azureMethod]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                true,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('user@acme.com')).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                showOptions: ['email', 'azuread'],
+            });
+        });
+
+        test('per-org Azure match + allow_password=false hides password input', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([{ ...azureMethod, allowPassword: false }]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                true,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('user@acme.com')).toEqual({
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/azuread?login_hint=user%40acme.com',
+                showOptions: ['azuread'],
+            });
+        });
+
+        test('brand-new user matching per-org Azure → forceRedirect with login_hint', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([azureMethod]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                false,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('newbie@acme.com')).toEqual({
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/azuread?login_hint=newbie%40acme.com',
+                showOptions: ['azuread'],
+            });
+        });
+
+        test('multiple per-org matches → both buttons, no forceRedirect', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([
+                { ...azureMethod, allowPassword: false },
+                googleMethod,
+            ]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                true,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            // Lenient password rule: googleMethod.allowPassword=true → password shown
+            expect(await service.getLoginOptions('user@acme.com')).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                showOptions: ['email', 'azuread', 'google'],
+            });
+        });
+
+        test('multiple per-org matches all allow_password=false → no password input', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([
+                { ...azureMethod, allowPassword: false },
+                { ...googleMethod, allowPassword: false },
+            ]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                true,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('user@acme.com')).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                showOptions: ['azuread', 'google'],
+            });
+        });
+
+        test("returning user's prior Google identity is ignored when per-org Azure matches", async () => {
+            // Org migrated from instance Google to per-org Azure.
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([azureMethod]);
+            (userModel.getOpenIdIssuers as jest.Mock).mockResolvedValueOnce([
+                OpenIdIdentityIssuerType.GOOGLE,
+            ]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                false,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('user@acme.com')).toEqual({
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/azuread?login_hint=user%40acme.com',
+                showOptions: ['azuread'],
+            });
+        });
+
+        test('returning user with linked SSO and password → single OIDC still forceRedirects (no other SSO option to show)', async () => {
+            // hasPassword=false, only one OIDC option (Azure), no password input
+            // ⇒ truly one option ⇒ forceRedirect
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([azureMethod]);
+            (userModel.getOpenIdIssuers as jest.Mock).mockResolvedValueOnce([
+                OpenIdIdentityIssuerType.AZUREAD,
+            ]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                false,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('user@acme.com')).toEqual({
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/azuread?login_hint=user%40acme.com',
+                showOptions: ['azuread'],
+            });
+        });
+
+        test('no email → returns instance defaults, no SSO lookup', async () => {
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions()).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                showOptions: ['email', 'google'],
+            });
+            expect(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('existing user in a DIFFERENT org → per-org SSO method is filtered out (cross-org hijack defence)', async () => {
+            // The Azure SSO row belongs to org-1, but the user is in org-2.
+            // Without filtering, an attacker org could redirect this user's
+            // SSO flow to their tenant.
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([azureMethod]); // org-1
+            (userModel.findUserByEmail as jest.Mock).mockResolvedValueOnce({
+                userUuid: 'victim-uuid',
+                email: 'victim@acme.com',
+            });
+            (
+                userModel.getOrganizationsForUser as jest.Mock
+            ).mockResolvedValueOnce([
+                { organizationUuid: 'org-2', organizationName: 'Victim Org' },
+            ]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                true,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('victim@acme.com')).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                // No Azure — the matching method belonged to a different org
+                showOptions: ['email'],
+            });
+        });
+
+        test('existing user in the SAME org → per-org SSO method is kept', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([azureMethod]); // org-1
+            (userModel.findUserByEmail as jest.Mock).mockResolvedValueOnce({
+                userUuid: 'member-uuid',
+                email: 'member@acme.com',
+            });
+            (
+                userModel.getOrganizationsForUser as jest.Mock
+            ).mockResolvedValueOnce([
+                { organizationUuid: 'org-1', organizationName: 'Acme Org' },
+            ]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                true,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('member@acme.com')).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                showOptions: ['email', 'azuread'],
+            });
+        });
+
+        test('brand-new user (no Lightdash account) → cross-org filter does not apply, discovery as normal', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([azureMethod]);
+            (userModel.findUserByEmail as jest.Mock).mockResolvedValueOnce(
+                undefined,
+            );
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                false,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('newcomer@acme.com')).toEqual({
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/azuread?login_hint=newcomer%40acme.com',
+                showOptions: ['azuread'],
+            });
         });
     });
 
@@ -532,6 +806,11 @@ describe('UserService', () => {
                 personalAccessTokenModel: {} as PersonalAccessTokenModel,
                 organizationAllowedEmailDomainsModel:
                     {} as OrganizationAllowedEmailDomainsModel,
+                organizationSsoModel: {
+                    findOrganizationUuidByProviderAndEmailDomain: jest.fn(
+                        async () => undefined,
+                    ),
+                } as unknown as OrganizationSsoModel,
                 userWarehouseCredentialsModel:
                     {} as UserWarehouseCredentialsModel,
                 warehouseAvailableTablesModel:
@@ -590,6 +869,11 @@ describe('UserService', () => {
                 personalAccessTokenModel: {} as PersonalAccessTokenModel,
                 organizationAllowedEmailDomainsModel:
                     {} as OrganizationAllowedEmailDomainsModel,
+                organizationSsoModel: {
+                    findOrganizationUuidByProviderAndEmailDomain: jest.fn(
+                        async () => undefined,
+                    ),
+                } as unknown as OrganizationSsoModel,
                 userWarehouseCredentialsModel:
                     {} as UserWarehouseCredentialsModel,
                 warehouseAvailableTablesModel:

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -78,6 +78,7 @@ import { OpenIdIdentityModel } from '../models/OpenIdIdentitiesModel';
 import { OrganizationAllowedEmailDomainsModel } from '../models/OrganizationAllowedEmailDomainsModel';
 import { OrganizationMemberProfileModel } from '../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../models/OrganizationModel';
+import { OrganizationSsoModel } from '../models/OrganizationSsoModel';
 import { PasswordResetLinkModel } from '../models/PasswordResetLinkModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
 import { SessionModel } from '../models/SessionModel';
@@ -103,6 +104,7 @@ type UserServiceArguments = {
     organizationModel: OrganizationModel;
     personalAccessTokenModel: PersonalAccessTokenModel;
     organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
+    organizationSsoModel: OrganizationSsoModel;
     userWarehouseCredentialsModel: UserWarehouseCredentialsModel;
     warehouseAvailableTablesModel: WarehouseAvailableTablesModel;
     projectModel: ProjectModel;
@@ -200,6 +202,8 @@ export class UserService extends BaseService {
 
     private readonly organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
 
+    private readonly organizationSsoModel: OrganizationSsoModel;
+
     private readonly userWarehouseCredentialsModel: UserWarehouseCredentialsModel;
 
     private readonly warehouseAvailableTablesModel: WarehouseAvailableTablesModel;
@@ -225,6 +229,7 @@ export class UserService extends BaseService {
         organizationMemberProfileModel,
         personalAccessTokenModel,
         organizationAllowedEmailDomainsModel,
+        organizationSsoModel,
         userWarehouseCredentialsModel,
         warehouseAvailableTablesModel,
         projectModel,
@@ -245,6 +250,7 @@ export class UserService extends BaseService {
         this.personalAccessTokenModel = personalAccessTokenModel;
         this.organizationAllowedEmailDomainsModel =
             organizationAllowedEmailDomainsModel;
+        this.organizationSsoModel = organizationSsoModel;
         this.userWarehouseCredentialsModel = userWarehouseCredentialsModel;
         this.warehouseAvailableTablesModel = warehouseAvailableTablesModel;
         this.projectModel = projectModel;
@@ -2427,18 +2433,84 @@ export class UserService extends BaseService {
             };
         }
 
-        const openIdIssuers = await this.userModel.getOpenIdIssuers(email);
-        const hasPassword = await this.userModel.hasPasswordByEmail(email);
-        const userOptions = hasPassword
-            ? [LocalIssuerTypes.EMAIL, ...openIdIssuers]
-            : openIdIssuers;
-        // Filter out the options that are not available for the instance. eg: user connected to google drive but google auth is not enabled
-        const validUserOptions = userOptions.filter((option) =>
-            instancesOptions.has(option),
+        // Discover all enabled per-org SSO methods whose effective whitelist
+        // matches the email's domain. When any per-org method matches, it
+        // takes precedence over instance-level SSO providers for this user.
+        const domain = email.split('@')[1]?.toLowerCase();
+        const allMatchingMethods = domain
+            ? await this.organizationSsoModel.findEnabledMethodsForEmailDomain(
+                  domain,
+              )
+            : [];
+
+        // Security: if the email belongs to an existing Lightdash user, only
+        // surface SSO methods from orgs they actually belong to. Prevents a
+        // malicious admin of org B from silently re-routing org A's existing
+        // users to their own Azure tenant by claiming the domain. Brand-new
+        // users (no account yet) still see all matching methods — the
+        // upstream feature flag + ops vetting is the gate for that case.
+        const existingUser = await this.userModel.findUserByEmail(email);
+        let matchingPerOrgMethods = allMatchingMethods;
+        if (existingUser) {
+            const userOrgs = await this.userModel.getOrganizationsForUser(
+                existingUser.userUuid,
+            );
+            const userOrgUuids = new Set(
+                userOrgs.map((o) => o.organizationUuid),
+            );
+            matchingPerOrgMethods = allMatchingMethods.filter((m) =>
+                userOrgUuids.has(m.organizationUuid),
+            );
+        }
+
+        // Each SSO provider enum value maps 1:1 to its OpenIdIdentityIssuerType
+        // string (e.g. 'azuread'); funnel through unknown to satisfy TS.
+        const matchingPerOrgProviders = new Set<OpenIdIdentityIssuerType>(
+            matchingPerOrgMethods.map(
+                (m) => m.provider as unknown as OpenIdIdentityIssuerType,
+            ),
         );
 
-        // if user has no valid options, return instance options
-        if (validUserOptions.length === 0) {
+        const openIdIssuers = await this.userModel.getOpenIdIssuers(email);
+        const hasPassword = await this.userModel.hasPasswordByEmail(email);
+
+        let ssoOptionsForUser: OpenIdIdentityIssuerType[];
+        let passwordAllowedForUser: boolean;
+
+        if (matchingPerOrgMethods.length > 0) {
+            // Per-org SSO suppresses instance-level SSO providers for this
+            // email's domain. Only the matching per-org methods are offered.
+            ssoOptionsForUser = Array.from(matchingPerOrgProviders);
+            // Password visibility is governed by the SSO rows: lenient rule
+            // — ANY matching method that permits password → show password.
+            passwordAllowedForUser = matchingPerOrgMethods.some(
+                (m) => m.allowPassword,
+            );
+        } else {
+            // No per-org SSO matches: instance-level behavior preserved.
+            // Show OIDC issuers the user has previously linked (filtered to
+            // instance-supported providers).
+            ssoOptionsForUser = openIdIssuers.filter((o) =>
+                instancesOptions.has(o),
+            );
+            passwordAllowedForUser = true;
+        }
+
+        const showOptions: LoginOptionTypes[] = [...ssoOptionsForUser];
+        if (
+            passwordAllowedForUser &&
+            hasPassword &&
+            instancesOptions.has(LocalIssuerTypes.EMAIL)
+        ) {
+            showOptions.unshift(LocalIssuerTypes.EMAIL);
+        }
+
+        // If the precheck yielded nothing for this email, fall back to
+        // instance-level options so the user isn't shown an empty form.
+        // This branch only fires when no per-org SSO matched and the user
+        // has no linked identity or password — i.e. they're effectively a
+        // new signup.
+        if (showOptions.length === 0) {
             return {
                 showOptions: Array.from(instancesOptions),
                 forceRedirect: false,
@@ -2446,11 +2518,14 @@ export class UserService extends BaseService {
             };
         }
 
-        const oidcOptions = validUserOptions.filter(isOpenIdIdentityIssuerType);
-        if (oidcOptions.length === 1) {
-            // Force redirect to the only issuer option
+        const oidcOptions = showOptions.filter(isOpenIdIdentityIssuerType);
+        // Auto-redirect when there is genuinely a single option (one OIDC
+        // provider, no password input). Wrong-account loops are mitigated
+        // by forwarding `login_hint` to the provider so the right account
+        // is surfaced.
+        if (oidcOptions.length === 1 && showOptions.length === 1) {
             return {
-                showOptions: validUserOptions,
+                showOptions,
                 forceRedirect: true,
                 redirectUri: new URL(
                     `/api/v1${this.getRedirectUri(
@@ -2461,7 +2536,7 @@ export class UserService extends BaseService {
             };
         }
         return {
-            showOptions: validUserOptions,
+            showOptions,
             forceRedirect: false,
             redirectUri: undefined,
         };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -132,6 +132,7 @@ export * from './types/oauth';
 export * from './types/openIdIdentity';
 export * from './types/organization';
 export * from './types/organizationMemberProfile';
+export * from './types/organizationSso';
 export * from './types/organizationWarehouseCredentials';
 export * from './types/paginateResults';
 export * from './types/parameters';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -144,6 +144,7 @@ import {
     type OrganizationMemberProfile,
     type OrganizationMemberRole,
 } from './organizationMemberProfile';
+import { type AzureAdSsoConfigSummary } from './organizationSso';
 import type { ResultsPaginationMetadata } from './paginateResults';
 import type { ParametersValuesMap } from './parameters';
 import {
@@ -917,6 +918,7 @@ type ApiResults =
     | FieldValueSearchResult
     | ApiDownloadCsv
     | AllowedEmailDomains
+    | AzureAdSsoConfigSummary
     | UpdateAllowedEmailDomains
     | UserAllowedOrganization[]
     | EmailStatusExpiring

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -112,6 +112,14 @@ export enum FeatureFlags {
      * already saved with the hexbin layer continue to render either way.
      */
     HexbinMap = 'hexbin-map',
+
+    /**
+     * Show the per-organization Single Sign-On settings panel (Azure AD and
+     * future SSO providers). Off by default while the domain-claim trust
+     * model is hardened — see security review notes. Enable per-org for
+     * vetted customers on shared multi-org instances.
+     */
+    SsoOrganizationSettings = 'sso-organization-settings',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/organizationSso.ts
+++ b/packages/common/src/types/organizationSso.ts
@@ -1,0 +1,65 @@
+export enum OrganizationSsoProvider {
+    AZUREAD = 'azuread',
+}
+
+export const isOrganizationSsoProvider = (
+    value: string,
+): value is OrganizationSsoProvider =>
+    Object.values(OrganizationSsoProvider).includes(
+        value as OrganizationSsoProvider,
+    );
+
+export type AzureAdSsoConfig = {
+    oauth2ClientId: string;
+    oauth2ClientSecret: string;
+    oauth2TenantId: string;
+};
+
+/**
+ * Per-row flags shared by every SSO method configured at the org level.
+ * Stored as plain columns alongside the encrypted provider-specific config.
+ */
+export type OrganizationSsoMethodFlags = {
+    /** When false the method is hidden from precheck even if discovery would match. */
+    enabled: boolean;
+    /**
+     * When true, the method's own `emailDomains` list governs discovery.
+     * When false, the org's `allowed_email_domains` is used instead.
+     */
+    overrideEmailDomains: boolean;
+    /** Strict whitelist (only consulted when `overrideEmailDomains` is true). */
+    emailDomains: string[];
+    /**
+     * Controls whether email+password sign-in is shown alongside this method
+     * when it matches a user. When multiple matching SSO methods disagree,
+     * lenient rule applies (ANY method that allows → show password).
+     */
+    allowPassword: boolean;
+};
+
+export type AzureAdSsoConfigSummary = Pick<
+    AzureAdSsoConfig,
+    'oauth2ClientId' | 'oauth2TenantId'
+> &
+    OrganizationSsoMethodFlags & {
+        hasClientSecret: boolean;
+    };
+
+export type UpsertAzureAdSsoConfig = {
+    oauth2ClientId: string;
+    /**
+     * When omitted on update, the stored secret is preserved. Required on create.
+     */
+    oauth2ClientSecret?: string;
+    oauth2TenantId: string;
+} & Partial<OrganizationSsoMethodFlags>;
+
+export type ApiAzureAdSsoConfigResponse = {
+    status: 'ok';
+    results: AzureAdSsoConfigSummary | null;
+};
+
+export type ApiUpsertAzureAdSsoConfigResponse = {
+    status: 'ok';
+    results: AzureAdSsoConfigSummary;
+};

--- a/packages/frontend/src/components/UserSettings/OrganizationSsoPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSsoPanel/index.tsx
@@ -1,0 +1,272 @@
+import {
+    Button,
+    Checkbox,
+    Group,
+    LoadingOverlay,
+    PasswordInput,
+    Stack,
+    Switch,
+    TagsInput,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconShieldCheck, IconTrash } from '@tabler/icons-react';
+import { useEffect, useState, type FC } from 'react';
+import { useAllowedEmailDomains } from '../../../hooks/organization/useAllowedDomains';
+import {
+    useAzureAdSsoConfig,
+    useDeleteAzureAdSsoConfig,
+    useUpsertAzureAdSsoConfig,
+} from '../../../hooks/organization/useOrganizationSso';
+import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
+
+type FormValues = {
+    oauth2ClientId: string;
+    oauth2ClientSecret: string;
+    oauth2TenantId: string;
+    enabled: boolean;
+    overrideEmailDomains: boolean;
+    emailDomains: string[];
+    allowPassword: boolean;
+};
+
+const OrganizationSsoPanel: FC = () => {
+    const { data: existing, isLoading } = useAzureAdSsoConfig();
+    const { data: allowedEmailDomains } = useAllowedEmailDomains();
+    const upsert = useUpsertAzureAdSsoConfig();
+    const deleteConfig = useDeleteAzureAdSsoConfig();
+    const [deleteOpen, setDeleteOpen] = useState(false);
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            oauth2ClientId: '',
+            oauth2ClientSecret: '',
+            oauth2TenantId: '',
+            enabled: true,
+            overrideEmailDomains: false,
+            emailDomains: [],
+            allowPassword: true,
+        },
+        validate: {
+            oauth2ClientId: (value) =>
+                value.trim().length === 0 ? 'Client ID is required' : null,
+            oauth2TenantId: (value) =>
+                value.trim().length === 0 ? 'Tenant ID is required' : null,
+            oauth2ClientSecret: (value) =>
+                !existing && value.trim().length === 0
+                    ? 'Client secret is required'
+                    : null,
+            emailDomains: (value, values) =>
+                values.overrideEmailDomains && value.length === 0
+                    ? 'Add at least one domain when override is enabled'
+                    : null,
+        },
+    });
+
+    useEffect(() => {
+        form.setValues({
+            oauth2ClientId: existing?.oauth2ClientId ?? '',
+            oauth2ClientSecret: '',
+            oauth2TenantId: existing?.oauth2TenantId ?? '',
+            enabled: existing?.enabled ?? true,
+            overrideEmailDomains: existing?.overrideEmailDomains ?? false,
+            emailDomains: existing?.emailDomains ?? [],
+            allowPassword: existing?.allowPassword ?? true,
+        });
+        form.resetDirty();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        existing?.oauth2ClientId,
+        existing?.oauth2TenantId,
+        existing?.enabled,
+        existing?.overrideEmailDomains,
+        existing?.emailDomains,
+        existing?.allowPassword,
+    ]);
+
+    const orgDomains = allowedEmailDomains?.emailDomains ?? [];
+
+    const handleSubmit = form.onSubmit((values) => {
+        upsert.mutate({
+            oauth2ClientId: values.oauth2ClientId.trim(),
+            oauth2TenantId: values.oauth2TenantId.trim(),
+            enabled: values.enabled,
+            overrideEmailDomains: values.overrideEmailDomains,
+            emailDomains: values.emailDomains.map((d) =>
+                d.trim().toLowerCase(),
+            ),
+            allowPassword: values.allowPassword,
+            ...(values.oauth2ClientSecret.trim().length > 0
+                ? { oauth2ClientSecret: values.oauth2ClientSecret.trim() }
+                : {}),
+        });
+    });
+
+    return (
+        <Stack pos="relative" mb="lg">
+            <LoadingOverlay visible={isLoading} />
+            <Group justify="space-between" align="flex-start">
+                <Stack gap="xs">
+                    <Title order={5}>Azure Active Directory</Title>
+                    <Text c="dimmed" size="sm">
+                        Enable Azure AD single sign-on for users in this
+                        organization. Users whose email matches the discovery
+                        whitelist will see a "Sign in with Microsoft" button on
+                        the login page; instance-level SSO providers are
+                        suppressed for matched users.
+                    </Text>
+                </Stack>
+                <Switch
+                    label="Enabled"
+                    checked={form.values.enabled}
+                    onChange={(event) =>
+                        form.setFieldValue(
+                            'enabled',
+                            event.currentTarget.checked,
+                        )
+                    }
+                />
+            </Group>
+
+            <form onSubmit={handleSubmit}>
+                <Stack>
+                    <Title order={6} mt="md">
+                        Application credentials
+                    </Title>
+                    <TextInput
+                        label="Application (client) ID"
+                        placeholder="00000000-0000-0000-0000-000000000000"
+                        description="From the Azure AD application's overview page."
+                        required
+                        {...form.getInputProps('oauth2ClientId')}
+                    />
+                    <TextInput
+                        label="Directory (tenant) ID"
+                        placeholder="00000000-0000-0000-0000-000000000000"
+                        description="From the Azure AD application's overview page."
+                        required
+                        {...form.getInputProps('oauth2TenantId')}
+                    />
+                    <PasswordInput
+                        label="Client secret"
+                        placeholder={
+                            existing
+                                ? 'Leave blank to keep the existing secret'
+                                : 'Azure AD client secret value'
+                        }
+                        description="The secret value from Azure AD (not the secret ID)."
+                        required={!existing}
+                        {...form.getInputProps('oauth2ClientSecret')}
+                    />
+
+                    <Title order={6} mt="md">
+                        Discovery
+                    </Title>
+                    <Checkbox
+                        label="Override organization's allowed email domains"
+                        description="When unchecked, users matching any of the organization's allowed email domains see this method."
+                        checked={form.values.overrideEmailDomains}
+                        onChange={(event) =>
+                            form.setFieldValue(
+                                'overrideEmailDomains',
+                                event.currentTarget.checked,
+                            )
+                        }
+                    />
+                    {form.values.overrideEmailDomains ? (
+                        <TagsInput
+                            label="Email domains for this method"
+                            description="Only users whose email domain matches one of these will see Azure AD. Domains are case-insensitive."
+                            placeholder="microsoft.com, contoso.com"
+                            value={form.values.emailDomains}
+                            onChange={(domains) =>
+                                form.setFieldValue('emailDomains', domains)
+                            }
+                            error={form.errors.emailDomains}
+                            clearable
+                        />
+                    ) : (
+                        <Text size="sm" c="dimmed">
+                            Using organization's allowed email domains:{' '}
+                            {orgDomains.length > 0 ? (
+                                <b>{orgDomains.join(', ')}</b>
+                            ) : (
+                                <i>none configured</i>
+                            )}
+                        </Text>
+                    )}
+
+                    <Title order={6} mt="md">
+                        Password sign-in
+                    </Title>
+                    <Checkbox
+                        label="Allow password sign-in for users matching this method"
+                        description="When unchecked, users whose email domain matches Azure AD discovery will not see the password input. Lenient rule: if any matching method allows password, it is shown."
+                        checked={form.values.allowPassword}
+                        onChange={(event) =>
+                            form.setFieldValue(
+                                'allowPassword',
+                                event.currentTarget.checked,
+                            )
+                        }
+                    />
+
+                    <Group justify="space-between" mt="md">
+                        {existing ? (
+                            <Button
+                                variant="outline"
+                                color="red"
+                                leftSection={<MantineIcon icon={IconTrash} />}
+                                onClick={() => setDeleteOpen(true)}
+                            >
+                                Remove configuration
+                            </Button>
+                        ) : (
+                            <div />
+                        )}
+                        <Button
+                            type="submit"
+                            loading={upsert.isLoading}
+                            disabled={upsert.isLoading}
+                        >
+                            {existing ? 'Save changes' : 'Enable Azure AD'}
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+
+            {deleteOpen && (
+                <MantineModal
+                    opened
+                    onClose={() => setDeleteOpen(false)}
+                    title="Remove Azure AD configuration"
+                    icon={IconShieldCheck}
+                    cancelLabel="Cancel"
+                    actions={
+                        <Button
+                            color="red"
+                            loading={deleteConfig.isLoading}
+                            onClick={async () => {
+                                await deleteConfig.mutateAsync();
+                                setDeleteOpen(false);
+                            }}
+                        >
+                            Remove
+                        </Button>
+                    }
+                >
+                    <Text>
+                        After removing this configuration, users in this
+                        organization will no longer be able to sign in with
+                        Azure AD via the per-organization configuration.
+                    </Text>
+                </MantineModal>
+            )}
+        </Stack>
+    );
+};
+
+export default OrganizationSsoPanel;

--- a/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
+++ b/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
@@ -15,6 +15,18 @@ type ThirdPartySignInButtonProps = {
     providerName: OpenIdIdentitySummary['issuerType'];
     // Default redirect is the current window.location.href
     redirect?: string;
+    /**
+     * Email captured during the precheck step. Forwarded as `login_hint` to
+     * the SSO login route so the backend can resolve per-org SSO config by
+     * email domain (and so the provider surfaces the right account).
+     */
+    loginHint?: string;
+    /**
+     * When true, render the button even if the env-level provider gate in
+     * health is disabled. Used for multi-org shared instances where the
+     * decision to show the button comes from per-org login options.
+     */
+    forceShow?: boolean;
 } & ButtonProps;
 
 const ThirdPartySignInButtonBase: FC<
@@ -23,6 +35,7 @@ const ThirdPartySignInButtonBase: FC<
         logo: string | ReactNode;
         providerName: string;
         redirect?: string;
+        loginHint?: string;
     } & Pick<ThirdPartySignInButtonProps, 'inviteCode' | 'intent'> &
         ButtonProps
 > = ({
@@ -32,6 +45,7 @@ const ThirdPartySignInButtonBase: FC<
     providerName,
     intent,
     redirect,
+    loginHint,
     ...props
 }) => {
     return (
@@ -45,6 +59,8 @@ const ThirdPartySignInButtonBase: FC<
                 inviteCode
                     ? `&inviteCode=${encodeURIComponent(inviteCode)}`
                     : ''
+            }${
+                loginHint ? `&login_hint=${encodeURIComponent(loginHint)}` : ''
             }`}
             leftSection={
                 typeof logo === 'string' ? (
@@ -68,6 +84,8 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
     intent = 'signin',
     providerName,
     redirect,
+    loginHint,
+    forceShow,
     ...props
 }) => {
     const { health } = useApp();
@@ -80,6 +98,7 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
                     redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
+                    loginHint={loginHint}
                     providerName="Google"
                     logo="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj48cGF0aCBkPSJNMTcuNiA5LjJsLS4xLTEuOEg5djMuNGg0LjhDMTMuNiAxMiAxMyAxMyAxMiAxMy42djIuMmgzYTguOCA4LjggMCAwIDAgMi42LTYuNnoiIGZpbGw9IiM0Mjg1RjQiIGZpbGwtcnVsZT0ibm9uemVybyIvPjxwYXRoIGQ9Ik05IDE4YzIuNCAwIDQuNS0uOCA2LTIuMmwtMy0yLjJhNS40IDUuNCAwIDAgMS04LTIuOUgxVjEzYTkgOSAwIDAgMCA4IDV6IiBmaWxsPSIjMzRBODUzIiBmaWxsLXJ1bGU9Im5vbnplcm8iLz48cGF0aCBkPSJNNCAxMC43YTUuNCA1LjQgMCAwIDEgMC0zLjRWNUgxYTkgOSAwIDAgMCAwIDhsMy0yLjN6IiBmaWxsPSIjRkJCQzA1IiBmaWxsLXJ1bGU9Im5vbnplcm8iLz48cGF0aCBkPSJNOSAzLjZjMS4zIDAgMi41LjQgMy40IDEuM0wxNSAyLjNBOSA5IDAgMCAwIDEgNWwzIDIuNGE1LjQgNS40IDAgMCAxIDUtMy43eiIgZmlsbD0iI0VBNDMzNSIgZmlsbC1ydWxlPSJub256ZXJvIi8+PHBhdGggZD0iTTAgMGgxOHYxOEgweiIvPjwvZz48L3N2Zz4="
                     {...props}
@@ -93,6 +112,7 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
                     redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
+                    loginHint={loginHint}
                     providerName="Okta"
                     logo="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCI+PHBhdGggZD0iTTMyIDBDMTQuMzcgMCAwIDE0LjI2NyAwIDMyczE0LjI2OCAzMiAzMiAzMiAzMi0xNC4yNjggMzItMzJTNDkuNjMgMCAzMiAwem0wIDQ4Yy04Ljg2NiAwLTE2LTcuMTM0LTE2LTE2czcuMTM0LTE2IDE2LTE2IDE2IDcuMTM0IDE2IDE2LTcuMTM0IDE2LTE2IDE2eiIgZmlsbD0iIzAwN2RjMSIvPjwvc3ZnPg=="
                     {...props}
@@ -105,6 +125,7 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
                     redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
+                    loginHint={loginHint}
                     providerName="OneLogin"
                     logo="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAb8AAAG/CAYAAADIE9lyAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAFXxJREFUeNrs3b9vJOd9wOERoVY61rEOt+kEEQGZIoFVcf+Do4EgXXCrwEiRABFlpEshKpWqiNe4Mqy9pEpsQLzSDgwti+CEqDCvYODOS5yU+qj7A5h5jy/lPYt34pI7M++P5wGIlQHDImfX/PD7zjszr52dnTUAUJM1hwAA8QMA8QMA8QMA8QMA8QMA8QMA8QMA8QMA8QMA8QMA8QMA8QMA8QMA8QMA8QNA/ABA/ABA/ABA/ABA/AAgba87BNCN26ONrfZl/Qb/E/Mn8+O5Iwmr99rZ2ZmjAK+O2Kh9GcX/OI6vIWpbC/+18M+3evh2TkIUF/7zLL4+bb+O4j8ftdF86p0D8YNXxe0iZBeR21qI262Mf7SLUF58hTg+bcM4864jfuJHfRPceCF025UejtMYw6OFMJoYET8oIHTjhdjlPsX1OS1eRHEmiIgfpBu6iyXKsdB1GsSLGM4cEsQPhondeOFr01Hp3WGM4UwMET/oLng7YpdFDA/aGB45HIgfXC92o/blInh3HZGshM00BwsxdM4Q8YNXBG8cgxe+7jgixXjcfk1jCOcOB+KH4J0vZ1582aRSvpM4FU4tjyJ+CB5CCOJHgcELlx9M4pfgcVkI9xtLo4gfBQRvFKe73cY5PK4u7BydNjbLIH5kFr2dOOHZpclNXOwa3bcsiviR8pQ3iV+mPFYt7BjdNw0ifqQSvXFzvqxpyqOvaXAap8G5w4H40Xf0woS3Z8pjQA9jBGcOBeJHl8Fbj1Ne+LJjk1SEnaJ7bQSnDgXixyqjN4pTnuvySD2C0zgNOi+I+HHj6N1zNMhIOC+4L4KIH6KHCIL4IXqIIOKH6IkeIoj4UUn01mP03nc0qCyCYXfovkMhftQXPZcsUDuXSIgfFYVv0rg4HRYdxgjOHArxo7zojWP0th0NuNSDGMG5QyF+5B+9sMQZzm3YzALf7/mmmDaAew6F+JFv+HbjtOe8HiwnnA+cWAoVP/KK3jhOe5uOBtxIuHn2rqVQ8SPt6Ll0AVbPpRHiR8LhCzednjaWOKErh3EK9FR58SORaS9Ez8NkoR8f2RAjfpj2oEaPm/MNMaZA8cO0B6ZAxA/THtQyBe7YESp+dDfthb8w7eSE9NgRKn50EL6tOO25bg/SFq4LnHhkUvrWHILkwxfu0vJb4YMshPPw83ijCUx+XCN6NrVA3myGET+WDF9Y5jxoPHYIchcujN+xDJoey57phW/SnC9zCh/kLzxCbB7/oMXkxyXR8+ghKNsHdoOKHy+Gb9ScL3Pa1AJlCw/M3bUMKn7Cd74rLITPRetQh3BR/FgAh+Wc37Dhm7QvnwsfVCWs8DgPKH7Vhm/avnzqSECVwh+8v41/ADMAy579Ry9sbAnLnNuOBtC6/2R+vOswiF/J4Rs1NrYA3/WgDaApUPyKDF9Y3581zu8Bl7MRpkfO+fUTvrHwAd8jrAjN4goR4pd9+CaNHZ3A1QN4ZCeo+JUQPjs6gWXcihOgAIpfluHbFz7ghgGcOBTdsOGlm/BNG/foBFbjvSfz46nDYPITPqAmn5oAxU/4AAFE/IQPEEDET/gAAUT8hA8QQMRP+AABFD+EDxBA8UP4AAEUP4QPEMCSuMPLcuELHzC3LANSc9qcPw7pyKEw+QkfUAs3wzb5dRK+nfblM0cCyGAC3GonwLlDYfK7afjCX1JTRwLIZAI8aH9vrTsU4nfT8M0aD6IF8rEZf28hftcK33qc+IQPyC6AcWc64re0WfwLCiBH9+JDtRG/K099U+EDCvC+awAvZ7fnd8O327584kgABflz1wCK36vC55IGoEQugfgjlj3/ED6XNAClcgmE+F0aPjs7gdKFfQw2wIjfC6aNDS5A+e7FfQ3Vq/6cnw0uQIWq3wBTdfza8I3bl8/9/wCoTNgAM2oD+LTWA1Dtsmc8z3fg/wNAhW7V/vuv5nN+B40NLkC9ttshYE/86pr6whu+7bMPVO7DePqnOtWd83OeD+AFVZ7/q2ryW7ieD4Bzt2r8vVjbsmd4g+/4rAO84G5t1/9Vs+wZ72z+qc84wKWquv9nFZNfG75R47Y+AK9S1eUPtSx7ThuXNQB8n81aLn8oftnT7csAllb87c+KnvzicueezzHAUqal/4BrFbyBljsBllP88mexy56WOwFurNjlzyInP8udACtR7C75tYLfMMudADezXerF78Ute7Zv1E778pnPLMBKFHnxe1GTX7x3p4vZAVbnVom/V0tb9gzjuXt3AqzW3dIefVTMsmfc5PJ7n1GATpw8mR+PTH7pmfpsAnTmTknX/hUx+dnkAtCLYja/lDL52eQC0L2w+aWI6S/7+MUx3CYXgH7cK2HzS9bxi5c27PosAvQq++kv98nPnVwA+hfu/DLJ+QfIdsOLSxsABpX1pQ85T35Tnz2AwdzJ+b6fWU5+8WTr5z57AIMKlz6M2gnwqcmvH3s+cwCDC3suspz+spv8TH0Apr8aJz9TH4Dpr57Jz9QHYPqrcfIz9QGY/uqZ/Ex9AKa/Gic/Ux+A6a+eyc/UB2D6q3HyM/UBmP7qiV879W21L9s+UwBZmIjfanhkEUA+7uTwxIekz/l5cgNAlpJ/4kPqk9/EZwggy+lvLH7Xm/o8pR0gX3vidz07jae0A+RqO566Er+S/moA4Hslu3qX5IYXF7UDFCHZi95TnfwmPjMA2QunrnZS/MaSi1/c6HLPZwagCEkufaY4+Zn6AMqxGe/UJX45/pUAQDm/15OKX9zocsfnBKAoO/GUlvi9xMRnBKA4yW18SSZ+8a+CHZ8RgCIlNdykNPm5owtAuZK640tq8QOgXMn8nk8ifvGvgbs+FwBFS2bXZyqTn6kPoHx3UrnmL5X4TXwmAKqQxO/7weMXlzw3fR4AqpDESt/rDgQ5evPNN5q//qsfNe+++xfP/5lXOz7+XfOzn/9789VXXzsYDO350ueT+fHRkN/E4I80ag/CkcmPZWy883bzi/+YNm+8IXrL+vHf/WPzq1//xoFgaPfb+A26+WXQ+MUlz9/7HLDMxPfFf/+X8F3Ts2fPmnf+7IcOBEM7aeM3GvIbGPqcnyVPlhKWOoXv+sKxC5MzDGzwXZ9Dx2/sM8Aywjk+bj49QwIG/f0/WPzivTxd2I5f3FCnSa2TnyVPgHptDvmYoyHjN/beA1RtsCHI5AdAdUPQIPGLu3w8vgjA5FfV5Df2ngNU79ZQlzwMFT9LngAM1oOh4rft/QagGWglsPf4tSPu2HsNwJDD0BCTn/gBMOhQJH4ADK2K+DnfB0A98XO+D4AUhqK+Jz/xA2Dw4Uj8AEhBrxe7r5X8wwGQjTInv3akHTXu5wlAZZPf2HsLwEvc6fP5fn3Gz5InAEkMSeIHQCp660Sf8XNxOwD1xC9udgGAqiY/S54AfJ/eNr2IHwDVTX/iB4D4dWTk/QQglV70Fb9N7ycA1Ux+t0cbljwBqCt+jSVPAK6ul3tA9xE/kx8AV9bHs/1MfgCkpvNr/cQPgNR0vmIofgCkpvNu9BG/O95HAKqJnxtaA1Dj5Cd+ACyr8xXDruO37j0EYFldP92h6/i5xg+A5Pqx5viSk2++eeYgAMnHb+wQs0qPHn3pIIDJz+RHXf7zl581z56Z/qACWZ/zg5UKy54ffvSxAAI38nrH//vbDjGr9otfHjSPvviy+fHf/k2zsfF289ZbP2je+sGfODBQlnHO8YNOfPXV183ev3w8yL/7J7v/0Hyw+/feBMiYZU8AxG9VPMEdgBsY5Tr5ubsLANfV6S3OLHsCUB3xA0D8AED8rm/s8AJwXV1unDT5AZCqzjZOih8A1RE/AMQPAMQPAMQPAMQPAMQPAMQPAMQPAMQPAMQPAMQPAMQPAMQPAMQPAPqO35HDC8B1PZkfz3KM31NvHQC1TX4AIH4AIH4AcLnTLOPX5YlKAIrX6aZJkx8A1RE/AMRvxR47xABcQ9bLnq71AyC5flj2BKA6XcfPLc4AuI5ZzvGz7AlAdZPf3CEGILV+iB8AyXkyP846fpY9AVjWadf/gk7j15bbhhcAltV5O/q41OHU+wjAEjpfNewjfqY/AKqb/Jz3A2AZc5MfAOKXYfzm3kcAUhqaxA+ApDyZH+e/4cUT3QFYwmEf/5K+nupw4v0E4ArmJcVv7v0EoLb4zbyfAKTSC5MfACY/8QNgIKddP82h1/jZ8QnAFfR2U5S1Hn+ox95XAGqLn9ucASB+ACB+ANTqtM8HoPcWP5teAEhlQFrr+Yc79P4CcIleB6S+42fpE4Dq4jfz/gIw9HAkfgAM7XEfz/AbLH7xh3OxOwCDDkZrNfyQAIif+AEgfuIHwEB6P983SPyc9wNg6IForaYfFgDxEz8ABvVkfnxQTfyG+mEBSMpgt7xcG/CHfuh9B6jaYIPQkPGbed8BxK+2+Fn6BKjXyZP58by6+MUf2iUPAKa+qia/YOb9BxC/2uI39f4DVOf0yfx40OFn0Pi1P3x4ftOJzwGAqa+myS+JgwCA+PVt6nMAUI3TFG50Mnj8LH0CmPpqnPySORgAiF+fpj4PAMU7TeXezknEz9InQBWSGXTWEjoo+z4XAOJXW/yc9wMo10lc5RO/RfFenx5zBFCmpFb31hI7OKY/knf8v79zECDz3+9Jxa+d/qbty6nPCCn75ptvMv/+n3kT6dvDIR9flMPkZ/ojeY+++LJ59izPgHz19f+ZXBnCNLVvKMX42fVJ8v71k59m+X3vffSxN4++naRybV/S8Yu7gQ59XkjZz37+b80n+z/NZgIM3+dP/umfm1/9+jfePKqf+oLXzs7Okvumbo82Ju3Lpz4zpO7NN99o3v3hXzYb77yd7PcYljkfffE/zvUxlD9N7XxfsvGLAXzavtzyuQHIVtjospPiN7aW8EFz7g8gb8n+Hk85flOfG4BshY0uM/FbUlwjfuDzA5ClvZS/ubXED57pDyA/p/GmJeJ3zekvjMwuewDIS/J7NtYcRABWOfWJ32qmv3BnAA+6BcjDQft7+6n4rcaezxOA39dVxS+eODX9AaTtQYp3c8l58jP9Afg9XV/8TH8Apr4aJz/TH4Dfz/XFz/QHYOqrcfIz/QH4vVxf/Ex/AKa+Gic/0x+A38f1xc/0B2Dqq3HyCyY+dwCDCffw3M31m882fp74ADCo/Rzu4Vni5Bfs+fwB9C6cdsr6iTtZxy9Of572DtDz4JHz1FfC5Hcx/Z36LAL04nHqT2mvIn5xp5EH3gL0Y7eEH+K1s7OzIt6N26ONEME7PpcAnQmXNkxK+EHWCnpTdn0uATqT9aUNxcav/WvkoHHpA0BXst/kUurkF0wam18AVi1scilqb0VR8bP5BaATxZ1WKmbDy6Lbo42j9mXT5xXgxu63g0Vx8Vsr9M2y+QXg5sJppL0Sf7Ai4xfv/HLf5xbgRiYlbXKpYfJr4l8rHnsEcD0P4y76IhUbv/jXysTnF2Bpp6X//ix58rP8CXA9xS53VhG/aK+x/AlwVUUvd1YTP8ufAFdW/HJnTZOf5U+Aqyl+ufNCkRe5v4yL3wFeqsiL2aue/Bb/qvH5BviOx02hF7OLX/N8+TNMfh/4nAO8OBjUstxZ6+TXxDuTP/RZB3jugzgYVGWt0jd70rj8AeBhaY8qEr9XT39hvN/xuQcqdtJUvA+i1snP+T+gdju1necTvz8E0Pk/oEZVnucTvxeFsf+xwwBU4kGt5/nE78Xp7+L2Z6f+PwEULvyh72Hf4vdtAI8aF8ADZQt/4Fd9nk/8Lg9guIv5R44EUKgQvrnDIH6XBXCvfXngSACFeS/e4B/xe6mwHm4DDFCKsMFl6jC8qKqnOlzV7dHGevsSlgduORpAxg7b8I0dBpPflcQTwuEDYwcokKuwguVOVuK3dADtAAVyZWen+N0ogGEH6HuOBJBZ+MZ2dorfTQM4bV/uOxJAJia137pM/FYXwLAD1CUQQOreiytWiN/KAjgRQCDx8E0dBvHrgmsAgRS5lk/8Op3+Li6BEEAgpfBNHAbxE0BA+BA/AQSED/ETQED4xA8BBIRP/BBAQPjEDwEEhE/8EEBA+MQPAQSET/wEUAAB4RO/KgP40NEArukD4evOa2dnZ45Ch26PNqbtyz1HAliCm1Sb/LKfAsNfbp4HCFzFqfCZ/EqbAEMEP3UkgFeEb+xBtCa/0ibA8Jfcj+IHHGDRY+Ez+ZU+AW61L7P265ajASyE76lDIX6lB3A9BnDT0YCquZRhIJY9B7BwKcQDRwOq5VIGk1/VU+Be+/KhIwHVCOf9J234DhwK8as9gDvty7RxHhBK9ziGz8aWgVn2TED8C3DcuCUalCzc8cmOTpMfl0yA63ECvOtoQFE+aqO35zCIH6+O4G778okjAdkL5/d22vDNHArx42oBDNcDhuXQO44GZOkwhs/1e+LHkgG0DAp5sswpfqwggpZBIQ8nzfluzplDIX6sJoBbcQp0VxhI08MYPsuc4kcHEdxvX953JCAZYVPLrscQiR/dB3Acp0CbYWBYh3HamzsU4kc/AQybYfZMgTDYtLfXRm/foRA/TIFg2kP8MAWCaQ/xwxQIeQo7OXdNe+JH2hEMU2C4NtBTIuBmTmL0PH5I/MgkgKM4BW47GnAt95vzZU7X7YkfGUYwPCswnKOwFApXcxinPY8eEj8yD2DYELPbWAqFV7HEKX4UGsFRc74r9J6jAd8KuzjD6si+JU7xo+wIjmMEnQ+kdg/itCd64kdlEZw2zgdSHxeqi5/4ieDGJE6CIkgN0dvzyCHEDxFE9BA/EEFED/FDBEUQ0UP8EEEQPcSPeiIY7hYTLpR3iQSpCZcs7LsrC+JHlxEcty9hGnSxPEMKF6dPY/TmDgfiR18RHMUIum0afQq3Idtrvw5cnI74MXQIJzGElkTpSljanDqfh/iRYgS34iS4YxpkRVPeNEZv7nAgfpgGKVU4l3dgykP8yD2CozgJhonQ5RK8zGGc8pzLQ/woLoRbcRrcEUJajxeCN3c4ED+EEMED8aOSEI7br01HpDhhSfNA8BA/eHkIR3EaDCG864hk6WLTyqxxDg/xg2vF8CKEpsL0p7uL2LnNGOIHKwzh+sJUuCWGg8fuKMZu5nAgftBvDMcLMXRNYTdOY+hC5GZih/hBekG8COGW6fDGU93zL8uYiB/kG8RR/LqIo9uvnd8+7Gjhay50iB/UFcUQxPUCwxgCN1/4EjnET/zgpWFcjOH6wj83MZYpXJgfLhi/uIxgFl+/DZ1r6kD8oOsJctFiKG9i9kf/+amJDcQPAJa25hAAIH4AIH4AIH4AIH4AIH4AIH4AIH4AIH4AIH4AIH4AIH4AIH4AIH4AIH4AIH4AiB8AiB8AiB8AiB8AiB8ApO3/BRgAt/sE3Me4zZAAAAAASUVORK5CYII="
                     {...props}
@@ -112,12 +133,15 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
             ) : null;
 
         case OpenIdIdentityIssuerType.AZUREAD:
-            return health.data?.auth.azuread.enabled ? (
+            return health.data?.auth.azuread.enabled || forceShow ? (
                 <ThirdPartySignInButtonBase
-                    loginPath={health.data.auth.azuread.loginPath}
+                    loginPath={
+                        health.data?.auth.azuread.loginPath ?? '/login/azuread'
+                    }
                     redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
+                    loginHint={loginHint}
                     providerName="Microsoft"
                     logo="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAACCSURBVEiJ7ZSxDcJAEATnTxd8CBlNkJK/CFwAETW4QV4EbsEd0ASBg5eOFlZIDizdxrs7J5205Xu/vYAJQVGsPecLwKL4gW5q+Z+abMdyABKQgASAR7GmmsfYVgcGyBm/Pt76OdvgczoDVY54CXm4iOoNKljImeM/OQEJOAig79jff9AUF4fE3EHkAAAAAElFTkSuQmCC"
                     {...props}
@@ -130,6 +154,7 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
                     redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}
+                    loginHint={loginHint}
                     providerName="OpenID Connect"
                     logo={<MantineIcon icon={IconLock} />}
                     {...props}

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -292,7 +292,9 @@ const Login: FC<{}> = () => {
                                             key={providerName}
                                             providerName={providerName}
                                             redirect={redirectUrl}
+                                            loginHint={preCheckEmail}
                                             disabled={isFormLoading}
+                                            forceShow
                                         />
                                     ))}
                                 </Stack>

--- a/packages/frontend/src/hooks/organization/useOrganizationSso.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationSso.ts
@@ -1,0 +1,81 @@
+import {
+    type ApiError,
+    type AzureAdSsoConfigSummary,
+    type UpsertAzureAdSsoConfig,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+import useToaster from '../toaster/useToaster';
+
+const QUERY_KEY = ['organization_sso', 'azuread'];
+
+const getAzureAdSsoConfig = async () =>
+    lightdashApi<AzureAdSsoConfigSummary | null>({
+        url: '/org/sso/azuread',
+        method: 'GET',
+        body: undefined,
+    });
+
+const upsertAzureAdSsoConfig = async (data: UpsertAzureAdSsoConfig) =>
+    lightdashApi<AzureAdSsoConfigSummary>({
+        url: '/org/sso/azuread',
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+
+const deleteAzureAdSsoConfig = async () =>
+    lightdashApi<undefined>({
+        url: '/org/sso/azuread',
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useAzureAdSsoConfig = () =>
+    useQuery<AzureAdSsoConfigSummary | null, ApiError>({
+        queryKey: QUERY_KEY,
+        queryFn: getAzureAdSsoConfig,
+    });
+
+export const useUpsertAzureAdSsoConfig = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<
+        AzureAdSsoConfigSummary,
+        ApiError,
+        UpsertAzureAdSsoConfig
+    >(upsertAzureAdSsoConfig, {
+        mutationKey: ['organization_sso', 'azuread', 'upsert'],
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(QUERY_KEY);
+            showToastSuccess({
+                title: 'Azure AD SSO settings saved',
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to save Azure AD SSO settings',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useDeleteAzureAdSsoConfig = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<undefined, ApiError>(deleteAzureAdSsoConfig, {
+        mutationKey: ['organization_sso', 'azuread', 'delete'],
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(QUERY_KEY);
+            showToastSuccess({
+                title: 'Azure AD SSO settings removed',
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to remove Azure AD SSO settings',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -60,6 +60,7 @@ import MyAppsPanel from '../components/UserSettings/MyAppsPanel';
 import { MyWarehouseConnectionsPanel } from '../components/UserSettings/MyWarehouseConnectionsPanel';
 import OAuthClientsPanel from '../components/UserSettings/OAuthClientsPanel';
 import OrganizationPanel from '../components/UserSettings/OrganizationPanel';
+import OrganizationSsoPanel from '../components/UserSettings/OrganizationSsoPanel';
 import { OrganizationWarehouseCredentialsPanel } from '../components/UserSettings/OrganizationWarehouseCredentialsPanel';
 import PasswordPanel from '../components/UserSettings/PasswordPanel';
 import ProfilePanel from '../components/UserSettings/ProfilePanel';
@@ -134,6 +135,12 @@ const Settings: FC = () => {
     const { data: dataAppsFlag } = useServerFeatureFlag(
         FeatureFlags.EnableDataApps,
     );
+
+    const { data: ssoOrganizationSettingsFlag } = useServerFeatureFlag(
+        FeatureFlags.SsoOrganizationSettings,
+    );
+    const isSsoOrganizationSettingsEnabled =
+        ssoOrganizationSettingsFlag?.enabled ?? false;
 
     const { track } = useTracking();
     const {
@@ -417,6 +424,29 @@ const Settings: FC = () => {
             });
         }
 
+        if (
+            user?.ability.can('manage', 'Organization') &&
+            isSsoOrganizationSettingsEnabled
+        ) {
+            allowedRoutes.push({
+                path: '/sso',
+                element: (
+                    <Stack gap="xl">
+                        <SettingsGridCard>
+                            <Stack gap="xs">
+                                <Title order={4}>Single Sign-On</Title>
+                                <Text c="ldGray.6" fz="xs">
+                                    Configure SSO providers for this
+                                    organization.
+                                </Text>
+                            </Stack>
+                            <OrganizationSsoPanel />
+                        </SettingsGridCard>
+                    </Stack>
+                ),
+            });
+        }
+
         // Commercial route
         if (
             user?.ability.can('manage', 'Organization') &&
@@ -471,6 +501,7 @@ const Settings: FC = () => {
         health?.hasGithub,
         health?.hasGitlab,
         dataAppsFlag?.enabled,
+        isSsoOrganizationSettingsEnabled,
     ]);
     const routeElements = useRoutes(routes);
 
@@ -785,6 +816,18 @@ const Settings: FC = () => {
                                         }
                                     />
                                 )}
+
+                                {user.ability.can('manage', 'Organization') &&
+                                    isSsoOrganizationSettingsEnabled && (
+                                        <RouterNavLink
+                                            label="Single Sign-On"
+                                            exact
+                                            to="/generalSettings/sso"
+                                            leftSection={
+                                                <MantineIcon icon={IconLock} />
+                                            }
+                                        />
+                                    )}
 
                                 {user.ability.can(
                                     'manage',


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7481/support-azure-ad-for-shared-multi-org-lightdash-instances

<img width="967" height="1011" alt="CleanShot 2026-05-11 at 13 01 32" src="https://github.com/user-attachments/assets/be715d2a-c587-4698-be6a-3c0a3c25f9b8" />

<img width="506" height="592" alt="CleanShot 2026-05-11 at 12 45 49" src="https://github.com/user-attachments/assets/32237b76-fc7a-4c1d-b590-38e9fe760e8f" />

Default state (override off, allow_password=true)

  - (no email) → [email, google] — Instance defaults
  - demo@lightdash.com (existing user, has password) → [email, azuread] — Google suppressed, password + Azure
  - javier@lightdash.com (new user, matches domain) → [azuread] + forceRedirect — Auto-redirect, no other option
  - foo@gmail.com (non-matching) → [email, google] — Instance defaults preserved

  Override on with email_domains=[microsoft.com]

  - demo@lightdash.com → [email] — Azure removed (lightdash.com not in whitelist)
  - test@microsoft.com (new user, matches override) → [azuread] + forceRedirect — Override match works
  - foo@gmail.com → [email, google] — Instance defaults preserved


### Description:

Adds per-organization Azure AD SSO configuration stored in the database, enabling multi-tenant Lightdash instances to support Azure AD login without requiring environment-level credentials.

**Database:**
- New `organization_sso_configurations` table stores encrypted provider configs (client ID, client secret, tenant ID) per organization, with a unique constraint on `(organization_uuid, provider)`.

**Backend:**
- `OrganizationSsoModel` handles encrypted read/write of SSO configs using the existing `EncryptionUtil`.
- `OrganizationSsoService` exposes CRUD operations gated on organization-manage permissions, plus helpers for resolving the correct Azure AD config by email domain (used during login).
- `OrganizationSsoController` exposes `GET /api/v1/org/sso/azuread`, `PUT /api/v1/org/sso/azuread`, and `DELETE /api/v1/org/sso/azuread`. Sensitive fields (client secret) are never returned; a `hasClientSecret` boolean is returned instead. Omitting `oauth2ClientSecret` on update preserves the stored secret.
- The Azure AD login and callback routes now dynamically resolve and register a per-org passport strategy (keyed `azuread:<orgUuid>`) based on the email hint. Strategies are cached with a 10-minute TTL and re-registered on callback if the server restarted between login and callback. The existing env-based strategy is retained as a fallback.
- `createAzureAdOidcStrategyForConfig` is extracted so both the env-based and per-org paths share the same strategy construction logic.
- `UserService.getLoginOptions` now surfaces the Azure AD login option for first-time SSO users whose email domain matches an org with a DB-stored Azure AD config, even when no instance-level env config is set.

**Frontend:**
- New `OrganizationSsoPanel` settings page under **General Settings → Single Sign-On**, allowing org admins to configure, update, or remove the Azure AD SSO credentials. Warns when no allowed email domains are configured (which would prevent first-time users from seeing the login button).
- `ThirdPartySignInButton` accepts a `forceShow` prop to render the Azure AD button even when the instance-level health flag is disabled, used when per-org login options indicate Azure AD is available.