### PR TITLE
feat: send screenshots to data app generator (iframe-side)

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -308,6 +308,15 @@ Allowed routes (defined in `packages/frontend/src/features/apps/hooks/useAppSdkB
 
 All other routes are rejected.
 
+The same postMessage channel carries the capability announces
+(`lightdash:inspect:available`, `lightdash:sdk:screenshot-available`),
+inspector toggle/click events, and the screenshot round-trip
+(`lightdash:sdk:screenshot-request` / `…response`). The bridge filters by
+message `type` and forwards each to the right hook —
+`useAppSdkBridge` for SDK fetches and capability announces,
+`useIframeScreenshot` for screenshot responses. See
+[Screenshot Capture](#screenshot-capture) below.
+
 ### Preview Token Authentication
 
 Preview requests use short-lived JWTs (signed with `LIGHTDASH_SECRET`), not session cookies:
@@ -328,55 +337,159 @@ Each preview response includes a strict CSP header:
 
 ## Image Uploads
 
-Users can attach images (screenshots, mockups, diagrams) to their prompts. These images are uploaded to S3 and passed
-to Claude as context during code generation.
+Users can attach images to their prompts. There are two kinds and they share the same upload pipeline,
+distinguished only by an opaque `kind` tag stored on the S3 object's metadata:
+
+| Kind                       | Source                                                                                | Purpose for the agent                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **attachment** *(default)* | User picks an image from disk / pastes / drag-and-drops in the chat UI.               | A **design reference** for layout, color, component choice — something to approximate. |
+| **screenshot**             | "Screenshot" button captures the live preview iframe (see [Screenshot Capture](#screenshot-capture)). | The **current state** of the built app — what the user is looking at when they prompt. |
+
+Up to `MAX_IMAGES_PER_VERSION = 4` images per submit, mixed kinds allowed.
 
 ### Upload Flow
 
 ```mermaid
 flowchart LR
-    A["1. User attaches\nimage in chat UI"] --> B["2. POST raw bytes\nto backend"]
-    B --> C["3. Backend streams\nto S3 staging path"]
+    A["1. User attaches image\n(or clicks Screenshot)"] --> B["2. POST raw bytes\nto backend\n?kind=screenshot if applicable"]
+    B --> C["3. Backend streams to\nS3 staging path,\nstamps kind metadata"]
     C --> D["4. Return imageId\n(opaque UUID)"]
     D --> E["5. Include imageId in\ngenerate/iterate request"]
     E --> F["6. Pipeline copies to\nversion assets folder"]
-    F --> G["7. Write to sandbox\nfor Claude"]
+    F --> G["7. Write to sandbox\nfor Claude with\nkind-aware filename"]
 ```
 
-1. **User attaches image** — The chat UI lets users add an image file. A local preview is shown immediately.
+1. **User attaches image (or captures screenshot)** — The chat UI shows a local preview immediately. Screenshots
+   originate from the iframe-side capture pipeline (see [Screenshot Capture](#screenshot-capture)); from the upload's
+   perspective they're just another `File`.
 
-2. **Upload to backend** — The frontend sends the raw file bytes directly to the backend via
+2. **Upload to backend** — The frontend sends the raw bytes directly to
    `POST /api/v1/ee/projects/{projectUuid}/apps/{appUuid}/upload-image` with the image's MIME type as the
-   `Content-Type` header. This is a plain `fetch` call (not `lightdashApi`) because the body is raw binary, not JSON.
+   `Content-Type` header. For screenshots the URL gains `?kind=screenshot`. This is a plain `fetch` (not `lightdashApi`)
+   because the body is raw binary, not JSON.
 
-3. **Stream to S3 staging** — The backend streams the request body directly to S3 via `PutObjectCommand` without
-   buffering the entire file in memory. The image is stored at a deterministic staging path:
-   `apps/{appUuid}/uploads/{imageId}` (no file extension — MIME type is stored as the S3 object's `ContentType`).
+3. **Stream to S3 staging, stamp kind** — The backend buffers and validates the body (magic-byte check), then writes
+   it to a deterministic staging path: `apps/{appUuid}/uploads/{imageId}` (no file extension — MIME is stored on the
+   S3 object's `ContentType`). When `kind=screenshot` is set, the upload also writes `Metadata: { kind: 'screenshot' }`
+   on the staging object so downstream stages can tell the two apart without a DB column.
 
-4. **Return imageId** — The backend returns `{ imageId }` — an opaque UUID. The frontend never sees the S3 key.
+4. **Return imageId** — The backend returns `{ imageId }` — an opaque UUID. The frontend never sees the S3 key or the
+   stored `kind`.
 
-5. **Attach to prompt** — When the user submits their prompt, the `imageId` is included in the generate or iterate
-   request body. The backend reconstructs the S3 staging key from the deterministic convention.
+5. **Attach to prompt** — When the user submits, every `imageId` (attachments and screenshots alike) goes in the same
+   `imageIds: string[]` field on the generate or iterate request. The backend reconstructs the S3 staging key from the
+   deterministic convention.
 
-6. **Copy to version assets** — During the pipeline, the image is copied from the staging path to the version assets
-   folder: `apps/{appUuid}/versions/{version}/assets/images/{imageId}.{ext}`.
+6. **Copy to version assets** — During the pipeline, each image is copied from staging to the version's assets folder:
+   `apps/{appUuid}/versions/{version}/assets/images/{filename}`. For screenshots, `filename` is `screenshot-{imageId}.{ext}`;
+   for attachments it's `{imageId}.{ext}`. Mirroring the prefix into the archive keeps the artifact identifiable later.
 
-7. **Write to sandbox** — The image bytes are written to the E2B sandbox at `/tmp/images/reference.{ext}` for Claude
-   to read as a design reference.
+7. **Write to sandbox** — Bytes are written to the E2B sandbox at `/tmp/images/{filename}` using the same `screenshot-`
+   prefix convention. The prompt-prepend step emits a different sentence for each kind, anchored on that filename.
+
+### Telling the agent what kind it's looking at
+
+`AppGenerateService.writeCatalogAndPrompt` prepends a one-line reference to `/tmp/prompt.txt` per attached image,
+with wording chosen from the filename:
+
+- **Attachment** → `[Design reference image N at /tmp/images/<uuid>.<ext> — use the Read tool to view it]`
+- **Screenshot** → `[Screenshot of the current app at /tmp/images/screenshot-<uuid>.<ext> — use the Read tool to view it. This is what the user is looking at right now, not a design to reproduce.]`
+
+The screenshot wording is paired with a section in `sandboxes/data-apps/template/skill.md` ("Attached images") that
+documents the filename convention so Claude doesn't try to reproduce its own screenshot pixel-for-pixel. Both lines
+are added by `writeCatalogAndPrompt` in `AppGenerateService.ts` — if you change the prefix string or the filename
+convention, update the skill at the same time.
 
 ### Security
 
 The frontend only ever sees an opaque `imageId` (UUID). It has no knowledge of S3 keys, bucket names, or storage
 paths. The backend reconstructs all storage paths from a deterministic convention using values it controls
 (`appUuid` + `imageId`). This eliminates Insecure Direct Object Reference (IDOR) risks where a modified client
-could read arbitrary S3 objects.
+could read arbitrary S3 objects. The `kind` tag is set by the backend at upload time based on the validated
+query param — clients can't retroactively re-label an image once staged.
 
 ### Constraints
 
 - **Allowed MIME types**: `image/png`, `image/jpeg`, `image/gif`, `image/webp`
 - **Max size**: 10 MB (validated via `Content-Length` header before streaming)
+- **Max per submit**: `MAX_IMAGES_PER_VERSION = 4` (attachments + screenshots combined)
 - **Permission**: For an existing app, the standard manage check applies (space role, self for personal apps, or
   project admin). For an upload tied to a not-yet-created app (initial creation flow), `create:DataApp` is required.
+
+### Screenshot Capture
+
+Screenshots are produced **inside** the sandboxed preview iframe and shipped back to the parent as a PNG `Blob` over
+postMessage. The iframe is the only thing that can read its own DOM (the parent has no `allow-same-origin` access),
+so it's also the only thing that should be rendering it. Doing the rasterization there keeps the trust boundary
+intact: pixels cross to the parent, not HTML.
+
+```mermaid
+flowchart LR
+    A["1. Iframe announces\nscreenshot-available\non mount"] --> B["2. Parent shows\nScreenshot button"]
+    B --> C["3. User clicks\nScreenshot"]
+    C --> D["4. Parent posts\nscreenshot-request"]
+    D --> E["5. Iframe rasterizes\ndocument.body with\nhtml-to-image"]
+    E --> F["6. canvas.toBlob → PNG"]
+    F --> G["7. Iframe posts\nscreenshot-response\n{ id, blob }"]
+    G --> H["8. Parent wraps Blob\nin File, attaches as\nscreenshot kind"]
+```
+
+1. **Capability announce** — On mount, `sandboxes/data-apps/template/src/screenshotHandler.js` posts
+   `{ type: 'lightdash:sdk:screenshot-available' }` to `window.parent`. `useAppSdkBridge` routes the announce to
+   `AppIframePreview`, which flips `screenshotAvailable` in `AppGenerate` to `true`. Older templates running in
+   resumed sandboxes never announce, so the Screenshot button stays hidden for them — they keep working as before.
+   Mirrors the inspector availability handshake.
+
+2. **Request** — `useIframeScreenshot.captureScreenshot()` posts `{ type: 'lightdash:sdk:screenshot-request', id }`
+   to the iframe's `contentWindow` and arms a 30s timeout. The parent exposes this through the
+   `AppIframePreviewHandle` imperative handle.
+
+3. **Rasterize inside the iframe** — `screenshotHandler.js` calls `toBlob(document.body, { pixelRatio })` from
+   [`html-to-image`](https://www.npmjs.com/package/html-to-image). The library walks the live DOM, copies
+   `computedStyle.cssText` straight onto the clone, then wraps the result in SVG `<foreignObject>` and rasterizes
+   via `<img src="data:image/svg+xml,...">` → canvas → blob. **Crucially it does not internally create any hidden
+   iframe.** This matters here: the preview iframe runs with `sandbox="allow-scripts"` (no `allow-same-origin`) so
+   its origin is opaque, and any child iframe it creates would land in a *different* opaque origin — two opaque
+   origins are never same-origin with each other, so the parent iframe's own JS can't read its child iframe's
+   document. That breaks both `html2canvas` (clones the whole page into a nested iframe) and `modern-screenshot`
+   (creates a sandbox iframe for default-style computation): both throw `Permission denied to access property
+   'document' on cross-origin object`. `html-to-image` avoids the problem by never touching a nested document.
+
+4. **Response** — The iframe posts back `{ type: 'lightdash:sdk:screenshot-response', id, blob }` to
+   `window.parent` with `'*'` as the target origin (the sandboxed iframe's origin is opaque). The parent listener
+   filters by `event.source === iframe.contentWindow` (unforgeable Window reference, mirrors `useAppSdkBridge`).
+
+5. **Wrap and upload** — The parent wraps the Blob in a `File` named `screenshot.png` and feeds it into
+   `handleImageAttach(file, 'screenshot')`. From there the regular [Upload Flow](#upload-flow) takes over and the
+   `?kind=screenshot` query param flows down to the backend.
+
+The bridge protocol types (`SdkScreenshotRequest`, `SdkScreenshotResponse`, `SdkScreenshotAvailableMessage`) live in
+`packages/query-sdk/src/postMessageTransport.ts` alongside the existing SDK fetch and inspector types.
+
+### Why iframe-side capture
+
+The alternative — serializing the DOM out of the iframe and re-rendering it in a hidden `srcdoc` iframe on the
+parent side — would force adversarial HTML across the trust boundary and depend on a `sandbox` attribute to keep
+the parent's origin safe. Capturing in-iframe avoids all of that, plus:
+
+- **Live state, not a cold re-render.** `<input>`/`<textarea>` values, hover/focus visuals, animation mid-frames,
+  IntersectionObserver-driven state, chart canvas pixels — all preserved, because html-to-image walks the live DOM.
+- **No silent CSS dropout.** Anything visible to the iframe is visible to its in-iframe rasterizer. No
+  cross-origin-stylesheet skipping.
+- **No payload-size cap.** The transferred payload is a Blob bounded by the rendered canvas size, not a stringified
+  HTML snapshot that has to be capped to keep `iframe.srcdoc = ...` from crashing the parent.
+- **Smaller surface area.** ~70 lines of new code total (handler + hook) vs. the parent-side approach's hidden
+  srcdoc iframe + DOM-clone + CSS-inlining + size-cap path.
+
+### Trust boundary summary
+
+There's only one trust boundary that matters: the preview iframe's `sandbox="allow-scripts allow-modals"`. The
+screenshot path doesn't cross any new boundary — pixels are inert. Two defences keep the path robust:
+
+1. **`event.source` identity check** in `useIframeScreenshot`'s response listener — only messages from the actual
+   preview `contentWindow` are accepted, so a sibling window can't deliver a fake blob to upload.
+2. **Capability handshake** — the parent only shows the Screenshot button after the iframe announces capability,
+   so the user can't trigger a request against a template that never installed the handler.
 
 ---
 
@@ -404,6 +517,7 @@ could read arbitrary S3 objects.
 | `useAppPreviewToken`   | `features/apps/hooks/useAppPreviewToken.ts`   | Mint JWT for iframe preview          |
 | `useCancelAppVersion`  | `features/apps/hooks/useCancelAppVersion.ts`  | Cancel a building version            |
 | `useUpdateApp`         | `features/apps/hooks/useUpdateApp.ts`         | Update app name/description          |
+| `useIframeScreenshot`  | `features/apps/hooks/useIframeScreenshot.ts`  | Requests a PNG blob from the iframe (rasterized in-iframe by html-to-image) |
 
 ### Build Status Polling
 
@@ -463,8 +577,11 @@ S3 credentials are configured through the existing `S3_*` environment variables 
 | `packages/backend/src/database/entities/apps.ts`                            | DB entity type definitions                     |
 | `packages/common/src/ee/apps/types.ts`                                      | Shared API response types                      |
 | `packages/frontend/src/pages/AppGenerate.tsx`                               | Split-panel chat UI for creation and iteration |
-| `packages/frontend/src/features/apps/AppIframePreview.tsx`                  | Sandboxed iframe component                     |
-| `packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts`              | postMessage fetch proxy for iframe API access  |
+| `packages/frontend/src/features/apps/AppIframePreview.tsx`                  | Sandboxed iframe component (forwards ref so the parent can call `captureScreenshot()`) |
+| `packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts`              | postMessage fetch proxy + inspector/screenshot capability routing |
+| `packages/frontend/src/features/apps/hooks/useIframeScreenshot.ts`          | postMessage round-trip to fetch a PNG blob from the iframe |
+| `sandboxes/data-apps/template/src/screenshotHandler.js`                     | Iframe-side handler — html-to-image rasterizes the live DOM and posts the blob back |
+| `packages/query-sdk/src/postMessageTransport.ts`                            | Shared SDK message types — fetch, ready, inspector, screenshot |
 
 ---
 

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -122,6 +122,7 @@ export class AppGenerateController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
         @Path() appUuid: string,
+        @Query() kind?: 'screenshot',
     ): Promise<ApiAppImageUploadResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -145,6 +146,7 @@ export class AppGenerateController extends BaseController {
             req,
             contentLength,
             appUuid,
+            kind,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -514,6 +514,7 @@ export class AppGenerateService extends BaseService {
         body: Readable,
         contentLength: number,
         appUuid: string,
+        kind?: 'screenshot',
     ): Promise<{ imageId: string }> {
         await this.assertDataAppsEnabled(user);
 
@@ -580,6 +581,10 @@ export class AppGenerateService extends BaseService {
                 Body: bufferedBody,
                 ContentLength: bufferedBody.length,
                 ContentType: mimeType,
+                // Persist the upload kind on the staged object so
+                // `writeImageToSandbox` can decide the filename prefix later
+                // without needing a separate DB column.
+                ...(kind ? { Metadata: { kind } } : {}),
             }),
         );
 
@@ -1066,13 +1071,22 @@ export class AppGenerateService extends BaseService {
                     ),
                 ),
             );
+            // Label screenshots distinctly so the agent treats them as
+            // "current state of the built app" rather than design targets.
+            // Filename convention is set in `writeImageToSandbox`.
+            let designIndex = 0;
             const referenceLines = imagePaths
-                .map(
-                    (p, i) =>
-                        `[Design reference image ${
-                            i + 1
-                        } at ${p} — use the Read tool to view it]`,
-                )
+                .map((p) => {
+                    const isScreenshot = p
+                        .split('/')
+                        .pop()
+                        ?.startsWith('screenshot-');
+                    if (isScreenshot) {
+                        return `[Screenshot of the current app at ${p} — use the Read tool to view it. This is what the user is looking at right now, not a design to reproduce.]`;
+                    }
+                    designIndex += 1;
+                    return `[Design reference image ${designIndex} at ${p} — use the Read tool to view it]`;
+                })
                 .join('\n');
             finalPrompt = `${referenceLines}\n\n${finalPrompt}`;
         }
@@ -1141,7 +1155,14 @@ export class AppGenerateService extends BaseService {
 
         const mimeType = response.ContentType ?? 'image/png';
         const ext = AppGenerateService.mimeToExt(mimeType);
-        const sandboxPath = `/tmp/images/${imageId}.${ext}`;
+        // Screenshots get a filename prefix so the agent can tell them apart
+        // from user-provided design references. Stamped on the staging object
+        // at upload time via S3 metadata (see `uploadImage`).
+        const isScreenshot = response.Metadata?.kind === 'screenshot';
+        const filename = isScreenshot
+            ? `screenshot-${imageId}.${ext}`
+            : `${imageId}.${ext}`;
+        const sandboxPath = `/tmp/images/${filename}`;
 
         // Read the image bytes
         const chunks: Uint8Array[] = [];
@@ -1155,8 +1176,9 @@ export class AppGenerateService extends BaseService {
         }
         const buffer = Buffer.concat(chunks);
 
-        // Copy to version assets folder
-        const versionKey = `apps/${appUuid}/versions/${version}/assets/images/${imageId}.${ext}`;
+        // Copy to version assets folder. Match the sandbox filename so the
+        // archived asset is identifiable as a screenshot too.
+        const versionKey = `apps/${appUuid}/versions/${version}/assets/images/${filename}`;
         this.logger.info(
             `App ${appUuid}: copying image to version path (${stagingKey} → ${versionKey})`,
         );

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7379,7 +7379,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                spaceUuid: { dataType: 'string' },
                 clarifications: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'AppClarification' },
@@ -9522,11 +9521,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10004,11 +10003,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10023,11 +10022,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10042,11 +10041,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10061,11 +10060,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10080,11 +10079,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -21996,7 +21995,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22006,7 +22005,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22016,7 +22015,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -22029,7 +22028,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -22440,7 +22439,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22450,7 +22449,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -22460,7 +22459,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -22473,7 +22472,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -34463,6 +34462,12 @@ export function RegisterRoutes(app: Router) {
             name: 'appUuid',
             required: true,
             dataType: 'string',
+        },
+        kind: {
+            in: 'query',
+            name: 'kind',
+            dataType: 'enum',
+            enums: ['screenshot'],
         },
     };
     app.post(

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8757,9 +8757,6 @@
             },
             "GenerateAppRequestBody": {
                 "properties": {
-                    "spaceUuid": {
-                        "type": "string"
-                    },
                     "clarifications": {
                         "items": {
                             "$ref": "#/components/schemas/AppClarification"
@@ -10974,6 +10971,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -23374,22 +23384,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -23744,22 +23754,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -32271,7 +32281,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2915.0",
+        "version": "0.2915.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -1,9 +1,20 @@
-import { useCallback, useEffect, useRef, type FC } from 'react';
+import {
+    forwardRef,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+} from 'react';
 import {
     useAppSdkBridge,
     type ElementSelectedEvent,
     type QueryEvent,
 } from './hooks/useAppSdkBridge';
+import { useIframeScreenshot } from './hooks/useIframeScreenshot';
+
+export type AppIframePreviewHandle = {
+    captureScreenshot: () => Promise<File>;
+};
 
 type Props = {
     src: string;
@@ -13,10 +24,11 @@ type Props = {
      *  same-origin fallback case. */
     expectedPreviewOrigin: string;
     /** Stable identity for the served bundle (e.g. `${appUuid}:${version}`).
-     *  Drives the inspector-availability reset — changes here mean a new
-     *  bundle whose SDK capabilities are unknown, so we re-await an announce.
-     *  A pure URL bump (e.g. the manual refresh counter) keeps this stable
-     *  so the Inspect button doesn't flash off and back on. */
+     *  Drives the inspector/screenshot availability resets — changes here
+     *  mean a new bundle whose SDK capabilities are unknown, so we re-await
+     *  the announces. A pure URL bump (e.g. the manual refresh counter)
+     *  keeps this stable so the Inspect/Screenshot buttons don't flash off
+     *  and back on. */
     identityKey: string;
     onQueryEvent?: (event: QueryEvent) => void;
     onElementSelected?: (event: ElementSelectedEvent) => void;
@@ -29,6 +41,12 @@ type Props = {
      *  pre-inspector SDK) keep this `false` and let the parent hide the
      *  Inspect button. Resets to `false` on every `identityKey` change. */
     onInspectorAvailabilityChange?: (available: boolean) => void;
+    /** Same handshake as the inspector, for screenshot capture. The iframe
+     *  template that ships html2canvas-pro posts
+     *  `lightdash:sdk:screenshot-available` on mount; older templates in
+     *  resumed sandboxes never announce, so the Screenshot button stays
+     *  hidden for them. */
+    onScreenshotAvailabilityChange?: (available: boolean) => void;
     /** Called when the user presses Esc to leave inspect mode. The handler
      *  lives on the parent's window because that's where focus actually
      *  sits during inspect mode (the toolbar button before any click; the
@@ -46,83 +64,111 @@ type Props = {
  * already isolated from parent origin. The SDK inside the iframe routes all
  * API calls through postMessage, and this component's bridge executes them
  * using the current user's session.
+ *
+ * Exposes a `captureScreenshot()` imperative handle for the parent. The
+ * iframe rasterizes its own DOM with html2canvas-pro and posts the PNG
+ * blob back over postMessage — see `useIframeScreenshot` and
+ * `sandboxes/data-apps/template/src/screenshotHandler.js`.
  */
-const AppIframePreview: FC<Props> = ({
-    src,
-    expectedPreviewOrigin,
-    identityKey,
-    onQueryEvent,
-    onElementSelected,
-    inspectorEnabled,
-    onInspectorAvailabilityChange,
-    onInspectorCancelled,
-}) => {
-    const iframeRef = useRef<HTMLIFrameElement>(null);
-    // Memoized so the bridge's message listener doesn't re-attach on every
-    // parent render — AppGenerate re-renders on every keystroke (editor's
-    // `onUpdate` → `setIsPromptEmpty`) and we don't want to thrash listeners.
-    const handleAnnounce = useCallback(() => {
-        onInspectorAvailabilityChange?.(true);
-    }, [onInspectorAvailabilityChange]);
-    const { handleIframeLoad, enableInspector, disableInspector } =
-        useAppSdkBridge(
-            iframeRef,
+const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
+    (
+        {
+            src,
             expectedPreviewOrigin,
+            identityKey,
             onQueryEvent,
             onElementSelected,
-            handleAnnounce,
-        );
+            inspectorEnabled,
+            onInspectorAvailabilityChange,
+            onScreenshotAvailabilityChange,
+            onInspectorCancelled,
+        },
+        ref,
+    ) => {
+        const iframeRef = useRef<HTMLIFrameElement>(null);
+        // Memoized so the bridge's message listener doesn't re-attach on every
+        // parent render — AppGenerate re-renders on every keystroke (editor's
+        // `onUpdate` → `setIsPromptEmpty`) and we don't want to thrash listeners.
+        const handleInspectorAnnounce = useCallback(() => {
+            onInspectorAvailabilityChange?.(true);
+        }, [onInspectorAvailabilityChange]);
+        const handleScreenshotAnnounce = useCallback(() => {
+            onScreenshotAvailabilityChange?.(true);
+        }, [onScreenshotAvailabilityChange]);
+        const { handleIframeLoad, enableInspector, disableInspector } =
+            useAppSdkBridge(
+                iframeRef,
+                expectedPreviewOrigin,
+                onQueryEvent,
+                onElementSelected,
+                handleInspectorAnnounce,
+                handleScreenshotAnnounce,
+            );
+        const { captureScreenshot } = useIframeScreenshot(iframeRef);
 
-    // Reset availability to false when the served bundle changes (new app or
-    // new version). Fires before the browser starts loading the new content,
-    // so the new SDK's `available` announce will flip it back to true if it's
-    // wired up. Old SDKs in resumed sandboxes never announce, so it stays
-    // false. Keyed on `identityKey` rather than `src` so that pure URL bumps
-    // (manual preview refresh) don't reset — same bundle means same SDK
-    // capability, and resetting would briefly hide the Inspect button.
-    useEffect(() => {
-        onInspectorAvailabilityChange?.(false);
-    }, [identityKey, onInspectorAvailabilityChange]);
+        useImperativeHandle(ref, () => ({ captureScreenshot }), [
+            captureScreenshot,
+        ]);
 
-    // Toggling the prop while the iframe is alive — push the change through.
-    useEffect(() => {
-        if (inspectorEnabled) enableInspector();
-        else disableInspector();
-    }, [inspectorEnabled, enableInspector, disableInspector]);
+        // Reset availability to false when the served bundle changes (new app or
+        // new version). Fires before the browser starts loading the new content,
+        // so the new SDK's `available` announce will flip it back to true if it's
+        // wired up. Old SDKs in resumed sandboxes never announce, so it stays
+        // false. Keyed on `identityKey` rather than `src` so that pure URL bumps
+        // (manual preview refresh) don't reset — same bundle means same SDK
+        // capability, and resetting would briefly hide the Inspect/Screenshot
+        // buttons.
+        useEffect(() => {
+            onInspectorAvailabilityChange?.(false);
+            onScreenshotAvailabilityChange?.(false);
+        }, [
+            identityKey,
+            onInspectorAvailabilityChange,
+            onScreenshotAvailabilityChange,
+        ]);
 
-    // Esc-to-cancel. Lives on the parent's window because focus is on the
-    // parent (the toolbar button before any click; the editor afterwards) —
-    // the iframe never holds focus during inspect mode, so an iframe-side
-    // keydown listener would never fire.
-    useEffect(() => {
-        if (!inspectorEnabled) return;
-        const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                onInspectorCancelled?.();
-            }
+        // Toggling the prop while the iframe is alive — push the change through.
+        useEffect(() => {
+            if (inspectorEnabled) enableInspector();
+            else disableInspector();
+        }, [inspectorEnabled, enableInspector, disableInspector]);
+
+        // Esc-to-cancel. Lives on the parent's window because focus is on the
+        // parent (the toolbar button before any click; the editor afterwards) —
+        // the iframe never holds focus during inspect mode, so an iframe-side
+        // keydown listener would never fire.
+        useEffect(() => {
+            if (!inspectorEnabled) return;
+            const onKey = (e: KeyboardEvent) => {
+                if (e.key === 'Escape') {
+                    onInspectorCancelled?.();
+                }
+            };
+            window.addEventListener('keydown', onKey);
+            return () => window.removeEventListener('keydown', onKey);
+        }, [inspectorEnabled, onInspectorCancelled]);
+
+        // The iframe reloads on every new app version. The useEffect above won't
+        // re-fire if `inspectorEnabled` was already true, so re-sync on load.
+        const handleLoad = () => {
+            handleIframeLoad();
+            if (inspectorEnabled) enableInspector();
         };
-        window.addEventListener('keydown', onKey);
-        return () => window.removeEventListener('keydown', onKey);
-    }, [inspectorEnabled, onInspectorCancelled]);
 
-    // The iframe reloads on every new app version. The useEffect above won't
-    // re-fire if `inspectorEnabled` was already true, so re-sync on load.
-    const handleLoad = () => {
-        handleIframeLoad();
-        if (inspectorEnabled) enableInspector();
-    };
+        return (
+            <iframe
+                ref={iframeRef}
+                src={src}
+                style={{ width: '100%', height: '100%', border: 'none' }}
+                title="App preview"
+                sandbox="allow-scripts allow-modals"
+                allow=""
+                onLoad={handleLoad}
+            />
+        );
+    },
+);
 
-    return (
-        <iframe
-            ref={iframeRef}
-            src={src}
-            style={{ width: '100%', height: '100%', border: 'none' }}
-            title="App preview"
-            sandbox="allow-scripts allow-modals"
-            allow=""
-            onLoad={handleLoad}
-        />
-    );
-};
+AppIframePreview.displayName = 'AppIframePreview';
 
 export default AppIframePreview;

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
+    IconCamera,
     IconClick,
     IconDatabase,
     IconDatabaseOff,
@@ -73,6 +74,31 @@ export const ImageButton: FC<{
         className={classes.resourceButton}
     >
         Images
+    </Button>
+);
+
+/**
+ * Button that captures a screenshot of the live preview and adds it as an
+ * image attachment. Shows a loader while the capture is in flight.
+ *
+ * The caller is expected to render this only when a capture-capable preview
+ * is mounted (i.e. gate on `screenshotAvailable`), mirroring `InspectButton`.
+ */
+export const ScreenshotButton: FC<{
+    onClick: () => void;
+    disabled: boolean;
+    loading?: boolean;
+}> = ({ onClick, disabled, loading }) => (
+    <Button
+        variant="default"
+        size="xs"
+        leftSection={<MantineIcon icon={IconCamera} size={14} />}
+        onClick={onClick}
+        disabled={disabled}
+        loading={loading}
+        className={classes.resourceButton}
+    >
+        Screenshot
     </Button>
 );
 

--- a/packages/frontend/src/features/apps/hooks/useAppImageUpload.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppImageUpload.ts
@@ -8,6 +8,10 @@ type UploadImageParams = {
     projectUuid: string;
     file: File;
     appUuid: string;
+    /** Marks the image as a screenshot of the current preview so the
+     *  backend can label it for the agent. Optional — defaults to a
+     *  regular design-reference attachment. */
+    kind?: 'screenshot';
 };
 
 type UploadImageResult = ApiAppImageUploadResponse['results'];
@@ -16,15 +20,16 @@ const uploadImage = async ({
     projectUuid,
     file,
     appUuid,
+    kind,
 }: UploadImageParams): Promise<UploadImageResult> => {
-    const response = await fetch(
-        `/api/v1/ee/projects/${projectUuid}/apps/${appUuid}/upload-image`,
-        {
-            method: 'POST',
-            body: file,
-            headers: { 'Content-Type': file.type },
-        },
-    );
+    const url = `/api/v1/ee/projects/${projectUuid}/apps/${appUuid}/upload-image${
+        kind ? `?kind=${kind}` : ''
+    }`;
+    const response = await fetch(url, {
+        method: 'POST',
+        body: file,
+        headers: { 'Content-Type': file.type },
+    });
     if (!response.ok) {
         const errorBody = await response.json();
         throw new Error(

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -89,9 +89,10 @@ export type ElementSelectedEvent = {
  * enableInspector / disableInspector helpers to toggle the iframe-side
  * overlay.
  *
- * `onInspectorAvailable` fires when the iframe SDK announces capability on
- * mount. The bridge doesn't track availability state itself — the parent
- * owns it and is responsible for resetting on iframe `src` change.
+ * `onInspectorAvailable` and `onScreenshotAvailable` fire when the iframe
+ * SDK announces those capabilities on mount. The bridge doesn't track
+ * availability state itself — the parent owns it and is responsible for
+ * resetting on iframe `src` change.
  */
 export function useAppSdkBridge(
     iframeRef: RefObject<HTMLIFrameElement | null>,
@@ -109,6 +110,7 @@ export function useAppSdkBridge(
     onQueryEvent?: (event: QueryEvent) => void,
     onElementSelected?: (event: ElementSelectedEvent) => void,
     onInspectorAvailable?: () => void,
+    onScreenshotAvailable?: () => void,
 ) {
     const handleMessage = useCallback(
         async (event: MessageEvent) => {
@@ -128,6 +130,11 @@ export function useAppSdkBridge(
 
             if (data?.type === 'lightdash:inspect:available') {
                 onInspectorAvailable?.();
+                return;
+            }
+
+            if (data?.type === 'lightdash:sdk:screenshot-available') {
+                onScreenshotAvailable?.();
                 return;
             }
 
@@ -313,6 +320,7 @@ export function useAppSdkBridge(
             onQueryEvent,
             onElementSelected,
             onInspectorAvailable,
+            onScreenshotAvailable,
         ],
     );
 

--- a/packages/frontend/src/features/apps/hooks/useIframeScreenshot.ts
+++ b/packages/frontend/src/features/apps/hooks/useIframeScreenshot.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
+
+const SCREENSHOT_TIMEOUT_MS = 30_000;
+
+type PendingScreenshot = {
+    resolve: (blob: Blob) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * Provides a `captureScreenshot()` that asks the sandboxed preview iframe
+ * to rasterize its own DOM (via html2canvas-pro inside the iframe) and
+ * post the resulting PNG blob back. The parent only forwards the blob
+ * into a `File` — no HTML serialization, no parent-side rendering, no
+ * trust-boundary dance.
+ *
+ * Capability is announced separately by the iframe via
+ * `lightdash:sdk:screenshot-available` and routed through
+ * `useAppSdkBridge` — see `onScreenshotAvailable` there.
+ */
+export function useIframeScreenshot(
+    iframeRef: RefObject<HTMLIFrameElement | null>,
+) {
+    const pending = useRef<Map<string, PendingScreenshot>>(new Map());
+
+    useEffect(() => {
+        const handleMessage = (event: MessageEvent) => {
+            // Identity check via `event.source` is unforgeable — it's the
+            // actual Window reference, not a string the sender chose. Mirrors
+            // `useAppSdkBridge`. Origin can be `"null"` here because the
+            // preview iframe has an opaque origin (no `allow-same-origin`),
+            // so we don't gate on it.
+            if (event.source !== iframeRef.current?.contentWindow) return;
+
+            const { data } = event;
+            if (data?.type !== 'lightdash:sdk:screenshot-response') return;
+
+            const { id, blob, error } = data;
+            const request = pending.current.get(id);
+            if (!request) return;
+
+            clearTimeout(request.timer);
+            pending.current.delete(id);
+
+            if (error) {
+                request.reject(new Error(error));
+                return;
+            }
+
+            if (!(blob instanceof Blob)) {
+                request.reject(new Error('Screenshot response missing blob'));
+                return;
+            }
+
+            request.resolve(blob);
+        };
+
+        window.addEventListener('message', handleMessage);
+        return () => window.removeEventListener('message', handleMessage);
+    }, [iframeRef]);
+
+    const captureScreenshot = useCallback(async (): Promise<File> => {
+        const iframe = iframeRef.current;
+        if (!iframe?.contentWindow) {
+            throw new Error('Iframe not available');
+        }
+
+        const id = crypto.randomUUID();
+
+        const blob = await new Promise<Blob>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                pending.current.delete(id);
+                reject(new Error('Screenshot timed out'));
+            }, SCREENSHOT_TIMEOUT_MS);
+
+            pending.current.set(id, { resolve, reject, timer });
+
+            // Wildcard targetOrigin — the preview iframe is sandboxed without
+            // `allow-same-origin` so its origin is opaque (`"null"`); a
+            // specific targetOrigin would be silently dropped. Delivery is
+            // targeted by `iframe.contentWindow`, not by origin, and the
+            // payload carries no sensitive data. Mirrors `useAppSdkBridge`'s
+            // parent→iframe sends.
+            iframe.contentWindow!.postMessage(
+                { type: 'lightdash:sdk:screenshot-request', id },
+                '*',
+            );
+        });
+
+        return new File([blob], 'screenshot.png', { type: blob.type });
+    }, [iframeRef]);
+
+    return { captureScreenshot };
+}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -46,6 +46,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import ReactMarkdownPreview from '@uiw/react-markdown-preview';
 import {
+    forwardRef,
     useCallback,
     useEffect,
     useMemo,
@@ -68,7 +69,9 @@ import AppUpdateModal from '../components/common/modal/AppUpdateModal';
 import { ChartIcon, IconBox } from '../components/common/ResourceIcon';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import TransferItemsModal from '../components/common/TransferItemsModal/TransferItemsModal';
-import AppIframePreview from '../features/apps/AppIframePreview';
+import AppIframePreview, {
+    type AppIframePreviewHandle,
+} from '../features/apps/AppIframePreview';
 import AppPromptEditor, {
     type AppPromptEditorHandle,
     type ElementRef,
@@ -78,6 +81,7 @@ import {
     ImageButton,
     InspectButton,
     QueryButton,
+    ScreenshotButton,
     SelectedDashboardSection,
     SelectedImageSection,
     SelectedQuerySection,
@@ -157,7 +161,7 @@ const AppResourceImage: FC<{
     return <Image src={data.imageUrl} className={className} alt="Attached" />;
 };
 
-const AppPreview: FC<{
+type AppPreviewProps = {
     projectUuid: string;
     appUuid: string;
     version: number;
@@ -170,64 +174,77 @@ const AppPreview: FC<{
     inspectorEnabled?: boolean;
     onElementSelected?: (event: { label: string }) => void;
     onInspectorAvailabilityChange?: (available: boolean) => void;
+    onScreenshotAvailabilityChange?: (available: boolean) => void;
     onInspectorCancelled?: () => void;
-}> = ({
-    projectUuid,
-    appUuid,
-    version,
-    refreshKey,
-    onQueryEvent,
-    inspectorEnabled,
-    onElementSelected,
-    onInspectorAvailabilityChange,
-    onInspectorCancelled,
-}) => {
-    const {
-        data: token,
-        isLoading,
-        error,
-    } = useAppPreviewToken(projectUuid, appUuid, version);
-
-    const previewOrigin = usePreviewOrigin();
-    const previewUrl = token
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/?token=${token}&r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
-        : undefined;
-
-    if (isLoading) {
-        return (
-            <Group gap="sm" p="md" justify="center">
-                <Loader size="sm" />
-                <Text size="sm" c="dimmed">
-                    Loading preview...
-                </Text>
-            </Group>
-        );
-    }
-
-    if (error) {
-        return (
-            <Text c="red" p="md" size="sm">
-                Failed to load preview:{' '}
-                {error instanceof Error ? error.message : 'Unknown error'}
-            </Text>
-        );
-    }
-
-    if (!previewUrl) return null;
-
-    return (
-        <AppIframePreview
-            src={previewUrl}
-            expectedPreviewOrigin={previewOrigin}
-            identityKey={`${appUuid}:${version}`}
-            onQueryEvent={onQueryEvent}
-            inspectorEnabled={inspectorEnabled}
-            onElementSelected={onElementSelected}
-            onInspectorAvailabilityChange={onInspectorAvailabilityChange}
-            onInspectorCancelled={onInspectorCancelled}
-        />
-    );
 };
+
+const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
+    (
+        {
+            projectUuid,
+            appUuid,
+            version,
+            refreshKey,
+            onQueryEvent,
+            inspectorEnabled,
+            onElementSelected,
+            onInspectorAvailabilityChange,
+            onScreenshotAvailabilityChange,
+            onInspectorCancelled,
+        },
+        ref,
+    ) => {
+        const {
+            data: token,
+            isLoading,
+            error,
+        } = useAppPreviewToken(projectUuid, appUuid, version);
+
+        const previewOrigin = usePreviewOrigin();
+        const previewUrl = token
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/?token=${token}&r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
+            : undefined;
+
+        if (isLoading) {
+            return (
+                <Group gap="sm" p="md" justify="center">
+                    <Loader size="sm" />
+                    <Text size="sm" c="dimmed">
+                        Loading preview...
+                    </Text>
+                </Group>
+            );
+        }
+
+        if (error) {
+            return (
+                <Text c="red" p="md" size="sm">
+                    Failed to load preview:{' '}
+                    {error instanceof Error ? error.message : 'Unknown error'}
+                </Text>
+            );
+        }
+
+        if (!previewUrl) return null;
+
+        return (
+            <AppIframePreview
+                ref={ref}
+                src={previewUrl}
+                expectedPreviewOrigin={previewOrigin}
+                identityKey={`${appUuid}:${version}`}
+                onQueryEvent={onQueryEvent}
+                inspectorEnabled={inspectorEnabled}
+                onElementSelected={onElementSelected}
+                onInspectorAvailabilityChange={onInspectorAvailabilityChange}
+                onScreenshotAvailabilityChange={onScreenshotAvailabilityChange}
+                onInspectorCancelled={onInspectorCancelled}
+            />
+        );
+    },
+);
+
+AppPreview.displayName = 'AppPreview';
 
 const LoadingDots: FC = () => (
     <span className={classes.loadingDots}>
@@ -295,6 +312,7 @@ const AppGenerate: FC = () => {
         Array<{
             file: File;
             previewUrl: string;
+            kind?: 'screenshot';
         }>
     >([]);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -311,6 +329,12 @@ const AppGenerate: FC = () => {
     // inspector. Existing apps in resumed sandboxes may have an older SDK
     // that never announces, in which case the toggle stays hidden.
     const [inspectorAvailable, setInspectorAvailable] = useState(false);
+    // Same handshake for screenshot capture. Older templates (resumed
+    // sandboxes built before this feature shipped) never announce, so the
+    // Screenshot button stays hidden — they keep working as before.
+    const [screenshotAvailable, setScreenshotAvailable] = useState(false);
+    const [isCapturingScreenshot, setIsCapturingScreenshot] = useState(false);
+    const previewRef = useRef<AppIframePreviewHandle>(null);
     const [trackedQueries, setTrackedQueries] = useState<QueryEvent[]>([]);
     // Mirrors Chrome DevTools "Preserve log". When off (default), the queries
     // panel is cleared on iframe refresh and on new-version load — fresh
@@ -473,6 +497,8 @@ const AppGenerate: FC = () => {
         setTrackedQueries([]);
         setInspectorEnabled(false);
         setInspectorAvailable(false);
+        setScreenshotAvailable(false);
+        setIsCapturingScreenshot(false);
         setSelectedTemplate(null);
         setWizardStage('pick');
         setPendingClarification(null);
@@ -853,7 +879,7 @@ const AppGenerate: FC = () => {
         'image/webp',
     ];
 
-    const handleImageAttach = (file: File) => {
+    const handleImageAttach = (file: File, kind?: 'screenshot') => {
         if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
             showToastError({
                 title: 'Unsupported image type',
@@ -876,7 +902,10 @@ const AppGenerate: FC = () => {
                 });
                 return prev;
             }
-            return [...prev, { file, previewUrl: URL.createObjectURL(file) }];
+            return [
+                ...prev,
+                { file, previewUrl: URL.createObjectURL(file), kind },
+            ];
         });
     };
 
@@ -888,7 +917,7 @@ const AppGenerate: FC = () => {
             );
             if (imageFiles.length > 0) {
                 e.preventDefault();
-                imageFiles.forEach(handleImageAttach);
+                imageFiles.forEach((file) => handleImageAttach(file));
             }
         }
     };
@@ -896,7 +925,7 @@ const AppGenerate: FC = () => {
     const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = e.target.files;
         if (files) {
-            Array.from(files).forEach(handleImageAttach);
+            Array.from(files).forEach((file) => handleImageAttach(file));
         }
         e.target.value = '';
     };
@@ -916,7 +945,24 @@ const AppGenerate: FC = () => {
         e.preventDefault();
         Array.from(e.dataTransfer.files)
             .filter((f) => f.type.startsWith('image/'))
-            .forEach(handleImageAttach);
+            .forEach((file) => handleImageAttach(file));
+    };
+
+    const handleCaptureScreenshot = async () => {
+        const capture = previewRef.current?.captureScreenshot;
+        if (!capture) return;
+        setIsCapturingScreenshot(true);
+        try {
+            const file = await capture();
+            handleImageAttach(file, 'screenshot');
+        } catch (err) {
+            showToastError({
+                title: 'Screenshot failed',
+                subtitle: err instanceof Error ? err.message : 'Unknown error',
+            });
+        } finally {
+            setIsCapturingScreenshot(false);
+        }
     };
 
     const buildSubmitCallbacks = () => ({
@@ -992,6 +1038,7 @@ const AppGenerate: FC = () => {
                             projectUuid: projectUuid!,
                             file: att.file,
                             appUuid: targetAppUuid!,
+                            kind: att.kind,
                         });
                         ids.push(result.imageId);
                     } catch (err) {
@@ -1053,6 +1100,7 @@ const AppGenerate: FC = () => {
             promptEditorRef.current?.clear();
             setIsPromptEmpty(true);
             setImageAttachments([]);
+            setIsCapturingScreenshot(false);
             setSelectedCharts([]);
             setSelectedDashboard(null);
             resetGenerate();
@@ -1768,6 +1816,19 @@ const AppGenerate: FC = () => {
                                                 MAX_IMAGES_PER_VERSION
                                         }
                                     />
+                                    {previewApp && screenshotAvailable && (
+                                        <ScreenshotButton
+                                            onClick={() =>
+                                                void handleCaptureScreenshot()
+                                            }
+                                            disabled={
+                                                isLoading ||
+                                                imageAttachments.length >=
+                                                    MAX_IMAGES_PER_VERSION
+                                            }
+                                            loading={isCapturingScreenshot}
+                                        />
+                                    )}
                                     {inspectorAvailable && (
                                         <InspectButton
                                             enabled={inspectorEnabled}
@@ -2072,6 +2133,7 @@ const AppGenerate: FC = () => {
                         <Box className={classes.previewContent}>
                             {previewApp ? (
                                 <AppPreview
+                                    ref={previewRef}
                                     projectUuid={projectUuid}
                                     appUuid={previewApp.appUuid}
                                     version={previewApp.version}
@@ -2081,6 +2143,9 @@ const AppGenerate: FC = () => {
                                     onElementSelected={handleElementSelected}
                                     onInspectorAvailabilityChange={
                                         setInspectorAvailable
+                                    }
+                                    onScreenshotAvailabilityChange={
+                                        setScreenshotAvailable
                                     }
                                     onInspectorCancelled={
                                         handleInspectorCancelled

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -42,6 +42,9 @@ export type {
     SdkFetchRequest,
     SdkFetchResponse,
     SdkReadyMessage,
+    SdkScreenshotAvailableMessage,
+    SdkScreenshotRequest,
+    SdkScreenshotResponse,
 } from './postMessageTransport';
 
 // Element inspector (click-to-edit) — protocol types for parent bridge.

--- a/packages/query-sdk/src/postMessageTransport.ts
+++ b/packages/query-sdk/src/postMessageTransport.ts
@@ -37,6 +37,29 @@ export type SdkReadyMessage = {
     type: 'lightdash:sdk:ready';
 };
 
+export type SdkScreenshotRequest = {
+    type: 'lightdash:sdk:screenshot-request';
+    id: string;
+};
+
+export type SdkScreenshotResponse = {
+    type: 'lightdash:sdk:screenshot-response';
+    id: string;
+    /** PNG blob rasterized inside the iframe. Absent when `error` is set. */
+    blob?: Blob;
+    error?: string;
+};
+
+/**
+ * Announced by the iframe SDK on mount so the parent can detect that
+ * screenshot capture is wired up. Older templates running in resumed
+ * sandboxes don't send this, so the parent leaves the Screenshot button
+ * hidden for them — mirrors the inspector availability handshake.
+ */
+export type SdkScreenshotAvailableMessage = {
+    type: 'lightdash:sdk:screenshot-available';
+};
+
 // ---------------------------------------------------------------------------
 // postMessage FetchAdapter
 // ---------------------------------------------------------------------------

--- a/sandboxes/data-apps/template/package.json
+++ b/sandboxes/data-apps/template/package.json
@@ -27,6 +27,7 @@
         "d3-cloud": "1.2.9",
         "d3-sankey": "0.12.3",
         "date-fns": "3.6.0",
+        "html-to-image": "1.11.13",
         "lodash-es": "4.18.1",
         "lucide-react": "0.469.0",
         "react": "19.2.5",

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -142,6 +142,21 @@ Each file contains:
   **Only strip the prefix if it matches the explore name.** If it doesn't match, it's a joined table.
 - **Table calculation names:** Do NOT strip — pass them through as-is.
 
+## Attached images
+
+The user can attach images to a prompt. They land at `/tmp/images/`. Use the
+Read tool to view each one before deciding how to use it.
+
+Two kinds, distinguished by filename:
+
+| Filename pattern | Meaning | How to use it |
+|---|---|---|
+| `screenshot-<uuid>.<ext>` | A live screenshot of the **current** built app — what the user is looking at when they wrote the prompt. | Treat as *context for the request*, not a target. The user's prompt usually says "change X" or "this looks wrong" — the screenshot tells you what the layout actually renders as right now (colors, spacing, missing data, broken charts). Do NOT try to reproduce the screenshot; the existing source files already produce it. |
+| `<uuid>.<ext>` (no prefix) | A design reference uploaded by the user — mockup, sketch, screenshot from elsewhere, or a chart they like. | Treat as a *target to approximate* for layout, color, typography, or component choice. Match the spirit, not pixel-perfect. The prompt prepend will also call these "Design reference image N". |
+
+If both are attached, the user is most likely saying "here's what it looks
+like now (screenshot) — change it to look more like this (design reference)."
+
 ## Element references in iteration prompts
 
 The Lightdash preview pane has an "Inspect" toggle. When the user clicks an

--- a/sandboxes/data-apps/template/src/main.jsx
+++ b/sandboxes/data-apps/template/src/main.jsx
@@ -6,6 +6,7 @@ import { FilterProvider } from '@/lib/filters';
 import App from './App';
 import './index.css';
 import './chart-overrides.css';
+import initScreenshotHandler from './screenshotHandler';
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -17,6 +18,8 @@ const queryClient = new QueryClient({
     },
 });
 const lightdash = createClient();
+
+initScreenshotHandler();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>

--- a/sandboxes/data-apps/template/src/screenshotHandler.js
+++ b/sandboxes/data-apps/template/src/screenshotHandler.js
@@ -1,0 +1,70 @@
+/**
+ * Rasterizes the iframe's own DOM with html-to-image and posts the
+ * resulting PNG blob back to the parent. Doing the capture inside the
+ * iframe keeps it on the trust side of the sandbox boundary: pixels
+ * (not HTML) cross over, so there's nothing the parent has to neutralize
+ * before consuming.
+ *
+ * Why html-to-image specifically: the preview iframe runs with
+ * `sandbox="allow-scripts"` (no `allow-same-origin`), so its origin is
+ * opaque. Two opaque origins are never same-origin with each other,
+ * which breaks every DOM-to-image library that internally creates a
+ * hidden iframe and then reads `iframe.contentDocument` — both
+ * html2canvas (clones the whole page into a nested iframe) and
+ * modern-screenshot (creates a sandbox iframe to compute default styles)
+ * throw "Permission denied to access property 'document' on cross-origin
+ * object" here. html-to-image doesn't use that trick — it walks the live
+ * DOM and copies `computedStyle.cssText` straight onto the clone, then
+ * wraps in SVG <foreignObject>. No nested iframe access, no cross-origin
+ * lookups.
+ *
+ * Mirrors the inspector capability handshake — on init we announce
+ * `lightdash:sdk:screenshot-available` so the parent can show a
+ * Screenshot button. Older templates loaded by resumed sandboxes don't
+ * send this, so the button stays hidden for them.
+ */
+import { toBlob } from 'html-to-image';
+
+const REQUEST_TYPE = 'lightdash:sdk:screenshot-request';
+const RESPONSE_TYPE = 'lightdash:sdk:screenshot-response';
+const AVAILABLE_TYPE = 'lightdash:sdk:screenshot-available';
+
+function captureBlob() {
+    return toBlob(document.body, {
+        pixelRatio: Math.min(2, window.devicePixelRatio || 1),
+        cacheBust: false,
+    });
+}
+
+function initScreenshotHandler() {
+    if (typeof window === 'undefined') return;
+
+    window.parent.postMessage({ type: AVAILABLE_TYPE }, '*');
+
+    window.addEventListener('message', async (event) => {
+        const { data } = event;
+        if (data?.type !== REQUEST_TYPE) return;
+
+        const { id } = data;
+        try {
+            const blob = await captureBlob();
+            if (!blob) throw new Error('html-to-image returned no blob');
+            window.parent.postMessage(
+                { type: RESPONSE_TYPE, id, blob },
+                '*',
+            );
+        } catch (err) {
+            window.parent.postMessage(
+                {
+                    type: RESPONSE_TYPE,
+                    id,
+                    error:
+                        err instanceof Error ? err.message : 'Screenshot failed',
+                },
+                '*',
+            );
+        }
+    });
+}
+
+export default initScreenshotHandler;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-368/add-an-option-to-send-screenshots-to-data-apps

### Description:
Capture the live preview as a PNG inside the sandboxed iframe and ship the Blob to the parent. The iframe is the only context with access to its own DOM (the parent has no `allow-same-origin`), so it's also the only context that should render it — pixels cross the trust boundary, not HTML.

Bundled into the data-app template with `html-to-image`. html2canvas and modern-screenshot both internally create a hidden iframe (for DOM cloning / default-style computation) and then read `iframe.contentDocument` — this fails under `sandbox="allow-scripts"` because nested opaque origins are never same-origin with their host. html-to-image avoids that pattern entirely.

Capability handshake mirrors the inspector: the iframe announces `lightdash:sdk:screenshot-available` on mount; older templates in resumed sandboxes never announce, so the Screenshot button stays hidden for them.

<img width="138" height="67" alt="image" src="https://github.com/user-attachments/assets/06d96b54-66e7-4830-abdd-f0fb75e787c2" />

