### PR TITLE
feat(spk-447): gate custom roles via DB feature flag

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -1,4 +1,4 @@
-import { CommercialFeatureFlags } from '@lightdash/common';
+import { CommercialFeatureFlags, FeatureFlag } from '@lightdash/common';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
 import {
@@ -14,6 +14,8 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             // Add new commercial handlers
             [CommercialFeatureFlags.AiCopilot]:
                 this.getAiCopilotFlag.bind(this),
+            [CommercialFeatureFlags.CustomRoles]:
+                this.getCustomRolesFlag.bind(this),
         };
     }
 
@@ -39,5 +41,15 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
 
         const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });
         return dbResult ?? { id: featureFlagId, enabled: false };
+    }
+
+    private async getCustomRolesFlag(
+        args: FeatureFlagLogicArgs,
+    ): Promise<FeatureFlag> {
+        if (this.lightdashConfig.customRoles.enabled) {
+            return { id: args.featureFlagId, enabled: true };
+        }
+        const dbResult = await this.tryGetFromDatabase(args);
+        return dbResult ?? { id: args.featureFlagId, enabled: false };
     }
 }

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -1,4 +1,4 @@
-import { CommercialFeatureFlags, FeatureFlag } from '@lightdash/common';
+import { CommercialFeatureFlags } from '@lightdash/common';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
 import {
@@ -14,8 +14,6 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             // Add new commercial handlers
             [CommercialFeatureFlags.AiCopilot]:
                 this.getAiCopilotFlag.bind(this),
-            [CommercialFeatureFlags.CustomRoles]:
-                this.getCustomRolesFlag.bind(this),
         };
     }
 
@@ -41,15 +39,5 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
 
         const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });
         return dbResult ?? { id: featureFlagId, enabled: false };
-    }
-
-    private async getCustomRolesFlag(
-        args: FeatureFlagLogicArgs,
-    ): Promise<FeatureFlag> {
-        if (this.lightdashConfig.customRoles.enabled) {
-            return { id: args.featureFlagId, enabled: true };
-        }
-        const dbResult = await this.tryGetFromDatabase(args);
-        return dbResult ?? { id: args.featureFlagId, enabled: false };
     }
 }

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -611,6 +611,7 @@ export class ModelRepository
                 new UserModel({
                     database: this.database,
                     lightdashConfig: this.lightdashConfig,
+                    featureFlagModel: this.getFeatureFlagModel(),
                 }),
         );
     }

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -723,7 +723,9 @@ export class UserModel {
                 pat: this.lightdashConfig.auth.pat,
             },
             customRoleScopes,
