### PR TITLE
chore: remove `dataApps.enabled` from health endpoint

### DIFF
--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -138,7 +138,6 @@ export const BaseResponse: HealthState = {
         enabled: false,
     },
     dataApps: {
-        enabled: false,
         previewOrigin: null,
     },
 };

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -239,7 +239,6 @@ export class HealthService extends BaseService {
                 enabled: this.lightdashConfig.preAggregates.enabled,
             },
             dataApps: {
-                enabled: this.lightdashConfig.appRuntime.enabled,
                 previewOrigin: this.lightdashConfig.appRuntime.previewOrigin,
             },
         };

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -518,7 +518,6 @@ export type HealthState = {
         enabled: boolean;
     };
     dataApps: {
-        enabled: boolean;
         /**
          * Origin where data-app preview iframes are served (e.g.,
          * `https://analytics.lightdash.app`). Used by the frontend to construct

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -138,7 +138,6 @@ export default function mockHealthResponse(
             enabled: false,
         },
         dataApps: {
-            enabled: false,
             previewOrigin: null,
         },
         ...overrides,


### PR DESCRIPTION
### Description:
This property is essentially dead code which we don't rely on anymore. The correct one is using the feature flag service. Removing it to avoid confusion.