### PR TITLE
fix: preserve configured custom date zoom granularities on embedded dashboards (PROD-7514)

### DIFF
--- a/packages/common/src/utils/dateZoom.test.ts
+++ b/packages/common/src/utils/dateZoom.test.ts
@@ -608,7 +608,7 @@ describe('getDateZoomCapabilities', () => {
         });
     });
 
-    it('does not include custom granularities from unrelated base dimensions', () => {
+    it('exposes every custom granularity defined in the explore, regardless of which dim the chart currently queries', () => {
         const orderDate = makeDimension({
             name: 'order_date',
             table: 'orders',
@@ -628,11 +628,17 @@ describe('getDateZoomCapabilities', () => {
             label: 'Shipped Fiscal Quarter',
         });
         const explore = makeExplore([orderDate, shippedDate, shippedFiscal]);
-        // Only querying order_date — should NOT pick up shipped_date's custom granularities
+        // Even though the chart only queries order_date, fiscal_quarter is
+        // still surfaced. Dashboard-level date-zoom availability must not
+        // depend on which dim a tile's metricQuery happens to reference,
+        // otherwise configured customs get stripped whenever explore
+        // discovery races with chart-query loading (PROD-7514).
         const metricQuery = makeMetricQuery(['orders_order_date']);
 
         const result = getDateZoomCapabilities(explore, metricQuery);
 
-        expect(result.availableCustomGranularities).toEqual({});
+        expect(result.availableCustomGranularities).toEqual({
+            fiscal_quarter: 'Shipped Fiscal Quarter',
+        });
     });
 });

--- a/packages/common/src/utils/dateZoom.ts
+++ b/packages/common/src/utils/dateZoom.ts
@@ -111,8 +111,10 @@ export const getDateZoomCapabilities = (
 
     let hasTimestampDimension = false;
     let hasDateDimension = false;
-    const availableCustomGranularities: Record<string, string> = {};
 
+    // hasDateDimension / hasTimestampDimension reflect the chart's own usage
+    // (used to gate sub-day standard granularities on DATE-only dashboards),
+    // so they stay scoped to dims referenced by the chart's metricQuery.
     for (const dimId of metricQuery.dimensions) {
         const baseDim = resolveToBaseTimeDimension(
             dimId,
@@ -127,18 +129,20 @@ export const getDateZoomCapabilities = (
             if (baseDim.type === DimensionType.DATE) {
                 hasDateDimension = true;
             }
+        }
+    }
 
-            // Find sibling dimensions with customTimeInterval
-            const baseName = baseDim.name;
-            for (const sibling of allDimensions) {
-                if (
-                    sibling.customTimeInterval &&
-                    sibling.timeIntervalBaseDimensionName === baseName
-                ) {
-                    availableCustomGranularities[sibling.customTimeInterval] =
-                        sibling.label;
-                }
-            }
+    // Custom granularities are sourced from any `customTimeInterval` dim in
+    // the explore, not just siblings of the chart's currently-queried base.
+    // The previous chart-query intersection here stripped configured customs
+    // whenever a dashboard tile's query didn't currently reference the owning
+    // base dim — and was also timing-sensitive, since metricQuery loads
+    // asynchronously alongside the explore (PROD-7514, regression of
+    // PROD-6788).
+    const availableCustomGranularities: Record<string, string> = {};
+    for (const dim of allDimensions) {
+        if (dim.customTimeInterval) {
+            availableCustomGranularities[dim.customTimeInterval] = dim.label;
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes [PROD-7514](https://linear.app/lightdash/issue/PROD-7514/configured-custom-date-zoom-granularities-are-stripped-from-embedded): configured custom date zoom granularities (e.g. `fiscal_quarter`, `biweekly`) were stripped from the date zoom dropdown — and a custom value passed via the `?dateZoom=` URL param was reset — once all charts on an embedded dashboard finished loading. This was a regression of PROD-6788 (#21721) in a new shape.
- `getDateZoomCapabilities` now collects custom granularities from every `customTimeInterval` dim in the explore directly, instead of intersecting with the chart's current `metricQuery.dimensions`. `DashboardGranularitySync` is untouched and still cleans up sub-day standards / stale customs — just against a correctly-widened "available" set.
- `has{Date,Timestamp}Dimension` stays chart-scoped because it gates sub-day standard granularities (a per-chart concern, not a per-dashboard concern).

## Root cause

`DashboardGranularitySync` (added in #21721 to fix PROD-6788) filters `dateZoomGranularities` against `availableCustomGranularities`, which is built per-tile by `getDateZoomCapabilities(explore, metricQuery)`. The function only emitted a custom granularity when its owning base dim was reachable from `metricQuery.dimensions`. On a dashboard whose tiles don't currently reference that base dim — or where tile-query loading races with explore loading in embed contexts — `availableCustomGranularities` was empty for that key, the sync stripped the configured custom from the saved list, and the active `dateZoomGranularity` (e.g. from URL) was reset to undefined.

## What changed

`packages/common/src/utils/dateZoom.ts` — split `getDateZoomCapabilities` into two passes:

- **Pass 1 (unchanged scope):** walk `metricQuery.dimensions` to compute `hasTimestampDimension` / `hasDateDimension`. These still gate sub-day standard granularities on DATE-only dashboards.
- **Pass 2 (widened):** collect `availableCustomGranularities` from any `customTimeInterval` dim in the explore, regardless of whether the chart's query currently references its base.

`packages/common/src/utils/dateZoom.test.ts` — the one test that codified the old chart-scoped intersection (`does not include custom granularities from unrelated base dimensions`) is rewritten to assert the new, correct behavior, with a comment explaining why.

## Test plan

- [x] `pnpm -F common test` — all 21 dateZoom unit tests pass (one rewritten, two new edge cases would be welcome but the underlying behavior is exercised).
- [x] `pnpm -F common typecheck` — clean.
- [x] Manual repro against the seeded `Compass` dashboard in Jaffle Shop (saved config: `["Day", "Week", "Month", "Quarter", "Year", "biweekly", "fiscal_quarter"]`; tiles use `events` + `customers`, neither referencing `Orders.order_date`):
  - [x] Date Zoom dropdown shows `Bi-weekly` and `Fiscal Quarter` after tiles finish loading (before the fix: both stripped).
  - [x] `?dateZoom=fiscal_quarter` URL param is honored and **stays applied** — polled the active value every 1s for 6s after `areAllChartsLoaded`, never reset (before the fix: cleared once tiles settled).
- [ ] CI

## Notes / tradeoffs

- The widening means a chart from explore `Orders` will now surface every `customTimeInterval` defined in that explore, even if it's rooted at a different base dim than the chart's current time dim. In practice the only way to have a custom selectable on a dashboard is for its owning explore to be loaded by some tile, so this is the correct invariant for dashboard-level date zoom availability. Per-chart applicability is determined elsewhere when the granularity is applied to the query.
- Not touched: the conservative server-side cleanup of customs that have been deleted from `lightdash.config.yml`. If we want that, it belongs at save time against the project's `custom_granularities` set, not in a per-render filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)