### PR TITLE
feat(data-apps): surface data apps in the omnibar

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -28,6 +28,7 @@ export type DbApp = {
     deleted_at: Date | null;
     deleted_by_user_uuid: string | null;
     views_count: number;
+    search_vector: string;
 };
 
 export type AppsTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20260512084657_add_search_vector_to_apps.ts
+++ b/packages/backend/src/database/migrations/20260512084657_add_search_vector_to_apps.ts
@@ -1,0 +1,27 @@
+import { type Knex } from 'knex';
+import { AppsTableName } from '../entities/apps';
+
+const customSearchConfigName = 'lightdash_english_config';
+const indexName = 'apps_search_vector_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${AppsTableName} ADD COLUMN search_vector tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('${customSearchConfigName}', coalesce(name, '')), 'A') ||
+            setweight(to_tsvector('${customSearchConfigName}', coalesce(description, '')), 'B')
+        ) STORED;
+    `);
+
+    await knex.schema.alterTable(AppsTableName, (table) => {
+        table.index('search_vector', indexName, 'GIN');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(AppsTableName, 'search_vector')) {
+        await knex.schema.alterTable(AppsTableName, (table) => {
+            table.dropColumn('search_vector');
+        });
+    }
+}

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -312,13 +312,81 @@ export class AppGenerateService extends BaseService {
     }
 
     private async assertDataAppsEnabled(user: SessionUser): Promise<void> {
+        const enabled = await this.dataAppsEnabledFor(user);
+        if (!enabled) {
+            throw new ForbiddenError('Data apps are not enabled');
+        }
+    }
+
+    async dataAppsEnabledFor(user: SessionUser): Promise<boolean> {
         const { enabled } = await this.featureFlagModel.get({
             user,
             featureFlagId: FeatureFlags.EnableDataApps,
         });
-        if (!enabled) {
-            throw new ForbiddenError('Data apps are not enabled');
-        }
+        return enabled;
+    }
+
+    /**
+     * Boolean variant of `assertCanViewApp` — does not throw on denial.
+     * Use for filtering lists where unauthorized items should be silently
+     * dropped (e.g. omnibar search) rather than surfacing a permission error.
+     */
+    async canViewApp(
+        user: SessionUser,
+        app: Pick<
+            DbApp,
+            'project_uuid' | 'space_uuid' | 'created_by_user_uuid'
+        > & {
+            organization_uuid: string;
+        },
+    ): Promise<boolean> {
+        const spaceContext = app.space_uuid
+            ? await this.spacePermissionService.getSpaceAccessContext(
+                  user.userUuid,
+                  app.space_uuid,
+              )
+            : {};
+        const auditedAbility = this.createAuditedAbility(user);
+        return auditedAbility.can(
+            'view',
+            subject('DataApp', {
+                organizationUuid: app.organization_uuid,
+                projectUuid: app.project_uuid,
+                ...spaceContext,
+                createdByUserUuid: app.created_by_user_uuid,
+            }),
+        );
+    }
+
+    /**
+     * Bulk filter for callers that have a list of apps already loaded
+     * (e.g. SearchService). Resolves space access contexts in parallel —
+     * one `getSpaceAccessContext` call per app with a space.
+     */
+    async filterAppsUserCanView<
+        T extends {
+            spaceUuid: string | null;
+            createdBy: { userUuid: string } | null;
+        },
+    >(
+        user: SessionUser,
+        organizationUuid: string,
+        projectUuid: string,
+        apps: T[],
+    ): Promise<T[]> {
+        const checks = await Promise.all(
+            apps.map((app) =>
+                this.canViewApp(user, {
+                    organization_uuid: organizationUuid,
+                    project_uuid: projectUuid,
+                    space_uuid: app.spaceUuid,
+                    // A null createdBy can never match the self rule — coerce
+                    // to a sentinel that won't equal any real userUuid.
+                    created_by_user_uuid: app.createdBy?.userUuid ?? '',
+                }),
+            ),
+        );
+        return apps.filter((_, i) => checks[i]);
     }
 
     /**

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -4,6 +4,7 @@ import {
     ContentType,
     DashboardSearchResult,
     DashboardTabResult,
+    DataAppSearchResult,
     Explore,
     ExploreError,
     ExploreType,
@@ -23,6 +24,10 @@ import {
     TableSelectionType,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import {
+    AppsTableName,
+    AppVersionsTableName,
+} from '../../database/entities/apps';
 import {
     DashboardsTableName,
     DashboardTabsTableName,
@@ -987,6 +992,96 @@ export class SearchModel {
         }));
     }
 
+    private async searchApps(
+        projectUuid: string,
+        query: string,
+        filters?: SearchFilters,
+    ): Promise<DataAppSearchResult[]> {
+        if (!shouldSearchForType(SearchItemType.DATA_APP, filters?.type)) {
+            return [];
+        }
+
+        const searchRankRawSql = getFullTextSearchRankCalcSql({
+            database: this.database,
+            variables: {
+                searchVectorColumn: `${AppsTableName}.search_vector`,
+                searchQuery: query,
+            },
+        });
+
+        const searchFilterSql = getFullTextSearchFilterSql({
+            database: this.database,
+            searchVectorColumn: `${AppsTableName}.search_vector`,
+            searchQuery: query,
+        });
+
+        // Only surface apps that have at least one ready version — apps that
+        // have only ever been building or errored have no preview to land on.
+        const hasReadyVersionSql = this.database.raw(
+            `EXISTS (
+                SELECT 1 FROM ?? v
+                WHERE v.app_id = ??.app_id AND v.status = 'ready'
+            )`,
+            [AppVersionsTableName, AppsTableName],
+        );
+
+        let subquery = this.database(AppsTableName)
+            .leftJoin(
+                `${UserTableName} as created_by_user`,
+                `created_by_user.user_uuid`,
+                `${AppsTableName}.created_by_user_uuid`,
+            )
+            .column(
+                { uuid: `${AppsTableName}.app_id` },
+                `${AppsTableName}.name`,
+                `${AppsTableName}.description`,
+                { spaceUuid: `${AppsTableName}.space_uuid` },
+                { projectUuid: `${AppsTableName}.project_uuid` },
+                { search_rank: searchRankRawSql },
+                { viewsCount: `${AppsTableName}.views_count` },
+                { createdByFirstName: 'created_by_user.first_name' },
+                { createdByLastName: 'created_by_user.last_name' },
+                { createdByUserUuid: 'created_by_user.user_uuid' },
+            )
+            .where(`${AppsTableName}.project_uuid`, projectUuid)
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .whereRaw(hasReadyVersionSql)
+            .whereRaw(searchFilterSql)
+            .orderBy('search_rank', 'desc');
+
+        subquery = filterByCreatedAt(AppsTableName, subquery, filters);
+        subquery = filterByCreatedByUuid(
+            subquery,
+            {
+                tableName: AppsTableName,
+                tableUserUuidColumnName: 'created_by_user_uuid',
+            },
+            filters,
+        );
+
+        const apps = await this.database(AppsTableName)
+            .select()
+            .from(subquery.as('apps_with_rank'))
+            .limit(SEARCH_LIMIT_PER_ITEM_TYPE);
+
+        return apps.map((app) => ({
+            uuid: app.uuid,
+            name: app.name,
+            description: app.description,
+            spaceUuid: app.spaceUuid,
+            projectUuid: app.projectUuid,
+            search_rank: app.search_rank,
+            viewsCount: app.viewsCount || 0,
+            createdBy: app.createdByUserUuid
+                ? {
+                      firstName: app.createdByFirstName,
+                      lastName: app.createdByLastName,
+                      userUuid: app.createdByUserUuid,
+                  }
+                : null,
+        }));
+    }
+
     async searchAllCharts(
         projectUuid: string,
         query: string,
@@ -1520,6 +1615,7 @@ export class SearchModel {
             query,
             filters,
         );
+        const dataApps = await this.searchApps(projectUuid, query, filters);
 
         const explores = await this.getProjectExplores(projectUuid);
         const tableErrors = await this.searchTableErrors(
@@ -1545,6 +1641,7 @@ export class SearchModel {
             fields,
             pages,
             dashboardTabs,
+            dataApps,
         };
     }
 }

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -14,6 +14,7 @@ import {
     TableSearchResult,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
+import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SearchModel } from '../../models/SearchModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -29,6 +30,8 @@ type SearchServiceArguments = {
     spaceModel: SpaceModel;
     userAttributesModel: UserAttributesModel;
     spacePermissionService: SpacePermissionService;
+    // EE-only — undefined on OSS builds where data apps don't exist.
+    appGenerateService?: AppGenerateService;
 };
 
 export class SearchService extends BaseService {
@@ -44,6 +47,8 @@ export class SearchService extends BaseService {
 
     private readonly spacePermissionService: SpacePermissionService;
 
+    private readonly appGenerateService?: AppGenerateService;
+
     constructor(args: SearchServiceArguments) {
         super();
         this.analytics = args.analytics;
@@ -52,6 +57,7 @@ export class SearchService extends BaseService {
         this.spaceModel = args.spaceModel;
         this.userAttributesModel = args.userAttributesModel;
         this.spacePermissionService = args.spacePermissionService;
+        this.appGenerateService = args.appGenerateService;
     }
 
     async getSearchResults(
@@ -214,6 +220,24 @@ export class SearchService extends BaseService {
             results.spaces.map(filterItem),
         );
 
+        // Data apps are EE-only and have a per-app permission shape (space
+        // access OR creator self-access). Skip entirely on OSS builds and
+        // when the feature flag is off; otherwise filter via the bulk helper.
+        let filteredDataApps: SearchResults['dataApps'] = [];
+        if (this.appGenerateService && results.dataApps.length > 0) {
+            const dataAppsEnabled =
+                await this.appGenerateService.dataAppsEnabledFor(user);
+            if (dataAppsEnabled) {
+                filteredDataApps =
+                    await this.appGenerateService.filterAppsUserCanView(
+                        user,
+                        organizationUuid,
+                        projectUuid,
+                        results.dataApps,
+                    );
+            }
+        }
+
         const filteredResults = {
             ...results,
             tables: filteredTables,
@@ -240,6 +264,7 @@ export class SearchService extends BaseService {
             )
                 ? results.pages
                 : [], // For now there is only 1 page and it is for admins only
+            dataApps: filteredDataApps,
         };
 
         this.analytics.track({
@@ -254,6 +279,7 @@ export class SearchService extends BaseService {
                 tablesResultsCount: filteredResults.tables.length,
                 fieldsResultsCount: filteredResults.fields.length,
                 dashboardTabsResultsCount: filteredResults.dashboardTabs.length,
+                dataAppsResultsCount: filteredResults.dataApps.length,
                 source,
             },
         });

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -801,6 +801,11 @@ export class ServiceRepository
                     spaceModel: this.models.getSpaceModel(),
                     userAttributesModel: this.models.getUserAttributesModel(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    // Only wired when EE license is active. Core builds get
+                    // undefined and SearchService drops data apps from results.
+                    appGenerateService: this.providers.appGenerateService
+                        ? this.getAppGenerateService<AppGenerateService>()
+                        : undefined,
                 }),
         );
     }

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -167,6 +167,21 @@ export type FieldSearchResult = Pick<
     regexMatchCount: number;
 };
 
+export type DataAppSearchResult = {
+    uuid: string;
+    name: string;
+    description: string;
+    // Personal apps live outside any space, so spaceUuid is nullable.
+    spaceUuid: string | null;
+    projectUuid: string;
+    viewsCount: number;
+    createdBy: {
+        firstName: string;
+        lastName: string;
+        userUuid: string;
+    } | null;
+} & RankedItem;
+
 type PageResult = {
     uuid: string;
     name: string;
@@ -189,7 +204,8 @@ export type SearchResult =
     | TableErrorSearchResult
     | TableSearchResult
     | FieldSearchResult
-    | PageResult;
+    | PageResult
+    | DataAppSearchResult;
 
 export const isExploreSearchResult = (
     value: SearchResult,
@@ -227,6 +243,7 @@ export type SearchResults = {
     fields: FieldSearchResult[];
     pages: PageResult[];
     dashboardTabs: DashboardTabResult[];
+    dataApps: DataAppSearchResult[];
 };
 
 export const getSearchResultId = (meta: SearchResult | undefined) => {
@@ -251,6 +268,7 @@ export enum SearchItemType {
     TABLE = 'table',
     FIELD = 'field',
     PAGE = 'page',
+    DATA_APP = 'data_app',
 }
 
 export function getSearchItemTypeFromResultKey(
@@ -273,6 +291,8 @@ export function getSearchItemTypeFromResultKey(
             return SearchItemType.SQL_CHART;
         case 'dashboardTabs':
             return SearchItemType.DASHBOARD_TAB;
+        case 'dataApps':
+            return SearchItemType.DATA_APP;
         default:
             return assertUnreachable(
                 searchResultKey,

--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -9,6 +9,7 @@ import { DatePicker } from '@mantine/dates';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAdjustments,
+    IconAppWindow,
     IconBrowser,
     IconCalendar,
     IconChartBar,
@@ -49,6 +50,8 @@ const getOmnibarItemIcon = (itemType: SearchItemType) => {
             return IconBrowser;
         case SearchItemType.SQL_CHART:
             return IconCodeCircle;
+        case SearchItemType.DATA_APP:
+            return IconAppWindow;
         default:
             return assertUnreachable(
                 itemType,

--- a/packages/frontend/src/features/omnibar/components/utils.ts
+++ b/packages/frontend/src/features/omnibar/components/utils.ts
@@ -8,6 +8,7 @@ import {
 import {
     Icon123,
     IconAbc,
+    IconAppWindow,
     IconBrowser,
     IconFolder,
     IconLayoutDashboard,
@@ -35,6 +36,8 @@ export const getOmnibarItemColor = (itemType: SearchItemType) => {
             return 'ldGray.7';
         case SearchItemType.SQL_CHART:
             return 'blue.7';
+        case SearchItemType.DATA_APP:
+            return 'orange.6';
         default:
             return assertUnreachable(
                 itemType,
@@ -67,6 +70,8 @@ export const getOmnibarItemIcon = (item: SearchItem) => {
             return IconBrowser;
         case SearchItemType.DASHBOARD_TAB:
             return IconLayoutNavbarInactive;
+        case SearchItemType.DATA_APP:
+            return IconAppWindow;
         default:
             return assertUnreachable(
                 item.type,

--- a/packages/frontend/src/features/omnibar/types/searchItem.ts
+++ b/packages/frontend/src/features/omnibar/types/searchItem.ts
@@ -1,6 +1,19 @@
 import { SearchItemType, type SearchResult } from '@lightdash/common';
 
-export const allSearchItemTypes = Object.values(SearchItemType);
+// Display order for the omnibar's "Item type" filter dropdown.
+// Data apps slot just above Spaces so they sit alongside the other
+// "container" content types (spaces) rather than at the bottom.
+export const allSearchItemTypes: SearchItemType[] = [
+    SearchItemType.DASHBOARD,
+    SearchItemType.DASHBOARD_TAB,
+    SearchItemType.CHART,
+    SearchItemType.SQL_CHART,
+    SearchItemType.DATA_APP,
+    SearchItemType.SPACE,
+    SearchItemType.TABLE,
+    SearchItemType.FIELD,
+    SearchItemType.PAGE,
+];
 
 export type SearchItem = {
     type: SearchItemType;

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemLabel.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemLabel.ts
@@ -18,6 +18,8 @@ export const getSearchItemLabel = (itemType: SearchItemType) => {
             return 'Pages';
         case SearchItemType.SQL_CHART:
             return 'SQL Charts';
+        case SearchItemType.DATA_APP:
+            return 'Data apps';
         default:
             return assertUnreachable(
                 itemType,
@@ -39,6 +41,7 @@ export const getSearchItemErrorLabel = (itemType: SearchItemType) => {
         case SearchItemType.SPACE:
         case SearchItemType.TABLE:
         case SearchItemType.PAGE:
+        case SearchItemType.DATA_APP:
 
         default:
             return new Error(`Unknown error item type: ${itemType}`);

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
@@ -151,6 +151,17 @@ export const getSearchItemMap = (
         location: { pathname: item.url },
     }));
 
+    const dataApps = results.dataApps.map<SearchItem>((item) => ({
+        type: SearchItemType.DATA_APP,
+        title: item.name,
+        description: item.description || undefined,
+        item: item,
+        searchRank: item.search_rank,
+        location: {
+            pathname: `/projects/${projectUuid}/apps/${item.uuid}/preview`,
+        },
+    }));
+
     return {
         spaces,
         dashboards,
@@ -160,5 +171,6 @@ export const getSearchItemMap = (
         fields,
         pages,
         dashboardTabs,
+        dataApps,
     };
 };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-425/show-data-apps-in-the-search

### Description:
Data apps now appear alongside dashboards, charts, spaces, etc. in the global search. Only apps with a ready version are surfaced, and results are filtered through the existing canViewApp permission rules so personal apps stay invisible to non-creators.

<img width="864" height="366" alt="Screenshot 2026-05-12 at 09 30 43" src="https://github.com/user-attachments/assets/81b2ca44-f491-4a65-839d-c7dae0525507" />
<img width="864" height="269" alt="Screenshot 2026-05-12 at 09 30 53" src="https://github.com/user-attachments/assets/c4676f08-b8e9-4174-a04f-015eb092c0fc" />
<img width="864" height="219" alt="Screenshot 2026-05-12 at 09 31 13" src="https://github.com/user-attachments/assets/99b5315d-b811-4891-9d19-92931ed6a89e" />
