### PR TITLE
refactor(echarts): consume padded dataset directly for stack decorations

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/barChartStyles.test.ts
+++ b/packages/common/src/visualizations/helpers/styles/barChartStyles.test.ts
@@ -1,11 +1,10 @@
-import { type ResultRow } from '../../../types/results';
 import { CartesianSeriesType } from '../../../types/savedCharts';
 import { type EChartsSeries } from '../../types';
 import { applyRoundedCornersToStackData } from './barChartStyles';
 
-const makeRow = (date: string, value: number): ResultRow => ({
-    date_month: { value: { raw: date, formatted: date } },
-    count: { value: { raw: value, formatted: String(value) } },
+const makeRow = (date: string, value: number): Record<string, unknown> => ({
+    date_month: date,
+    count: value,
 });
 
 const makeStackedBarSeries = (
@@ -27,23 +26,18 @@ const makeStackedBarSeries = (
 });
 
 describe('applyRoundedCornersToStackData', () => {
-    test('substitutes canonical category values into series.data tuples', () => {
-        const rows = [
+    test('builds tuples directly from canonical flat dataset values', () => {
+        // Caller passes the canonicalized dataset (post-padding), so DST-drifted
+        // input rows arrive already normalized to the axis labels.
+        const dataset = [
             makeRow('2024-01-01T05:00:00Z', 1),
-            // DST-drifted row: warehouse emits -04:00 while axis stays at -05:00.
-            makeRow('2024-11-01T04:00:00Z', 11),
+            makeRow('2024-11-01T05:00:00Z', 11),
             makeRow('2024-12-01T05:00:00Z', 12),
-        ];
-        const categoryValues = [
-            '2024-01-01T05:00:00Z',
-            '2024-11-01T05:00:00Z',
-            '2024-12-01T05:00:00Z',
         ];
 
         const [out] = applyRoundedCornersToStackData(
             [makeStackedBarSeries()],
-            rows,
-            { categoryValues },
+            dataset,
         );
 
         const tuples = (out.data as { value: unknown[] }[]).map((d) => d.value);
@@ -55,37 +49,48 @@ describe('applyRoundedCornersToStackData', () => {
         expect(tuples[2][1]).toBe(12);
     });
 
-    test('falls back to raw row value when categoryValues is omitted', () => {
-        const rows = [
-            makeRow('2024-01-01T05:00:00Z', 1),
-            makeRow('2024-11-01T04:00:00Z', 11),
+    test('marks the visible top of each stack with borderRadius', () => {
+        const dataset = [
+            { date_month: '2024-01-01', count: 5, count_b: 7 },
+            { date_month: '2024-02-01', count: 3, count_b: 7 },
         ];
+        const a = makeStackedBarSeries({ name: 'a' });
+        const b = makeStackedBarSeries({
+            name: 'b',
+            encode: {
+                x: 'date_month',
+                y: 'count_b',
+                tooltip: [],
+                seriesName: 'count_b',
+            },
+        });
 
-        const [out] = applyRoundedCornersToStackData(
-            [makeStackedBarSeries()],
-            rows,
-        );
+        const result = applyRoundedCornersToStackData([a, b], dataset);
 
-        const tuples = (out.data as { value: unknown[] }[]).map((d) => d.value);
-        expect(tuples[0][0]).toBe('2024-01-01T05:00:00Z');
-        expect(tuples[1][0]).toBe('2024-11-01T04:00:00Z');
+        // b is at the visible end (last in the stack group), so its tuples get
+        // a borderRadius itemStyle; a's tuples don't.
+        const aData = result[0].data as Array<{
+            value: unknown[];
+            itemStyle?: unknown;
+        }>;
+        const bData = result[1].data as Array<{
+            value: unknown[];
+            itemStyle?: unknown;
+        }>;
+        expect(aData.every((d) => d.itemStyle === undefined)).toBe(true);
+        expect(bData.every((d) => d.itemStyle !== undefined)).toBe(true);
     });
 
-    test('falls back to raw row value at indices missing from categoryValues', () => {
-        const rows = [
-            makeRow('2024-01-01T05:00:00Z', 1),
-            makeRow('2024-11-01T04:00:00Z', 11),
-        ];
-        const categoryValues = ['2024-01-01T05:00:00Z'];
+    test('skips non-bar series', () => {
+        const lineSeries: EChartsSeries = {
+            ...makeStackedBarSeries(),
+            type: CartesianSeriesType.LINE,
+        };
+        const dataset = [makeRow('2024-01-01', 1)];
 
-        const [out] = applyRoundedCornersToStackData(
-            [makeStackedBarSeries()],
-            rows,
-            { categoryValues },
-        );
+        const result = applyRoundedCornersToStackData([lineSeries], dataset);
 
-        const tuples = (out.data as { value: unknown[] }[]).map((d) => d.value);
-        expect(tuples[0][0]).toBe('2024-01-01T05:00:00Z');
-        expect(tuples[1][0]).toBe('2024-11-01T04:00:00Z');
+        // No mutation: the line series passes through unchanged.
+        expect(result[0]).toEqual(lineSeries);
     });
 });

--- a/packages/common/src/visualizations/helpers/styles/barChartStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/barChartStyles.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-plusplus */
 /* eslint-disable no-continue */
 import { type AnyType } from '../../../types/any';
-import { type RawResultRow, type ResultRow } from '../../../types/results';
+import { type RawResultRow } from '../../../types/results';
 import { CartesianSeriesType } from '../../../types/savedCharts';
 import { type EChartsSeries, type SqlRunnerEChartsSeries } from '../../types';
 import { GRAY_9 } from './themeColors';
@@ -241,16 +241,12 @@ export const applyRoundedCornersToSqlRunnerStackData = (
  * Apply rounded corners to the visible end-segments of stacked bar series.
  * Ref: https://github.com/apache/echarts/issues/12319#issuecomment-1341387601
  *
- * Process:
- * - For each stack and each category (row), finds which segment is visually at the end of the stack
- *   (top-most for positive values, bottom-most for negative values).
- * - Annotates only those segments with `itemStyle.borderRadius`, considering chart orientation
- *   and legend visibility.
- * - We scan from top to bottom of the stack using an index-based loop so the first visible segment
- *   per category "wins" without extra allocations.
+ * Consumes the same flat dataset that ECharts renders from (post-padding for
+ * continuous-date axes) so category values match xAxis.data exactly.
  *
  * @param series ECharts series produced for a cartesian chart
- * @param rows Result rows aligned with the chart categories (Explorer format with nested values)
+ * @param rows Flat dataset rows aligned with the chart categories (same shape
+ *             as dataset.source)
  * @param options.radius Corner radius in px (default: 4)
  * @param options.isHorizontal Whether the chart is horizontal (flipAxes)
  * @param options.legendSelected Map of legend selection states used to ignore hidden series
@@ -259,23 +255,15 @@ export const applyRoundedCornersToSqlRunnerStackData = (
  */
 export const applyRoundedCornersToStackData = (
     series: EChartsSeries[],
-    rows: ResultRow[],
+    rows: Record<string, unknown>[],
     {
         radius = 4,
         isHorizontal = false,
         legendSelected,
-        categoryValues,
     }: {
         radius?: number;
         isHorizontal?: boolean;
         legendSelected?: LegendValues;
-        // Optional canonical category values aligned with `rows` by index.
-        // When provided, used as the tuple's cat slot instead of the raw row
-        // value. The continuous-date axis snap canonicalizes its labels via
-        // padDatasetForContinuousAxis; passing the matching canonical values
-        // here keeps series.data tuples aligned with the axis so DST-drifted
-        // rows still find their slot.
-        categoryValues?: unknown[];
     } = {},
 ): EChartsSeries[] => {
     const out = series.map((s) => ({ ...s }));
@@ -321,9 +309,7 @@ export const applyRoundedCornersToStackData = (
                 ? getHashFromEncode(s, 'x')
                 : getHashFromEncode(s, 'y');
             for (let r = 0; r < rows.length; r++) {
-                const raw = valHash
-                    ? rows[r]?.[valHash]?.value?.raw
-                    : undefined;
+                const raw = valHash ? rows[r]?.[valHash] : undefined;
                 let v: number | null = null;
                 if (typeof raw === 'number') {
                     v = raw;
@@ -353,9 +339,8 @@ export const applyRoundedCornersToStackData = (
                 const catHash = isHorizontal ? yHash : xHash; // category field in data
                 const valHash = isHorizontal ? xHash : yHash; // numeric field in data
 
-                const rawCat = catHash ? row[catHash]?.value?.raw : undefined;
-                const cat = categoryValues?.[r] ?? rawCat;
-                const raw = valHash ? row[valHash]?.value?.raw : undefined;
+                const cat = catHash ? row[catHash] : undefined;
+                const raw = valHash ? row[valHash] : undefined;
                 let v: number | null = null;
                 if (typeof raw === 'number') {
                     v = raw;

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
@@ -297,23 +297,24 @@ describe('transformToPercentageStacking', () => {
         expect(originalValues.get('2024-02-01')?.get('b')).toBe(1);
     });
 
-    test('tolerates rows with undefined yField values without producing NaN', () => {
+    test('preserves yField absence on gap rows instead of writing explicit 0%', () => {
         // Shape padDatasetForContinuousAxis produces for gap rows:
-        // only the xField populated, every yField absent.
-        const rows = [
+        // only the xField populated, every yField absent. Writing 0% here
+        // would surface as a "0.0% (0)" tooltip line at gap dates.
+        const rows: Record<string, unknown>[] = [
             { date: '2024-01-01', a: 3, b: 7 },
             { date: '2024-02-01' }, // gap row from padding
             { date: '2024-03-01', a: 4, b: 6 },
         ];
 
-        const { transformedResults } = transformToPercentageStacking(
-            rows,
-            'date',
-            ['a', 'b'],
-        );
+        const { transformedResults, originalValues } =
+            transformToPercentageStacking(rows, 'date', ['a', 'b']);
 
-        expect(Number.isNaN(transformedResults[1].a)).toBe(false);
-        expect(Number.isNaN(transformedResults[1].b)).toBe(false);
+        // Gap row keeps yFields absent — no NaN, no explicit 0.
+        expect('a' in transformedResults[1]).toBe(false);
+        expect('b' in transformedResults[1]).toBe(false);
+        // originalValues has no entry for the gap xValue.
+        expect(originalValues.has('2024-02-01')).toBe(false);
         // Real rows still total 100% — gap rows don't perturb other buckets.
         expect(
             (transformedResults[0].a as number) +

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
@@ -1,6 +1,7 @@
 import { VizAggregationOptions, type EChartsSeries } from '../types';
 import {
     findPivotColumnFromSeriesRef,
+    transformToPercentageStacking,
     translatePivotRef,
 } from './tooltipFormatter';
 
@@ -275,5 +276,64 @@ describe('findPivotColumnFromSeriesRef', () => {
         // hashFieldReference produces a string from the pivotReference
         expect(result).toBeDefined();
         expect(typeof result).toBe('string');
+    });
+});
+
+describe('transformToPercentageStacking', () => {
+    test('converts absolute values to percentages summing to 100 per x bucket', () => {
+        const rows = [
+            { date: '2024-01-01', a: 3, b: 7 },
+            { date: '2024-02-01', a: 1, b: 1 },
+        ];
+
+        const { transformedResults, originalValues } =
+            transformToPercentageStacking(rows, 'date', ['a', 'b']);
+
+        expect(transformedResults[0].a).toBeCloseTo(30);
+        expect(transformedResults[0].b).toBeCloseTo(70);
+        expect(transformedResults[1].a).toBeCloseTo(50);
+        expect(transformedResults[1].b).toBeCloseTo(50);
+        expect(originalValues.get('2024-01-01')?.get('a')).toBe(3);
+        expect(originalValues.get('2024-02-01')?.get('b')).toBe(1);
+    });
+
+    test('tolerates rows with undefined yField values without producing NaN', () => {
+        // Shape padDatasetForContinuousAxis produces for gap rows:
+        // only the xField populated, every yField absent.
+        const rows = [
+            { date: '2024-01-01', a: 3, b: 7 },
+            { date: '2024-02-01' }, // gap row from padding
+            { date: '2024-03-01', a: 4, b: 6 },
+        ];
+
+        const { transformedResults } = transformToPercentageStacking(
+            rows,
+            'date',
+            ['a', 'b'],
+        );
+
+        expect(Number.isNaN(transformedResults[1].a)).toBe(false);
+        expect(Number.isNaN(transformedResults[1].b)).toBe(false);
+        // Real rows still total 100% — gap rows don't perturb other buckets.
+        expect(
+            (transformedResults[0].a as number) +
+                (transformedResults[0].b as number),
+        ).toBeCloseTo(100);
+        expect(
+            (transformedResults[2].a as number) +
+                (transformedResults[2].b as number),
+        ).toBeCloseTo(100);
+    });
+
+    test('passes rows through when no yFieldRefs are supplied', () => {
+        const rows = [{ date: '2024-01-01', a: 3 }];
+
+        const { transformedResults } = transformToPercentageStacking(
+            rows,
+            'date',
+            [],
+        );
+
+        expect(transformedResults[0]).toEqual({ date: '2024-01-01', a: 3 });
     });
 });

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -639,6 +639,12 @@ export function createStack100TooltipFormatter(
 
                 const percentage = valueObject[dimensionName];
 
+                // Skip series rows that have no data at this x — happens on
+                // gap rows inserted by padDatasetForContinuousAxis. Without
+                // this guard the formatter would render a "0.0% (0)" line
+                // per series at every gap date.
+                if (percentage === undefined) return '';
+
                 // Get the raw x-axis value from the data for originalValues lookup
                 const rawXValue = String(valueObject[xAxisField] ?? '');
                 const originalValue =
@@ -665,6 +671,10 @@ export function createStack100TooltipFormatter(
             })
             .filter(Boolean)
             .join('');
+
+        // No data at this x (e.g., gap row from continuous-axis padding):
+        // suppress the tooltip entirely rather than showing an empty header.
+        if (!rowsHtml) return '';
 
         const divider = getTooltipDivider();
 
@@ -696,12 +706,16 @@ export function transformToPercentageStacking<
     const originalValues = new Map<string, Map<string, number>>();
     const totals = new Map<string, number>();
 
-    // Calculate totals for each x-axis value
+    // Calculate totals for each x-axis value. Skip fields absent from the
+    // row so gap rows (inserted by padDatasetForContinuousAxis) don't
+    // contribute zeros to originalValues — that would surface as
+    // "0.0% (0)" tooltip lines at gap dates.
     rows.forEach((row) => {
         const xValue = String(row[xAxisField]);
         let total = 0;
 
         yFieldRefs.forEach((yField) => {
+            if (row[yField] === undefined) return;
             const value = toNumber(row[yField]) || 0;
             total += value;
 
@@ -715,13 +729,15 @@ export function transformToPercentageStacking<
         totals.set(xValue, total);
     });
 
-    // Transform data to percentages
+    // Transform data to percentages. Preserve absence for gap-row yFields
+    // so ECharts (and the tooltip) treat them as missing instead of 0%.
     const transformedResults = rows.map((row) => {
         const xValue = String(row[xAxisField]);
         const total = totals.get(xValue) || 1; // Avoid division by zero
         const newRow = { ...row };
 
         yFieldRefs.forEach((yField) => {
+            if (row[yField] === undefined) return;
             const value = toNumber(row[yField]) || 0;
             (newRow as Record<string, unknown>)[yField] = (value / total) * 100;
         });

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -1430,6 +1430,11 @@ export const buildCartesianTooltipFormatter =
             }
         }
 
+        // No data at this x and no custom template (e.g., gap row from
+        // continuous-axis padding): suppress the tooltip entirely rather
+        // than showing an empty header.
+        if (!rowsHtml && !tooltipHtml) return '';
+
         const divider = getTooltipDivider();
         const dimensionId = params[0]?.dimensionNames?.[0];
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -1,6 +1,7 @@
 import {
     CartesianSeriesType,
     TimeFrames,
+    transformToPercentageStacking,
     type EChartsSeries,
     type Field,
     type ResultRow,
@@ -752,5 +753,86 @@ describe('padDatasetForContinuousAxis', () => {
 
         const result = padDatasetForContinuousAxis(data, range, xField);
         expect(result).toEqual(data);
+    });
+});
+
+describe('padDatasetForContinuousAxis ∘ transformToPercentageStacking', () => {
+    // Padding and the 100%-stack transform must commute on non-gap rows so
+    // dataset.source consumers can read from either composition order.
+    const xField = 'date';
+    const yFields = ['a', 'b'];
+    const range = [
+        '2024-01-01T00:00:00Z',
+        '2024-02-01T00:00:00Z',
+        '2024-03-01T00:00:00Z',
+    ];
+
+    test('produces equivalent ratios on non-gap rows regardless of order', () => {
+        // Drifted offsets — same calendar dates, different hours.
+        const rows = [
+            { [xField]: '2024-01-01T01:00:00Z', a: 3, b: 7 },
+            { [xField]: '2024-02-01T01:00:00Z', a: 1, b: 1 },
+            { [xField]: '2024-03-01T01:00:00Z', a: 4, b: 6 },
+        ];
+
+        const transformedFirst = transformToPercentageStacking(
+            rows,
+            xField,
+            yFields,
+        ).transformedResults;
+        const padThenTransform = padDatasetForContinuousAxis(
+            transformedFirst,
+            range,
+            xField,
+        );
+
+        const paddedFirst = padDatasetForContinuousAxis(rows, range, xField);
+        const transformThenPad = transformToPercentageStacking(
+            paddedFirst,
+            xField,
+            yFields,
+        ).transformedResults;
+
+        // Cats must match xAxis.data in both orders.
+        for (let i = 0; i < range.length; i++) {
+            expect(padThenTransform[i][xField]).toBe(range[i]);
+            expect(transformThenPad[i][xField]).toBe(range[i]);
+        }
+
+        // Ratios for present rows must match. Gap-row values legitimately
+        // differ between orders (undefined vs explicit 0%) — covered by the
+        // gap-tolerance test in tooltipFormatter.test.ts.
+        for (let i = 0; i < range.length; i++) {
+            for (const y of yFields) {
+                expect(transformThenPad[i][y]).toBe(padThenTransform[i][y]);
+            }
+        }
+    });
+
+    test('canonicalizes cats even when transform writes ratios first', () => {
+        const rows = [
+            { [xField]: '2024-01-01T01:00:00Z', a: 3, b: 7 },
+            { [xField]: '2024-02-01T01:00:00Z', a: 1, b: 1 },
+        ];
+        const partialRange = range.slice(0, 2);
+
+        const transformedFirst = transformToPercentageStacking(
+            rows,
+            xField,
+            yFields,
+        ).transformedResults;
+        const padThenTransformCats = padDatasetForContinuousAxis(
+            transformedFirst,
+            partialRange,
+            xField,
+        ).map((r) => r[xField]);
+        const transformThenPadCats = transformToPercentageStacking(
+            padDatasetForContinuousAxis(rows, partialRange, xField),
+            xField,
+            yFields,
+        ).transformedResults.map((r) => r[xField]);
+
+        expect(padThenTransformCats).toEqual(partialRange);
+        expect(transformThenPadCats).toEqual(partialRange);
     });
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2588,6 +2588,26 @@ const useEchartsCartesianConfig = (
         axisDisplayTimezone,
     ]);
 
+    // Shared by stackedSeriesWithColorAssignments (non-stacked bar styling) and
+    // decoratedSeriesForChart (stacked rounded corners). Same inputs in both
+    // places — keep the calc in one spot.
+    const dynamicRadius = useMemo(() => {
+        const isHorizontal = Boolean(validCartesianConfig?.layout.flipAxes);
+        const barSeries = series.filter(
+            (s) => s.type === CartesianSeriesType.BAR,
+        );
+        const isStacked = barSeries.some((s) => s.stack);
+        const nonStackedBarCount = isStacked
+            ? barSeries.filter((s) => !s.stack).length
+            : barSeries.length;
+        return calculateDynamicBorderRadius(
+            rows.length,
+            Math.max(1, nonStackedBarCount),
+            isStacked,
+            isHorizontal,
+        );
+    }, [rows.length, series, validCartesianConfig?.layout.flipAxes]);
+
     const stackedSeriesWithColorAssignments = useMemo(() => {
         if (!itemsMap) return;
 
@@ -2601,7 +2621,6 @@ const useEchartsCartesianConfig = (
         // it does NOT swap xField/yField in the layout.
         const categoryFieldId = validCartesianConfig?.layout?.xField;
 
-        // Calculate dynamic border radius based on chart characteristics
         const barSeries = series.filter(
             (s) => s.type === CartesianSeriesType.BAR,
         );
@@ -2624,17 +2643,6 @@ const useEchartsCartesianConfig = (
             !isColorByCategory &&
             !hasCustomColorsStacking &&
             Boolean(conditionalFormattings?.length);
-        const isStacked = barSeries.some((s) => s.stack);
-        const nonStackedBarCount = isStacked
-            ? barSeries.filter((s) => !s.stack).length
-            : barSeries.length;
-
-        const dynamicRadius = calculateDynamicBorderRadius(
-            rows.length,
-            Math.max(1, nonStackedBarCount),
-            isStacked,
-            isHorizontal,
-        );
 
         const seriesColors = series.map((serie) => getSeriesColor(serie));
 
@@ -2760,7 +2768,7 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout?.xField,
         validCartesianConfig?.conditionalFormattings,
         series,
-        rows,
+        dynamicRadius,
         pivotDimensions,
         getSeriesColor,
         colorPalette,
@@ -3083,26 +3091,12 @@ const useEchartsCartesianConfig = (
         const isStack100 = stackValue === StackType.PERCENT;
         const isStackNone = stackValue === StackType.NONE;
 
-        const barSeries = stackedSeriesWithColorAssignments.filter(
-            (s) => s.type === CartesianSeriesType.BAR,
-        );
-        const isStacked = barSeries.some((s) => s.stack);
         const stackedBarSeries = stackedSeriesWithColorAssignments.filter(
             (s) =>
                 s.type === CartesianSeriesType.BAR &&
                 s.stack &&
                 !isStack100 &&
                 !isStackNone,
-        );
-        const nonStackedBarCount = isStacked
-            ? barSeries.filter((s) => !s.stack).length
-            : barSeries.length;
-        // Scale off real-row count; gap rows don't render bars.
-        const dynamicRadius = calculateDynamicBorderRadius(
-            rows.length,
-            Math.max(1, nonStackedBarCount),
-            isStacked,
-            isHorizontal,
         );
 
         const seriesWithRoundedStacks =
@@ -3134,7 +3128,7 @@ const useEchartsCartesianConfig = (
     }, [
         stackedSeriesWithColorAssignments,
         paddedSortedResults,
-        rows,
+        dynamicRadius,
         itemsMap,
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.flipAxes,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3072,6 +3072,27 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout?.xField,
     ]);
 
+    // Parallel to paddedDataToRender but built from xAxisSortedResults (pre
+    // 100%-stack transform) so y-values stay raw. Stack-total labels need the
+    // raw sum, not the 0-1-ratio values that 100%-stacking writes into
+    // dataToRender. Cat values are canonicalized the same way as the dataset,
+    // so labels still name-match xAxis.data exactly.
+    const paddedRawDataForStackTotals = useMemo(() => {
+        const continuousRange = axes.continuousDateRange;
+        if (!continuousRange) return xAxisSortedResults;
+        const dateFieldId = validCartesianConfig?.layout?.xField;
+        if (!dateFieldId) return xAxisSortedResults;
+        return padDatasetForContinuousAxis(
+            xAxisSortedResults,
+            continuousRange,
+            dateFieldId,
+        );
+    }, [
+        xAxisSortedResults,
+        axes.continuousDateRange,
+        validCartesianConfig?.layout?.xField,
+    ]);
+
     // Rounded-corner decoration and stack-total labels both need category
     // values that match xAxis.data exactly. Running them after paddedDataToRender
     // lets them read from the same canonicalized dataset that backs the axis,
@@ -3123,7 +3144,7 @@ const useEchartsCartesianConfig = (
         return [
             ...seriesWithRoundedStacks,
             ...getStackTotalSeries(
-                paddedDataToRender,
+                paddedRawDataForStackTotals,
                 seriesWithRoundedStacks,
                 itemsMap,
                 validCartesianConfig?.layout.flipAxes,
@@ -3136,6 +3157,7 @@ const useEchartsCartesianConfig = (
     }, [
         stackedSeriesWithColorAssignments,
         paddedDataToRender,
+        paddedRawDataForStackTotals,
         itemsMap,
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.flipAxes,
@@ -3206,7 +3228,7 @@ const useEchartsCartesianConfig = (
             !isStack100 ||
             !stackedSeriesWithColorAssignments ||
             !itemsMap ||
-            !paddedDataToRender
+            !paddedRawDataForStackTotals
         )
             return { right: 0, top: 0 };
 
@@ -3228,7 +3250,7 @@ const useEchartsCartesianConfig = (
             if (!stack || !stackSeries[0]?.stackLabel?.show) return;
 
             const stackTotalData = getStackTotalRows(
-                paddedDataToRender,
+                paddedRawDataForStackTotals,
                 stackSeries,
                 flipAxis,
                 validCartesianConfigLegend,
@@ -3263,7 +3285,7 @@ const useEchartsCartesianConfig = (
     }, [
         stackedSeriesWithColorAssignments,
         itemsMap,
-        paddedDataToRender,
+        paddedRawDataForStackTotals,
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.flipAxes,
         validCartesianConfigLegend,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2746,7 +2746,7 @@ const useEchartsCartesianConfig = (
         );
 
         // Rounded corners and stack-total labels are applied downstream in
-        // `decoratedSeriesForChart` so they can consume `paddedDataToRender`
+        // `decoratedSeriesForChart` so they can consume `paddedSortedResults`
         // (the canonicalized, flat dataset that backs xAxis.data). Returning
         // the un-decorated series here keeps internal consumers (sort,
         // 100%-stack, color overrides) reading raw values as before.
@@ -3000,7 +3000,23 @@ const useEchartsCartesianConfig = (
         validCartesianConfigLegend,
     ]);
 
-    // Apply 100% stacking transformation if needed
+    const paddedSortedResults = useMemo(() => {
+        const continuousRange = axes.continuousDateRange;
+        const dateFieldId = validCartesianConfig?.layout?.xField;
+        if (!continuousRange || !dateFieldId) return xAxisSortedResults;
+        return padDatasetForContinuousAxis(
+            xAxisSortedResults,
+            continuousRange,
+            dateFieldId,
+        );
+    }, [
+        xAxisSortedResults,
+        axes.continuousDateRange,
+        validCartesianConfig?.layout?.xField,
+    ]);
+
+    // Convert raw values to per-x percentages for 100% stacking. Stack-total
+    // labels read `paddedSortedResults` directly so they see raw values.
     const { dataToRender, originalValues } = useMemo(() => {
         const stackValue = validCartesianConfig?.layout?.stack;
         const shouldStack100 = stackValue === StackType.PERCENT;
@@ -3014,7 +3030,7 @@ const useEchartsCartesianConfig = (
             !stackedSeriesWithColorAssignments
         ) {
             return {
-                dataToRender: xAxisSortedResults,
+                dataToRender: paddedSortedResults,
                 originalValues: undefined,
             };
         }
@@ -3036,67 +3052,27 @@ const useEchartsCartesianConfig = (
 
         // Use shared transformation utility
         const { transformedResults, originalValues: originalValuesMap } =
-            transformToPercentageStacking(sortedResults, xFieldId, yFieldRefs);
+            transformToPercentageStacking(
+                paddedSortedResults,
+                xFieldId,
+                yFieldRefs,
+            );
 
         return {
             dataToRender: transformedResults,
             originalValues: originalValuesMap,
         };
     }, [
-        sortedResults,
+        paddedSortedResults,
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.xField,
         validCartesianConfig?.layout.flipAxes,
         stackedSeriesWithColorAssignments,
-        xAxisSortedResults,
     ]);
 
-    // Pad whenever a continuous date range exists: the row's date field can
-    // drift from the snap's category string across DST, and ECharts matches
-    // by strict equality. Padding normalizes both to YYYY-MM-DD. The date
-    // dimension is layout.xField regardless of flipAxes — flipping only
-    // swaps which visual axis renders it.
-    const paddedDataToRender = useMemo(() => {
-        const continuousRange = axes.continuousDateRange;
-        if (!continuousRange) return dataToRender;
-        const dateFieldId = validCartesianConfig?.layout?.xField;
-        if (!dateFieldId) return dataToRender;
-        return padDatasetForContinuousAxis(
-            dataToRender,
-            continuousRange,
-            dateFieldId,
-        );
-    }, [
-        dataToRender,
-        axes.continuousDateRange,
-        validCartesianConfig?.layout?.xField,
-    ]);
-
-    // Parallel to paddedDataToRender but built from xAxisSortedResults (pre
-    // 100%-stack transform) so y-values stay raw. Stack-total labels need the
-    // raw sum, not the 0-1-ratio values that 100%-stacking writes into
-    // dataToRender. Cat values are canonicalized the same way as the dataset,
-    // so labels still name-match xAxis.data exactly.
-    const paddedRawDataForStackTotals = useMemo(() => {
-        const continuousRange = axes.continuousDateRange;
-        if (!continuousRange) return xAxisSortedResults;
-        const dateFieldId = validCartesianConfig?.layout?.xField;
-        if (!dateFieldId) return xAxisSortedResults;
-        return padDatasetForContinuousAxis(
-            xAxisSortedResults,
-            continuousRange,
-            dateFieldId,
-        );
-    }, [
-        xAxisSortedResults,
-        axes.continuousDateRange,
-        validCartesianConfig?.layout?.xField,
-    ]);
-
-    // Rounded-corner decoration and stack-total labels both need category
-    // values that match xAxis.data exactly. Running them after paddedDataToRender
-    // lets them read from the same canonicalized dataset that backs the axis,
-    // so DST-drifted rows can't end up with mismatched cat strings.
+    // Decorate the stacked series off the same padded dataset: cats match
+    // xAxis.data exactly, and stack totals read raw values instead of the
+    // 100%-stack ratios. Rounded corners are skipped in 100% mode.
     const decoratedSeriesForChart = useMemo(() => {
         if (!stackedSeriesWithColorAssignments || !itemsMap) {
             return stackedSeriesWithColorAssignments;
@@ -3121,8 +3097,9 @@ const useEchartsCartesianConfig = (
         const nonStackedBarCount = isStacked
             ? barSeries.filter((s) => !s.stack).length
             : barSeries.length;
+        // Scale off real-row count; gap rows don't render bars.
         const dynamicRadius = calculateDynamicBorderRadius(
-            paddedDataToRender.length,
+            rows.length,
             Math.max(1, nonStackedBarCount),
             isStacked,
             isHorizontal,
@@ -3132,7 +3109,7 @@ const useEchartsCartesianConfig = (
             stackedBarSeries.length > 0
                 ? applyRoundedCornersToStackData(
                       stackedSeriesWithColorAssignments,
-                      paddedDataToRender,
+                      paddedSortedResults,
                       {
                           radius: dynamicRadius,
                           isHorizontal,
@@ -3144,7 +3121,7 @@ const useEchartsCartesianConfig = (
         return [
             ...seriesWithRoundedStacks,
             ...getStackTotalSeries(
-                paddedRawDataForStackTotals,
+                paddedSortedResults,
                 seriesWithRoundedStacks,
                 itemsMap,
                 validCartesianConfig?.layout.flipAxes,
@@ -3156,8 +3133,8 @@ const useEchartsCartesianConfig = (
         ];
     }, [
         stackedSeriesWithColorAssignments,
-        paddedDataToRender,
-        paddedRawDataForStackTotals,
+        paddedSortedResults,
+        rows,
         itemsMap,
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.flipAxes,
@@ -3228,7 +3205,7 @@ const useEchartsCartesianConfig = (
             !isStack100 ||
             !stackedSeriesWithColorAssignments ||
             !itemsMap ||
-            !paddedRawDataForStackTotals
+            !paddedSortedResults
         )
             return { right: 0, top: 0 };
 
@@ -3250,7 +3227,7 @@ const useEchartsCartesianConfig = (
             if (!stack || !stackSeries[0]?.stackLabel?.show) return;
 
             const stackTotalData = getStackTotalRows(
-                paddedRawDataForStackTotals,
+                paddedSortedResults,
                 stackSeries,
                 flipAxis,
                 validCartesianConfigLegend,
@@ -3285,7 +3262,7 @@ const useEchartsCartesianConfig = (
     }, [
         stackedSeriesWithColorAssignments,
         itemsMap,
-        paddedRawDataForStackTotals,
+        paddedSortedResults,
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.flipAxes,
         validCartesianConfigLegend,
@@ -3572,7 +3549,7 @@ const useEchartsCartesianConfig = (
             legend: legendConfigWithInstructionsTooltip,
             dataset: {
                 id: 'lightdashResults',
-                source: paddedDataToRender,
+                source: dataToRender,
             },
             tooltip,
             grid: currentGrid,
@@ -3616,7 +3593,7 @@ const useEchartsCartesianConfig = (
         isInDashboard,
         minimal,
         legendConfigWithInstructionsTooltip,
-        paddedDataToRender,
+        dataToRender,
         tooltip,
         currentGrid,
         theme?.other.chartFont,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2276,7 +2276,7 @@ const getValidStack = (series: EChartsSeries | undefined) => {
 type LegendValues = { [name: string]: boolean } | undefined;
 
 const calculateStackTotal = (
-    row: ResultRow,
+    row: Record<string, unknown>,
     series: EChartsSeries[],
     flipAxis: boolean | undefined,
     selectedLegendNames: LegendValues,
@@ -2290,8 +2290,7 @@ const calculateStackTotal = (
                 selected = selectedLegendNames[key];
             }
         }
-        const numberValue =
-            hash && selected ? toNumber(row[hash]?.value.raw) : 0;
+        const numberValue = hash && selected ? toNumber(row[hash]) : 0;
         if (!Number.isNaN(numberValue)) {
             acc += numberValue;
         }
@@ -2305,7 +2304,7 @@ const calculateStackTotal = (
 // - the total of that stack to be used in the label
 // The x/axis value and the "0" need to flip position if the axis are flipped
 const getStackTotalRows = (
-    rows: ResultRow[],
+    rows: Record<string, unknown>[],
     series: EChartsSeries[],
     flipAxis: boolean | undefined,
     selectedLegendNames: LegendValues,
@@ -2327,15 +2326,13 @@ const getStackTotalRows = (
         if (!hash) {
             return [null, null, 0];
         }
-        return flipAxis
-            ? [0, row[hash]?.value.raw, total]
-            : [row[hash]?.value.raw, 0, total];
+        return flipAxis ? [0, row[hash], total] : [row[hash], 0, total];
     });
 };
 
 // To hack the stack totals in echarts we need to create a fake series with the value 0 and display the total in the label
 const getStackTotalSeries = (
-    rows: ResultRow[],
+    rows: Record<string, unknown>[],
     seriesWithStack: EChartsSeries[],
     itemsMap: ItemsMap,
     flipAxis: boolean | undefined,
@@ -2748,73 +2745,16 @@ const useEchartsCartesianConfig = (
             },
         );
 
-        // Apply border radius to stacked bar charts (only regular stacked, not 100%)
-        const isStack100 =
-            validCartesianConfig?.layout?.stack === StackType.PERCENT;
-
-        const isStackNone =
-            validCartesianConfig?.layout?.stack === StackType.NONE;
-
-        const stackedBarSeries = seriesWithValidStack.filter(
-            (s) =>
-                s.type === CartesianSeriesType.BAR &&
-                s.stack &&
-                !isStack100 &&
-                !isStackNone,
-        );
-
-        // Canonical category values for stacked bars on a continuous-date
-        // axis. The axis labels are snapped to a single offset, but row
-        // x-values can drift across DST. padDatasetForContinuousAxis already
-        // normalizes dataset.source — do the same for series.data tuples so
-        // stacked DST bars find their axis slot.
-        const continuousRange = axes.continuousDateRange;
-        const xFieldId = validCartesianConfig?.layout?.xField;
-        const categoryValues =
-            continuousRange && xFieldId && stackedBarSeries.length > 0
-                ? (() => {
-                      const dateKeyToCanonical = new Map<string, string>();
-                      continuousRange.forEach((d) =>
-                          dateKeyToCanonical.set(d.slice(0, 10), d),
-                      );
-                      return rows.map((row) => {
-                          const raw = row[xFieldId]?.value?.raw;
-                          if (typeof raw !== 'string') return raw;
-                          return (
-                              dateKeyToCanonical.get(raw.slice(0, 10)) ?? raw
-                          );
-                      });
-                  })()
-                : undefined;
-
-        const seriesWithRoundedStacks =
-            stackedBarSeries.length > 0
-                ? applyRoundedCornersToStackData(seriesWithValidStack, rows, {
-                      radius: dynamicRadius,
-                      isHorizontal: !!isHorizontal,
-                      legendSelected: validCartesianConfigLegend,
-                      categoryValues,
-                  })
-                : seriesWithValidStack;
-
-        return [
-            ...seriesWithRoundedStacks,
-            ...getStackTotalSeries(
-                rows,
-                seriesWithRoundedStacks,
-                itemsMap,
-                validCartesianConfig?.layout.flipAxes,
-                validCartesianConfigLegend,
-                isStack100,
-                validCartesianConfig?.layout.connectNulls,
-                resolvedTimezone,
-            ),
-        ];
+        // Rounded corners and stack-total labels are applied downstream in
+        // `decoratedSeriesForChart` so they can consume `paddedDataToRender`
+        // (the canonicalized, flat dataset that backs xAxis.data). Returning
+        // the un-decorated series here keeps internal consumers (sort,
+        // 100%-stack, color overrides) reading raw values as before.
+        return seriesWithValidStack;
     }, [
         itemsMap,
         validCartesianConfig?.layout.flipAxes,
         validCartesianConfig?.layout?.stack,
-        validCartesianConfig?.layout.connectNulls,
         validCartesianConfig?.layout?.colorByCategory,
         validCartesianConfig?.layout?.categoryColorOverrides,
         validCartesianConfig?.layout?.xField,
@@ -2822,12 +2762,9 @@ const useEchartsCartesianConfig = (
         series,
         rows,
         pivotDimensions,
-        validCartesianConfigLegend,
         getSeriesColor,
         colorPalette,
         theme.colors.background,
-        resolvedTimezone,
-        axes.continuousDateRange,
     ]);
     const sortedResults = useMemo(() => {
         const results =
@@ -2969,7 +2906,7 @@ const useEchartsCartesianConfig = (
                 : 0;
 
             const stackTotals = getStackTotalRows(
-                rows,
+                sortedResults,
                 stackedSeriesWithColorAssignments,
                 validCartesianConfig?.layout.flipAxes,
                 validCartesianConfigLegend,
@@ -3060,7 +2997,6 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.eChartsConfig.xAxis,
         axes.yAxis,
         axes.xAxis,
-        rows,
         validCartesianConfigLegend,
     ]);
 
@@ -3136,6 +3072,78 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout?.xField,
     ]);
 
+    // Rounded-corner decoration and stack-total labels both need category
+    // values that match xAxis.data exactly. Running them after paddedDataToRender
+    // lets them read from the same canonicalized dataset that backs the axis,
+    // so DST-drifted rows can't end up with mismatched cat strings.
+    const decoratedSeriesForChart = useMemo(() => {
+        if (!stackedSeriesWithColorAssignments || !itemsMap) {
+            return stackedSeriesWithColorAssignments;
+        }
+
+        const isHorizontal = !!validCartesianConfig?.layout?.flipAxes;
+        const stackValue = validCartesianConfig?.layout?.stack;
+        const isStack100 = stackValue === StackType.PERCENT;
+        const isStackNone = stackValue === StackType.NONE;
+
+        const barSeries = stackedSeriesWithColorAssignments.filter(
+            (s) => s.type === CartesianSeriesType.BAR,
+        );
+        const isStacked = barSeries.some((s) => s.stack);
+        const stackedBarSeries = stackedSeriesWithColorAssignments.filter(
+            (s) =>
+                s.type === CartesianSeriesType.BAR &&
+                s.stack &&
+                !isStack100 &&
+                !isStackNone,
+        );
+        const nonStackedBarCount = isStacked
+            ? barSeries.filter((s) => !s.stack).length
+            : barSeries.length;
+        const dynamicRadius = calculateDynamicBorderRadius(
+            paddedDataToRender.length,
+            Math.max(1, nonStackedBarCount),
+            isStacked,
+            isHorizontal,
+        );
+
+        const seriesWithRoundedStacks =
+            stackedBarSeries.length > 0
+                ? applyRoundedCornersToStackData(
+                      stackedSeriesWithColorAssignments,
+                      paddedDataToRender,
+                      {
+                          radius: dynamicRadius,
+                          isHorizontal,
+                          legendSelected: validCartesianConfigLegend,
+                      },
+                  )
+                : stackedSeriesWithColorAssignments;
+
+        return [
+            ...seriesWithRoundedStacks,
+            ...getStackTotalSeries(
+                paddedDataToRender,
+                seriesWithRoundedStacks,
+                itemsMap,
+                validCartesianConfig?.layout.flipAxes,
+                validCartesianConfigLegend,
+                isStack100,
+                validCartesianConfig?.layout.connectNulls,
+                resolvedTimezone,
+            ),
+        ];
+    }, [
+        stackedSeriesWithColorAssignments,
+        paddedDataToRender,
+        itemsMap,
+        validCartesianConfig?.layout?.stack,
+        validCartesianConfig?.layout?.flipAxes,
+        validCartesianConfig?.layout.connectNulls,
+        validCartesianConfigLegend,
+        resolvedTimezone,
+    ]);
+
     const tooltip = useMemo<TooltipOption>(() => {
         // Check if any series is line/area/scatter (use line pointer) vs bar (use shadow pointer)
         const hasLineAreaScatterSeries = series.some(
@@ -3198,7 +3206,7 @@ const useEchartsCartesianConfig = (
             !isStack100 ||
             !stackedSeriesWithColorAssignments ||
             !itemsMap ||
-            !rows
+            !paddedDataToRender
         )
             return { right: 0, top: 0 };
 
@@ -3220,7 +3228,7 @@ const useEchartsCartesianConfig = (
             if (!stack || !stackSeries[0]?.stackLabel?.show) return;
 
             const stackTotalData = getStackTotalRows(
-                rows,
+                paddedDataToRender,
                 stackSeries,
                 flipAxis,
                 validCartesianConfigLegend,
@@ -3255,7 +3263,7 @@ const useEchartsCartesianConfig = (
     }, [
         stackedSeriesWithColorAssignments,
         itemsMap,
-        rows,
+        paddedDataToRender,
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.flipAxes,
         validCartesianConfigLegend,
@@ -3460,13 +3468,13 @@ const useEchartsCartesianConfig = (
     // When xField is EMPTY_X_AXIS (pivoted bars with no x-axis dimension),
     // sorting must reorder the series array since bars are series, not categories.
     const sortedSeriesForChart = useMemo(() => {
-        if (!stackedSeriesWithColorAssignments?.length) {
-            return stackedSeriesWithColorAssignments;
+        if (!decoratedSeriesForChart?.length) {
+            return decoratedSeriesForChart;
         }
 
         const xFieldId = validCartesianConfig?.layout?.xField;
         if (xFieldId !== EMPTY_X_AXIS) {
-            return stackedSeriesWithColorAssignments;
+            return decoratedSeriesForChart;
         }
 
         const xAxisConfig = validCartesianConfig?.eChartsConfig.xAxis?.[0];
@@ -3474,10 +3482,10 @@ const useEchartsCartesianConfig = (
         const isInverse = xAxisConfig?.inverse ?? false;
 
         if (sortType === XAxisSortType.DEFAULT && !isInverse) {
-            return stackedSeriesWithColorAssignments;
+            return decoratedSeriesForChart;
         }
 
-        const sorted = [...stackedSeriesWithColorAssignments];
+        const sorted = [...decoratedSeriesForChart];
 
         if (sortType === XAxisSortType.CATEGORY) {
             // Sort by series name (pivot value label) alphabetically
@@ -3522,7 +3530,7 @@ const useEchartsCartesianConfig = (
 
         return sorted;
     }, [
-        stackedSeriesWithColorAssignments,
+        decoratedSeriesForChart,
         validCartesianConfig?.layout?.xField,
         validCartesianConfig?.eChartsConfig.xAxis,
         xAxisSortedResults,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2315,7 +2315,18 @@ const getStackTotalRows = (
             s.type === CartesianSeriesType.SCATTER,
     );
     if (isNonStackable) return [];
-    return rows.map((row) => {
+    return rows.reduce<[unknown, unknown, number][]>((acc, row) => {
+        // Skip padded gap rows: when every stacked series value is absent from
+        // the row, this is a date inserted by padDatasetForContinuousAxis and
+        // should not render a stack-total label.
+        const hasAnyValue = series.some((s) => {
+            const valueHash = flipAxis ? s.encode?.x : s.encode?.y;
+            return (
+                typeof valueHash === 'string' && row[valueHash] !== undefined
+            );
+        });
+        if (!hasAnyValue) return acc;
+
         const total = calculateStackTotal(
             row,
             series,
@@ -2324,10 +2335,12 @@ const getStackTotalRows = (
         );
         const hash = flipAxis ? series[0].encode?.y : series[0].encode?.x;
         if (!hash) {
-            return [null, null, 0];
+            acc.push([null, null, 0]);
+            return acc;
         }
-        return flipAxis ? [0, row[hash], total] : [row[hash], 0, total];
-    });
+        acc.push(flipAxis ? [0, row[hash], total] : [row[hash], 0, total]);
+        return acc;
+    }, []);
 };
 
 // To hack the stack totals in echarts we need to create a fake series with the value 0 and display the total in the label


### PR DESCRIPTION
Follow-up to #22922 (DST padding fix on continuous category axes).

That PR turned padding on for every continuous-range bar chart but only normalized `dataset.source`. Stack decorations (rounded corners on top segments, stack-total labels in 100% mode) were still built from the raw, drifted-cat rows — so on a non-UTC project timezone with DST, stacked bars kept dropping even after #22922.

This PR routes those decorations through the same padded dataset. Two follow-on cleanups bundled in:

- Decorations consume the canonicalized flat dataset (`paddedSortedResults`) directly, so cat strings match `xAxis.data` exactly.
- Padding runs once, upstream of the 100%-stack transform, instead of producing two parallel padded datasets. Composition equivalence is pinned by new tests.

### Tests
- `transformToPercentageStacking` was untested — added basic / gap-tolerance / no-op coverage.
- New `pad ∘ transform` test asserts the two composition orders agree on non-gap rows.
- All tests pass against both the pre- and post-collapse implementations.