### PR TITLE
feat(scheduler): notify owner by email when admin modifies their scheduler

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -830,6 +830,50 @@ export default class EmailClient {
         });
     }
 
+    public async sendSchedulerModifiedByOtherUserEmail({
+        recipient,
+        modifyingUserName,
+        schedulerName,
+        actionVerb,
+        timestamp,
+        resourceUrl,
+    }: {
+        recipient: string;
+        modifyingUserName: string;
+        schedulerName: string;
+        actionVerb: 'updated' | 'deleted' | 'enabled' | 'disabled';
+        timestamp: string;
+        resourceUrl: string | undefined;
+    }) {
+        const safeModifier = sanitizeHtml(modifyingUserName);
+        const safeName = sanitizeHtml(schedulerName);
+        const message = `
+            <p style="margin: 0 0 12px 0;">
+                <strong>${safeModifier}</strong>
+                ${actionVerb} your scheduled delivery
+                <strong>&ldquo;${safeName}&rdquo;</strong>
+                on ${sanitizeHtml(timestamp)}.
+            </p>${
+                resourceUrl
+                    ? `\n            <p style="margin: 0;"><a href="${resourceUrl}" style="color: #7262FF; text-decoration: underline;">View the scheduled delivery</a></p>`
+                    : ''
+            }
+        `;
+        return this.sendEmail({
+            to: recipient,
+            subject: `Your scheduled delivery "${schedulerName}" was ${actionVerb}`,
+            template: 'genericNotification',
+            context: {
+                title: `Your scheduled delivery was ${actionVerb}`,
+                message,
+                host: this.lightdashConfig.siteUrl,
+            },
+            text: `${modifyingUserName} ${actionVerb} your scheduled delivery "${schedulerName}" on ${timestamp}.${
+                resourceUrl ? ` View it at ${resourceUrl}` : ''
+            }`,
+        });
+    }
+
     public async sendGenericNotificationEmail(
         to: string[],
         subject: string,

--- a/packages/backend/src/clients/EmailClient/templates/genericNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/genericNotification.html
@@ -119,9 +119,9 @@
                 }
             }
 
