### PR TITLE
fix(echarts): snap category date axis in UTC for DATE base dimensions

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1501,9 +1501,12 @@ export const getCategoryDateAxisConfig = (
     );
     const boundaryGap = hasBarSeries;
 
-    // Row values are aligned to project-TZ midnights — snap boundaries in
-    // the same zone so category strings match.
-    const tz = resolvedTimezone ?? 'UTC';
+    // DATE-base intervals are raw calendar values — snap in UTC to match.
+    const isDateBaseInterval =
+        isDimension(axisField) &&
+        axisField.timeIntervalBaseDimensionType === DimensionType.DATE;
+    const tz =
+        isDateBaseInterval || !resolvedTimezone ? 'UTC' : resolvedTimezone;
     const inTz = (v: string | number) => dayjs.tz(dayjs.utc(v).toDate(), tz);
 
     if (timeInterval === TimeFrames.WEEK) {


### PR DESCRIPTION
## Summary

Follow-up to #22884. That PR made `getCategoryDateAxisConfig` snap WEEK/MONTH/QUARTER/YEAR boundaries in the project timezone so category strings line up with the DATE_TRUNC round-trip on the backend.

For time-interval dimensions whose base column is a **DATE**, the backend bypasses the round-trip and emits raw calendar values (no time component). Interpreting those as UTC instants and shifting into a negative-offset project timezone pushes them back a period (e.g. `2024-03-01` → `2024-02-29 ET` → `.startOf('month')` → `2024-02-01`), so the snapped categories no longer match the row values.

This change keeps the snap in UTC when the base dimension is a DATE, matching the behaviour documented in \`docs/timezone-handling.md\` for every other DATE-base bypass (SELECT, filter literals, display formatting, ECharts wall-clock shift).

**Before**
<img width="2128" height="1185" alt="CleanShot 2026-05-11 at 11 42 28" src="https://github.com/user-attachments/assets/6447de0b-099a-43ab-8bea-140df00ff546" />


**After**
<img width="2123" height="1178" alt="CleanShot 2026-05-11 at 11 42 55" src="https://github.com/user-attachments/assets/66f2500b-775f-4af8-a90d-143971d12778" />
