### PR TITLE
feat(cli): add --combine-manifest option to preview commands

### DIFF
--- a/packages/cli/src/dbt/manifest.test.ts
+++ b/packages/cli/src/dbt/manifest.test.ts
@@ -1,0 +1,120 @@
+import { DbtManifest, DbtNode } from '@lightdash/common';
+import { combineManifests } from './manifest';
+
+const modelNode = (uniqueId: string, extra: Record<string, unknown> = {}) =>
+    ({
+        unique_id: uniqueId,
+        resource_type: 'model',
+        ...extra,
+    }) as unknown as DbtNode;
+
+const testNode = (uniqueId: string) =>
+    ({
+        unique_id: uniqueId,
+        resource_type: 'test',
+    }) as unknown as DbtNode;
+
+const buildManifest = (
+    nodes: Record<string, DbtNode>,
+    overrides: Partial<DbtManifest> = {},
+): DbtManifest =>
+    ({
+        nodes,
+        metadata: {
+            adapter_type: 'postgres',
+        },
+        metrics: {},
+        docs: {},
+        ...overrides,
+    }) as unknown as DbtManifest;
+
+describe('combineManifests', () => {
+    test('adds external-only model nodes and lists their unique_ids', () => {
+        const primary = buildManifest({
+            'model.proj.a': modelNode('model.proj.a', { tag: 'primary' }),
+        });
+        const external = buildManifest({
+            'model.proj.b': modelNode('model.proj.b'),
+            'model.proj.c': modelNode('model.proj.c'),
+        });
+
+        const { manifest, addedModelIds } = combineManifests(primary, external);
+
+        expect(Object.keys(manifest.nodes).sort()).toEqual([
+            'model.proj.a',
+            'model.proj.b',
+            'model.proj.c',
+        ]);
+        expect(addedModelIds.sort()).toEqual(['model.proj.b', 'model.proj.c']);
+    });
+
+    test('primary wins on conflict and does not list the conflicting id as added', () => {
+        const primary = buildManifest({
+            'model.proj.a': modelNode('model.proj.a', { tag: 'primary' }),
+        });
+        const external = buildManifest({
+            'model.proj.a': modelNode('model.proj.a', { tag: 'external' }),
+            'model.proj.b': modelNode('model.proj.b'),
+        });
+
+        const { manifest, addedModelIds } = combineManifests(primary, external);
+
+        const mergedA = manifest.nodes['model.proj.a'] as unknown as {
+            tag: string;
+        };
+        expect(mergedA.tag).toBe('primary');
+        expect(addedModelIds).toEqual(['model.proj.b']);
+    });
+
+    test('non-model external nodes are merged into nodes but not reported as added', () => {
+        const primary = buildManifest({
+            'model.proj.a': modelNode('model.proj.a'),
+        });
+        const external = buildManifest({
+            'test.proj.t': testNode('test.proj.t'),
+            'model.proj.b': modelNode('model.proj.b'),
+        });
+
+        const { manifest, addedModelIds } = combineManifests(primary, external);
+
+        expect(manifest.nodes['test.proj.t']).toBeDefined();
+        expect(addedModelIds).toEqual(['model.proj.b']);
+    });
+
+    test('metrics, docs, and metadata come from primary only', () => {
+        const primary = buildManifest(
+            { 'model.proj.a': modelNode('model.proj.a') },
+            {
+                metrics: {
+                    'metric.proj.p': { id: 'p' },
+                } as unknown as DbtManifest['metrics'],
+                docs: {
+                    'doc.proj.p': { id: 'p' },
+                } as unknown as DbtManifest['docs'],
+                metadata: {
+                    adapter_type: 'postgres',
+                } as unknown as DbtManifest['metadata'],
+            },
+        );
+        const external = buildManifest(
+            { 'model.proj.b': modelNode('model.proj.b') },
+            {
+                metrics: {
+                    'metric.proj.e': { id: 'e' },
+                } as unknown as DbtManifest['metrics'],
+                docs: {
+                    'doc.proj.e': { id: 'e' },
+                } as unknown as DbtManifest['docs'],
+                metadata: {
+                    adapter_type: 'snowflake',
+                } as unknown as DbtManifest['metadata'],
+            },
+        );
+
+        const { manifest } = combineManifests(primary, external);
+
+        expect(Object.keys(manifest.metrics)).toEqual(['metric.proj.p']);
+        expect(Object.keys(manifest.docs)).toEqual(['doc.proj.p']);
+        expect(manifest.metadata.adapter_type).toBe('postgres');
+    });
+});

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -1,4 +1,4 @@
-import { DbtManifest, getErrorMessage } from '@lightdash/common';
+import { DbtManifest, DbtNode, getErrorMessage } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import globalState from '../globalState';
@@ -10,10 +10,9 @@ export type LoadManifestArgs = {
 export const getManifestPath = async (targetDir: string): Promise<string> =>
     path.join(targetDir, 'manifest.json');
 
-export const loadManifest = async ({
-    targetDir,
-}: LoadManifestArgs): Promise<DbtManifest> => {
-    const filename = await getManifestPath(targetDir);
+export const loadManifestFromFile = async (
+    filename: string,
+): Promise<DbtManifest> => {
     globalState.debug(`> Loading dbt manifest from ${filename}`);
     try {
         const manifest = JSON.parse(
@@ -24,4 +23,44 @@ export const loadManifest = async ({
         const msg = getErrorMessage(err);
         throw new Error(`Could not load manifest from ${filename}:\n  ${msg}`);
     }
+};
+
+export const loadManifest = async ({
+    targetDir,
+}: LoadManifestArgs): Promise<DbtManifest> => {
+    const filename = await getManifestPath(targetDir);
+    return loadManifestFromFile(filename);
+};
+
+export type CombineManifestsResult = {
+    manifest: DbtManifest;
+    addedModelIds: string[];
+};
+
+/**
+ * Merge model nodes from `external` into `primary`. Nodes already present in
+ * `primary` keep their primary version (primary wins on conflict). Returns the
+ * combined manifest and the unique_ids of model nodes pulled in from the
+ * external manifest, so callers can mark them as compiled.
+ *
+ * Metrics, docs, and metadata are taken from `primary` only.
+ */
+export const combineManifests = (
+    primary: DbtManifest,
+    external: DbtManifest,
+): CombineManifestsResult => {
+    const mergedNodes: Record<string, DbtNode> = { ...external.nodes };
+    Object.assign(mergedNodes, primary.nodes);
+
+    const addedModelIds: string[] = [];
+    Object.entries(external.nodes).forEach(([id, node]) => {
+        if (!(id in primary.nodes) && node.resource_type === 'model') {
+            addedModelIds.push(id);
+        }
+    });
+
+    return {
+        manifest: { ...primary, nodes: mergedNodes },
+        addedModelIds,
+    };
 };

--- a/packages/cli/src/handlers/compile.test.ts
+++ b/packages/cli/src/handlers/compile.test.ts
@@ -79,6 +79,7 @@ dimensions:
             defer: false,
             targetPath: undefined,
             favorState: false,
+            combineManifest: undefined,
             warehouseCredentials: false,
             disableTimestampConversion: false,
         });

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -24,7 +24,11 @@ import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getDbtContext } from '../dbt/context';
-import { loadManifest } from '../dbt/manifest';
+import {
+    combineManifests,
+    loadManifest,
+    loadManifestFromFile,
+} from '../dbt/manifest';
 import { validateDbtModel } from '../dbt/validation';
 import GlobalState from '../globalState';
 import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
@@ -226,12 +230,37 @@ export const compile = async (options: CompileHandlerOptions) => {
                 { targetDir: context.targetDir },
                 options,
             );
-        const manifest = await loadManifest({ targetDir: context.targetDir });
+        let manifest = await loadManifest({ targetDir: context.targetDir });
+        let effectiveCompiledModelIds = compiledModelIds;
+        if (options.combineManifest) {
+            const externalManifestPath = path.resolve(options.combineManifest);
+            const externalManifest =
+                await loadManifestFromFile(externalManifestPath);
+            const { manifest: merged, addedModelIds } = combineManifests(
+                manifest,
+                externalManifest,
+            );
+            manifest = merged;
+            if (
+                effectiveCompiledModelIds !== undefined &&
+                addedModelIds.length > 0
+            ) {
+                effectiveCompiledModelIds = [
+                    ...effectiveCompiledModelIds,
+                    ...addedModelIds,
+                ];
+            }
+            console.info(
+                styles.info(
+                    `Combined external manifest from ${externalManifestPath}: added ${addedModelIds.length} model(s) not present in the preview manifest`,
+                ),
+            );
+        }
         const manifestVersion = getDbtManifestVersion(manifest);
         const manifestModels = getModelsFromManifest(manifest);
         const compiledModels = getCompiledModels(
             manifestModels,
-            compiledModelIds,
+            effectiveCompiledModelIds,
         );
 
         // When using --defer, non-selected models pulled in via joins

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -34,6 +34,7 @@ export type DbtCompileOptions = {
     defer: boolean | undefined;
     targetPath: string | undefined;
     favorState: boolean | undefined;
+    combineManifest: string | undefined;
 };
 
 const dbtCompileArgs = [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -532,6 +532,10 @@ program
     )
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
     .option(
+        '--combine-manifest <path>',
+        'Path to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
+    )
+    .option(
         '--table-configuration <prod|all>',
         `If set to 'prod' it will copy the table configuration from prod project`,
         'all',
@@ -653,6 +657,10 @@ program
         true,
     )
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
+    .option(
+        '--combine-manifest <path>',
+        'Path to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
+    )
     .option(
         '--table-configuration <prod|all>',
         `If set to 'prod' it will copy the table configuration from prod project`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-7535

### Description:

Adds a `--combine-manifest <path>` option to the `preview` and `start-preview` CLI commands. When set, the CLI merges the model nodes from the provided dbt `manifest.json` (e.g., one produced by a full CI run on `main`) on top of the manifest produced by the preview's own dbt run, so the preview reflects the full project even when the local dbt run only compiled a slice (`--select`, `--state:modified+`, etc.).

The combine step runs after the preview manifest is loaded, so it stacks with every other dbt flag (`--skip-dbt-compile`, `--select`, `--defer`/`--state`). The preview-generated manifest always wins on conflicts, and external-only model nodes are appended to `compiledModelIds` so they show up as explores. Only model nodes are merged; metrics, docs, and metadata come from the preview manifest only.

Includes unit tests for the new `combineManifests` helper.

### Example

```bash
# 1. Produce a full baseline manifest from main (or grab the one CI uploads)
dbt compile --profiles-dir ./profiles
cp target/manifest.json /tmp/baseline-manifest.json

# 2. On a feature branch, only compile the slice you're iterating on,
#    but layer the baseline on top so the preview shows the full project
lightdash preview \
  --project-dir ./dbt \
  --profiles-dir ./profiles \
  --select customers+ \
  --combine-manifest /tmp/baseline-manifest.json
```

Result: the preview project shows every model (orders, payments, …), with your local changes to `customers` and its descendants taking precedence over the baseline versions.