-            [style*='Roboto'] {
+            [style*='Inter'] {
                 font-family:
-                    'Roboto',
+                    'Inter',
                     BlinkMacSystemFont,
                     Segoe UI,
                     Helvetica Neue,
@@ -163,7 +163,7 @@
             }
         </style>
         <link
-            href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Albert+Sans:wght@500;700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Albert+Sans:wght@500;700&display=swap"
             rel="stylesheet"
             type="text/css"
         />
@@ -176,7 +176,7 @@
             background-color: #292929;
         "
     >
-        <div style="background-color: #292929">
+        <div style="background-color: #292929; padding-top: 24px;">
             <table
                 role="presentation"
                 width="100%"
@@ -348,6 +348,7 @@
                                                                                             >
                                                                                                 <h1
                                                                                                     style="
+                                                                                                        margin-bottom: 0;
                                                                                                         font-family:
                                                                                                             BlinkMacSystemFont,
                                                                                                             Segoe
@@ -356,17 +357,18 @@
                                                                                                                 Neue,
                                                                                                             Arial,
                                                                                                             sans-serif,
-                                                                                                            'Roboto';
-                                                                                                        line-height: 28px;
-                                                                                                        font-weight: 500;
+                                                                                                            'Inter';
+                                                                                                        line-height: 20px;
+                                                                                                        font-weight: 600;
                                                                                                         font-style: normal;
-                                                                                                        font-size: 24px;
+                                                                                                        font-size: 15px;
                                                                                                         text-decoration: none;
                                                                                                         text-transform: none;
                                                                                                         direction: ltr;
                                                                                                         color: #121212;
                                                                                                         text-align: left;
-                                                                                                        margin-bottom: 20px;
+                                                                                                        mso-line-height-rule: exactly;
+                                                                                                        mso-text-raise: 2px;
                                                                                                     "
                                                                                                 >
                                                                                                     {{title}}
@@ -392,6 +394,8 @@
                                                                                             >
                                                                                                 <div
                                                                                                     style="
+                                                                                                        margin-top: 12px;
+                                                                                                        margin-bottom: 0;
                                                                                                         font-family:
                                                                                                             BlinkMacSystemFont,
                                                                                                             Segoe
@@ -400,16 +404,18 @@
                                                                                                                 Neue,
                                                                                                             Arial,
                                                                                                             sans-serif,
-                                                                                                            'Roboto';
-                                                                                                        line-height: 24px;
+                                                                                                            'Inter';
+                                                                                                        line-height: 16px;
                                                                                                         font-weight: 400;
                                                                                                         font-style: normal;
-                                                                                                        font-size: 16px;
+                                                                                                        font-size: 12px;
                                                                                                         text-decoration: none;
                                                                                                         text-transform: none;
                                                                                                         direction: ltr;
-                                                                                                        color: #333333;
+                                                                                                        color: #5f5f73;
                                                                                                         text-align: left;
+                                                                                                        mso-line-height-rule: exactly;
+                                                                                                        mso-text-raise: 1px;
                                                                                                     "
                                                                                                 >
                                                                                                     {{{message}}}

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -50,6 +50,7 @@ import {
     SchedulerDashboardUpsertEvent,
     SchedulerUpsertEvent,
 } from '../../analytics/LightdashAnalytics';
+import EmailClient from '../../clients/EmailClient/EmailClient';
 import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
 import { SlackClient } from '../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -81,6 +82,7 @@ type SchedulerServiceArguments = {
     projectModel: ProjectModel;
     schedulerClient: SchedulerClient;
     slackClient: SlackClient;
+    emailClient: EmailClient;
     userModel: UserModel;
     googleDriveClient: GoogleDriveClient;
     userService: UserService;
@@ -114,6 +116,8 @@ export class SchedulerService extends BaseService {
 
     slackClient: SlackClient;
 
+    emailClient: EmailClient;
+
     projectModel: ProjectModel;
 
     userModel: UserModel;
@@ -135,6 +139,7 @@ export class SchedulerService extends BaseService {
         savedSqlModel,
         schedulerClient,
         slackClient,
+        emailClient,
         projectModel,
         userModel,
         googleDriveClient,
@@ -151,6 +156,7 @@ export class SchedulerService extends BaseService {
         this.savedSqlModel = savedSqlModel;
         this.schedulerClient = schedulerClient;
         this.slackClient = slackClient;
+        this.emailClient = emailClient;
         this.projectModel = projectModel;
         this.userModel = userModel;
         this.googleDriveClient = googleDriveClient;
@@ -185,6 +191,79 @@ export class SchedulerService extends BaseService {
             };
         }
         throw new ParameterError('Invalid scheduler type');
+    }
+
+    private getSchedulerResourceUrl(
+        scheduler: Scheduler,
+        projectUuid: string,
+    ): string | undefined {
+        const { siteUrl } = this.lightdashConfig;
+        if (isChartScheduler(scheduler)) {
+            return `${siteUrl}/projects/${projectUuid}/saved/${scheduler.savedChartUuid}/view?scheduler_uuid=${scheduler.schedulerUuid}`;
+        }
+        if (isDashboardScheduler(scheduler)) {
+            return `${siteUrl}/projects/${projectUuid}/dashboards/${scheduler.dashboardUuid}/view?scheduler_uuid=${scheduler.schedulerUuid}`;
+        }
+        return undefined;
+    }
+
+    private async notifySchedulerOwnerOfModification(
+        modifyingUser: SessionUser,
+        scheduler: Scheduler,
+        projectUuid: string,
+        actionVerb: 'updated' | 'deleted' | 'enabled' | 'disabled',
+    ): Promise<void> {
+        if (modifyingUser.userUuid === scheduler.createdBy) {
+            return;
+        }
+        try {
+            if (!this.emailClient.canSendEmail()) {
+                this.logger.info(
+                    `Skipping scheduler-owner notification: email transporter is not configured`,
+                    {
+                        schedulerUuid: scheduler.schedulerUuid,
+                        ownerUuid: scheduler.createdBy,
+                        actionVerb,
+                    },
+                );
+                return;
+            }
+            const owner = await this.userModel.getUserDetailsByUuid(
+                scheduler.createdBy,
+            );
+            if (!owner.email) {
+                this.logger.info(
+                    `Skipping scheduler-owner notification: owner has no email on record`,
+                    {
+                        schedulerUuid: scheduler.schedulerUuid,
+                        ownerUuid: scheduler.createdBy,
+                        actionVerb,
+                    },
+                );
+                return;
+            }
+            await this.emailClient.sendSchedulerModifiedByOtherUserEmail({
+                recipient: owner.email,
+                modifyingUserName:
+                    `${modifyingUser.firstName} ${modifyingUser.lastName}`.trim(),
+                schedulerName: scheduler.name,
+                actionVerb,
+                timestamp: `${new Date().toLocaleString('en-US', {
+                    dateStyle: 'long',
+                    timeStyle: 'short',
+                    timeZone: 'UTC',
+                })} UTC`,
+                resourceUrl: this.getSchedulerResourceUrl(
+                    scheduler,
+                    projectUuid,
+                ),
+            });
+        } catch (error) {
+            this.logger.error(
+                `Failed to notify scheduler owner ${scheduler.createdBy} of ${actionVerb} action on scheduler ${scheduler.schedulerUuid}`,
+                { error },
+            );
+        }
     }
 
     private async checkUserCanUpdateSchedulerResource(
@@ -631,6 +710,13 @@ export class SchedulerService extends BaseService {
             );
         }
 
+        await this.notifySchedulerOwnerOfModification(
+            user,
+            scheduler,
+            projectUuid,
+            'updated',
+        );
+
         return scheduler;
     }
 
@@ -674,6 +760,13 @@ export class SchedulerService extends BaseService {
                 defaultTimezone,
             );
         }
+
+        await this.notifySchedulerOwnerOfModification(
+            user,
+            scheduler,
+            projectUuid,
+            enabled ? 'enabled' : 'disabled',
+        );
 
         return scheduler;
     }
@@ -843,6 +936,13 @@ export class SchedulerService extends BaseService {
                 softDelete: false,
             },
         });
+
+        await this.notifySchedulerOwnerOfModification(
+            user,
+            scheduler,
+            projectUuid,
+            'deleted',
+        );
     }
 
     /**

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -763,6 +763,7 @@ export class ServiceRepository
                     projectModel: this.models.getProjectModel(),
                     schedulerClient: this.clients.getSchedulerClient(),
                     slackClient: this.clients.getSlackClient(),
+                    emailClient: this.clients.getEmailClient(),
                     userModel: this.models.getUserModel(),
                     googleDriveClient: this.clients.getGoogleDriveClient(),
                     userService: this.getUserService(),


### PR DESCRIPTION
Closes: SPK-426

### Description:
When another user (e.g. an admin) updates, deletes, enables, or disables a scheduler they don't own, the original creator now receives an email notification with the modifier's name, action, a readable UTC timestamp, and a link back to the resource. The notification is best-effort — failures are caught and logged so a broken email never blocks the user-facing operation. Also restyles the shared `genericNotification` email template (Inter font, smaller heading/body, top breathing room) so all scheduler notifications match the rest of the product emails.

### Demo

<img width="900" height="800" alt="email-consolidated" src="https://github.com/user-attachments/assets/dcea24c7-819c-4e84-8430-7feaf7913d7d" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)