### PR TITLE
fix(prod-7520): opaque background on save chart modal sticky footer

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartCreateModal/ChartCreateModal.module.css
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/ChartCreateModal.module.css
@@ -4,4 +4,5 @@
     bottom: 0;
     z-index: 2;
     padding: var(--mantine-spacing-md);
+    background-color: var(--mantine-color-body);
 }


### PR DESCRIPTION
## Before

<img width="1312" height="1154" alt="CleanShot 2026-05-11 at 15 14 29@2x" src="https://github.com/user-attachments/assets/60b52834-fbe5-4a55-99fe-2da78c1f2abd" />


## After

<img width="1330" height="1176" alt="CleanShot 2026-05-11 at 15 12 43@2x" src="https://github.com/user-attachments/assets/51172e14-1dc0-4a36-8342-3c0ee68ad081" />

## Summary

- The footer in `ChartCreateModal` is `position: sticky; bottom: 0` inside the modal body's `ScrollArea`, but had no `background-color`.
- When the body overflowed (many spaces, short viewport), rows visibly scrolled through the footer — most easily reproduced on the space-picker step.
- Added `background-color: var(--mantine-color-body)` to match the same sticky-footer pattern already used in `RoleBuilder.module.css` — adapts to light/dark theme automatically.

Linear: [PROD-7520](https://linear.app/lightdash/issue/PROD-7520/save-chart-modal-footer-is-transparent)

## Test plan

- [ ] Open Explore → pick a dimension/metric → click **Save chart**
- [ ] Click **Next** → choose **Space**
- [ ] With enough spaces (or a short viewport) to overflow the body, scroll the space list
- [ ] Confirm the footer (`+ New Space` / `Back` / `Save`) is opaque and no row content shows through
- [ ] Verify in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)