### PR TITLE
fix(echarts): re-sort pivot series on metric-sort to react to filters (PROD-2999)

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -99,6 +99,7 @@ import { DateZoomInfoOnTile } from '../../features/dateZoom';
 import { ExportToGoogleSheet } from '../../features/export';
 import {
     getExpectedSeriesMap,
+    isPivotSeriesOrderDeterminedByQuery,
     mergeExistingAndExpectedSeries,
 } from '../../hooks/cartesianChartConfig/utils';
 import { useDashboardChartDownload } from '../../hooks/dashboard/useDashboardChartDownload';
@@ -227,11 +228,11 @@ const computeDashboardChartSeries = (
             itemsMap,
             columnLimit: chart.chartConfig.config.columnLimit,
         });
-        const sortedByPivot =
-            !!validPivotDimensions?.length &&
-            chart.metricQuery.sorts.some((sort) =>
-                validPivotDimensions.includes(sort.fieldId),
-            );
+        const sortedByPivot = isPivotSeriesOrderDeterminedByQuery(
+            validPivotDimensions,
+            chart.chartConfig.config.layout.yField,
+            chart.metricQuery.sorts,
+        );
 
         const newSeries = mergeExistingAndExpectedSeries({
             expectedSeriesMap,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -19,7 +19,10 @@ import { Checkbox, Divider, Stack, Switch } from '@mantine/core';
 import { produce } from 'immer';
 import React, { Fragment, useCallback, useMemo, type FC } from 'react';
 import { createPortal } from 'react-dom';
-import { getSeriesGroupedByField } from '../../../../hooks/cartesianChartConfig/utils';
+import {
+    getSeriesGroupedByField,
+    isPivotSeriesOrderDeterminedByQuery,
+} from '../../../../hooks/cartesianChartConfig/utils';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { ColorPaletteSection } from '../../common/ColorPaletteSection';
@@ -53,13 +56,18 @@ export const Series: FC<Props> = ({ items }) => {
         colorPalette,
     } = useVisualizationContext();
 
+    const yField = isCartesianVisualizationConfig(visualizationConfig)
+        ? visualizationConfig.chartConfig.dirtyLayout?.yField
+        : undefined;
+
     const sortedByPivot = useMemo(
         () =>
-            !!pivotDimensions?.length &&
-            !!resultsData?.metricQuery?.sorts?.some((sort) =>
-                pivotDimensions.includes(sort.fieldId),
+            isPivotSeriesOrderDeterminedByQuery(
+                pivotDimensions,
+                yField,
+                resultsData?.metricQuery?.sorts,
             ),
-        [pivotDimensions, resultsData?.metricQuery?.sorts],
+        [pivotDimensions, yField, resultsData?.metricQuery?.sorts],
     );
 
     const isCartesianChart =

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
@@ -29,6 +29,7 @@ import { type VisualizationProviderProps } from '../../../components/LightdashVi
 import { type MetricQueryDataContext } from '../../../components/MetricQueryData/context';
 import {
     getExpectedSeriesMap,
+    isPivotSeriesOrderDeterminedByQuery,
     mergeExistingAndExpectedSeries,
 } from '../../../hooks/cartesianChartConfig/utils';
 import { useExplore } from '../../../hooks/useExplore';
@@ -437,11 +438,11 @@ export function useMetricVisualization({
         });
 
         const pivotKeys = segmentDimensionId ? [segmentDimensionId] : undefined;
-        const sortedByPivot =
-            !!pivotKeys?.length &&
-            !!executedMetricQuery?.sorts?.some((sort) =>
-                pivotKeys.includes(sort.fieldId),
-            );
+        const sortedByPivot = isPivotSeriesOrderDeterminedByQuery(
+            pivotKeys,
+            chartConfig.config.layout.yField,
+            executedMetricQuery?.sorts,
+        );
 
         return mergeExistingAndExpectedSeries({
             expectedSeriesMap,

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -30,6 +30,7 @@ import {
 import {
     getExpectedSeriesMap,
     getSeriesGroupedByField,
+    isPivotSeriesOrderDeterminedByQuery,
     mergeExistingAndExpectedSeries,
     sortDimensions,
 } from './utils';
@@ -667,6 +668,84 @@ describe('mergeExistingAndExpectedSeries', () => {
         expect(result.map((s) => s.encode.yRef.pivotValues?.[0].value)).toEqual(
             ['a', 'b', 'c'],
         );
+    });
+});
+
+describe('isPivotSeriesOrderDeterminedByQuery', () => {
+    test('returns false when chart is not pivoted', () => {
+        expect(
+            isPivotSeriesOrderDeterminedByQuery(
+                undefined,
+                ['metric'],
+                [{ fieldId: 'metric' }],
+            ),
+        ).toBe(false);
+        expect(
+            isPivotSeriesOrderDeterminedByQuery(
+                [],
+                ['metric'],
+                [{ fieldId: 'metric' }],
+            ),
+        ).toBe(false);
+    });
+
+    test('returns false when there are no sorts', () => {
+        expect(
+            isPivotSeriesOrderDeterminedByQuery(
+                ['status'],
+                ['metric'],
+                undefined,
+            ),
+        ).toBe(false);
+        expect(
+            isPivotSeriesOrderDeterminedByQuery(['status'], ['metric'], []),
+        ).toBe(false);
+    });
+
+    test('returns true when sort is on a pivot dimension (PROD-2927)', () => {
+        expect(
+            isPivotSeriesOrderDeterminedByQuery(
+                ['status'],
+                ['metric'],
+                [{ fieldId: 'status' }],
+            ),
+        ).toBe(true);
+    });
+
+    test('returns true when sort is on a y-axis metric (PROD-2999)', () => {
+        // Repro: pivoted chart sorted by metric desc — saved series order
+        // ignores the SQL ranking and stays frozen across filter changes.
+        // Series order should track the query, so this predicate must fire.
+        expect(
+            isPivotSeriesOrderDeterminedByQuery(
+                ['status'],
+                ['total_amount'],
+                [{ fieldId: 'total_amount' }],
+            ),
+        ).toBe(true);
+    });
+
+    test('returns false when sort is on a non-pivot, non-metric field (e.g. x-axis dimension)', () => {
+        // Manual drag-reorder still wins when the chart sort doesn't
+        // determine pivot ranking — sorting by the x-axis dimension does
+        // not produce a meaningful series order via DENSE_RANK.
+        expect(
+            isPivotSeriesOrderDeterminedByQuery(
+                ['status'],
+                ['metric'],
+                [{ fieldId: 'order_date' }],
+            ),
+        ).toBe(false);
+    });
+
+    test('returns true when at least one sort matches even if others do not', () => {
+        expect(
+            isPivotSeriesOrderDeterminedByQuery(
+                ['status'],
+                ['metric'],
+                [{ fieldId: 'order_date' }, { fieldId: 'metric' }],
+            ),
+        ).toBe(true);
     });
 });
 

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -34,6 +34,7 @@ import type { InfiniteQueryResults } from '../useQueryResults';
 import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import {
     getExpectedSeriesMap,
+    isPivotSeriesOrderDeterminedByQuery,
     mergeExistingAndExpectedSeries,
     sortDimensions,
 } from './utils';
@@ -1110,12 +1111,11 @@ const useCartesianChartConfig = ({
                     itemsMap,
                     columnLimit,
                 });
-                // Check if any sort field matches a pivot dimension
-                const sortedByPivot =
-                    !!pivotKeys?.length &&
-                    !!resultsData?.metricQuery?.sorts?.some((sort) =>
-                        pivotKeys.includes(sort.fieldId),
-                    );
+                const sortedByPivot = isPivotSeriesOrderDeterminedByQuery(
+                    pivotKeys,
+                    dirtyLayout.yField,
+                    resultsData?.metricQuery?.sorts,
+                );
 
                 const newSeries = mergeExistingAndExpectedSeries({
                     expectedSeriesMap,

--- a/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
@@ -176,6 +176,24 @@ export const getExpectedSeriesMap = ({
     return expectedSeriesMap;
 };
 
+// A pivoted chart's series order follows the SQL result's DENSE_RANK
+// columnIndex, which the backend builds from the active sort. Re-sort
+// merged series to that order when the sort references either a pivot
+// dimension (PROD-2927) or a y-axis metric (PROD-2999) — both cases
+// produce a deterministic pivot-value ranking that should drive the
+// legend instead of the saved series order.
+export const isPivotSeriesOrderDeterminedByQuery = (
+    pivotKeys: string[] | undefined,
+    yField: string[] | undefined,
+    sorts: { fieldId: string }[] | undefined,
+): boolean =>
+    !!pivotKeys?.length &&
+    !!sorts?.some(
+        (sort) =>
+            pivotKeys.includes(sort.fieldId) ||
+            !!yField?.includes(sort.fieldId),
+    );
+
 type MergeExistingAndExpectedSeriesArgs = {
     expectedSeriesMap: Record<string, Series>;
     existingSeries: Series[];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2999/grouped-bar-chart-ordering-does-not-react-to-filters

### Description:

Extends [#20435](https://github.com/lightdash/lightdash/pull/20435)'s auto-sort trigger so the legend follows the SQL ranking when the query is sorted by a y-axis metric — not just when sorted by the pivot dimension. Before this fix, a grouped bar chart sorted by a metric kept its creation-time series order even after a filter changed which group was highest-ranked.

#### Root cause
`mergeExistingAndExpectedSeries` only re-sorted the merged series when `sortedByPivot` was true, and `sortedByPivot` only fired when the SQL sort referenced a pivot dimension. PROD-2999's repro sorts by a metric, so the saved (creation-time) series order won. Since the backend already builds `pivotDetails.valuesColumns` from a SQL `DENSE_RANK()` that respects any active sort (pivot dim *or* metric), the merge logic was already capable of producing the right order — the trigger was just too narrow.

#### Fix
- Extract the predicate into `isPivotSeriesOrderDeterminedByQuery(pivotKeys, yField, sorts)` in `packages/frontend/src/hooks/cartesianChartConfig/utils.ts`.
- Widen the predicate to also fire when a sort references a y-axis metric.
- Use the helper at all four callsites (`useCartesianChartConfig`, `DashboardChartTile`, `useMetricVisualization`, `Series` config panel).
- The shipped `mergeExistingAndExpectedSeries` function is **unchanged** — only the upstream predicate moved.

#### Behaviour delta
The only new case where `sortedByPivot` flips from `false` to `true` is `pivotKeys.length > 0 && some sort.fieldId is in yField`. Everything else is identical to `main`:

| Scenario | Before | After |
|---|---|---|
| Sort by pivot dim (PROD-2927, shipped in #20435) | re-sorts | re-sorts |
| Sort by y-axis metric in a pivoted chart (PROD-2999) | frozen | **re-sorts** |
| Sort by x-axis dim only | frozen, drag enabled | frozen, drag enabled |
| Non-pivoted chart | unchanged | unchanged |

### Before

Filter `Order date year = 2026` — legend stays in creation order `completed, placed, shipped` despite the metric ranking being `completed, shipped, placed`:

`.scratch/prod2999-filtered.png` (legend: completed, placed, shipped; results: completed → shipped → placed)

### After

Same filter — legend now matches the SQL ranking:

`.scratch/verify-filtered.png` (legend: completed, shipped, placed; results: completed → shipped → placed)

### Test plan

- [x] `pnpm exec vitest run useCartesianChartConfig.test.ts` — 43/43 pass (6 new unit tests on the helper cover the truth table: not pivoted, no sorts, sort on pivot dim, sort on y-axis metric, sort on unrelated field, mixed sorts).
- [x] `pnpm -F frontend lint` — clean.
- [x] Manual repro on Jaffle Postgres: grouped bar chart (`order_date_year` × `status`, metric `total_order_amount`, sorted desc), apply `year = 2026` filter → legend re-sorts to match Results table ranking.
- [ ] Verify PROD-2927 path still works (sort by pivot dim still re-sorts) — covered by the existing regression test in `useCartesianChartConfig.test.ts`.
- [ ] Verify a manually drag-reordered chart with **no** sort on metric/pivot dim still preserves user order (regression check for the existing `sortedByPivot === false` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)