### PR TITLE
feat(ai-agent): subtler streaming UI — collapsed tool calls, fade-in parts, collapsible reasoning

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
@@ -6,3 +6,24 @@
         outline: 4px solid var(--mantine-color-ldGray-2);
     }
 }
+
+@keyframes streamPartFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.streamPart {
+    animation: streamPartFadeIn 240ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .streamPart {
+        animation: none;
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -5,6 +5,7 @@ import {
 import {
     ActionIcon,
     Alert,
+    Box,
     Button,
     CopyButton,
     Group,
@@ -15,11 +16,14 @@ import {
     Text,
     Textarea,
     Tooltip,
+    UnstyledButton,
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconBug,
     IconCheck,
+    IconChevronRight,
+    IconChevronUp,
     IconCopy,
     IconExclamationCircle,
     IconMessageX,
@@ -63,6 +67,58 @@ import { AiProposeChangeToolCall } from './ToolCalls/AiProposeChangeToolCall';
 import { AiReasoning } from './ToolCalls/AiReasoning';
 import { InlineToolCallCard } from './ToolCalls/InlineToolCallCard';
 import { SqlApprovalCard } from './ToolCalls/SqlApprovalCard';
+
+const COLLAPSED_TEXT_PREVIEW_LENGTH = 80;
+
+const CollapsibleStreamTextSlot: FC<{
+    text: string;
+    children: React.ReactNode;
+}> = ({ text, children }) => {
+    const [expanded, setExpanded] = useState(false);
+    if (expanded) {
+        return (
+            <Stack gap={2}>
+                {children}
+                <UnstyledButton
+                    onClick={() => setExpanded(false)}
+                    aria-expanded
+                >
+                    <Group gap={4} align="center" wrap="nowrap">
+                        <MantineIcon
+                            icon={IconChevronUp}
+                            size={10}
+                            stroke={1.6}
+                            color="ldGray.5"
+                        />
+                        <Text size="xs" c="dimmed">
+                            Hide reasoning
+                        </Text>
+                    </Group>
+                </UnstyledButton>
+            </Stack>
+        );
+    }
+    const preview = text
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, COLLAPSED_TEXT_PREVIEW_LENGTH);
+    return (
+        <UnstyledButton onClick={() => setExpanded(true)} aria-expanded={false}>
+            <Group gap={4} align="center" wrap="nowrap">
+                <MantineIcon
+                    icon={IconChevronRight}
+                    size={10}
+                    stroke={1.6}
+                    color="ldGray.5"
+                />
+                <Text size="xs" c="dimmed" lineClamp={1}>
+                    {preview}
+                    {text.length > COLLAPSED_TEXT_PREVIEW_LENGTH ? '…' : ''}
+                </Text>
+            </Group>
+        </UnstyledButton>
+    );
+};
 
 const AssistantBubbleContent: FC<{
     message: AiAgentMessageAssistant;
@@ -198,91 +254,127 @@ const AssistantBubbleContent: FC<{
 
                 if (streamingParts.length > 0) {
                     // Interleaved view during streaming: text -> tool -> text -> tool
+                    const lastTextIdx = (() => {
+                        for (
+                            let i = streamingParts.length - 1;
+                            i >= 0;
+                            i -= 1
+                        ) {
+                            if (streamingParts[i].type === 'text') return i;
+                        }
+                        return -1;
+                    })();
                     return (
                         <Stack gap="xs" pt="xs">
-                            {streamingParts.map((part, idx) =>
-                                part.type === 'text' ? (
-                                    <MDEditor.Markdown
-                                        // eslint-disable-next-line react/no-array-index-key
-                                        key={`text-${idx}`}
-                                        rehypeRewrite={rehypeRemoveHeaderLinks}
-                                        source={part.text}
-                                        style={{
-                                            ...mdStyle,
-                                            padding: 0,
-                                        }}
-                                        rehypePlugins={[
-                                            rehypeAiAgentContentLinks,
-                                        ]}
-                                        components={{
-                                            ...mdEditorComponents,
-                                            a: ({
-                                                node,
-                                                children,
-                                                ...props
-                                            }) => {
-                                                const contentType =
-                                                    'data-content-type' in
-                                                        props &&
-                                                    typeof props[
-                                                        'data-content-type'
-                                                    ] === 'string'
-                                                        ? props[
-                                                              'data-content-type'
-                                                          ]
-                                                        : undefined;
-
-                                                return (
-                                                    <ContentLink
-                                                        contentType={
-                                                            contentType
-                                                        }
-                                                        props={props}
-                                                        message={message}
-                                                        projectUuid={
-                                                            projectUuid
-                                                        }
-                                                        agentUuid={agentUuid}
-                                                    >
-                                                        {children}
-                                                    </ContentLink>
-                                                );
-                                            },
-                                        }}
-                                    />
-                                ) : part.toolName === 'runSql' &&
-                                  !streamingState?.decidedToolCallIds.includes(
-                                      part.toolCallId,
-                                  ) ? (
-                                    <SqlApprovalCard
-                                        key={part.toolCallId}
-                                        projectUuid={projectUuid}
-                                        agentUuid={agentUuid}
-                                        threadUuid={message.threadUuid}
-                                        toolCallId={part.toolCallId}
-                                        toolArgs={
-                                            part.toolArgs as {
-                                                sql: string;
-                                                limit?: number;
+                            {streamingParts.map((part, idx) => {
+                                const partKey =
+                                    part.type === 'text'
+                                        ? `text-${idx}`
+                                        : part.toolCallId;
+                                const isLatestText =
+                                    part.type === 'text' && idx === lastTextIdx;
+                                const child: React.ReactNode =
+                                    part.type === 'text' ? (
+                                        <MDEditor.Markdown
+                                            rehypeRewrite={
+                                                rehypeRemoveHeaderLinks
                                             }
-                                        }
-                                        autoApprove={
-                                            streamingState?.sqlAutoApprove ??
-                                            false
-                                        }
-                                    />
-                                ) : (
-                                    <InlineToolCallCard
-                                        key={part.toolCallId}
-                                        toolName={part.toolName}
-                                        toolCall={{
-                                            toolCallId: part.toolCallId,
-                                            toolName: part.toolName,
-                                            toolArgs: part.toolArgs,
-                                        }}
-                                    />
-                                ),
-                            )}
+                                            source={part.text}
+                                            style={{
+                                                ...mdStyle,
+                                                padding: 0,
+                                            }}
+                                            rehypePlugins={[
+                                                rehypeAiAgentContentLinks,
+                                            ]}
+                                            components={{
+                                                ...mdEditorComponents,
+                                                a: ({
+                                                    node,
+                                                    children,
+                                                    ...props
+                                                }) => {
+                                                    const contentType =
+                                                        'data-content-type' in
+                                                            props &&
+                                                        typeof props[
+                                                            'data-content-type'
+                                                        ] === 'string'
+                                                            ? props[
+                                                                  'data-content-type'
+                                                              ]
+                                                            : undefined;
+
+                                                    return (
+                                                        <ContentLink
+                                                            contentType={
+                                                                contentType
+                                                            }
+                                                            props={props}
+                                                            message={message}
+                                                            projectUuid={
+                                                                projectUuid
+                                                            }
+                                                            agentUuid={
+                                                                agentUuid
+                                                            }
+                                                        >
+                                                            {children}
+                                                        </ContentLink>
+                                                    );
+                                                },
+                                            }}
+                                        />
+                                    ) : part.toolName === 'runSql' &&
+                                      !streamingState?.decidedToolCallIds.includes(
+                                          part.toolCallId,
+                                      ) ? (
+                                        <SqlApprovalCard
+                                            projectUuid={projectUuid}
+                                            agentUuid={agentUuid}
+                                            threadUuid={message.threadUuid}
+                                            toolCallId={part.toolCallId}
+                                            toolArgs={
+                                                part.toolArgs as {
+                                                    sql: string;
+                                                    limit?: number;
+                                                }
+                                            }
+                                            autoApprove={
+                                                streamingState?.sqlAutoApprove ??
+                                                false
+                                            }
+                                        />
+                                    ) : (
+                                        <InlineToolCallCard
+                                            toolName={part.toolName}
+                                            toolCall={{
+                                                toolCallId: part.toolCallId,
+                                                toolName: part.toolName,
+                                                toolArgs: part.toolArgs,
+                                            }}
+                                        />
+                                    );
+                                const wrappedChild =
+                                    part.type === 'text' && !isLatestText ? (
+                                        <CollapsibleStreamTextSlot
+                                            text={part.text}
+                                        >
+                                            {child}
+                                        </CollapsibleStreamTextSlot>
+                                    ) : (
+                                        child
+                                    );
+                                return (
+                                    <Box
+                                        // eslint-disable-next-line react/no-array-index-key
+                                        key={partKey}
+                                        className={styles.streamPart}
+                                    >
+                                        {wrappedChild}
+                                    </Box>
+                                );
+                            })}
                         </Stack>
                     );
                 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/InlineToolCallCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/InlineToolCallCard.tsx
@@ -1,6 +1,14 @@
 import { TOOL_DISPLAY_MESSAGES, type ToolName } from '@lightdash/common';
-import { Box, Group, Stack, Text } from '@mantine-8/core';
-import { type FC } from 'react';
+import {
+    Box,
+    Collapse,
+    Group,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine-8/core';
+import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { ToolCallDescription } from './descriptions/ToolCallDescription';
 import { getToolIcon } from './utils/toolIcons';
@@ -25,9 +33,10 @@ export const InlineToolCallCard: FC<InlineToolCallCardProps> = ({
     const IconComponent = getToolIcon(toolName);
     const label = TOOL_DISPLAY_MESSAGES[toolName];
     const hasDescription = !TOOLS_WITHOUT_DESCRIPTION.has(toolName);
+    const [expanded, setExpanded] = useState(false);
 
-    return (
-        <Stack gap={4}>
+    if (!hasDescription) {
+        return (
             <Group gap={6} align="center" wrap="nowrap">
                 <MantineIcon
                     icon={IconComponent}
@@ -39,14 +48,41 @@ export const InlineToolCallCard: FC<InlineToolCallCardProps> = ({
                     {label}
                 </Text>
             </Group>
-            {hasDescription ? (
+        );
+    }
+
+    return (
+        <Stack gap={4}>
+            <UnstyledButton
+                onClick={() => setExpanded((prev) => !prev)}
+                aria-expanded={expanded}
+            >
+                <Group gap={6} align="center" wrap="nowrap">
+                    <MantineIcon
+                        icon={IconComponent}
+                        size={12}
+                        stroke={1.6}
+                        color="indigo.4"
+                    />
+                    <Text size="xs" fw={500} c="ldGray.7">
+                        {label}
+                    </Text>
+                    <MantineIcon
+                        icon={expanded ? IconChevronDown : IconChevronRight}
+                        size={10}
+                        stroke={1.6}
+                        color="ldGray.5"
+                    />
+                </Group>
+            </UnstyledButton>
+            <Collapse in={expanded}>
                 <Box pl="md">
                     <ToolCallDescription
                         toolName={toolName}
                         toolCall={toolCall}
                     />
                 </Box>
-            ) : null}
+            </Collapse>
         </Stack>
     );
 };


### PR DESCRIPTION
## Summary
Three small UI tweaks that make the streaming experience feel calmer instead of a wall of text:

- **Tool-call descriptions collapsed by default** — `InlineToolCallCard` now renders as a single one-liner (icon + label + chevron). Click to reveal the `ToolCallDescription` (search query, field pills, SQL preview, etc.). Tool calls that already had no description stay as a non-clickable line.
- **Fade-in animation per stream part** — each text/tool block fades in (240ms ease-out + 4px slide-up) only on mount. Streaming text accumulates inside an existing mounted block so the animation does *not* re-fire as text grows. Respects `prefers-reduced-motion`.
- **Older reasoning collapses behind a preview** — once a new part is appended after a text block, that text block collapses to a single-line preview (first 80 chars, dimmed) with a chevron to expand. The latest text part always stays fully expanded. After streaming ends, intermediate reasoning stays collapsed (Attio-style) — user can click to inspect any step.

## Regression analysis
- **Persisted (post-streaming) view**: unchanged. The interleaved render only runs when `streamingState?.parts` is populated and `length > 0`. The default Markdown render below it (used for completed messages without saved parts) still shows the full message body.
- **Tools without descriptions** (`improveContext`, `proposeChange`, `runSavedChart`, `listWarehouseTables`): render as a plain non-clickable one-liner, identical to before this PR for those tools.
- **`SqlApprovalCard`** (the runSql approval path): not affected — it's a separate component, never wrapped by the new collapse logic, and stays expanded so the user can read the SQL before approving.
- **Reduced motion**: `@media (prefers-reduced-motion: reduce)` disables the keyframe animation entirely.
- **Stable React keys**: text-part keys use `text-${idx}`; tool parts use `toolCallId`. Since the streaming pipeline only appends, indices remain stable for existing text parts so the mount-only animation behaves correctly.

## Stack
- Stacked on top of #22925 (Slack parity).
- This is pure FE polish — no server, no schema, no flag changes.

## Test plan
- [ ] Ask the agent a runSql-flavoured question and watch streaming: each block should fade in, prior text should collapse once the next tool fires
- [ ] Click the chevron on a tool-call one-liner → description expands; click again → collapses
- [ ] Click the chevron on a collapsed reasoning preview → full markdown expands; "Hide reasoning" → collapses
- [ ] Set `prefers-reduced-motion: reduce` in DevTools → no animation
- [ ] Reload a previously-completed thread → unchanged persisted view (no collapse, no fade)
- [ ] The `SqlApprovalCard` still appears fully expanded mid-stream with the SQL visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)