-            customRolesEnabled: customRolesFlag.enabled,
+            customRolesEnabled:
+                this.lightdashConfig.customRoles.enabled ||
+                customRolesFlag.enabled,
             isEnterprise: this.lightdashConfig.license.licenseKey !== undefined,
         });
 

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -4,6 +4,7 @@ import {
     AlreadyExistsError,
     applyServiceAccountAbilities,
     buildAbilityFromScopes,
+    CommercialFeatureFlags,
     CreateUserArgs,
     CreateUserWithRole,
     ForbiddenError,
@@ -64,6 +65,7 @@ import {
     PatSessionCache,
 } from './caches/PatSessionCache';
 import { PersonalAccessTokenModel } from './DashboardModel/PersonalAccessTokenModel';
+import { FeatureFlagModel } from './FeatureFlagModel/FeatureFlagModel';
 import Transaction = Knex.Transaction;
 
 export type DbUserDetails = {
@@ -131,6 +133,7 @@ const userDetailsQueryBuilder = (
 type UserModelArguments = {
     database: Knex;
     lightdashConfig: LightdashConfig;
+    featureFlagModel: FeatureFlagModel;
 };
 
 const sessionUserCache =
@@ -146,9 +149,16 @@ export class UserModel {
 
     private readonly database: Knex;
 
-    constructor({ database, lightdashConfig }: UserModelArguments) {
+    private readonly featureFlagModel: FeatureFlagModel;
+
+    constructor({
+        database,
+        lightdashConfig,
+        featureFlagModel,
+    }: UserModelArguments) {
         this.database = database;
         this.lightdashConfig = lightdashConfig;
+        this.featureFlagModel = featureFlagModel;
     }
 
     private canTrackingBeAnonymized() {
@@ -699,7 +709,13 @@ export class UserModel {
         const customRoleUuids = [...projectRoles, ...groupProjectRoles]
             .map((role) => role.roleUuid)
             .filter(Boolean) as string[];
-        const customRoleScopes = await this.customRoleScopes(customRoleUuids);
+        const [customRoleScopes, customRolesFlag] = await Promise.all([
+            this.customRoleScopes(customRoleUuids),
+            this.featureFlagModel.get({
+                user: lightdashUser,
+                featureFlagId: CommercialFeatureFlags.CustomRoles,
+            }),
+        ]);
         const abilityBuilder = getUserAbilityBuilder({
             user: lightdashUser,
             projectProfiles: [...projectRoles, ...groupProjectRoles],
@@ -707,7 +723,7 @@ export class UserModel {
                 pat: this.lightdashConfig.auth.pat,
             },
             customRoleScopes,
-            customRolesEnabled: this.lightdashConfig.customRoles?.enabled,
+            customRolesEnabled: customRolesFlag.enabled,
             isEnterprise: this.lightdashConfig.license.licenseKey !== undefined,
         });
 

--- a/packages/backend/src/overrideUserPassword.ts
+++ b/packages/backend/src/overrideUserPassword.ts
@@ -3,6 +3,7 @@ import knex from 'knex';
 import { lightdashConfig } from './config/lightdashConfig';
 import knexConfig from './knexfile';
 import Logger from './logging/logger';
+import { FeatureFlagModel } from './models/FeatureFlagModel/FeatureFlagModel';
 import { UserModel } from './models/UserModel';
 
 (async function init() {
@@ -22,13 +23,18 @@ import { UserModel } from './models/UserModel';
             process.env.NODE_ENV === 'development'
                 ? 'development'
                 : 'production';
+        const database = knex(
+            environment === 'production'
+                ? knexConfig.production
+                : knexConfig.development,
+        );
         const userModel = new UserModel({
             lightdashConfig,
-            database: knex(
-                environment === 'production'
-                    ? knexConfig.production
-                    : knexConfig.development,
-            ),
+            database,
+            featureFlagModel: new FeatureFlagModel({
+                database,
+                lightdashConfig,
+            }),
         });
 
         Logger.info(`Get user by email: ${email}`);

--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -4,4 +4,5 @@ export enum CommercialFeatureFlags {
     AiCopilot = 'ai-copilot',
     ServiceAccounts = 'service-accounts',
     OrganizationWarehouseCredentials = 'organization-warehouse-credentials',
+    CustomRoles = 'custom-roles',
 }

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -1,4 +1,5 @@
 import {
+    CommercialFeatureFlags,
     CustomFormatType,
     getErrorMessage,
     getItemId,
@@ -69,6 +70,7 @@ import { useConvertSqlToFormula } from '../../../hooks/useConvertSqlToFormula';
 import { useExplore } from '../../../hooks/useExplore';
 import { useProject } from '../../../hooks/useProject';
 import { useCannotAuthorCustomSqlTableCalculations } from '../../../hooks/user/useCannotAuthorCustomSqlTableCalculations';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { getUniqueTableCalculationName } from '../utils';
 import { FormatRow } from './FormatRow/FormatRow';
 import { FormulaForm, type FormulaFormHandle } from './FormulaForm/FormulaForm';
@@ -130,7 +132,11 @@ const TableCalculationModal: FC<Props> = ({
         );
 
     const isAmbientAiEnabled = health?.ai?.isAmbientAiEnabled === true;
-    const isCustomRolesEnabled = health?.isCustomRolesEnabled === true;
+    const { data: customRolesFlag } = useServerFeatureFlag(
+        CommercialFeatureFlags.CustomRoles,
+    );
+    const isCustomRolesEnabled =
+        health?.isCustomRolesEnabled || customRolesFlag?.enabled;
     const requestContext = useMemo(() => {
         const tcLabel =
             tableCalculation?.displayName || 'this SQL table calculation';

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -132,7 +132,11 @@ const Settings: FC = () => {
     );
     const isLeaveOrganizationEnabled = leaveOrganizationFlag?.enabled === true;
 
-    const isCustomRolesEnabled = health?.isCustomRolesEnabled;
+    const { data: customRolesFlag } = useServerFeatureFlag(
+        CommercialFeatureFlags.CustomRoles,
+    );
+    const isCustomRolesEnabled =
+        health?.isCustomRolesEnabled || customRolesFlag?.enabled;
 
     const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,


### PR DESCRIPTION
## Summary

Adds a per-organization DB-backed gate for custom roles, layered on top of the existing `CUSTOM_ROLES_ENABLED` env var. Either signal enables the feature.

Closes [SPK-447](https://linear.app/lightdash/issue/SPK-447).

## Why

Service accounts already work with both env var and DB-backed flag overrides; custom roles only honored the env var, so cloud orgs couldn't be opted in without a backend redeploy. This brings custom roles into line.

## Approach

- New EE flag: `CommercialFeatureFlags.CustomRoles = 'custom-roles'`.
- New handler `CommercialFeatureFlagModel.getCustomRolesFlag`: returns `true` if env is set, else falls back to `feature_flags` + `feature_flag_overrides` (user → org → default). Mirrors `getEnableDataAppsEnabled` / `getAiCopilotFlag`.
- `UserModel.generateUserAbilityBuilder` resolves the flag per-session via `featureFlagModel.get(...)` and passes the resolved boolean into `getUserAbilityBuilder`. Service-account branch is **untouched** — role bindings still apply regardless of the flag.
- Frontend (`Settings.tsx`, `TableCalculationModal.tsx`): OR `health.isCustomRolesEnabled` (env-only) with `useServerFeatureFlag(CommercialFeatureFlags.CustomRoles)` — same pattern as service-accounts.

## Behavior matrix

| `CUSTOM_ROLES_ENABLED` env | DB flag for `'custom-roles'` | Frontend (menu visible?) | Backend (scopes applied?) |
|---|---|---|---|
| false | false | hidden | no |
| false | true | shown | yes |
| true | false | shown | yes |
| true | true | shown | yes |

Also gated by `isEnterprise` (license key) on the backend — non-EE installs always resolve to no regardless of env/DB.

## Test plan

- [x] \`pnpm -F backend test:dev:nowatch\` passes
- [x] \`pnpm -F common typecheck\` / \`pnpm -F backend typecheck\` / \`pnpm -F frontend typecheck\` clean
- [x] Manual: with \`CUSTOM_ROLES_ENABLED\` unset, insert a \`feature_flag_overrides\` row for a test org → Settings menu shows Custom Roles and a custom role works end-to-end
- [x] Manual: with neither env nor DB row, menu is hidden and API rejects custom-role operations
- [x] Manual: with \`CUSTOM_ROLES_ENABLED=true\`, behavior matches today's main
- [x] Verify service-account flows are unaffected

## Notes

\`/api/v1/health.isCustomRolesEnabled\` remains env-only by design; per-org resolution is exposed via \`/api/v2/feature-flag/custom-roles\`, which the frontend ORs with the health value. SPK-447's third acceptance criterion ("health reflects the resolved value") was intentionally dropped to avoid an extra DB round-trip on every health probe.