### PR TITLE
fix(dashboards): prevent FK violation and orphan-cleanup crash on save (PROD-5905)

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -744,4 +744,58 @@ describe('DashboardModel', () => {
             ),
         ).rejects.toThrowError(NotFoundError);
     });
+
+    test('should null out tile.tabUuid that does not match any tab in this version (PROD-5905)', async () => {
+        // Simulates the bad payload that triggered the FK violation in
+        // production: tabs[] empty (or missing the tile's tab) while a tile
+        // still carries a stale tabUuid.
+        const staleTabUuid = '00000000-0000-0000-0000-000000000000';
+        const versionWithStaleTabUuid: typeof addDashboardVersion = {
+            ...addDashboardVersion,
+            tabs: [],
+            tiles: [
+                {
+                    ...addDashboardVersion.tiles[0],
+                    tabUuid: staleTabUuid,
+                },
+            ],
+        };
+
+        tracker.on.select(DashboardsTableName).responseOnce([dashboardEntry]);
+        tracker.on.select(SpaceTableName).responseOnce([spaceEntry]);
+        tracker.on.insert(DashboardsTableName).responseOnce([dashboardEntry]);
+        tracker.on
+            .insert(DashboardVersionsTableName)
+            .responseOnce([dashboardVersionEntry]);
+        tracker.on
+            .insert(DashboardViewsTableName)
+            .responseOnce([dashboardViewEntry]);
+        tracker.on
+            .insert(DashboardTilesTableName)
+            .responseOnce([dashboardTileEntry]);
+        tracker.on.select(SavedChartsTableName).responseOnce([savedChartEntry]);
+        tracker.on.insert(DashboardTileChartTableName).responseOnce([]);
+        tracker.on.update(DashboardViewsTableName).responseOnce([]);
+
+        jest.spyOn(model, 'getByIdOrSlug').mockImplementationOnce(() =>
+            Promise.resolve(expectedDashboard),
+        );
+
+        await expect(
+            model.addVersion(
+                expectedDashboard.uuid,
+                versionWithStaleTabUuid,
+                user,
+                projectUuid,
+            ),
+        ).resolves.not.toThrow();
+
+        const tilesInsert = tracker.history.insert.find((q) =>
+            q.sql.includes(DashboardTilesTableName),
+        );
+        expect(tilesInsert).toBeDefined();
+        // Stale uuid must have been dropped before the FK insert.
+        expect(tilesInsert!.bindings).not.toContain(staleTabUuid);
+        expect(tilesInsert!.bindings).toContain(null);
+    });
 });

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -74,6 +74,7 @@ import { SavedSqlTableName } from '../../database/entities/savedSql';
 import { SpaceTableName } from '../../database/entities/spaces';
 import { UserTable, UserTableName } from '../../database/entities/users';
 import { DbValidationTable } from '../../database/entities/validation';
+import Logger from '../../logging/logger';
 import { generateUniqueSlug } from '../../utils/SlugUtils';
 import { ContentVerificationModel } from '../ContentVerificationModel';
 import { SpaceModel } from '../SpaceModel';
@@ -183,6 +184,12 @@ export class DashboardModel {
             );
         }
 
+        // Tiles may carry a tabUuid for a tab that no longer exists in this
+        // version (stale frontend state, concurrent edits, CLI/promotion).
+        // Drop those references so the insert can't violate the
+        // (tab_uuid, dashboard_version_id) FK on dashboard_tabs.
+        const validTabUuids = new Set(version.tabs.map((tab) => tab.uuid));
+
         const tilesWithUuids: Array<
             | (CreateDashboardChartTile & { uuid: string })
             | (CreateDashboardMarkdownTile & { uuid: string })
@@ -194,6 +201,22 @@ export class DashboardModel {
             uuid: tile.uuid || uuidv4(),
         }));
 
