### PR TITLE
feat(scheduler): show last-run status badge on dashboard/chart scheduler list

### DIFF
--- a/packages/backend/src/controllers/v2/DashboardController.ts
+++ b/packages/backend/src/controllers/v2/DashboardController.ts
@@ -35,6 +35,8 @@ export class DashboardControllerV2 extends BaseController {
      * @param req express request
      * @param pageSize number of items per page
      * @param page page number
+     * @param searchQuery filter schedulers by name
+     * @param includeLatestRun include the most recent run for each scheduler
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -46,6 +48,7 @@ export class DashboardControllerV2 extends BaseController {
         @Query() pageSize?: number,
         @Query() page?: number,
         @Query() searchQuery?: string,
+        @Query() includeLatestRun?: boolean,
     ): Promise<ApiDashboardPaginatedSchedulersResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -67,6 +70,7 @@ export class DashboardControllerV2 extends BaseController {
                     dashboardUuid,
                     searchQuery,
                     paginateArgs,
+                    includeLatestRun,
                 ),
         };
     }

--- a/packages/backend/src/controllers/v2/SavedChartController.ts
+++ b/packages/backend/src/controllers/v2/SavedChartController.ts
@@ -35,6 +35,9 @@ export class SavedChartControllerV2 extends BaseController {
      * @param req express request
      * @param pageSize number of items per page
      * @param page page number
+     * @param searchQuery filter schedulers by name
+     * @param formats comma-separated list of scheduler formats to include
+     * @param includeLatestRun include the most recent run for each scheduler
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -47,6 +50,7 @@ export class SavedChartControllerV2 extends BaseController {
         @Query() page?: number,
         @Query() searchQuery?: string,
         @Query() formats?: string,
+        @Query() includeLatestRun?: boolean,
     ): Promise<ApiSavedChartPaginatedSchedulersResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -73,6 +77,7 @@ export class SavedChartControllerV2 extends BaseController {
                     searchQuery,
                     paginateArgs,
                     filters,
+                    includeLatestRun,
                 ),
         };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -21996,7 +21996,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22006,7 +22006,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22016,7 +22016,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -22029,7 +22029,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -59344,6 +59344,11 @@ export function RegisterRoutes(app: Router) {
         page: { in: 'query', name: 'page', dataType: 'double' },
         searchQuery: { in: 'query', name: 'searchQuery', dataType: 'string' },
         formats: { in: 'query', name: 'formats', dataType: 'string' },
+        includeLatestRun: {
+            in: 'query',
+            name: 'includeLatestRun',
+            dataType: 'boolean',
+        },
     };
     app.get(
         '/api/v2/saved/:chartUuid/schedulers',
@@ -61267,6 +61272,11 @@ export function RegisterRoutes(app: Router) {
         pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
         page: { in: 'query', name: 'page', dataType: 'double' },
         searchQuery: { in: 'query', name: 'searchQuery', dataType: 'string' },
+        includeLatestRun: {
+            in: 'query',
+            name: 'includeLatestRun',
+            dataType: 'boolean',
+        },
     };
     app.get(
         '/api/v2/dashboards/:dashboardUuid/schedulers',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -23374,22 +23374,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -32271,7 +32271,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2913.1",
+        "version": "0.2915.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -50324,6 +50324,7 @@
                         }
                     },
                     {
+                        "description": "filter schedulers by name",
                         "in": "query",
                         "name": "searchQuery",
                         "required": false,
@@ -50332,11 +50333,21 @@
                         }
                     },
                     {
+                        "description": "comma-separated list of scheduler formats to include",
                         "in": "query",
                         "name": "formats",
                         "required": false,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "description": "include the most recent run for each scheduler",
+                        "in": "query",
+                        "name": "includeLatestRun",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ]
@@ -51825,11 +51836,21 @@
                         }
                     },
                     {
+                        "description": "filter schedulers by name",
                         "in": "query",
                         "name": "searchQuery",
                         "required": false,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "description": "include the most recent run for each scheduler",
+                        "in": "query",
+                        "name": "includeLatestRun",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ]

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -1659,6 +1659,7 @@ export class SchedulerModel {
         searchQuery,
         sort,
         filters,
+        latestOnly,
     }: {
         schedulers: SchedulerAndTargets[];
         paginateArgs?: KnexPaginateArgs;
@@ -1672,6 +1673,9 @@ export class SchedulerModel {
             resourceType?: 'chart' | 'dashboard' | 'sqlChart';
             resourceUuids?: string[];
         };
+        // When true, returns at most one row per scheduler (its most recent run)
+        // by adding a per-scheduler ROW_NUMBER filter at the SQL layer.
+        latestOnly?: boolean;
     }): Promise<KnexPaginatedData<SchedulerRun[]>> {
         // Apply scheduler-level filters
         let filteredSchedulers = schedulers;
@@ -1972,7 +1976,27 @@ export class SchedulerModel {
         // (WHERE clause can't reference SELECT aliases, so we need an outer query)
         const runsWithStatusSubquery = runsQuery.as('runs_with_status');
 
-        let finalQuery = this.database(runsWithStatusSubquery).select('*');
+        let finalQuery;
+        if (latestOnly) {
+            // Add a per-scheduler ROW_NUMBER and keep only rn = 1 so we get the
+            // most recent run for each scheduler (avoids pulling N runs/scheduler
+            // just to take the first one in JS).
+            const rankedPerSchedulerSubquery = this.database(
+                runsWithStatusSubquery,
+            )
+                .select(
+                    '*',
+                    this.database.raw(
+                        'ROW_NUMBER() OVER (PARTITION BY scheduler_uuid ORDER BY scheduled_time DESC) as scheduler_rn',
+                    ),
+                )
+                .as('ranked_per_scheduler');
+            finalQuery = this.database(rankedPerSchedulerSubquery)
+                .select('*')
+                .where('scheduler_rn', 1);
+        } else {
+            finalQuery = this.database(runsWithStatusSubquery).select('*');
+        }
 
         // Apply runStatus filter on the outer query (run_status is now a real column)
         if (filters?.statuses && filters.statuses.length > 0) {
@@ -2058,6 +2082,33 @@ export class SchedulerModel {
         return {
             pagination,
             data: runs,
+        };
+    }
+
+    async attachLatestRunToSchedulers(
+        schedulers: KnexPaginatedData<SchedulerAndTargets[]>,
+    ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
+        if (schedulers.data.length === 0) {
+            return schedulers;
+        }
+
+        const runs = await this.getRunsForSchedulers({
+            schedulers: schedulers.data,
+            latestOnly: true,
+        });
+
+        const latestRunByScheduler = new Map<string, SchedulerRun>();
+        runs.data.forEach((run) => {
+            latestRunByScheduler.set(run.schedulerUuid, run);
+        });
+
+        return {
+            ...schedulers,
+            data: schedulers.data.map((scheduler) => ({
+                ...scheduler,
+                latestRun:
+                    latestRunByScheduler.get(scheduler.schedulerUuid) ?? null,
+            })),
         };
     }
 

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1446,12 +1446,13 @@ export class DashboardService
         dashboardUuid: string,
         searchQuery?: string,
         paginateArgs?: KnexPaginateArgs,
+        includeLatestRun?: boolean,
     ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
         const dashboard = await this.checkCreateScheduledDeliveryAccess(
             user,
             dashboardUuid,
         );
-        return this.schedulerModel.getSchedulers({
+        const schedulers = await this.schedulerModel.getSchedulers({
             projectUuid: dashboard.projectUuid,
             organizationUuid: dashboard.organizationUuid,
             paginateArgs,
@@ -1461,6 +1462,12 @@ export class DashboardService
                 resourceUuids: [dashboardUuid],
             },
         });
+
+        if (!includeLatestRun) {
+            return schedulers;
+        }
+
+        return this.schedulerModel.attachLatestRunToSchedulers(schedulers);
     }
 
     async createScheduler(

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -1653,12 +1653,13 @@ export class SavedChartService
         filters?: {
             formats?: string[];
         },
+        includeLatestRun?: boolean,
     ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
         const chart = await this.checkCreateScheduledDeliveryAccess(
             user,
             chartUuid,
         );
-        return this.schedulerModel.getSchedulers({
+        const schedulers = await this.schedulerModel.getSchedulers({
             projectUuid: chart.projectUuid,
             organizationUuid: chart.organizationUuid,
             paginateArgs,
@@ -1669,6 +1670,12 @@ export class SavedChartService
                 formats: filters?.formats,
             },
         });
+
+        if (!includeLatestRun) {
+            return schedulers;
+        }
+
+        return this.schedulerModel.attachLatestRunToSchedulers(schedulers);
     }
 
     async createScheduler(

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -447,34 +447,7 @@ export class SchedulerService extends BaseService {
             return schedulers;
         }
 
-        const schedulerUuids = schedulers.data.map(
-            (scheduler) => scheduler.schedulerUuid,
-        );
-
-        if (schedulerUuids.length === 0) {
-            return schedulers;
-        }
-
-        const runs = await this.schedulerModel.getRunsForSchedulers({
-            schedulers: schedulers.data,
-            sort: { column: 'scheduledTime', direction: 'desc' },
-        });
-
-        const latestRunByScheduler = new Map<string, SchedulerRun>();
-        runs.data.forEach((run) => {
-            if (!latestRunByScheduler.has(run.schedulerUuid)) {
-                latestRunByScheduler.set(run.schedulerUuid, run);
-            }
-        });
-
-        return {
-            ...schedulers,
-            data: schedulers.data.map((scheduler) => ({
-                ...scheduler,
-                latestRun:
-                    latestRunByScheduler.get(scheduler.schedulerUuid) ?? null,
-            })),
-        };
+        return this.schedulerModel.attachLatestRunToSchedulers(schedulers);
     }
 
     async getScheduler(
@@ -524,34 +497,7 @@ export class SchedulerService extends BaseService {
             return schedulers;
         }
 
-        const schedulerUuids = schedulers.data.map(
-            (scheduler) => scheduler.schedulerUuid,
-        );
-
-        if (schedulerUuids.length === 0) {
-            return schedulers;
-        }
-
-        const runs = await this.schedulerModel.getRunsForSchedulers({
-            schedulers: schedulers.data,
-            sort: { column: 'scheduledTime', direction: 'desc' },
-        });
-
-        const latestRunByScheduler = new Map<string, SchedulerRun>();
-        runs.data.forEach((run) => {
-            if (!latestRunByScheduler.has(run.schedulerUuid)) {
-                latestRunByScheduler.set(run.schedulerUuid, run);
-            }
-        });
-
-        return {
-            ...schedulers,
-            data: schedulers.data.map((scheduler) => ({
-                ...scheduler,
-                latestRun:
-                    latestRunByScheduler.get(scheduler.schedulerUuid) ?? null,
-            })),
-        };
+        return this.schedulerModel.attachLatestRunToSchedulers(schedulers);
     }
 
     async getSchedulerDefaultTimezone(schedulerUuid: string | undefined) {

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -7,7 +7,6 @@ import {
     isSchedulerGsheetsOptions,
     isSlackTarget,
     SchedulerFormat,
-    SchedulerRunStatus,
 } from '@lightdash/common';
 import {
     Anchor,
@@ -21,12 +20,10 @@ import {
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
-    IconAlertCircle,
     IconArrowDown,
     IconArrowsSort,
     IconArrowUp,
     IconChartBar,
-    IconCheck,
     IconClock,
     IconCodeDots,
     IconLayoutDashboard,
@@ -65,6 +62,7 @@ import ReassignSchedulerOwnerModal from './ReassignSchedulerOwnerModal';
 import SchedulersViewActionMenu from './SchedulersViewActionMenu';
 import { SchedulersViewTab } from './SchedulersViewConstants';
 import {
+    getRunStatusConfig,
     getSchedulerIcon,
     getSchedulerLink,
     type SchedulerItem,
@@ -83,27 +81,6 @@ interface SchedulersTableProps {
 }
 
 const fetchSize = 50;
-
-const getRunStatusConfig = (status: SchedulerRunStatus) => {
-    switch (status) {
-        case SchedulerRunStatus.COMPLETED:
-            return { color: 'green', icon: IconCheck, label: 'Completed' };
-        case SchedulerRunStatus.PARTIAL_FAILURE:
-            return {
-                color: 'yellow',
-                icon: IconAlertCircle,
-                label: 'Partial failure',
-            };
-        case SchedulerRunStatus.FAILED:
-            return { color: 'red', icon: IconAlertCircle, label: 'Failed' };
-        case SchedulerRunStatus.RUNNING:
-            return { color: 'blue', icon: IconRun, label: 'Running' };
-        case SchedulerRunStatus.SCHEDULED:
-            return { color: 'gray', icon: IconClock, label: 'Scheduled' };
-        default:
-            return assertUnreachable(status, 'Unknown scheduler run status');
-    }
-};
 
 const SchedulersTable: FC<SchedulersTableProps> = ({
     projectUuid,

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -3,20 +3,25 @@ import {
     SchedulerFormat,
     SchedulerJobStatus,
     SchedulerResourceType,
+    SchedulerRunStatus,
     type SchedulerAndTargets,
     type SchedulerRun,
     type SchedulerWithLogs,
 } from '@lightdash/common';
 import { type MantineTheme } from '@mantine-8/core';
 import {
+    IconAlertCircle,
     IconAlertTriangleFilled,
+    IconCheck,
     IconCircleCheckFilled,
+    IconClock,
     IconClockFilled,
     IconCsv,
     IconFileTypePdf,
     IconFileTypeXls,
     IconPhoto,
     IconProgress,
+    IconRun,
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { GSheetsIconFilled } from '../../components/common/GSheetsIcon';
@@ -130,6 +135,27 @@ export const getLogStatusIconWithoutTooltip = (
             );
         default:
             return assertUnreachable(status, 'Resource type not supported');
+    }
+};
+
+export const getRunStatusConfig = (status: SchedulerRunStatus) => {
+    switch (status) {
+        case SchedulerRunStatus.COMPLETED:
+            return { color: 'green', icon: IconCheck, label: 'Completed' };
+        case SchedulerRunStatus.PARTIAL_FAILURE:
+            return {
+                color: 'yellow',
+                icon: IconAlertCircle,
+                label: 'Partial failure',
+            };
+        case SchedulerRunStatus.FAILED:
+            return { color: 'red', icon: IconAlertCircle, label: 'Failed' };
+        case SchedulerRunStatus.RUNNING:
+            return { color: 'blue', icon: IconRun, label: 'Running' };
+        case SchedulerRunStatus.SCHEDULED:
+            return { color: 'gray', icon: IconClock, label: 'Scheduled' };
+        default:
+            return assertUnreachable(status, 'Unknown scheduler run status');
     }
 };
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
@@ -36,6 +36,7 @@ export const DashboardSchedulersModal: FC<DashboardSchedulersProps> = ({
     const schedulersQuery = useDashboardSchedulers({
         dashboardUuid,
         searchQuery: debouncedSearchQuery,
+        includeLatestRun: true,
     });
     const createMutation = useDashboardSchedulerCreateMutation();
 
@@ -93,6 +94,7 @@ export const ChartSchedulersModal: FC<ChartSchedulersProps> = ({
         chartUuid,
         searchQuery: debouncedSearchQuery,
         formats: DELIVERY_FORMATS,
+        includeLatestRun: true,
     });
     const createMutation = useChartSchedulerCreateMutation();
 

--- a/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
+    Badge,
     Box,
     Group,
     Paper,
@@ -19,8 +20,11 @@ import {
     IconSend,
     IconTrash,
 } from '@tabler/icons-react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { getRunStatusConfig } from '../../../components/SchedulersView/SchedulersViewUtils';
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
 import { useProject } from '../../../hooks/useProject';
 import useApp from '../../../providers/App/useApp';
@@ -28,6 +32,8 @@ import { useSendNowSchedulerByUuid } from '../hooks/useScheduler';
 import { useSchedulersEnabledUpdateMutation } from '../hooks/useSchedulersUpdateMutation';
 import ConfirmPauseSchedulerModal from './ConfirmPauseSchedulerModal';
 import ConfirmSendNowModal from './ConfirmSendNowModal';
+
+dayjs.extend(relativeTime);
 
 type SchedulersListItemProps = {
     scheduler: SchedulerAndTargets;
@@ -77,6 +83,15 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
             }),
         );
     }, [user.data, activeProjectUuid]);
+
+    const latestRunStatusConfig = useMemo(
+        () =>
+            scheduler.latestRun
+                ? getRunStatusConfig(scheduler.latestRun.runStatus)
+                : null,
+        [scheduler.latestRun],
+    );
+
     if (!project) {
         return null;
     }
@@ -103,6 +118,40 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
                         <Text c="ldGray.6" fz={12}>
                             {scheduler.targets.length} recipients
                         </Text>
+
+                        <Box c="ldGray.4">
+                            <MantineIcon icon={IconCircleFilled} size={5} />
+                        </Box>
+
+                        {scheduler.latestRun && latestRunStatusConfig ? (
+                            <Tooltip
+                                withinPortal
+                                label={`Last run ${dayjs(
+                                    scheduler.latestRun.scheduledTime,
+                                ).fromNow()} (${dayjs(
+                                    scheduler.latestRun.scheduledTime,
+                                ).format('YYYY/MM/DD HH:mm')})`}
+                            >
+                                <Badge
+                                    variant="light"
+                                    size="sm"
+                                    radius="sm"
+                                    color={latestRunStatusConfig.color}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={latestRunStatusConfig.icon}
+                                            size={10}
+                                        />
+                                    }
+                                >
+                                    {latestRunStatusConfig.label}
+                                </Badge>
+                            </Tooltip>
+                        ) : (
+                            <Text c="ldGray.6" fz={12} fs="italic">
+                                Not run yet
+                            </Text>
+                        )}
                     </Group>
                 </Stack>
                 {!userCanManageScheduledDelivery &&

--- a/packages/frontend/src/features/scheduler/hooks/useChartSchedulers.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useChartSchedulers.ts
@@ -22,6 +22,7 @@ const getChartSchedulers = async (
     paginateArgs: KnexPaginateArgs,
     searchQuery?: string,
     formats?: SchedulerFormat[],
+    includeLatestRun?: boolean,
 ) => {
     const params = new URLSearchParams({
         page: paginateArgs.page.toString(),
@@ -34,6 +35,10 @@ const getChartSchedulers = async (
 
     if (formats && formats.length > 0) {
         params.set('formats', formats.join(','));
+    }
+
+    if (includeLatestRun) {
+        params.set('includeLatestRun', 'true');
     }
 
     return lightdashApi<ChartSchedulersResponse>({
@@ -49,6 +54,7 @@ export type UseChartSchedulersParams = {
     searchQuery?: string;
     pageSize?: number;
     formats?: SchedulerFormat[];
+    includeLatestRun?: boolean;
 };
 
 export const useChartSchedulers = ({
@@ -56,6 +62,7 @@ export const useChartSchedulers = ({
     searchQuery,
     pageSize = 25,
     formats,
+    includeLatestRun,
 }: UseChartSchedulersParams) =>
     useInfiniteQuery<ChartSchedulersResponse, ApiError>({
         queryKey: [
@@ -64,6 +71,7 @@ export const useChartSchedulers = ({
             searchQuery,
             pageSize,
             formats,
+            includeLatestRun,
         ],
         queryFn: ({ pageParam = 1 }) =>
             getChartSchedulers(
@@ -71,6 +79,7 @@ export const useChartSchedulers = ({
                 { page: pageParam as number, pageSize },
                 searchQuery,
                 formats,
+                includeLatestRun,
             ),
         getNextPageParam: (lastPage) => {
             const currentPage = lastPage.pagination?.page ?? 1;

--- a/packages/frontend/src/features/scheduler/hooks/useDashboardSchedulers.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useDashboardSchedulers.ts
@@ -20,6 +20,7 @@ const getDashboardSchedulers = async (
     uuid: string,
     paginateArgs: KnexPaginateArgs,
     searchQuery?: string,
+    includeLatestRun?: boolean,
 ) => {
     const params = new URLSearchParams({
         page: paginateArgs.page.toString(),
@@ -28,6 +29,10 @@ const getDashboardSchedulers = async (
 
     if (searchQuery) {
         params.set('searchQuery', searchQuery);
+    }
+
+    if (includeLatestRun) {
+        params.set('includeLatestRun', 'true');
     }
 
     return lightdashApi<DashboardSchedulersResponse>({
@@ -42,12 +47,14 @@ export type UseDashboardSchedulersParams = {
     dashboardUuid: string;
     searchQuery?: string;
     pageSize?: number;
+    includeLatestRun?: boolean;
 };
 
 export const useDashboardSchedulers = ({
     dashboardUuid,
     searchQuery,
     pageSize = 25,
+    includeLatestRun,
 }: UseDashboardSchedulersParams) =>
     useInfiniteQuery<DashboardSchedulersResponse, ApiError>({
         queryKey: [
@@ -55,12 +62,14 @@ export const useDashboardSchedulers = ({
             dashboardUuid,
             searchQuery,
             pageSize,
+            includeLatestRun,
         ],
         queryFn: ({ pageParam = 1 }) =>
             getDashboardSchedulers(
                 dashboardUuid,
                 { page: pageParam as number, pageSize },
                 searchQuery,
+                includeLatestRun,
             ),
         getNextPageParam: (lastPage) => {
             const currentPage = lastPage.pagination?.page ?? 1;


### PR DESCRIPTION
Closes: SPK-448
Refs: SPK-422

### Description

Editors can now see at a glance whether each scheduled delivery's last run succeeded, failed, is running, or has never run, directly from the "Scheduled deliveries" modal on dashboard and chart pages — replacing the previously planned deep-link-to-settings approach with an inline badge.

**Backend** — Adds an `includeLatestRun` query param to the v2 resource-scoped scheduler endpoints (`/api/v2/dashboards/:uuid/schedulers`, `/api/v2/saved/:uuid/schedulers`). Permission gates are unchanged (`create ScheduledDeliveries` + space access via `checkCreateScheduledDeliveryAccess`). The latest-run enrichment is centralised in a new `SchedulerModel.attachLatestRunToSchedulers` helper, and a `latestOnly` flag on `getRunsForSchedulers` collapses results to one row per scheduler via a per-scheduler `ROW_NUMBER()` filter instead of fetching all runs and discarding them in JS.

**Frontend** — `SchedulersListItem` renders a status badge (Completed / Failed / Partial failure / Running / Scheduled) with a tooltip showing the relative timestamp; falls back to a muted "Not run yet" pill when there is no run. `getRunStatusConfig` is lifted from `SchedulersTable` into the shared `SchedulersViewUtils` so the admin view and the modal use the same source of truth.

### Screenshot

<img width="2400" height="2454" alt="spk-448-all-states" src="https://github.com/user-attachments/assets/18f91e18-ae16-4b8b-b57e-76101e4abb5a" />


| State | Visual |
|---|---|
| Brand new delivery | *Not run yet* (italic gray) |
| Daily revenue alert | ❗ **Failed** (red) |
| Partial-failure delivery | ⚠️ **Partial failure** (yellow) |
| Running right now | 🏃 **Running** (blue) |
| Weekly sales summary | ✓ **Completed** (green) |

Tooltip on hover: *Last run 2 hours ago (2026/05/11 15:53)*