### PR TITLE
fix(e2e): enable USE_SQL_PIVOT_RESULTS in preview env

### DIFF
--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -81,6 +81,13 @@ services:
             # enabledFeatureFlags allowlist (step 1a).
             EMBEDDING_ENABLED: true
 
+            # Force-enable the SQL-pivot path in preview envs. Cloud helm sets
+            # this true; preview deploys via docker-compose and otherwise
+            # falls back to PostHog targeting, which doesn't reach the
+            # ephemeral test org — pivotTables.cy.ts then times out waiting
+            # for `pivotConfiguration` in the metric-query POST.
+            USE_SQL_PIVOT_RESULTS: true
+
             PERSISTENT_DOWNLOAD_URLS_ENABLED: true
 
             # these were set in https://dashboard.render.com/env-group/evg-cfn4dlhmbjst4ho7s160 but can be public


### PR DESCRIPTION
### Description

`pivotTables.cy.ts` aliases the metric-query POST only when its body carries `pivotConfiguration`. `buildQueryArgs.ts` only sets that field when the `use-sql-pivot-results` flag is enabled.

Cloud helm sets `USE_SQL_PIVOT_RESULTS=true` (per the comment in `parseConfig.ts:1574-1578`), but the okteto preview env deploys via `docker/docker-compose.preview.yml` and otherwise falls back to PostHog targeting, which doesn't reach the ephemeral preview org. With the flag effectively `false` in preview, the 4 pivot chart specs in shard 3 deterministically time out at 60s × 3 retries × 4 specs (~12 min) on every PR — observed on #22912, #22920, #22922.

This mirrors the existing `EMBEDDING_ENABLED: true` block, which exists for the same reason.

test-all