### PR TITLE
fix(echarts): bypass dayjs.tz for UTC in category date axis snap

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -409,6 +409,82 @@ describe('getCategoryDateAxisConfig', () => {
             expect(result.data).toHaveLength(4);
         });
     });
+
+    // Regression: iteration landing exactly on maxX produced a duplicate
+    // trailing category due to dayjs.tz .isBefore drift.
+    describe('no duplicate entries when range lands exactly on maxX', () => {
+        const expectStrictlyIncreasingAndUnique = (data: string[]) => {
+            expect(new Set(data).size).toBe(data.length);
+            const values = data.map((d) => new Date(d).valueOf());
+            for (let i = 1; i < values.length; i += 1) {
+                expect(values[i]).toBeGreaterThan(values[i - 1]);
+            }
+        };
+
+        test('WEEK iteration ending exactly on maxX produces no duplicate', () => {
+            // 6 weeks apart — iteration lands exactly on maxX
+            const rows = createRows([
+                '2020-06-29T01:00:00Z',
+                '2020-08-10T01:00:00Z',
+            ]);
+            const result = getCategoryDateAxisConfig(
+                axisId,
+                createAxisField(TimeFrames.WEEK),
+                rows,
+                'category',
+            );
+            expect(result.data).toHaveLength(7);
+            expectStrictlyIncreasingAndUnique(result.data!);
+        });
+
+        test('MONTH iteration ending exactly on maxX produces no duplicate', () => {
+            const rows = createRows([
+                '2024-01-15T00:00:00.000Z',
+                '2024-06-15T00:00:00.000Z',
+            ]);
+            const result = getCategoryDateAxisConfig(
+                axisId,
+                createAxisField(TimeFrames.MONTH),
+                rows,
+                'category',
+            );
+            // Jan..Jun inclusive = 6 months
+            expect(result.data).toHaveLength(6);
+            expectStrictlyIncreasingAndUnique(result.data!);
+        });
+
+        test('QUARTER iteration ending exactly on maxX produces no duplicate', () => {
+            const rows = createRows([
+                '2024-01-15T00:00:00.000Z',
+                '2024-10-15T00:00:00.000Z',
+            ]);
+            const result = getCategoryDateAxisConfig(
+                axisId,
+                createAxisField(TimeFrames.QUARTER),
+                rows,
+                'category',
+            );
+            // Q1..Q4 = 4 quarters
+            expect(result.data).toHaveLength(4);
+            expectStrictlyIncreasingAndUnique(result.data!);
+        });
+
+        test('YEAR iteration ending exactly on maxX produces no duplicate', () => {
+            const rows = createRows([
+                '2020-06-15T00:00:00.000Z',
+                '2024-06-15T00:00:00.000Z',
+            ]);
+            const result = getCategoryDateAxisConfig(
+                axisId,
+                createAxisField(TimeFrames.YEAR),
+                rows,
+                'category',
+            );
+            // 2020..2024 inclusive = 5 years
+            expect(result.data).toHaveLength(5);
+            expectStrictlyIncreasingAndUnique(result.data!);
+        });
+    });
 });
 
 describe('filterSeriesWithNoData', () => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1507,7 +1507,10 @@ export const getCategoryDateAxisConfig = (
         axisField.timeIntervalBaseDimensionType === DimensionType.DATE;
     const tz =
         isDateBaseInterval || !resolvedTimezone ? 'UTC' : resolvedTimezone;
-    const inTz = (v: string | number) => dayjs.tz(dayjs.utc(v).toDate(), tz);
+    // Skip dayjs.tz for UTC: .add() chains drift sub-ms vs fresh .tz() objects
+    // and break .isBefore at the boundary.
+    const inTz = (v: string | number) =>
+        tz === 'UTC' ? dayjs.utc(v) : dayjs.tz(dayjs.utc(v).toDate(), tz);
 
     if (timeInterval === TimeFrames.WEEK) {
         const continuousRange: string[] = [];


### PR DESCRIPTION
WEEK / MONTH / QUARTER / YEAR bar charts rendered an empty trailing bar after #22884. The new snap math iterated through `dayjs.tz(date, 'UTC').add(...)`, but `dayjs.tz` objects produced via an `.add()` chain drift sub-ms vs fresh ones and disagree on `.isBefore`/`.isSame` at the boundary — when iteration landed exactly on `maxX`, both the loop and the trailing `push(endDate)` ran, producing a duplicate final category.

With the flag off `tz` is always `'UTC'`, so the `dayjs.tz` round-trip was unnecessary anyway. Skip it for UTC and the snap math matches pre-#22884 byte-for-byte.

**Before**
<img width="2133" height="1182" alt="CleanShot 2026-05-11 at 19 11 14" src="https://github.com/user-attachments/assets/e2e9fe49-50bc-42c8-babd-7993ab9edf49" />



**After**
<img width="1204" height="1143" alt="CleanShot 2026-05-11 at 19 10 09" src="https://github.com/user-attachments/assets/878ec919-b85b-4a55-b50f-3be2d25927aa" />


Closes [GLITCH-434](https://linear.app/lightdash/issue/GLITCH-434/echarts-category-axis-duplicates-final-weekmonthquarteryear)