### PR TITLE
feat(user-settings): "Leave organization" action (behind feature flag)

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -173,6 +173,14 @@ type UserJoinOrganizationEvent = BaseTrack & {
     };
 };
 
+type UserLeaveOrganizationEvent = BaseTrack & {
+    event: 'user.left_organization';
+    properties: {
+        organizationId: string;
+        role: OrganizationMemberRole;
+    };
+};
+
 export const getContextFromHeader = (req: Request) => {
     const method = getRequestMethod(req.header(LightdashRequestMethodHeader));
     switch (method) {
@@ -1941,6 +1949,7 @@ type TypedEvent =
     | DeleteUserEvent
     | VerifiedUserEvent
     | UserJoinOrganizationEvent
+    | UserLeaveOrganizationEvent
     | QueryExecutionEvent
     | QueryReadyEvent
     | QueryErrorEvent

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -39,6 +39,7 @@ import {
 } from '@tsoa/runtime';
 import express from 'express';
 import { toSessionUser } from '../auth/account';
+import Logger from '../logging/logger';
 import { UserModel } from '../models/UserModel';
 import {
     allowApiKeyAuthentication,
@@ -254,10 +255,16 @@ export class UserController extends BaseController {
                 userAgent: req.get('user-agent'),
             });
 
-        await new Promise<void>((resolve, reject) => {
+        // Membership has already been removed and DB sessions wiped above.
+        // Soft-fail this in-memory session destroy so a callback error doesn't
+        // mask the successful leave from the client.
+        await new Promise<void>((resolve) => {
             req.session.destroy((err) => {
                 if (err) {
-                    reject(err);
+                    Logger.error(
+                        'Failed to destroy session after leaving organization',
+                        { error: err },
+                    );
                 }
                 resolve();
             });

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -234,6 +234,42 @@ export class UserController extends BaseController {
     }
 
     /**
+     * Remove the current user from their organization. Fails if the caller is
+     * the only admin remaining. The user record is preserved so they can join
+     * another organization later.
+     * @summary Leave organization
+     * @param req express request
+     */
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @Delete('/me/leaveOrganization')
+    @OperationId('LeaveOrganization')
+    async leaveOrganization(
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getUserService()
+            .leaveOrganization(toSessionUser(req.account), {
+                ip: req.ip,
+                userAgent: req.get('user-agent'),
+            });
+
+        await new Promise<void>((resolve, reject) => {
+            req.session.destroy((err) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve();
+            });
+        });
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
      * Delete user
      * @summary Delete user
      * @param req express request

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -19415,6 +19415,8 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['checkForStuckJobs'] },
                 { dataType: 'enum', enums: ['cleanDeploySessions'] },
                 { dataType: 'enum', enums: ['managedAgentHeartbeat'] },
+                { dataType: 'enum', enums: ['workerHeartbeat'] },
+                { dataType: 'enum', enums: ['cleanWorkerHeartbeats'] },
             ],
             validators: {},
         },
@@ -21994,7 +21996,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22004,7 +22006,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22014,7 +22016,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -22027,7 +22029,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -22438,7 +22440,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22448,7 +22450,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22458,7 +22460,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -22471,7 +22473,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -40690,6 +40692,59 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'joinOrganization',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsUserController_leaveOrganization: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.delete(
+        '/api/v1/user/me/leaveOrganization',
+        ...fetchMiddlewares<RequestHandler>(UserController),
+        ...fetchMiddlewares<RequestHandler>(
+            UserController.prototype.leaveOrganization,
+        ),
+
+        async function UserController_leaveOrganization(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsUserController_leaveOrganization,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<UserController>(UserController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'leaveOrganization',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -20580,7 +20580,9 @@
                     "generateSlackChannelSyncJobs",
                     "checkForStuckJobs",
                     "cleanDeploySessions",
-                    "managedAgentHeartbeat"
+                    "managedAgentHeartbeat",
+                    "workerHeartbeat",
+                    "cleanWorkerHeartbeats"
                 ]
             },
             "BaseSchedulerLog": {
@@ -23372,22 +23374,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -23742,22 +23744,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -32269,7 +32271,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2907.0",
+        "version": "0.2913.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -35418,6 +35420,38 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/user/me/leaveOrganization": {
+            "delete": {
+                "operationId": "LeaveOrganization",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Remove the current user from their organization. Fails if the caller is\nthe only admin remaining. The user record is preserved so they can join\nanother organization later.",
+                "summary": "Leave organization",
+                "tags": ["My Account"],
+                "security": [],
+                "parameters": []
             }
         },
         "/api/v1/user/me": {

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -440,6 +440,28 @@ export class OrganizationMemberProfileModel {
         });
     }
 
+    async deleteOrganizationMembershipByUuid({
+        organizationUuid,
+        userUuid,
+    }: {
+        organizationUuid: string;
+        userUuid: string;
+    }): Promise<void> {
+        const userIdSubquery = this.database
+            .select('user_id')
+            .from(UserTableName)
+            .where('user_uuid', userUuid);
+        const organizationIdSubquery = this.database
+            .select('organization_id')
+            .from(OrganizationTableName)
+            .where('organization_uuid', organizationUuid);
+
+        await this.database(OrganizationMembershipsTableName)
+            .where('user_id', userIdSubquery)
+            .andWhere('organization_id', organizationIdSubquery)
+            .delete();
+    }
+
     async getOrganizationMemberByUuid(
         organizationUuid: string,
         userUuid: string,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -937,6 +937,7 @@ export class ServiceRepository
                     warehouseAvailableTablesModel:
                         this.models.getWarehouseAvailableTablesModel(),
                     projectModel: this.models.getProjectModel(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
                 }),
         );
     }

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -14,6 +14,7 @@ import { LightdashConfig } from '../config/parseConfig';
 import * as winston from '../logging/winston';
 import { PersonalAccessTokenModel } from '../models/DashboardModel/PersonalAccessTokenModel';
 import { EmailModel } from '../models/EmailModel';
+import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
 import { GroupsModel } from '../models/GroupsModel';
 import { InviteLinkModel } from '../models/InviteLinkModel';
 import { OpenIdIdentityModel } from '../models/OpenIdIdentitiesModel';
@@ -124,6 +125,12 @@ const createUserService = (lightdashConfig: LightdashConfig) =>
         userWarehouseCredentialsModel: {} as UserWarehouseCredentialsModel,
         warehouseAvailableTablesModel: {} as WarehouseAvailableTablesModel,
         projectModel: projectModel as unknown as ProjectModel,
+        featureFlagModel: {
+            get: jest.fn(async () => ({
+                id: 'leave-organization',
+                enabled: true,
+            })),
+        } as unknown as FeatureFlagModel,
     });
 
 jest.spyOn(analyticsMock, 'track');
