### PR TITLE
fix(ai-agents): truncate content descriptions and shrink dashboard chart preview in findContent

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/findContent.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/findContent.test.ts
@@ -4,6 +4,7 @@ import {
     type ToolFindContentOutput,
     type ToolGetDashboardChartsOutput,
 } from '@lightdash/common';
+import { DASHBOARD_CHARTS_PREVIEW_COUNT } from '../utils/truncation';
 import { getFindContent } from './findContent';
 import { getGetDashboardCharts } from './getDashboardCharts';
 
@@ -66,43 +67,46 @@ describe('getFindContent', () => {
         });
     };
 
-    it('renders all charts when dashboard has 3 charts (under limit)', async () => {
-        const tool = createTool([makeMockDashboard(3)]);
+    it('renders all charts when dashboard has fewer than the preview limit', async () => {
+        const underLimit = DASHBOARD_CHARTS_PREVIEW_COUNT - 1;
+        const tool = createTool([makeMockDashboard(underLimit)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
         });
 
         expect(output.metadata.status).toBe('success');
-        expect(output.result).toContain('<charts count="3">');
+        expect(output.result).toContain(`<charts count="${underLimit}">`);
 
         const chartMatches = output.result.match(/<chart /g);
-        expect(chartMatches).toHaveLength(3);
+        expect(chartMatches).toHaveLength(underLimit);
     });
 
-    it('renders exactly 5 charts when dashboard has 5 charts (at limit)', async () => {
-        const tool = createTool([makeMockDashboard(5)]);
+    it('renders exactly the preview limit when dashboard has that many charts', async () => {
+        const tool = createTool([
+            makeMockDashboard(DASHBOARD_CHARTS_PREVIEW_COUNT),
+        ]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
         });
 
-        expect(output.result).toContain('<charts count="5">');
+        expect(output.result).toContain(
+            `<charts count="${DASHBOARD_CHARTS_PREVIEW_COUNT}">`,
+        );
 
         const chartMatches = output.result.match(/<chart /g);
-        expect(chartMatches).toHaveLength(5);
+        expect(chartMatches).toHaveLength(DASHBOARD_CHARTS_PREVIEW_COUNT);
     });
 
-    it('crops to 5 charts when dashboard has many charts', async () => {
+    it('crops to the preview limit when dashboard has many charts', async () => {
         const tool = createTool([makeMockDashboard(100)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
         });
 
-        // Total count attribute reflects the real number
         expect(output.result).toContain('<charts count="100">');
 
-        // But only 5 chart elements are rendered
         const chartMatches = output.result.match(/<chart /g);
-        expect(chartMatches).toHaveLength(5);
+        expect(chartMatches).toHaveLength(DASHBOARD_CHARTS_PREVIEW_COUNT);
     });
 
     it('handles dashboard with one chart', async () => {
@@ -114,7 +118,6 @@ describe('getFindContent', () => {
         expect(output.result).toContain('<charts count="1">');
 
         const chartMatches = output.result.match(/<chart /g);
-        // 1 chart inside the <charts> block
         expect(chartMatches).toHaveLength(1);
     });
 
@@ -124,12 +127,11 @@ describe('getFindContent', () => {
             searchQueries: [{ label: 'test query' }],
         });
 
-        // Even with 200 charts, we only render 5 so size should be small
         expect(output.result.length).toBeLessThan(10_000);
         expect(output.result).toContain('<charts count="200">');
 
         const chartMatches = output.result.match(/<chart /g);
-        expect(chartMatches).toHaveLength(5);
+        expect(chartMatches).toHaveLength(DASHBOARD_CHARTS_PREVIEW_COUNT);
     });
 });
 

--- a/packages/backend/src/ee/services/ai/tools/findContent.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findContent.tsx
@@ -12,6 +12,11 @@ import moment from 'moment';
 import type { FindContentFn } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
+import {
+    CONTENT_DESCRIPTION_MAX_CHARS,
+    DASHBOARD_CHARTS_PREVIEW_COUNT,
+    truncate,
+} from '../utils/truncation';
 import { xmlBuilder } from '../xmlBuilder';
 
 type Dependencies = {
@@ -42,7 +47,9 @@ const renderChart = (chart: AllChartsSearchResult, siteUrl: string) => {
         >
             <name>{chart.name}</name>
             {chart.description && (
-                <description>{chart.description}</description>
+                <description>
+                    {truncate(chart.description, CONTENT_DESCRIPTION_MAX_CHARS)}
+                </description>
             )}
             {chart.firstViewedAt && (
                 <firstviewedat>
@@ -79,7 +86,9 @@ const renderDashboard = (dashboard: DashboardSearchResult, siteUrl: string) => (
         <searchrank>{dashboard.search_rank}</searchrank>
 
         {dashboard.description && (
-            <description>{dashboard.description}</description>
+            <description>
+                {truncate(dashboard.description, CONTENT_DESCRIPTION_MAX_CHARS)}
+            </description>
         )}
 
         {dashboard.firstViewedAt && (
@@ -104,14 +113,13 @@ const renderDashboard = (dashboard: DashboardSearchResult, siteUrl: string) => (
             </lastupdatedby>
         )}
         <charts count={dashboard.charts.length}>
-            {dashboard.charts.slice(0, 5).map((chart) => (
-                <chart chartUuid={chart.uuid} chartType={chart.chartType}>
-                    <name>{chart.name}</name>
-                    {chart.description && (
-                        <description>{chart.description}</description>
-                    )}
-                </chart>
-            ))}
+            {dashboard.charts
+                .slice(0, DASHBOARD_CHARTS_PREVIEW_COUNT)
+                .map((chart) => (
+                    <chart chartUuid={chart.uuid} chartType={chart.chartType}>
+                        <name>{chart.name}</name>
+                    </chart>
+                ))}
         </charts>
         {dashboard.validationErrors && dashboard.validationErrors.length > 0 ? (
             <validationerrors count={dashboard.validationErrors.length} />

--- a/packages/backend/src/ee/services/ai/utils/truncation.ts
+++ b/packages/backend/src/ee/services/ai/utils/truncation.ts
@@ -5,7 +5,10 @@
  */
 export const EXPLORE_DESCRIPTION_MAX_CHARS = 600;
 export const FIELD_DESCRIPTION_MAX_CHARS = 600;
+export const CONTENT_DESCRIPTION_MAX_CHARS = 600;
 export const AI_HINT_MAX_CHARS = 300;
+
+export const DASHBOARD_CHARTS_PREVIEW_COUNT = 3;
 
 export const truncate = (value: string, max: number) =>
     value.length > max ? `${value.slice(0, max)}…` : value;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #21225<!-- reference the related issue e.g. #150 -->

### Description:

Final work on truncating descriptions for findcontent

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->