### PR TITLE
feat(ai-agent): Slack approval buttons + collapsed CSV rendering for runSql (ZAP-381)

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -138,7 +138,10 @@ import { evaluateAgentReadiness } from '../ai/agents/readinessScorer';
 import { generateThreadTitle as generateTitleFromMessages } from '../ai/agents/titleGenerator';
 import { getAvailableModels, getDefaultModel, getModel } from '../ai/models';
 import { matchesPreset } from '../ai/models/presets';
-import { resolveSqlApproval } from '../ai/tools/sqlApprovals';
+import {
+    markSlackThreadAutoApproved,
+    resolveSqlApproval,
+} from '../ai/tools/sqlApprovals';
 import { AiAgentArgs, AiAgentDependencies } from '../ai/types/aiAgent';
 import {
     CreateChangeFn,
@@ -155,6 +158,7 @@ import {
     RunSqlJobFn,
     SearchFieldValuesFn,
     SendFileFn,
+    SendSlackBlocksFn,
     StoreReasoningFn,
     StoreToolCallFn,
     StoreToolResultsFn,
@@ -3181,6 +3185,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 () => this.projectService.getWarehouseTables(user, projectUuid),
             );
 
+        const sendSlackBlocks: SendSlackBlocksFn = async (args) =>
+            wrapSentryTransaction(
+                'AiAgent.sendSlackBlocks',
+                { channelId: args.channelId },
+                async () => {
+                    await this.slackClient.postMessage({
+                        organizationUuid: args.organizationUuid,
+                        channel: args.channelId,
+                        thread_ts: args.threadTs,
+                        text: args.text,
+                        blocks: args.blocks,
+                    });
+                },
+            );
+
         const storeToolCall: StoreToolCallFn = async (args) => {
             void wrapSentryTransaction(
                 'AiAgent.storeToolCall',
@@ -3359,6 +3378,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             listWarehouseTables,
             getSavedChart,
             sendFile,
+            sendSlackBlocks,
             storeToolCall,
             storeToolResults,
             storeReasoning,
@@ -3438,6 +3458,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             listWarehouseTables,
             getSavedChart,
             sendFile,
+            sendSlackBlocks,
             storeToolCall,
             storeToolResults,
             storeReasoning,
@@ -3556,6 +3577,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             getSavedChart,
             getPrompt,
             sendFile,
+            sendSlackBlocks,
             storeToolCall,
             storeToolResults,
             storeReasoning,
@@ -4214,6 +4236,76 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         app.action('actions.view_changesets_button_click', async ({ ack }) => {
             await ack();
         });
+    }
+
+    // Slack approve/reject buttons for runSql tool. Action ID format:
+    // actions.sql_approval:<toolCallId>:<threadUuid>:<decision>
+    // 'approved_always' marks the thread auto-approved server-side.
+    // eslint-disable-next-line class-methods-use-this
+    public handleSqlApprovalButton(app: App) {
+        app.action(
+            /^actions\.sql_approval:/,
+            async ({ ack, body, action, respond }) => {
+                await ack();
+                if (body.type !== 'block_actions' || action.type !== 'button') {
+                    return;
+                }
+                const actionId = 'action_id' in action ? action.action_id : '';
+                const parts = actionId.split(':');
+                if (parts.length !== 4) {
+                    return;
+                }
+                const toolCallId = parts[1];
+                const threadUuid = parts[2];
+                const rawDecision = parts[3];
+
+                const isApprovedAlways = rawDecision === 'approved_always';
+                const decision: 'approved' | 'rejected' =
+                    rawDecision === 'rejected' ? 'rejected' : 'approved';
+
+                if (
+                    rawDecision !== 'approved' &&
+                    rawDecision !== 'rejected' &&
+                    rawDecision !== 'approved_always'
+                ) {
+                    return;
+                }
+
+                if (isApprovedAlways) {
+                    markSlackThreadAutoApproved(threadUuid);
+                }
+
+                const delivered = resolveSqlApproval(toolCallId, decision);
+                if (!delivered) {
+                    await respond({
+                        text: ':warning: Could not deliver approval — the agent run may have already timed out.',
+                        replace_original: false,
+                    });
+                    return;
+                }
+
+                const emoji =
+                    decision === 'approved'
+                        ? ':white_check_mark:'
+                        : ':no_entry_sign:';
+                const suffix = isApprovedAlways
+                    ? " — won't ask again this thread"
+                    : '';
+                await respond({
+                    text: `SQL ${decision} by <@${body.user.id}>${suffix}`,
+                    replace_original: true,
+                    blocks: [
+                        {
+                            type: 'section',
+                            text: {
+                                type: 'mrkdwn',
+                                text: `${emoji} SQL *${decision}* by <@${body.user.id}>${suffix}`,
+                            },
+                        },
+                    ],
+                });
+            },
+        );
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/backend/src/ee/services/SlackService/SlackService.ts
+++ b/packages/backend/src/ee/services/SlackService/SlackService.ts
@@ -39,5 +39,6 @@ export class CommercialSlackService extends SlackService {
         this.aiAgentService.handleClickOAuthButton(slackApp);
         this.aiAgentService.handleExecuteFollowUpTool(slackApp);
         this.aiAgentService.handleViewChangesetsButtonClick(slackApp);
+        this.aiAgentService.handleSqlApprovalButton(slackApp);
     }
 }

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -130,6 +130,9 @@ const getAgentTools = (
         ? getRunSql({
               updateProgress: dependencies.updateProgress,
               runSqlJob: dependencies.runSqlJob,
+              getPrompt: dependencies.getPrompt,
+              sendFile: dependencies.sendFile,
+              sendSlackBlocks: dependencies.sendSlackBlocks,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -1,24 +1,92 @@
-import { toolRunSqlArgsSchema, type AnyType } from '@lightdash/common';
+import {
+    isSlackPrompt,
+    toolRunSqlArgsSchema,
+    type AnyType,
+} from '@lightdash/common';
 import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
 import type {
+    GetPromptFn,
     RunSqlJobFn,
+    SendFileFn,
+    SendSlackBlocksFn,
     UpdateProgressFn,
 } from '../types/aiAgentDependencies';
 import { serializeData } from '../utils/serializeData';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import { waitForSqlApproval } from './sqlApprovals';
+import {
+    isSlackThreadAutoApproved,
+    resolveSqlApproval,
+    waitForSqlApproval,
+} from './sqlApprovals';
 
 type Dependencies = {
     updateProgress: UpdateProgressFn;
     runSqlJob: RunSqlJobFn;
+    getPrompt: GetPromptFn;
+    sendFile: SendFileFn;
+    sendSlackBlocks: SendSlackBlocksFn;
 };
 
-const PREVIEW_ROW_LIMIT = 50;
+const truncateForSlack = (sql: string, maxLength = 2500) =>
+    sql.length > maxLength
+        ? `${sql.slice(0, maxLength)}\n... (truncated)`
+        : sql;
+
+const buildSlackApprovalBlocks = (
+    toolCallId: string,
+    threadUuid: string,
+    sql: string,
+) => [
+    {
+        type: 'section',
+        text: {
+            type: 'mrkdwn',
+            text: ':lock: *About to run SQL — approve to execute*',
+        },
+    },
+    {
+        type: 'section',
+        text: {
+            type: 'mrkdwn',
+            text: `\`\`\`sql\n${truncateForSlack(sql)}\n\`\`\``,
+        },
+    },
+    {
+        type: 'actions',
+        elements: [
+            {
+                type: 'button',
+                text: { type: 'plain_text', text: 'Approve' },
+                action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:approved`,
+                value: toolCallId,
+                style: 'primary',
+            },
+            {
+                type: 'button',
+                text: {
+                    type: 'plain_text',
+                    text: "Approve & don't ask again",
+                },
+                action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:approved_always`,
+                value: toolCallId,
+            },
+            {
+                type: 'button',
+                text: { type: 'plain_text', text: 'Reject' },
+                action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:rejected`,
+                value: toolCallId,
+                style: 'danger',
+            },
+        ],
+    },
+];
 
 const SELECT_OR_WITH = /^\s*(WITH|SELECT)\b/i;
 const FORBIDDEN_STATEMENTS =
     /\b(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|GRANT|REVOKE|MERGE|CALL|EXECUTE)\b/i;
+
+const PREVIEW_ROW_LIMIT = 50;
 
 const validateSelectOnly = (sql: string) => {
     if (!SELECT_OR_WITH.test(sql)) {
@@ -31,7 +99,13 @@ const validateSelectOnly = (sql: string) => {
     }
 };
 
-export const getRunSql = ({ updateProgress, runSqlJob }: Dependencies) =>
+export const getRunSql = ({
+    updateProgress,
+    runSqlJob,
+    getPrompt,
+    sendFile,
+    sendSlackBlocks,
+}: Dependencies) =>
     tool({
         description: toolRunSqlArgsSchema.description,
         inputSchema: toolRunSqlArgsSchema,
@@ -39,9 +113,40 @@ export const getRunSql = ({ updateProgress, runSqlJob }: Dependencies) =>
             try {
                 validateSelectOnly(sql);
 
-                await updateProgress('Awaiting approval to run SQL...');
+                const prompt = await getPrompt();
+                const isSlack = isSlackPrompt(prompt);
+                const slackAutoApproved =
+                    isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
 
-                const decision = await waitForSqlApproval(toolCallId);
+                if (slackAutoApproved) {
+                    await updateProgress('Running SQL query...');
+                } else {
+                    await updateProgress('Awaiting approval to run SQL...');
+                }
+
+                // Register the listener first, then trigger any auto-approval
+                // (the EventEmitter delivers synchronously, so the order matters).
+                const decisionPromise = waitForSqlApproval(toolCallId);
+
+                if (slackAutoApproved) {
+                    resolveSqlApproval(toolCallId, 'approved');
+                } else if (isSlack) {
+                    // Post a separate message with Approve/Reject buttons so
+                    // the user can decide without leaving Slack.
+                    await sendSlackBlocks({
+                        channelId: prompt.slackChannelId,
+                        threadTs: prompt.slackThreadTs,
+                        organizationUuid: prompt.organizationUuid,
+                        text: 'About to run SQL — approve to execute',
+                        blocks: buildSlackApprovalBlocks(
+                            toolCallId,
+                            prompt.threadUuid,
+                            sql,
+                        ),
+                    });
+                }
+
+                const decision = await decisionPromise;
                 if (decision === 'rejected') {
                     return {
                         result: 'User rejected this SQL execution. Do not retry the same query; ask the user what they would like instead.',
@@ -73,6 +178,74 @@ export const getRunSql = ({ updateProgress, runSqlJob }: Dependencies) =>
                     };
                 }
 
+                const csv = stringify(
+                    rows.map((row) =>
+                        columns.reduce<Record<string, AnyType>>((acc, col) => {
+                            acc[col] = row[col];
+                            return acc;
+                        }, {}),
+                    ),
+                    {
+                        header: true,
+                        columns,
+                    },
+                );
+
+                // For Slack: avoid the noisy auto-expanded CSV file preview by
+                // posting a collapsible code block of the first few rows. If
+                // the result is large, ALSO upload the full CSV file (Slack
+                // file previews are heavy, so we only do it when worth it).
+                if (isSlackPrompt(prompt)) {
+                    const SLACK_INLINE_ROW_LIMIT = 10;
+                    const LARGE_RESULT_THRESHOLD = 25;
+                    const inlineRows = rows.slice(0, SLACK_INLINE_ROW_LIMIT);
+                    const inlineCsv = stringify(
+                        inlineRows.map((row) =>
+                            columns.reduce<Record<string, AnyType>>(
+                                (acc, col) => {
+                                    acc[col] = row[col];
+                                    return acc;
+                                },
+                                {},
+                            ),
+                        ),
+                        { header: true, columns },
+                    );
+                    const truncatedNote =
+                        rowCount > SLACK_INLINE_ROW_LIMIT
+                            ? ` _(showing first ${SLACK_INLINE_ROW_LIMIT})_`
+                            : '';
+                    await sendSlackBlocks({
+                        channelId: prompt.slackChannelId,
+                        threadTs: prompt.slackThreadTs,
+                        organizationUuid: prompt.organizationUuid,
+                        text: `Query returned ${rowCount} rows`,
+                        blocks: [
+                            {
+                                type: 'section',
+                                text: {
+                                    type: 'mrkdwn',
+                                    text: `*Query returned ${rowCount} row${
+                                        rowCount === 1 ? '' : 's'
+                                    }*${truncatedNote}\n\`\`\`\n${inlineCsv}\n\`\`\``,
+                                },
+                            },
+                        ],
+                    });
+
+                    if (rowCount > LARGE_RESULT_THRESHOLD) {
+                        await sendFile({
+                            channelId: prompt.slackChannelId,
+                            threadTs: prompt.slackThreadTs,
+                            organizationUuid: prompt.organizationUuid,
+                            title: 'Full SQL query results',
+                            comment: `Full CSV — ${rowCount} rows`,
+                            filename: 'lightdash-sql-results.csv',
+                            file: Buffer.from(csv, 'utf-8'),
+                        });
+                    }
+                }
+
                 const previewRows = rows.slice(0, PREVIEW_ROW_LIMIT);
                 const previewCsv = stringify(
                     previewRows.map((row) =>
@@ -81,7 +254,10 @@ export const getRunSql = ({ updateProgress, runSqlJob }: Dependencies) =>
                             return acc;
                         }, {}),
                     ),
-                    { header: true, columns },
+                    {
+                        header: true,
+                        columns,
+                    },
                 );
 
                 const truncatedNote =

--- a/packages/backend/src/ee/services/ai/tools/sqlApprovals.ts
+++ b/packages/backend/src/ee/services/ai/tools/sqlApprovals.ts
@@ -3,7 +3,20 @@ import { EventEmitter } from 'events';
 const bus = new EventEmitter();
 bus.setMaxListeners(100);
 
+// Threads (Lightdash AI thread UUIDs) where the user clicked "Approve & don't
+// ask again" from a Slack approval message. Subsequent runSql calls in the
+// same thread skip the approval flow. In-memory, session-scoped — lost on
+// pod restart, same as the approval bus itself.
+const slackAutoApprovedThreads = new Set<string>();
+
 export type SqlApprovalDecision = 'approved' | 'rejected' | 'timeout';
+
+export const markSlackThreadAutoApproved = (threadUuid: string): void => {
+    slackAutoApprovedThreads.add(threadUuid);
+};
+
+export const isSlackThreadAutoApproved = (threadUuid: string): boolean =>
+    slackAutoApprovedThreads.has(threadUuid);
 
 export const waitForSqlApproval = (
     toolCallId: string,

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -18,6 +18,7 @@ import {
     RunSqlJobFn,
     SearchFieldValuesFn,
     SendFileFn,
+    SendSlackBlocksFn,
     StoreReasoningFn,
     StoreToolCallFn,
     StoreToolResultsFn,
@@ -76,6 +77,7 @@ export type AiAgentDependencies = {
     getSavedChart: GetSavedChartFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
+    sendSlackBlocks: SendSlackBlocksFn;
     updatePrompt: UpdatePromptFn;
     updateProgress: UpdateProgressFn;
     storeToolCall: StoreToolCallFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -110,6 +110,14 @@ export type GetSavedChartFn = (chartUuid: string) => Promise<SavedChart>;
 
 export type SendFileFn = (args: PostSlackFile) => Promise<void>;
 
+export type SendSlackBlocksFn = (args: {
+    channelId: string;
+    threadTs: string;
+    organizationUuid: string;
+    text: string;
+    blocks: AnyType[];
+}) => Promise<void>;
+
 export type UpdatePromptFn = (
     prompt: UpdateWebAppResponse | UpdateSlackResponse,
 ) => Promise<void>;


### PR DESCRIPTION
## Summary
- Slack approval message: when the agent calls runSql in a Slack thread, the bot posts a separate message with Approve / Approve-and-don't-ask-again / Reject buttons. The runSql tool waits for the click via the same in-pod EventEmitter primitive as web.
- "Approve & don't ask again" marks the AI thread auto-approved in-memory so subsequent runSql calls in the same Slack thread skip the approval flow (lost on pod restart, same as the approval bus).
- Slack result rendering: instead of auto-expanding a CSV file (noisy), the bot posts a collapsible code block with the first 10 rows. Full CSV file uploads only when the result has > 25 rows.

## Regression analysis
- **Web prompts**: unchanged — Slack-specific code paths are gated by `isSlackPrompt(prompt)`.
- **Slack prompts where `aiRequireOAuth=false`**: still fail-closed (already enforced in #22923), so this PR's code paths never fire for those orgs.
- **Approval button action_id collisions**: scoped under `actions.sql_approval:` and parsed with strict 4-part validation; unknown decisions return early without resolving.
- **Pod restart while waiting for a Slack click**: same behaviour as web — `resolveSqlApproval` returns false, the button click responds with `:warning: Could not deliver approval`, and the agent times out cleanly.
- **Thread auto-approve scope**: only applies to the AI thread UUID and is in-memory; cannot leak across pod boundaries or survive restart.

## Test plan
- [ ] Send a Slack prompt that triggers runSql — confirm the approval message appears with 3 buttons
- [ ] Click Approve — confirm SQL runs and the result renders inline (truncated to 10 rows)
- [ ] Click Approve & don't ask again — confirm subsequent runSql in the same thread skips the approval message
- [ ] Send a prompt producing > 25 result rows — confirm a CSV file is attached alongside the inline preview
- [ ] Click Reject — confirm agent moves on without executing
- [ ] Open a brand-new Slack thread after restart — confirm the auto-approve state did not leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)