@@ -816,6 +823,12 @@ describe('UserService', () => {
                 warehouseAvailableTablesModel:
                     {} as WarehouseAvailableTablesModel,
                 projectModel: projectModel as unknown as ProjectModel,
+                featureFlagModel: {
+                    get: jest.fn(async () => ({
+                        id: 'leave-organization',
+                        enabled: true,
+                    })),
+                } as unknown as FeatureFlagModel,
             });
 
             await expect(
@@ -879,6 +892,12 @@ describe('UserService', () => {
                 warehouseAvailableTablesModel:
                     {} as WarehouseAvailableTablesModel,
                 projectModel: projectModel as unknown as ProjectModel,
+                featureFlagModel: {
+                    get: jest.fn(async () => ({
+                        id: 'leave-organization',
+                        enabled: true,
+                    })),
+                } as unknown as FeatureFlagModel,
             });
 
             await expect(

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -981,7 +981,7 @@ describe('UserService', () => {
                     inviteUser,
                 ),
             ).rejects.toThrowError(
-                'Email is already used by a user in another organization',
+                'Email is already used by a user in another organization. Ask them to leave their organisation before inviting them.',
             );
         });
         test('should throw error when email belongs to an active user in same org', async () => {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -531,7 +531,7 @@ export class UserService extends BaseService {
         if (existingUserWithEmail && existingUserWithEmail.organizationUuid) {
             if (existingUserWithEmail.organizationUuid !== organizationUuid) {
                 throw new ParameterError(
-                    'Email is already used by a user in another organization',
+                    'Email is already used by a user in another organization. Ask them to leave their organisation before inviting them.',
                 );
             } else if (!existingUserWithEmail.isPending) {
                 throw new ParameterError(

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -15,6 +15,7 @@ import {
     DeleteOpenIdentity,
     EmailStatusExpiring,
     ExpiredError,
+    FeatureFlags,
     ForbiddenError,
     getEmailDomain,
     hasInviteCode,
@@ -72,6 +73,7 @@ import Logger from '../logging/logger';
 import { logAuditEvent } from '../logging/winston';
 import { PersonalAccessTokenModel } from '../models/DashboardModel/PersonalAccessTokenModel';
 import { EmailModel } from '../models/EmailModel';
+import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
 import { GroupsModel } from '../models/GroupsModel';
 import { InviteLinkModel } from '../models/InviteLinkModel';
 import { OpenIdIdentityModel } from '../models/OpenIdIdentitiesModel';
@@ -108,6 +110,7 @@ type UserServiceArguments = {
     userWarehouseCredentialsModel: UserWarehouseCredentialsModel;
     warehouseAvailableTablesModel: WarehouseAvailableTablesModel;
     projectModel: ProjectModel;
+    featureFlagModel: FeatureFlagModel;
 };
 
 function isSameMinute(a: Date | null, b: Date): boolean {
@@ -132,13 +135,19 @@ const emitAuthAuditEvent = ({
     context,
 }: {
     actor: AuditActor;
-    action: 'login' | 'logout' | 'impersonation_start' | 'impersonation_stop';
+    action:
+        | 'login'
+        | 'logout'
+        | 'impersonation_start'
+        | 'impersonation_stop'
+        | 'leave_organization';
     resourceType:
         | 'Session'
         | 'PersonalAccessToken'
         | 'ServiceAccount'
         | 'EmbedJwt'
-        | 'User';
+        | 'User'
+        | 'OrganizationMembership';
     status: AuditStatusType;
     reason?: string;
     organizationUuid?: string;
@@ -210,6 +219,8 @@ export class UserService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
+    private readonly featureFlagModel: FeatureFlagModel;
+
     private readonly emailOneTimePasscodeExpirySeconds = 60 * 15;
 
     private readonly emailOneTimePasscodeMaxAttempts = 5;
@@ -233,6 +244,7 @@ export class UserService extends BaseService {
         userWarehouseCredentialsModel,
         warehouseAvailableTablesModel,
         projectModel,
+        featureFlagModel,
     }: UserServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -254,6 +266,7 @@ export class UserService extends BaseService {
         this.userWarehouseCredentialsModel = userWarehouseCredentialsModel;
         this.warehouseAvailableTablesModel = warehouseAvailableTablesModel;
         this.projectModel = projectModel;
+        this.featureFlagModel = featureFlagModel;
     }
 
     private identifyUser(
@@ -1744,6 +1757,118 @@ export class UserService extends BaseService {
                 projectIds: allowedEmailDomains.projects.map(
                     (project) => project.projectUuid,
                 ),
+            },
+        });
+    }
+
+    async leaveOrganization(
+        user: SessionUser,
+        context?: AuthAuditContext,
+    ): Promise<void> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User does not belong to an organization');
+        }
+        const { organizationUuid } = user;
+        const actor = createActorFromUser(user);
+
+        const flag = await this.featureFlagModel.get({
+            user,
+            featureFlagId: FeatureFlags.LeaveOrganization,
+        });
+        if (!flag.enabled) {
+            this.logger.warn('Leave organization denied: feature disabled', {
+                userUuid: user.userUuid,
+                organizationUuid,
+            });
+            emitAuthAuditEvent({
+                actor,
+                action: 'leave_organization',
+                resourceType: 'OrganizationMembership',
+                status: 'denied',
+                reason: 'Feature disabled',
+                organizationUuid,
+                context,
+            });
+            throw new ForbiddenError(
+                'Leaving the organization is not enabled for this instance',
+            );
+        }
+
+        const member =
+            await this.organizationMemberProfileModel.getOrganizationMemberByUuid(
+                organizationUuid,
+                user.userUuid,
+            );
+
+        this.logger.info('User attempting to leave organization', {
+            userUuid: user.userUuid,
+            organizationUuid,
+            role: member.role,
+        });
+
+        // Race condition between check and delete is acceptable here — worst
+        // case the last admin slips out concurrently, matching the same trade-off
+        // accepted in `delete()` above.
+        const admins =
+            await this.organizationMemberProfileModel.getOrganizationAdmins(
+                organizationUuid,
+            );
+        if (
+            member.role === OrganizationMemberRole.ADMIN &&
+            admins.length === 1 &&
+            admins[0].userUuid === user.userUuid
+        ) {
+            const reason = 'Last admin in organization';
+            this.logger.warn('Leave organization denied: last admin', {
+                userUuid: user.userUuid,
+                organizationUuid,
+            });
+            emitAuthAuditEvent({
+                actor,
+                action: 'leave_organization',
+                resourceType: 'OrganizationMembership',
+                status: 'denied',
+                reason,
+                organizationUuid,
+                metadata: { role: member.role },
+                context,
+            });
+            throw new ForbiddenError(
+                'You are the only admin in this organization. Promote another member to admin before leaving.',
+            );
+        }
+
+        await this.organizationMemberProfileModel.deleteOrganizationMembershipByUuid(
+            {
+                organizationUuid,
+                userUuid: user.userUuid,
+            },
+        );
+
+        await this.sessionModel.deleteAllByUserUuid(user.userUuid);
+
+        this.logger.info('User left organization', {
+            userUuid: user.userUuid,
+            organizationUuid,
+            role: member.role,
+        });
+
+        emitAuthAuditEvent({
+            actor,
+            action: 'leave_organization',
+            resourceType: 'OrganizationMembership',
+            status: 'allowed',
+            organizationUuid,
+            metadata: { role: member.role },
+            context,
+        });
+
+        this.analytics.track({
+            userId: user.userUuid,
+            event: 'user.left_organization',
+            properties: {
+                organizationId: organizationUuid,
+                role: member.role,
             },
         });
     }

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -120,6 +120,15 @@ export enum FeatureFlags {
      * vetted customers on shared multi-org instances.
      */
     SsoOrganizationSettings = 'sso-organization-settings',
+
+    /**
+     * Expose the "Leave organization" action in the General settings danger
+     * zone and accept the corresponding API call. When disabled the panel is
+     * hidden and the endpoint returns a 403 — protects against accidental
+     * self-removal during early rollout and lets us disable the feature
+     * per-org if it causes operational issues.
+     */
+    LeaveOrganization = 'leave-organization',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/LeaveOrganizationModal.tsx
+++ b/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/LeaveOrganizationModal.tsx
@@ -1,0 +1,58 @@
+import { Stack, Text, TextInput, type ModalProps } from '@mantine-8/core';
+import { useState, type FC } from 'react';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useLeaveOrganizationMutation } from '../../../hooks/user/useLeaveOrganizationMutation';
+import MantineModal from '../../common/MantineModal';
+
+export const LeaveOrganizationModal: FC<
+    Pick<ModalProps, 'opened' | 'onClose'>
+> = ({ opened, onClose }) => {
+    const { isInitialLoading, data: organization } = useOrganization();
+    const { mutateAsync, isLoading: isLeaving } =
+        useLeaveOrganizationMutation();
+
+    const [confirmOrgName, setConfirmOrgName] = useState<string>();
+
+    if (isInitialLoading || !organization) return null;
+
+    const handleConfirm = async () => {
+        await mutateAsync();
+        onClose();
+    };
+
+    const handleOnClose = () => {
+        setConfirmOrgName(undefined);
+        onClose();
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleOnClose}
+            title="Leave organization"
+            variant="delete"
+            confirmLabel="Leave"
+            size="md"
+            onConfirm={handleConfirm}
+            confirmDisabled={
+                confirmOrgName?.toLowerCase() !==
+                organization.name.toLowerCase()
+            }
+            confirmLoading={isLeaving}
+        >
+            <Stack gap="sm">
+                <Text fz="sm" c="dimmed">
+                    Type the name of this organization to confirm. You will lose
+                    access to all of its projects and will be signed out.
+                </Text>
+
+                <TextInput
+                    name="confirmOrgName"
+                    placeholder={organization.name}
+                    value={confirmOrgName ?? ''}
+                    onChange={(e) => setConfirmOrgName(e.target.value)}
+                />
+            </Stack>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/index.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlags, OrganizationMemberRole } from '@lightdash/common';
-import { Button, Group, Tooltip } from '@mantine-8/core';
+import { Box, Button, Group, Tooltip } from '@mantine-8/core';
 import { IconLogout } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
@@ -64,7 +64,7 @@ export const LeaveOrganizationPanel: FC = () => {
                     w={260}
                     withArrow
                 >
-                    <div>{button}</div>
+                    <Box>{button}</Box>
                 </Tooltip>
             ) : (
                 button

--- a/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/index.tsx
@@ -1,0 +1,79 @@
+import { FeatureFlags, OrganizationMemberRole } from '@lightdash/common';
+import { Button, Group, Tooltip } from '@mantine-8/core';
+import { IconLogout } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../providers/App/useApp';
+import MantineIcon from '../../common/MantineIcon';
+import { LeaveOrganizationModal } from './LeaveOrganizationModal';
+
+export const LeaveOrganizationPanel: FC = () => {
+    const { user } = useApp();
+    const { isInitialLoading: isOrganizationLoading, data: organization } =
+        useOrganization();
+
+    const { data: leaveOrganizationFlag } = useServerFeatureFlag(
+        FeatureFlags.LeaveOrganization,
+    );
+    const isLeaveOrganizationEnabled = leaveOrganizationFlag?.enabled === true;
+
+    const isAdmin = user.data?.role === OrganizationMemberRole.ADMIN;
+
+    // Only admins can list org users — non-admins skip this query.
+    const { data: orgUsers, isInitialLoading: isOrgUsersLoading } =
+        useOrganizationUsers({
+            enabled: isAdmin && isLeaveOrganizationEnabled,
+        });
+
+    const [showModal, setShowModal] = useState(false);
+
+    const isOnlyAdmin = useMemo(() => {
+        if (!isAdmin || !orgUsers) return false;
+        const admins = orgUsers.filter(
+            (member) => member.role === OrganizationMemberRole.ADMIN,
+        );
+        return (
+            admins.length === 1 && admins[0].userUuid === user.data?.userUuid
+        );
+    }, [isAdmin, orgUsers, user.data?.userUuid]);
+
+    if (!isLeaveOrganizationEnabled) return null;
+    if (isOrganizationLoading || !organization || !user.data) return null;
+    if (isAdmin && isOrgUsersLoading) return null;
+
+    const button = (
+        <Button
+            variant="outline"
+            color="red"
+            leftSection={<MantineIcon icon={IconLogout} />}
+            onClick={() => setShowModal(true)}
+            disabled={isOnlyAdmin}
+        >
+            Leave '{organization.name}'
+        </Button>
+    );
+
+    return (
+        <Group justify="flex-end">
+            {isOnlyAdmin ? (
+                <Tooltip
+                    label="You are the only admin in this organization. Promote another member to admin before leaving."
+                    multiline
+                    w={260}
+                    withArrow
+                >
+                    <div>{button}</div>
+                </Tooltip>
+            ) : (
+                button
+            )}
+
+            <LeaveOrganizationModal
+                opened={showModal}
+                onClose={() => setShowModal(false)}
+            />
+        </Group>
+    );
+};

--- a/packages/frontend/src/hooks/user/useLeaveOrganizationMutation.ts
+++ b/packages/frontend/src/hooks/user/useLeaveOrganizationMutation.ts
@@ -1,0 +1,27 @@
+import { type ApiError } from '@lightdash/common';
+import { useMutation } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+import useToaster from '../toaster/useToaster';
+
+const leaveOrganizationQuery = async () =>
+    lightdashApi<null>({
+        url: `/user/me/leaveOrganization`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useLeaveOrganizationMutation = () => {
+    const { showToastApiError } = useToaster();
+    return useMutation<null, ApiError>(leaveOrganizationQuery, {
+        mutationKey: ['leave_organization'],
+        onSuccess: () => {
+            window.location.href = '/login';
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to leave organization',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -56,6 +56,7 @@ import { DeleteOrganizationPanel } from '../components/UserSettings/DeleteOrgani
 import GithubSettingsPanel from '../components/UserSettings/GithubSettingsPanel';
 import GitlabSettingsPanel from '../components/UserSettings/GitlabSettingsPanel';
 import ImpersonationPanel from '../components/UserSettings/ImpersonationPanel';
+import { LeaveOrganizationPanel } from '../components/UserSettings/LeaveOrganizationPanel';
 import MyAppsPanel from '../components/UserSettings/MyAppsPanel';
 import { MyWarehouseConnectionsPanel } from '../components/UserSettings/MyWarehouseConnectionsPanel';
 import OAuthClientsPanel from '../components/UserSettings/OAuthClientsPanel';
@@ -125,6 +126,11 @@ const Settings: FC = () => {
     const showImpersonationPanel =
         isUserImpersonationEnabled?.enabled &&
         user?.ability?.can('update', 'Organization');
+
+    const { data: leaveOrganizationFlag } = useServerFeatureFlag(
+        FeatureFlags.LeaveOrganization,
+    );
+    const isLeaveOrganizationEnabled = leaveOrganizationFlag?.enabled === true;
 
     const isCustomRolesEnabled = health?.isCustomRolesEnabled;
 
@@ -303,17 +309,31 @@ const Settings: FC = () => {
                             </SettingsGridCard>
                         )}
 
-                        {user.ability?.can('delete', 'Organization') && (
+                        {(isLeaveOrganizationEnabled ||
+                            user.ability?.can('delete', 'Organization')) && (
                             <SettingsGridCard>
                                 <div>
                                     <Title order={4}>Danger zone </Title>
                                     <Text c="ldGray.6" fz="xs">
-                                        This action deletes the whole workspace
-                                        and all its content, including users.
-                                        This action is not reversible.
+                                        {isLeaveOrganizationEnabled &&
+                                            'Leave the organization to remove yourself from it (you cannot leave if you are the only admin). '}
+                                        {user.ability?.can(
+                                            'delete',
+                                            'Organization',
+                                        ) &&
+                                            'Deleting the organization removes the whole workspace and all its content, including users. '}
+                                        These actions are not reversible.
                                     </Text>
                                 </div>
-                                <DeleteOrganizationPanel />
+                                <Stack gap="sm" align="flex-end">
+                                    {isLeaveOrganizationEnabled && (
+                                        <LeaveOrganizationPanel />
+                                    )}
+                                    {user.ability?.can(
+                                        'delete',
+                                        'Organization',
+                                    ) && <DeleteOrganizationPanel />}
+                                </Stack>
                             </SettingsGridCard>
                         )}
                     </Stack>
@@ -502,6 +522,7 @@ const Settings: FC = () => {
         health?.hasGitlab,
         dataAppsFlag?.enabled,
         isSsoOrganizationSettingsEnabled,
+        isLeaveOrganizationEnabled,
     ]);
     const routeElements = useRoutes(routes);
 


### PR DESCRIPTION
## Summary

- Adds a **Leave organization** button to the General settings danger zone. Removes the caller's `organization_memberships` row while keeping the `users` row intact, so they can rejoin or move to another org later.
- Refuses the call if the caller is the **only admin** remaining in the org — both the frontend (button disabled, tooltip) and the backend (403 with explicit reason) enforce this.
- Hidden behind a new `leave-organization` feature flag — disabled by default. Enable per-instance via `LIGHTDASH_ENABLE_FEATURE_FLAGS=leave-organization` or per-org/per-user via the existing DB-backed override system.

Part of #22211 — focuses on the in-app self-serve flow. The broader recovery scenarios in that issue (e.g. user has no admin to talk to) may need follow-ups.

## How it works

- New endpoint `DELETE /api/v1/user/me/leaveOrganization` derives the caller from `req.account` (no user identifier in the URL/body), so a user can only leave on their own behalf. Destroys the session on success.
- New model method `OrganizationMemberProfileModel.deleteOrganizationMembershipByUuid`.
- New service method `UserService.leaveOrganization` does: feature-flag check → fetch admin list → last-admin guard → delete membership → kill sessions → emit audit + analytics events.
- Frontend uses a `MantineModal` (delete variant) with type-the-org-name confirmation. On success the mutation hook redirects to `/login`.

## Observability

- `audit` log entries for both `allowed` and `denied` paths (denial reason is one of `Feature disabled` / `Last admin in organization`). Includes actor identity, request IP, user-agent, role metadata.
- `this.logger.info/warn` entries on each state transition for app-log visibility.
- New `user.left_organization` analytics event.

## Test plan

- [x] Backend unit-test fixture updated (added `featureFlagModel` mock).
- [x] `pnpm -F backend typecheck && pnpm -F frontend typecheck` clean.
- [x] `pnpm -F backend lint && pnpm -F frontend lint` clean.
- [x] Manual API smoke test (curl):
  - Flag off → 403 `Leaving the organization is not enabled for this instance`, audit log shows `denied - Feature disabled`, membership intact.
  - Flag on, editor leaves → 200, `organization_memberships` row removed, `users` row intact, subsequent request with same cookie 401s.
  - Flag on, sole admin attempts to leave → 403 `You are the only admin…`, audit log shows `denied - Last admin in organization`, membership intact.
- [x] Manual browser smoke test (Chrome DevTools MCP):
  - Editor sees enabled "Leave 'Jaffle Shop'" button → confirmation modal → typing org name enables Leave → click → redirected to `/login`.
  - Sole admin sees the Leave button **disabled** with tooltip explanation. Delete-organization button still works.
- [ ] Reviewer: enable the flag on a staging instance for the customer-support scenario; verify the audit log surfaces the leave events as expected.

## Rollout

1. Merge with the flag off — no behavior change.
2. Enable per-instance via env var, or per-org via the DB override table when a customer asks.
3. Kill switch: `LIGHTDASH_DISABLE_FEATURE_FLAGS=leave-organization` overrides any DB enablement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)