### PR TITLE
fix: log handled 4xx errors at warn level instead of error

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -746,10 +746,17 @@ export default class App {
                     // This intentionally uses console vs. winston because of problems from some error/JSON payloads.
                     console.error(error);
                 }
-                Logger.error(
-                    `Handled error of type ${errorResponse.name} on [${req.method}] ${req.path}`,
-                    errorResponse,
-                );
+                if (errorResponse.statusCode >= 500) {
+                    Logger.error(
+                        `Handled error of type ${errorResponse.name} on [${req.method}] ${req.path}`,
+                        errorResponse,
+                    );
+                } else {
+                    Logger.warn(
+                        `Handled error of type ${errorResponse.name} on [${req.method}] ${req.path}`,
+                        errorResponse,
+                    );
+                }
 
                 if (process.env.NODE_ENV === 'development') {
                     Logger.error(error.stack);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: <!-- no issue yet -->

### Description

The global error handler in `App.ts` logs all handled errors at `error` level, regardless of their HTTP status code. This means expected, user-facing 4xx responses — `ForbiddenError`, `NotFoundError`, `ResultsExpiredError`, `AuthorizationError` etc. — produce `error`-level log events even though they require no operator action.

For deployments using a log aggregator such as Datadog with `status:error` alerting, this creates significant noise that obscures real server-side failures.

This PR changes the log level to `warn` for any handled error with `statusCode < 500`, and keeps `error` for 5xx responses where operator attention is genuinely warranted.

**Before:**
- `ForbiddenError` (403) → `Logger.error` ❌
- `NotFoundError` (404) → `Logger.error` ❌
- `ResultsExpiredError` (410) → `Logger.error` ❌
- `UnexpectedServerError` (500) → `Logger.error` ✅

**After:**
- `ForbiddenError` (403) → `Logger.warn` ✅
- `NotFoundError` (404) → `Logger.warn` ✅
- `ResultsExpiredError` (410) → `Logger.warn` ✅
- `UnexpectedServerError` (500) → `Logger.error` ✅]