+        const droppedTabUuids = [
+            ...new Set(
+                tilesWithUuids
+                    .map((t) => t.tabUuid)
+                    .filter(
+                        (uuid): uuid is string =>
+                            !!uuid && !validTabUuids.has(uuid),
+                    ),
+            ),
+        ];
+        if (droppedTabUuids.length > 0) {
+            Logger.warn(
+                `Dropped stale tabUuid on tiles for dashboard ${dashboardId} version ${versionId.dashboard_version_id}: ${droppedTabUuids.join(', ')}`,
+            );
+        }
+
         if (tilesWithUuids.length > 0) {
             await trx(DashboardTilesTableName).insert(
                 tilesWithUuids.map(({ uuid, type, w, h, x, y, tabUuid }) => ({
@@ -204,7 +227,8 @@ export class DashboardModel {
                     width: w,
                     x_offset: x,
                     y_offset: y,
-                    tab_uuid: tabUuid,
+                    tab_uuid:
+                        tabUuid && validTabUuids.has(tabUuid) ? tabUuid : null,
                 })),
             );
         }

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -5,6 +5,7 @@ import {
     defineUserAbility,
     FilterOperator,
     ForbiddenError,
+    NotFoundError,
     OrganizationMemberRole,
     PossibleAbilities,
     ProjectMemberRole,
@@ -336,6 +337,29 @@ describe('DashboardService', () => {
             expect.objectContaining({
                 event: 'saved_chart.deleted',
             }),
+        );
+    });
+    test('should not fail save when an orphan chart is already gone', async () => {
+        // Race with a retried save: getOrphanedCharts returns a chart that
+        // permanentDelete then can't find. The save must still succeed.
+        (dashboardModel.getOrphanedCharts as jest.Mock).mockImplementationOnce(
+            async () => [{ uuid: 'missing_chart_uuid' }],
+        );
+        (savedChartModel.permanentDelete as jest.Mock).mockImplementationOnce(
+            async () => {
+                throw new NotFoundError('chart already deleted');
+            },
+        );
+
+        await expect(
+            service.update(user, dashboardUuid, updateDashboardTiles),
+        ).resolves.toBeDefined();
+
+        expect(savedChartModel.permanentDelete).toHaveBeenCalledTimes(1);
+        // The dashboard.updated + dashboard_version.created events still fire,
+        // but no saved_chart.deleted event for the already-missing chart.
+        expect(analyticsMock.track).not.toHaveBeenCalledWith(
+            expect.objectContaining({ event: 'saved_chart.deleted' }),
         );
     });
     test('should delete dashboard', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -315,18 +315,29 @@ export class DashboardService
 
         await Promise.all(
             orphanedCharts.map(async (chart) => {
-                const deletedChart = await this.savedChartModel.permanentDelete(
-                    chart.uuid,
-                );
-                this.analytics.track({
-                    event: 'saved_chart.deleted',
-                    userId: user.userUuid,
-                    properties: {
-                        savedQueryId: deletedChart.uuid,
-                        projectId: deletedChart.projectUuid,
-                        softDelete: false,
-                    },
-                });
+                try {
+                    const deletedChart =
+                        await this.savedChartModel.permanentDelete(chart.uuid);
+                    this.analytics.track({
+                        event: 'saved_chart.deleted',
+                        userId: user.userUuid,
+                        properties: {
+                            savedQueryId: deletedChart.uuid,
+                            projectId: deletedChart.projectUuid,
+                            softDelete: false,
+                        },
+                    });
+                } catch (error) {
+                    // A retried save may have already deleted the orphan.
+                    // Don't fail the whole save response for it.
+                    if (error instanceof NotFoundError) {
+                        this.logger.warn(
+                            `Skipping already-deleted orphan chart ${chart.uuid} for dashboard ${dashboardUuid}`,
+                        );
+                        return;
+                    }
+                    throw error;
+                }
             }),
         );
     }


### PR DESCRIPTION
## Summary

Two related backend fixes for dashboard save failures in production. Linear: [PROD-5905](https://linear.app/lightdash/issue/PROD-5905/dashboard-save-fails-with-fk-violation-when-editing-multi-tab).

### Bug 1 — FK violation on dashboard save

`DashboardModel.addVersion` inserts tiles with `tab_uuid` without verifying the value matches any tab being written in the same version. When a caller (frontend, CLI, promotion, concurrent edit) sends `tabs: []` (or any tab list that doesn't include a tile's `tabUuid`), Postgres rejects the tile insert with:

```
violates foreign key constraint "dashboard_tiles_tab_uuid_dashboard_version_id_foreign"
Key (tab_uuid, dashboard_version_id)=(…, N) is not present in table "dashboard_tabs".
```

The user sees a generic "Something went wrong" toast; the actual FK error only appears in **stderr**, not structured logs, which is why this went undetected for ~28 days across both multi-tenant instances and 5 self-hosted ones (~37 failed saves).

**Fix:** intersect each tile's `tabUuid` with the set of tab UUIDs being inserted in this version; stale references become `NULL`. The tile lands without a tab — the same state it would be in on a no-tab dashboard. No behavior change for valid payloads.

### Bug 2 — Orphan cleanup crash hides successful saves

`deleteOrphanedChartsInDashboards` runs *after* `addVersion` succeeds and calls `permanentDelete` on each orphaned chart. If a chart is already gone (e.g. race with a retried save), `NotFoundError` bubbles up and fails the save response — even though the version was already created. Surfaced in prod as 121 occurrences across 5 instances since March 11.

**Fix:** swallow `NotFoundError` per chart and log it. Other errors still propagate.

## Test plan

- [x] New unit test \`should null out tile.tabUuid that does not match any tab in this version (PROD-5905)\` in \`DashboardModel.test.ts\` — fails without Fix 1, passes with it.
- [x] \`pnpm -F backend lint\` clean.
- [x] \`pnpm -F backend typecheck\` clean.
- [x] Full \`DashboardModel\` + \`DashboardService\` jest suites pass (36 tests).
- [x] End-to-end repro: crafted bad payload (\`tabs: []\` + tiles carrying \`tabUuid\`) sent to \`PATCH /api/v2/projects/.../dashboards/...\` returns **500 on main**, **200 with \`tabUuid: null\` on this branch**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)