### PR TITLE
fix(scheduler): replace queued heartbeat with out-of-band pg ping

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTaskTracer.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.test.ts
@@ -55,30 +55,12 @@ const makeHelpers = () =>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any;
 
-describe('traceTasks — heartbeat tasks bypass the Sentry trace wrapper', () => {
+describe('traceTasks — wraps every task in the Sentry trace wrapper', () => {
     beforeEach(() => {
         startSpanMock.mockClear();
     });
 
-    it('does NOT wrap workerHeartbeat:<poolId> in Sentry.startSpan', async () => {
-        const innerHandler = jest.fn().mockResolvedValue(undefined);
-        const tasks: Partial<TypedTaskList> = {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ['workerHeartbeat:pod-abc' as any]: innerHandler,
-        };
-
-        const tracedList = traceTasks(tasks);
-        const heartbeatTask = tracedList['workerHeartbeat:pod-abc'];
-
-        expect(heartbeatTask).toBeDefined();
-        // Invoke the (pass-through) traced task and confirm Sentry wasn't called.
-        await heartbeatTask!({}, makeHelpers());
-
-        expect(innerHandler).toHaveBeenCalledTimes(1);
-        expect(startSpanMock).not.toHaveBeenCalled();
-    });
-
-    it('DOES wrap a regular scheduler task in Sentry.startSpan', async () => {
+    it('wraps a regular scheduler task in Sentry.startSpan', async () => {
         const innerHandler = jest.fn().mockResolvedValue(undefined);
         const tasks: Partial<TypedTaskList> = {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -91,33 +73,33 @@ describe('traceTasks — heartbeat tasks bypass the Sentry trace wrapper', () =>
         expect(wrappedTask).toBeDefined();
         await wrappedTask!({}, makeHelpers());
 
-        // The handler ran, and Sentry's startSpan was invoked.
         expect(innerHandler).toHaveBeenCalledTimes(1);
         expect(startSpanMock).toHaveBeenCalledTimes(1);
-        // First arg to startSpan carries the span name; sanity-check it.
         const firstCallArgs = startSpanMock.mock.calls[0];
         expect(firstCallArgs[0]).toMatchObject({
             name: 'worker.task.checkForStuckJobs',
         });
     });
 
-    it('handles mixed task lists — only the heartbeat name bypasses', async () => {
-        const heartbeatHandler = jest.fn().mockResolvedValue(undefined);
-        const regularHandler = jest.fn().mockResolvedValue(undefined);
+    it('wraps every task in a mixed list (heartbeats no longer flow through graphile)', async () => {
+        // The old bypass for workerHeartbeat:<poolId> existed because that
+        // task fired every 60s and produced noise. With pg-ping running
+        // out-of-band, nothing in the queue needs special-casing.
+        const handlerA = jest.fn().mockResolvedValue(undefined);
+        const handlerB = jest.fn().mockResolvedValue(undefined);
         const tasks: Partial<TypedTaskList> = {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ['workerHeartbeat:pod-xyz' as any]: heartbeatHandler,
+            checkForStuckJobs: handlerA as any,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            checkForStuckJobs: regularHandler as any,
+            cleanDeploySessions: handlerB as any,
         };
 
         const tracedList = traceTasks(tasks);
-        await tracedList['workerHeartbeat:pod-xyz']!({}, makeHelpers());
         await tracedList.checkForStuckJobs!({}, makeHelpers());
+        await tracedList.cleanDeploySessions!({}, makeHelpers());
 
-        expect(heartbeatHandler).toHaveBeenCalledTimes(1);
-        expect(regularHandler).toHaveBeenCalledTimes(1);
-        // Only ONE span — for the regular task, not the heartbeat.
-        expect(startSpanMock).toHaveBeenCalledTimes(1);
+        expect(handlerA).toHaveBeenCalledTimes(1);
+        expect(handlerB).toHaveBeenCalledTimes(1);
+        expect(startSpanMock).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -186,8 +186,6 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
         'managed_agent.triggered_by': payload.triggeredBy ?? 'cron',
     }),
-    [SCHEDULER_TASKS.WORKER_HEARTBEAT]: () => ({}),
-    [SCHEDULER_TASKS.CLEAN_WORKER_HEARTBEATS]: () => ({}),
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,
@@ -196,8 +194,6 @@ const getTagsForTask: {
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
 } as const;
 
-// Generic accessor function. Returns {} for dynamic task names that aren't
-// in the static map (e.g. per-pool heartbeat tasks named workerHeartbeat:<id>).
 const getTagsFromPayload = <T extends SchedulerTaskName>(
     taskName: T,
     payload: TaskPayloadMap[T],
@@ -352,9 +348,6 @@ export const traceTask = <T extends SchedulerTaskName>(
     return tracedTask;
 };
 
-// Skip wrapping the per-pool heartbeat tasks — they fire every 60s and produce no actionable trace signal.
-const TRACE_SKIP_PREFIX = 'workerHeartbeat:';
-
 /**
  * Traces a list of tasks and converts them to a Graphile Worker TaskList
  * @param tasks - The list of tasks to trace
@@ -366,9 +359,6 @@ export const traceTasks = (tasks: Partial<TypedTaskList>) => {
             const handler = tasks[
                 taskName as keyof TypedTaskList
             ] as TypedTask<unknown>;
-            if (taskName.startsWith(TRACE_SKIP_PREFIX)) {
-                return { ...accTasks, [taskName]: handler as Task };
-            }
             return {
                 ...accTasks,
                 // NOTE: Graphile Worker requires the task to be of type Task, which is not typed. We need to cast it to unknown.

--- a/packages/backend/src/scheduler/SchedulerWorker.heartbeat.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.heartbeat.test.ts
@@ -1,4 +1,4 @@
-import { ALL_TASK_NAMES, SCHEDULER_TASKS } from '@lightdash/common';
+import { ALL_TASK_NAMES } from '@lightdash/common';
 import { type LightdashConfig } from '../config/parseConfig';
 import {
     SchedulerWorker,
@@ -6,7 +6,6 @@ import {
 } from './SchedulerWorker';
 import { SchedulerWorkerHealth } from './SchedulerWorkerHealth';
 
-// A subclass exposing the protected getTaskList for assertion purposes.
 class TestableSchedulerWorker extends SchedulerWorker {
     public exposeTaskList() {
         return this.getTaskList();
@@ -16,17 +15,12 @@ class TestableSchedulerWorker extends SchedulerWorker {
         return this.getFullTaskList();
     }
 
-    public async enqueueHeartbeatOnce(health: SchedulerWorkerHealth) {
-        // The real interval is started in run(); we call the underlying enqueue
-        // directly so tests don't have to spin up graphile.
+    public async pingPgOnceExposed(health: SchedulerWorkerHealth) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await (this as any).enqueueOwnHeartbeat(health);
+        await (this as any).pingPgOnce(health);
     }
 }
 
-// Minimal lightdash config covering the bits SchedulerTask + SchedulerWorker
-// touch in their constructors. Cast to LightdashConfig — instantiating the
-// full config object would pull in dozens of services we don't need here.
 const makeConfig = (): LightdashConfig =>
     ({
         scheduler: {
@@ -48,205 +42,148 @@ const makeConfig = (): LightdashConfig =>
         database: { connectionUri: 'postgres://noop' },
     }) as unknown as LightdashConfig;
 
-// Build a minimal args bag. All services are stubs because the heartbeat
-// path only depends on schedulerClient.graphileUtils.
 const makeWorkerArgs = (
-    addJobSpy: jest.Mock,
+    withPgClient: jest.Mock,
     workerHealth?: SchedulerWorkerHealth,
-    withPgClient?: jest.Mock,
 ): SchedulerWorkerArguments => {
     const graphileUtils = Promise.resolve({
-        addJob: addJobSpy,
-        withPgClient: withPgClient ?? jest.fn(),
+        addJob: jest.fn(),
+        withPgClient,
     });
     return {
         lightdashConfig: makeConfig(),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         schedulerClient: { graphileUtils } as any,
         workerHealth,
-        // The remaining service slots are not touched by getTaskList or
-        // enqueueOwnHeartbeat. Cast through unknown to avoid stubbing 20+
-        // dependencies that the tests under this file never call.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as unknown as SchedulerWorkerArguments;
 };
 
-describe('SchedulerWorker — per-pool heartbeat registration', () => {
-    it('registers a workerHeartbeat:<poolId> task only when workerHealth is provided', () => {
+describe('SchedulerWorker — task list no longer carries heartbeat plumbing', () => {
+    it('does not register any workerHeartbeat:* task even when workerHealth is provided', () => {
+        // pg-ping runs out-of-band on a setInterval, so the queue should be
+        // free of dynamic per-pool heartbeat task names regardless of health
+        // wiring. This guards against accidental re-introduction of the
+        // graphile-routed heartbeat path.
         const health = new SchedulerWorkerHealth('pod-abc-123');
         const worker = new TestableSchedulerWorker(
             makeWorkerArgs(jest.fn(), health),
         );
 
-        const tasks = worker.exposeTaskList();
-        const taskNames = Object.keys(tasks);
-
-        expect(taskNames).toContain('workerHeartbeat:pod-abc-123');
-        // No leakage of any other workerHeartbeat:* names from this pool.
+        const taskNames = Object.keys(worker.exposeTaskList());
         const heartbeatNames = taskNames.filter((n) =>
             n.startsWith('workerHeartbeat:'),
         );
-        expect(heartbeatNames).toEqual(['workerHeartbeat:pod-abc-123']);
+        expect(heartbeatNames).toEqual([]);
+        // Likewise no static workerHeartbeat / cleanWorkerHeartbeats handlers.
+        expect(taskNames).not.toContain('workerHeartbeat');
+        expect(taskNames).not.toContain('cleanWorkerHeartbeats');
     });
 
-    it('does NOT register any workerHeartbeat:* task when workerHealth is omitted', () => {
+    it('does not register any heartbeat tasks when workerHealth is omitted', () => {
         const worker = new TestableSchedulerWorker(
             makeWorkerArgs(jest.fn(), undefined),
         );
 
-        const tasks = worker.exposeTaskList();
-        const heartbeatNames = Object.keys(tasks).filter((n) =>
-            n.startsWith('workerHeartbeat:'),
-        );
-
-        expect(heartbeatNames).toEqual([]);
-    });
-
-    it('isolates two pools running in the same process with different poolIds', () => {
-        // This is the multi-replica / dual-pool scenario: two workers running
-        // side by side must each register a UNIQUE task name so that neither
-        // pool can steal the other's heartbeat job.
-        const healthA = new SchedulerWorkerHealth('pod-a');
-        const healthB = new SchedulerWorkerHealth('pod-b');
-        const workerA = new TestableSchedulerWorker(
-            makeWorkerArgs(jest.fn(), healthA),
-        );
-        const workerB = new TestableSchedulerWorker(
-            makeWorkerArgs(jest.fn(), healthB),
-        );
-
-        const namesA = Object.keys(workerA.exposeTaskList()).filter((n) =>
-            n.startsWith('workerHeartbeat:'),
-        );
-        const namesB = Object.keys(workerB.exposeTaskList()).filter((n) =>
-            n.startsWith('workerHeartbeat:'),
-        );
-
-        expect(namesA).toEqual(['workerHeartbeat:pod-a']);
-        expect(namesB).toEqual(['workerHeartbeat:pod-b']);
-        expect(namesA[0]).not.toEqual(namesB[0]);
+        const taskNames = Object.keys(worker.exposeTaskList());
+        expect(
+            taskNames.filter((n) => n.startsWith('workerHeartbeat')),
+        ).toEqual([]);
+        expect(taskNames).not.toContain('cleanWorkerHeartbeats');
     });
 });
 
-describe('SchedulerWorker — enqueueOwnHeartbeat', () => {
-    it('enqueues the per-pool task name with poolId payload and matching jobKey', async () => {
+describe('SchedulerWorker — pingPgOnce', () => {
+    it('runs SELECT 1 through withPgClient and marks pg reachable on success', async () => {
         const health = new SchedulerWorkerHealth('pod-xyz');
-        const addJob = jest.fn().mockResolvedValue(undefined);
-        const worker = new TestableSchedulerWorker(
-            makeWorkerArgs(addJob, health),
-        );
+        const markPgReachableSpy = jest.spyOn(health, 'markPgReachable');
 
-        await worker.enqueueHeartbeatOnce(health);
-
-        expect(addJob).toHaveBeenCalledTimes(1);
-        const [taskName, payload, options] = addJob.mock.calls[0];
-        expect(taskName).toBe('workerHeartbeat:pod-xyz');
-        expect(payload).toEqual({
-            poolId: 'pod-xyz',
-            enqueuedAt: expect.stringMatching(
-                /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
-            ),
-        });
-        expect(options).toMatchObject({
-            jobKey: 'workerHeartbeat:pod-xyz',
-            // Explicit replace mode — collapses pending unlocked rows so a
-            // stuck pool can never leave more than one queued heartbeat.
-            jobKeyMode: 'replace',
-            maxAttempts: 1,
-        });
-    });
-
-    it('continues attempting heartbeats after a failed enqueue', async () => {
-        const health = new SchedulerWorkerHealth('pod-failing');
-        const addJob = jest
-            .fn()
-            .mockRejectedValueOnce(new Error('pg wedged'))
-            .mockResolvedValueOnce(undefined);
-        const worker = new TestableSchedulerWorker(
-            makeWorkerArgs(addJob, health),
-        );
-
-        await worker.enqueueHeartbeatOnce(health);
-        await worker.enqueueHeartbeatOnce(health);
-
-        // The second tick still ran — the first failure did not block subsequent enqueues.
-        expect(addJob).toHaveBeenCalledTimes(2);
-    });
-
-    it('does not hang forever when addJob never resolves (wedged pg)', async () => {
-        jest.useFakeTimers();
-        try {
-            const health = new SchedulerWorkerHealth('pod-hung');
-            // Simulate a wedged pg backend: addJob returns a promise that
-            // never resolves or rejects.
-            const addJob = jest.fn().mockImplementation(
-                () =>
-                    new Promise(() => {
-                        // intentionally pending forever
-                    }),
-            );
-            const worker = new TestableSchedulerWorker(
-                makeWorkerArgs(addJob, health),
-            );
-
-            const enqueuePromise = worker.enqueueHeartbeatOnce(health);
-
-            // Advance past the 10s timeout cap.
-            await jest.advanceTimersByTimeAsync(11_000);
-
-            // The enqueue method must resolve (catch swallows the timeout
-            // error). Without the timeout cap this test would hang.
-            await expect(enqueuePromise).resolves.toBeUndefined();
-            expect(addJob).toHaveBeenCalledTimes(1);
-        } finally {
-            jest.useRealTimers();
-        }
-    });
-});
-
-describe('SchedulerWorker — cleanWorkerHeartbeats', () => {
-    it('deletes orphan rows older than 10 minutes, including stale-locked ones', async () => {
         const pgClient = {
-            query: jest.fn().mockResolvedValue({ rows: [{ count: '5' }] }),
+            query: jest.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
         };
         const withPgClient = jest
             .fn()
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             .mockImplementation(async (fn: any) => fn(pgClient));
+
         const worker = new TestableSchedulerWorker(
-            makeWorkerArgs(jest.fn(), undefined, withPgClient),
+            makeWorkerArgs(withPgClient, health),
         );
 
-        const tasks = worker.exposeFullTaskList();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const handler = tasks[SCHEDULER_TASKS.CLEAN_WORKER_HEARTBEATS] as any;
-        expect(handler).toBeDefined();
-
-        await handler({}, {});
+        await worker.pingPgOnceExposed(health);
 
         expect(withPgClient).toHaveBeenCalledTimes(1);
-        const sql = pgClient.query.mock.calls[0][0] as string;
-        expect(sql).toMatch(/DELETE FROM graphile_worker\.jobs/);
-        expect(sql).toMatch(/task_identifier LIKE 'workerHeartbeat:%'/);
-        // Both gating conditions present: run_at staleness AND lock state.
-        expect(sql).toMatch(/run_at < NOW\(\) - INTERVAL '10 minutes'/);
-        // Crucially, stale locks count as orphaned — otherwise a pod that died
-        // mid-heartbeat would leave its row stuck for graphile's much longer
-        // jobTimeout window before this cron could touch it.
-        expect(sql).toMatch(
-            /locked_at IS NULL OR locked_at < NOW\(\) - INTERVAL '10 minutes'/,
-        );
+        expect(pgClient.query).toHaveBeenCalledWith('SELECT 1');
+        expect(markPgReachableSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('rethrows on DB failure so graphile retries the cron run', async () => {
-        const withPgClient = jest.fn().mockRejectedValue(new Error('db down'));
+    it('does NOT mark pg reachable when the query rejects', async () => {
+        const health = new SchedulerWorkerHealth('pod-down');
+        const markPgReachableSpy = jest.spyOn(health, 'markPgReachable');
+
+        const withPgClient = jest
+            .fn()
+            .mockRejectedValue(new Error('connection refused'));
+
         const worker = new TestableSchedulerWorker(
-            makeWorkerArgs(jest.fn(), undefined, withPgClient),
+            makeWorkerArgs(withPgClient, health),
         );
 
-        const tasks = worker.exposeFullTaskList();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const handler = tasks[SCHEDULER_TASKS.CLEAN_WORKER_HEARTBEATS] as any;
-        await expect(handler({}, {})).rejects.toThrow('db down');
+        await worker.pingPgOnceExposed(health);
+
+        expect(withPgClient).toHaveBeenCalledTimes(1);
+        expect(markPgReachableSpy).not.toHaveBeenCalled();
+    });
+
+    it('continues running after a failure (no exception escapes the ping)', async () => {
+        const health = new SchedulerWorkerHealth('pod-flapping');
+        const pgClient = {
+            query: jest
+                .fn()
+                .mockRejectedValueOnce(new Error('pg blip'))
+                .mockResolvedValueOnce({ rows: [] }),
+        };
+        const withPgClient = jest
+            .fn()
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .mockImplementation(async (fn: any) => fn(pgClient));
+
+        const worker = new TestableSchedulerWorker(
+            makeWorkerArgs(withPgClient, health),
+        );
+
+        await expect(worker.pingPgOnceExposed(health)).resolves.toBeUndefined();
+        await expect(worker.pingPgOnceExposed(health)).resolves.toBeUndefined();
+        expect(pgClient.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not hang when withPgClient never resolves (wedged backend)', async () => {
+        jest.useFakeTimers();
+        try {
+            const health = new SchedulerWorkerHealth('pod-wedged');
+            const markPgReachableSpy = jest.spyOn(health, 'markPgReachable');
+            const withPgClient = jest.fn().mockImplementation(
+                () =>
+                    new Promise(() => {
+                        // intentionally pending forever
+                    }),
+            );
+
+            const worker = new TestableSchedulerWorker(
+                makeWorkerArgs(withPgClient, health),
+            );
+
+            const ping = worker.pingPgOnceExposed(health);
+
+            // Advance past the 5s ping timeout.
+            await jest.advanceTimersByTimeAsync(6_000);
+
+            await expect(ping).resolves.toBeUndefined();
+            expect(withPgClient).toHaveBeenCalledTimes(1);
+            // Timeout path must NOT mark reachable — that's the whole point.
+            expect(markPgReachableSpy).not.toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -26,7 +26,8 @@ import { SchedulerWorkerHealth } from './SchedulerWorkerHealth';
 import { TypedTaskList } from './types';
 
 export type SchedulerWorkerArguments = SchedulerTaskArguments & {
-    // When omitted, no per-pool workerHeartbeat task is registered and no enqueue interval runs.
+    // When omitted, no pg-ping interval runs and the health probe falls back to
+    // job-activity events alone.
     workerHealth?: SchedulerWorkerHealth;
 };
 
@@ -40,15 +41,12 @@ const workerLogger = new GraphileLogger(
     },
 );
 
-// 60s vs the 3-min staleness threshold gives 3x headroom for insert -> LISTEN -> handler latency.
-const HEARTBEAT_ENQUEUE_INTERVAL_MS = 60_000;
+// 60s vs the 3-min staleness threshold gives 3x headroom for ping latency.
+const PG_PING_INTERVAL_MS = 60_000;
 
-// Cap addJob: a wedged pg backend can leave the call hanging forever and pile up promises.
-const HEARTBEAT_ENQUEUE_TIMEOUT_MS = 10_000;
-
-// Full task name `${prefix}${poolId}` is registered only in its own pool's task list,
-// so the job-activity probe proves THIS pool's insert -> LISTEN -> handler pipeline.
-const PER_POOL_HEARTBEAT_TASK_PREFIX = 'workerHeartbeat:';
+// Cap each ping: a wedged pg backend can leave the query hanging forever and
+// stack up overlapping client borrows from the pool.
+const PG_PING_TIMEOUT_MS = 5_000;
 
 export class SchedulerWorker extends SchedulerTask {
     runner: Runner | undefined;
@@ -59,16 +57,12 @@ export class SchedulerWorker extends SchedulerTask {
 
     protected readonly workerHealth: SchedulerWorkerHealth | undefined;
 
-    private heartbeatEnqueueInterval: NodeJS.Timeout | null = null;
+    private pgPingInterval: NodeJS.Timeout | null = null;
 
     constructor(schedulerWorkerArgs: SchedulerWorkerArguments) {
         super(schedulerWorkerArgs);
         this.enabledTasks = this.lightdashConfig.scheduler.tasks;
         this.workerHealth = schedulerWorkerArgs.workerHealth;
-    }
-
-    private static getHeartbeatTaskName(health: SchedulerWorkerHealth): string {
-        return `${PER_POOL_HEARTBEAT_TASK_PREFIX}${health.getPoolId()}`;
     }
 
     async run() {
@@ -105,86 +99,74 @@ export class SchedulerWorker extends SchedulerTask {
 
         this.isRunning = true;
         if (this.workerHealth) {
-            this.startHeartbeatEnqueue(this.workerHealth);
+            this.startPgPing(this.workerHealth);
         }
         // Don't await this! This promise will never resolve, as the worker will keep running until the process is killed
         void this.runner.promise.finally(() => {
             this.isRunning = false;
-            this.stopHeartbeatEnqueue();
+            this.stopPgPing();
         });
     }
 
-    private startHeartbeatEnqueue(health: SchedulerWorkerHealth) {
-        if (this.heartbeatEnqueueInterval) return;
-        const taskName = SchedulerWorker.getHeartbeatTaskName(health);
-        void this.enqueueOwnHeartbeat(health);
-        this.heartbeatEnqueueInterval = setInterval(() => {
-            void this.enqueueOwnHeartbeat(health);
-        }, HEARTBEAT_ENQUEUE_INTERVAL_MS);
+    private startPgPing(health: SchedulerWorkerHealth) {
+        if (this.pgPingInterval) return;
+        void this.pingPgOnce(health);
+        this.pgPingInterval = setInterval(() => {
+            void this.pingPgOnce(health);
+        }, PG_PING_INTERVAL_MS);
         Logger.info(
-            `[scheduler-health] heartbeat-enqueue started poolId=${health.getPoolId()} taskName=${taskName} intervalMs=${HEARTBEAT_ENQUEUE_INTERVAL_MS}`,
+            `[scheduler-health] pg-ping started poolId=${health.getPoolId()} intervalMs=${PG_PING_INTERVAL_MS} timeoutMs=${PG_PING_TIMEOUT_MS}`,
         );
     }
 
-    private stopHeartbeatEnqueue() {
-        if (this.heartbeatEnqueueInterval) {
-            clearInterval(this.heartbeatEnqueueInterval);
-            this.heartbeatEnqueueInterval = null;
+    private stopPgPing() {
+        if (this.pgPingInterval) {
+            clearInterval(this.pgPingInterval);
+            this.pgPingInterval = null;
             if (this.workerHealth) {
                 Logger.info(
-                    `[scheduler-health] heartbeat-enqueue stopped poolId=${this.workerHealth.getPoolId()}`,
+                    `[scheduler-health] pg-ping stopped poolId=${this.workerHealth.getPoolId()}`,
                 );
             }
         }
     }
 
-    private async enqueueOwnHeartbeat(health: SchedulerWorkerHealth) {
-        const taskName = SchedulerWorker.getHeartbeatTaskName(health);
+    private async pingPgOnce(health: SchedulerWorkerHealth) {
         let timeoutHandle: NodeJS.Timeout | undefined;
         try {
             const graphileClient = await this.schedulerClient.graphileUtils;
-            const enqueue = graphileClient.addJob(
-                taskName,
-                {
-                    poolId: health.getPoolId(),
-                    enqueuedAt: new Date().toISOString(),
-                },
-                {
-                    // 'replace' only dedups unlocked rows; locked (in-flight) ones briefly produce a second row.
-                    jobKey: taskName,
-                    jobKeyMode: 'replace',
-                    maxAttempts: 1,
-                },
+            // withPgClient borrows from graphile's existing pool and releases the
+            // client back when the callback resolves — no long-lived client to leak.
+            const ping = graphileClient.withPgClient((pgClient) =>
+                pgClient.query('SELECT 1'),
             );
             await Promise.race([
-                enqueue,
+                ping,
                 new Promise<never>((_resolve, reject) => {
                     timeoutHandle = setTimeout(() => {
                         reject(
                             new Error(
-                                `addJob timeout after ${HEARTBEAT_ENQUEUE_TIMEOUT_MS}ms`,
+                                `pg ping timeout after ${PG_PING_TIMEOUT_MS}ms`,
                             ),
                         );
-                    }, HEARTBEAT_ENQUEUE_TIMEOUT_MS);
-                    // Don't keep the process alive solely for this timer.
+                    }, PG_PING_TIMEOUT_MS);
                     if (typeof timeoutHandle.unref === 'function')
                         timeoutHandle.unref();
                 }),
             ]);
+            health.markPgReachable();
             Logger.debug(
-                `[scheduler-health] heartbeat-enqueued poolId=${health.getPoolId()}`,
+                `[scheduler-health] pg-ping ok poolId=${health.getPoolId()}`,
             );
         } catch (e) {
-            // Sustained failure ages activity past staleness -> probe trips.
+            // Sustained failure ages lastPgReachableAt past staleness — combined
+            // with no job activity, the probe trips. A single failure is harmless.
             Logger.warn(
-                `[scheduler-health] heartbeat-enqueue-failed poolId=${health.getPoolId()} error=${getErrorMessage(
+                `[scheduler-health] pg-ping failed poolId=${health.getPoolId()} error=${getErrorMessage(
                     e,
                 )}`,
             );
         } finally {
-            // Clear whichever path resolved the race so the loser's timer
-            // doesn't linger as an "active timer" past this tick — Jest
-            // workers will otherwise force-exit and flag a leak.
             if (timeoutHandle) clearTimeout(timeoutHandle);
         }
     }
@@ -233,40 +215,19 @@ export class SchedulerWorker extends SchedulerTask {
                     maxAttempts: 3,
                 },
             },
-            {
-                task: SCHEDULER_TASKS.CLEAN_WORKER_HEARTBEATS,
-                pattern: '17 * * * *', // Hourly, offset from other cleanup tasks
-                options: {
-                    backfillPeriod: 2 * 3600 * 1000,
-                    maxAttempts: 3,
-                },
-            },
-            // workerHeartbeat is driven by per-pool setInterval (see startHeartbeatEnqueue);
+            // worker-process pg liveness is driven by a setInterval (see startPgPing);
             // managed-agent heartbeat is self-scheduling (see SchedulerClient.scheduleManagedAgentHeartbeat).
         ];
     }
 
     protected getTaskList(): Partial<TypedTaskList> {
-        const filteredTaskList = Object.fromEntries(
+        return Object.fromEntries(
             Object.entries(this.getFullTaskList()).filter(
                 ([taskKey]) =>
                     isSchedulerTaskName(taskKey) &&
                     this.enabledTasks.includes(taskKey),
             ),
-        );
-        if (!this.workerHealth) {
-            return filteredTaskList as Partial<TypedTaskList>;
-        }
-        // Task name is dynamic (workerHeartbeat:<poolId>) so it isn't in SchedulerTaskName — cast required.
-        const taskName = SchedulerWorker.getHeartbeatTaskName(
-            this.workerHealth,
-        );
-        return {
-            ...filteredTaskList,
-            [taskName]: (async () => {
-                // No-op — activity is tracked by the job:start listener in wireWorkerHealthEvents.
-            }) as TypedTaskList[keyof TypedTaskList],
-        } as Partial<TypedTaskList>;
+        ) as Partial<TypedTaskList>;
     }
 
     protected getFullTaskList(): TypedTaskList {
@@ -1150,42 +1111,6 @@ export class SchedulerWorker extends SchedulerTask {
                     throw error;
                 }
             },
-            [SCHEDULER_TASKS.CLEAN_WORKER_HEARTBEATS]: async () => {
-                // Per-pod heartbeat task names (workerHeartbeat:<poolId>) die with
-                // the pod that registered the handler. Old pods' rows then sit in
-                // graphile_worker.jobs forever — no current task list registers
-                // their task name, so get_job never fetches them. Live pools refresh
-                // their row every 60s via jobKey 'replace', so anything older than
-                // 10 minutes is provably orphaned — including rows still locked by
-                // a worker that died mid-heartbeat (graphile only auto-releases
-                // those after its much longer jobTimeout).
-                const graphileClient = await this.schedulerClient.graphileUtils;
-                try {
-                    const result = await graphileClient.withPgClient(
-                        (pgClient) =>
-                            pgClient.query<{ count: string }>(
-                                `WITH deleted AS (
-                                    DELETE FROM graphile_worker.jobs
-                                    WHERE task_identifier LIKE 'workerHeartbeat:%'
-                                      AND run_at < NOW() - INTERVAL '10 minutes'
-                                      AND (locked_at IS NULL OR locked_at < NOW() - INTERVAL '10 minutes')
-                                    RETURNING id
-                                )
-                                SELECT COUNT(*)::text AS count FROM deleted`,
-                            ),
-                    );
-                    const deleted = Number(result.rows[0]?.count ?? '0');
-                    Logger.info(
-                        `Orphan worker-heartbeat cleanup completed deleted=${deleted}`,
-                    );
-                } catch (error) {
-                    Logger.error(
-                        'Error during orphan worker-heartbeat cleanup:',
-                        error,
-                    );
-                    throw error;
-                }
-            },
             [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: async (
                 payload,
                 helpers,
@@ -1298,8 +1223,6 @@ export class SchedulerWorker extends SchedulerTask {
             [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: async () => {
                 // EE-only: implemented in CommercialSchedulerWorker
             },
-            // Fallback for manual operator enqueues; per-pool heartbeat uses workerHeartbeat:<poolId>.
-            [SCHEDULER_TASKS.WORKER_HEARTBEAT]: async () => {},
         };
     }
 }

--- a/packages/backend/src/scheduler/SchedulerWorkerHealth.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerHealth.test.ts
@@ -99,7 +99,7 @@ describe('SchedulerWorkerHealth', () => {
         const result = health.isHealthy(startedAt + GRACE_MS + 1);
         expect(result.ok).toBe(false);
         expect(result.reason).toBe(
-            'no job activity within staleness threshold',
+            'no job activity or pg ping within staleness threshold',
         );
     });
 
@@ -125,7 +125,7 @@ describe('SchedulerWorkerHealth', () => {
         const result = health.isHealthy(activityAt + GRACE_MS + 1);
         expect(result.ok).toBe(false);
         expect(result.reason).toBe(
-            'no job activity within staleness threshold',
+            'no job activity or pg ping within staleness threshold',
         );
     });
 
@@ -202,6 +202,61 @@ describe('SchedulerWorkerHealth', () => {
             expect(result.reason).toMatch(/^LISTEN connection lost/);
         });
     });
+
+    describe('pg-reachable signal', () => {
+        it('keeps the probe healthy past staleness when only pg-ping is fresh', () => {
+            // The exact scenario this refactor exists to fix: no jobs flowed
+            // for longer than the activity staleness window, but pg-ping has
+            // proven the worker can still reach pg in the last 60s. Probe
+            // must NOT trip — the worker is healthy, just idle.
+            const health = new SchedulerWorkerHealth();
+            const startedAt = Date.now();
+
+            const pingAt = startedAt + GRACE_MS + 4 * 60_000;
+            Date.now = () => pingAt;
+            health.markPgReachable();
+
+            expect(health.isHealthy(pingAt + 60_000)).toEqual({ ok: true });
+        });
+
+        it('trips when both job activity and pg-ping are stale', () => {
+            const health = new SchedulerWorkerHealth();
+            const startedAt = Date.now();
+
+            const activityAt = startedAt + GRACE_MS + 1_000;
+            Date.now = () => activityAt;
+            health.markJobActivity();
+            health.markPgReachable();
+
+            const result = health.isHealthy(activityAt + GRACE_MS + 1);
+            expect(result.ok).toBe(false);
+            expect(result.reason).toBe(
+                'no job activity or pg ping within staleness threshold',
+            );
+        });
+
+        it('reports LISTEN failure even when pg ping is still fresh', () => {
+            // LISTEN and pg-ping cover different failure modes — a wedged
+            // LISTEN connection with healthy plain pg queries is the May
+            // wire-protocol corruption pattern, and the probe must trip.
+            const health = new SchedulerWorkerHealth();
+            const t = Date.now();
+            health.markPgReachable();
+            health.markListenLost();
+
+            const result = health.isHealthy(t + LISTEN_BUDGET_MS + 1);
+            expect(result.ok).toBe(false);
+            expect(result.reason).toMatch(/^LISTEN connection lost/);
+        });
+
+        it('treats a successful ping during startup as evidence the worker has progressed past "starting"', () => {
+            // classifyState should consider the worker healthy (not starting)
+            // once any liveness signal has fired, even before the first job.
+            const health = new SchedulerWorkerHealth();
+            health.markPgReachable();
+            expect(health.isHealthy()).toEqual({ ok: true });
+        });
+    });
 });
 
 describe('derivePoolIdFromEnv — multi-replica uniqueness', () => {
@@ -245,7 +300,8 @@ describe('derivePoolIdFromEnv — multi-replica uniqueness', () => {
 
     it('produces distinct poolIds for two replicas with different pod names', () => {
         // This is THE regression being guarded — pre-fix, both replicas
-        // received the same hardcoded 'scheduler-app' poolId.
+        // received the same hardcoded 'scheduler-app' poolId, collapsing
+        // their log streams under a single identifier.
         const replicaA = derivePoolIdFromEnv({
             HOSTNAME: 'scheduler-deployment-7df9c-aaa11',
         });
@@ -256,13 +312,6 @@ describe('derivePoolIdFromEnv — multi-replica uniqueness', () => {
         expect(replicaA).toBe('scheduler-deployment-7df9c-aaa11');
         expect(replicaB).toBe('scheduler-deployment-7df9c-bbb22');
         expect(replicaA).not.toBe(replicaB);
-
-        // And the downstream task names that drive the per-pool routing
-        // must also differ — this is what graphile-worker uses to decide
-        // which runner can fetch a given workerHeartbeat:* job.
-        const taskA = `workerHeartbeat:${replicaA}`;
-        const taskB = `workerHeartbeat:${replicaB}`;
-        expect(taskA).not.toBe(taskB);
     });
 
     it('uses the random fallback when env yields nothing — distinct replicas still differ', () => {

--- a/packages/backend/src/scheduler/SchedulerWorkerHealth.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerHealth.ts
@@ -4,6 +4,10 @@ const LISTEN_RECOVERY_BUDGET_MS = 60_000;
 
 const JOB_ACTIVITY_STALENESS_MS = 3 * 60_000;
 
+// A successful pg ping within this window proves the worker process can still
+// reach the database, even when no graphile-worker job has fired recently.
+const PG_REACHABLE_STALENESS_MS = 3 * 60_000;
+
 // Per-pod unique poolId — replicas sharing one would collapse to a single dedup'd heartbeat row,
 // leaving all but the lock-winning replica's activity clock to age past staleness.
 export const derivePoolIdFromEnv = (
@@ -24,6 +28,8 @@ export class SchedulerWorkerHealth {
 
     private lastJobActivityAt: number | null = null;
 
+    private lastPgReachableAt: number | null = null;
+
     private inFlightJobCount: number = 0;
 
     private startedAt: number = Date.now();
@@ -35,7 +41,7 @@ export class SchedulerWorkerHealth {
         Logger.info(
             `[scheduler-health] initialized poolId=${this.poolId} startedAt=${new Date(
                 this.startedAt,
-            ).toISOString()} listenBudgetMs=${LISTEN_RECOVERY_BUDGET_MS} activityStalenessMs=${JOB_ACTIVITY_STALENESS_MS}`,
+            ).toISOString()} listenBudgetMs=${LISTEN_RECOVERY_BUDGET_MS} activityStalenessMs=${JOB_ACTIVITY_STALENESS_MS} pgReachableStalenessMs=${PG_REACHABLE_STALENESS_MS}`,
         );
     }
 
@@ -90,6 +96,18 @@ export class SchedulerWorkerHealth {
         this.markJobActivity();
     }
 
+    markPgReachable() {
+        const now = Date.now();
+        const ageMs =
+            this.lastPgReachableAt === null
+                ? null
+                : now - this.lastPgReachableAt;
+        this.lastPgReachableAt = now;
+        Logger.debug(
+            `[scheduler-health] pg-reachable poolId=${this.poolId} previousAgeMs=${ageMs}`,
+        );
+    }
+
     getInFlightJobCount(): number {
         return this.inFlightJobCount;
     }
@@ -126,28 +144,39 @@ export class SchedulerWorkerHealth {
             return { ok: true };
         }
 
-        if (
-            this.lastJobActivityAt === null ||
-            now - this.lastJobActivityAt > JOB_ACTIVITY_STALENESS_MS
-        ) {
-            return {
-                ok: false,
-                reason: 'no job activity within staleness threshold',
-            };
+        const jobActivityFresh =
+            this.lastJobActivityAt !== null &&
+            now - this.lastJobActivityAt <= JOB_ACTIVITY_STALENESS_MS;
+        if (jobActivityFresh) {
+            return { ok: true };
         }
 
-        return { ok: true };
+        // pg ping runs independently of the job queue, so it stays fresh during
+        // idle stretches between bursts when no job:start fires.
+        const pgReachableFresh =
+            this.lastPgReachableAt !== null &&
+            now - this.lastPgReachableAt <= PG_REACHABLE_STALENESS_MS;
+        if (pgReachableFresh) {
+            return { ok: true };
+        }
+
+        return {
+            ok: false,
+            reason: 'no job activity or pg ping within staleness threshold',
+        };
     }
 
     private static classifyState(
         result: HealthCheckResult,
         ageSinceStartMs: number,
         lastJobActivityAt: number | null,
+        lastPgReachableAt: number | null,
     ): HealthState {
         if (!result.ok) return 'unhealthy';
         if (
             ageSinceStartMs < JOB_ACTIVITY_STALENESS_MS &&
-            lastJobActivityAt === null
+            lastJobActivityAt === null &&
+            lastPgReachableAt === null
         ) {
             return 'starting';
         }
@@ -159,6 +188,7 @@ export class SchedulerWorkerHealth {
             result,
             now - this.startedAt,
             this.lastJobActivityAt,
+            this.lastPgReachableAt,
         );
         if (newState !== this.lastReportedState) {
             Logger.info(

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -89,8 +89,6 @@ export const SCHEDULER_TASKS = {
     CHECK_FOR_STUCK_JOBS: 'checkForStuckJobs',
     CLEAN_DEPLOY_SESSIONS: 'cleanDeploySessions',
     MANAGED_AGENT_HEARTBEAT: 'managedAgentHeartbeat',
-    WORKER_HEARTBEAT: 'workerHeartbeat',
-    CLEAN_WORKER_HEARTBEATS: 'cleanWorkerHeartbeats',
     ...EE_SCHEDULER_TASKS,
 } as const;
 
@@ -132,8 +130,6 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: TraceTaskBase;
     [SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS]: TraceTaskBase;
     [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: ManagedAgentHeartbeatPayload;
-    [SCHEDULER_TASKS.WORKER_HEARTBEAT]: TraceTaskBase;
-    [SCHEDULER_TASKS.CLEAN_WORKER_HEARTBEATS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;


### PR DESCRIPTION
## Summary

- The current scheduler health probe enqueues a `workerHeartbeat:<poolId>` graphile-worker job every 60s and refreshes `lastJobActivityAt` off `job:start`. On pods with saturated concurrency the heartbeat row sits queued waiting for a slot, is overwritten by the next tick (`jobKeyMode: 'replace'`), and never reaches a handler. After bursts of real work, the activity clock then ages past the staleness threshold during idle stretches and the probe flaps.
- Replace it with a `setInterval` that runs `SELECT 1` through `graphileUtils.withPgClient` every 60s with a 5s per-call timeout. `withPgClient` borrows from the existing pg pool and releases the client when the callback resolves, so there's no long-lived client to leak.
- On success, the ping stamps a new `lastPgReachableAt` timestamp on `SchedulerWorkerHealth`. `computeHealth` ORs it into the existing checks: in-flight jobs → fresh job activity → fresh pg ping → otherwise unhealthy. `pool:listen:error` / `pool:listen:success` continue to feed `markListenLost` / `markListenUp`, so the wire-protocol-corruption failure mode is still detected independently.

## What's removed

- `SCHEDULER_TASKS.WORKER_HEARTBEAT` and `SCHEDULER_TASKS.CLEAN_WORKER_HEARTBEATS` (plus their payload-map entries).
- The hourly `cleanWorkerHeartbeats` cron and its `DELETE FROM graphile_worker.jobs … WHERE task_identifier LIKE 'workerHeartbeat:%'` handler — no rows are produced so nothing needs reaping.
- `startHeartbeatEnqueue` / `enqueueOwnHeartbeat` / `stopHeartbeatEnqueue` and the dynamic per-pool task-name injection in `getTaskList`.
- `TRACE_SKIP_PREFIX` and the bypass for `workerHeartbeat:<poolId>` in `SchedulerTaskTracer` — no dynamic task names enter the tracer anymore.

## Why this is safer

- Heartbeat liveness is no longer coupled to graphile-worker's concurrency budget — long-running jobs cannot starve the probe.
- The signal tested is exactly the one the previous wedge required: can this worker process talk to pg?
- One query per minute on a reusable client; negligible pool pressure.
- The activity-event short-circuits (in-flight count, recent `job:start`/`job:complete`) and the LISTEN budget all remain, so multiple independent signals contribute to "healthy".

## Test plan

- [x] `pnpm -F common typecheck`
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend test` covering `SchedulerWorkerHealth.test.ts`, `SchedulerWorker.heartbeat.test.ts`, `SchedulerTaskTracer.test.ts`, `SchedulerWorkerEventEmitter.test.ts` (43 tests) and adjacent `SchedulerWorker.test.ts`, `SchedulerTask.test.ts`, `parseConfig.test.ts` (116 tests)
- [x] eslint on changed files in backend + common
- [ ] Soak in a non-prod environment for one staleness window with concurrency intentionally saturated, confirm no false-positive `/api/v1/health` 503s
- [ ] Manually break pg connectivity (e.g. `pg_terminate_backend` on the ping connection or block port 5432 briefly) and confirm the probe flips to unhealthy within ~3 min once both job activity and ping ages exceed staleness

🤖 Generated with [Claude Code](https://claude.com/claude-code)