### PR TITLE
feat(data-apps): show description info popup for data apps in spaces

### DIFF
--- a/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
@@ -1,4 +1,8 @@
 import {
+    isAppVersionInProgress,
+    type AppVersionStatus,
+} from '@lightdash/common';
+import {
     Anchor,
     Box,
     CopyButton,
@@ -17,6 +21,7 @@ import {
     IconEye,
     IconFolder,
     IconHash,
+    IconHistory,
     IconInfoCircle,
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
@@ -27,6 +32,13 @@ import MantineIcon from '../MantineIcon';
 import InfoRow from '../PageHeader/InfoRow';
 import { DashboardList } from './DashboardList';
 import styles from './ResourceInfoPopup.module.css';
+
+const versionStatusLabel = (status: AppVersionStatus): string => {
+    if (status === 'error') return 'error';
+    if (status === 'ready') return 'ready';
+    if (isAppVersionInProgress(status)) return 'building';
+    return status;
+};
 
 type Props = {
     resourceUuid: string;
@@ -40,6 +52,7 @@ type Props = {
     projectUuid: string;
     viewStats?: number;
     firstViewedAt?: Date | string | null;
+    latestVersion?: { number: number; status: AppVersionStatus } | null;
 };
 
 export const ResourceInfoPopup: FC<Props> = ({
@@ -54,6 +67,7 @@ export const ResourceInfoPopup: FC<Props> = ({
     viewStats,
     firstViewedAt,
     withChartData = false,
+    latestVersion,
 }) => {
     const timeAgo = useTimeAgo(updatedAt ?? new Date());
     const label =
@@ -63,7 +77,10 @@ export const ResourceInfoPopup: FC<Props> = ({
               )}`
             : undefined;
     const hasMetadataRows =
-        !!updatedAt || viewStats !== undefined || !!(spaceName && spaceUuid);
+        !!updatedAt ||
+        viewStats !== undefined ||
+        !!(spaceName && spaceUuid) ||
+        !!latestVersion;
     const shouldShowDivider =
         !!slug && (hasMetadataRows || !!description || withChartData);
     const hasContent =
@@ -73,7 +90,8 @@ export const ResourceInfoPopup: FC<Props> = ({
         !!withChartData ||
         !!updatedAt ||
         viewStats !== undefined ||
-        !!(spaceName && spaceUuid);
+        !!(spaceName && spaceUuid) ||
+        !!latestVersion;
 
     if (!hasContent) return null;
 
@@ -137,6 +155,20 @@ export const ResourceInfoPopup: FC<Props> = ({
                                     {spaceName}
                                 </Anchor>
                             </InfoRow>
+                        )}
+
+                        {latestVersion && (
+                            <Group gap={6} wrap="nowrap">
+                                <MantineIcon
+                                    icon={IconHistory}
+                                    color="ldGray.6"
+                                    size={14}
+                                />
+                                <Text fz="xs" c="ldGray.6" fw={600}>
+                                    Version {latestVersion.number} (
+                                    {versionStatusLabel(latestVersion.status)})
+                                </Text>
+                            </Group>
                         )}
 
                         {withChartData && (

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -198,11 +198,12 @@ const InfiniteResourceTableColumnName = ({
                             verification={verification}
                         />
                         {!isSpace &&
-                            // If there is no description, don't show the info icon on dashboards.
+                            // If there is no description, don't show the info icon on dashboards or data apps.
                             // For charts we still show it for the dashboard list
                             (item.data.description ||
                                 isResourceViewItemChart(item)) &&
-                            isChartOrDashboard && (
+                            (isChartOrDashboard ||
+                                isResourceViewDataAppItem(item)) && (
                                 <Box>
                                     <ResourceInfoPopup
                                         resourceUuid={item.data.uuid}
@@ -211,6 +212,20 @@ const InfiniteResourceTableColumnName = ({
                                         withChartData={isResourceViewItemChart(
                                             item,
                                         )}
+                                        latestVersion={
+                                            isResourceViewDataAppItem(item) &&
+                                            item.data.latestVersionNumber !==
+                                                null &&
+                                            item.data.latestVersionStatus !==
+                                                null
+                                                ? {
+                                                      number: item.data
+                                                          .latestVersionNumber,
+                                                      status: item.data
+                                                          .latestVersionStatus,
+                                                  }
+                                                : null
+                                        }
                                     />
                                 </Box>
                             )}


### PR DESCRIPTION
### Description:
Surface the same info icon + hover popup next to a data app's name in the space content table that charts and dashboards already get, so the description and latest-version status are readable without opening the app. Data apps don't have the chart "Used in N dashboards" backlink, so the popup gets a "Version N (status)" row instead — terminal `ready` and `error` are surfaced as-is and all in-progress stages collapse to "building".

<img width="401" height="136" alt="Screenshot 2026-05-12 at 14 48 00" src="https://github.com/user-attachments/assets/da6855c6-e211-4df5-b868-959c301510b9" />

