### PR TITLE
feat(ai-agent): aggregate Slack message across consecutive runSql + block information_schema server-side

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3994,7 +3994,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             slackPrompt.promptUuid,
         );
 
-        const feedbackBlocks = getFeedbackBlocks(slackPrompt, threadArtifacts);
+        const feedbackBlocks = agent
+            ? getFeedbackBlocks(
+                  slackPrompt,
+                  agent.uuid,
+                  this.lightdashConfig.siteUrl,
+              )
+            : [];
         const followUpToolBlocks = getFollowUpToolBlocks(
             slackPrompt,
             threadArtifacts,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -145,6 +145,7 @@ import {
 import { AiAgentArgs, AiAgentDependencies } from '../ai/types/aiAgent';
 import {
     CreateChangeFn,
+    DescribeWarehouseTableFn,
     FindContentFn,
     FindExploresFn,
     FindFieldFn,
@@ -3186,6 +3187,48 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 () => this.projectService.getWarehouseTables(user, projectUuid),
             );
 
+        const describeWarehouseTable: DescribeWarehouseTableFn = ({
+            table,
+            schema,
+        }) =>
+            wrapSentryTransaction(
+                'AiAgent.describeWarehouseTable',
+                { projectUuid, table, schema: schema ?? null },
+                async () => {
+                    // When the agent doesn't pass a schema, fall back to the
+                    // project's default schema (same fallback the runSql
+                    // system prompt uses). getWarehouseFields throws if it
+                    // ends up undefined.
+                    let resolvedSchema = schema ?? null;
+                    if (!resolvedSchema) {
+                        const creds =
+                            await this.projectModel.getWarehouseCredentialsForProject(
+                                projectUuid,
+                            );
+                        resolvedSchema = creds
+                            ? ('schema' in creds && creds.schema) ||
+                              ('dataset' in creds && creds.dataset) ||
+                              null ||
+                              null
+                            : null;
+                    }
+                    const fields = await this.projectService.getWarehouseFields(
+                        user,
+                        projectUuid,
+                        QueryExecutionContext.AI,
+                        table,
+                        resolvedSchema ?? undefined,
+                    );
+                    return {
+                        columns: Object.entries(fields).map(([name, type]) => ({
+                            name,
+                            type: String(type),
+                        })),
+                        resolvedSchema,
+                    };
+                },
+            );
+
         const sendSlackBlocks: SendSlackBlocksFn = async (args) =>
             wrapSentryTransaction(
                 'AiAgent.sendSlackBlocks',
@@ -3395,6 +3438,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             runAsyncQuery,
             runSqlJob,
             listWarehouseTables,
+            describeWarehouseTable,
             getSavedChart,
             sendFile,
             sendSlackBlocks,
@@ -3476,6 +3520,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             runAsyncQuery,
             runSqlJob,
             listWarehouseTables,
+            describeWarehouseTable,
             getSavedChart,
             sendFile,
             sendSlackBlocks,
@@ -3595,6 +3640,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             runAsyncQuery,
             runSqlJob,
             listWarehouseTables,
+            describeWarehouseTable,
             getSavedChart,
             getPrompt,
             sendFile,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -179,6 +179,7 @@ import {
     getReferencedArtifactsBlocks,
     getTextBlocks,
     getThinkingBlocks,
+    getViewInLightdashBlocks,
 } from '../ai/utils/getSlackBlocks';
 import { llmAsAJudge } from '../ai/utils/llmAsAJudge';
 import { populateCustomMetricsSQL } from '../ai/utils/populateCustomMetricsSQL';
@@ -3994,8 +3995,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             slackPrompt.promptUuid,
         );
 
-        const feedbackBlocks = agent
-            ? getFeedbackBlocks(
+        const feedbackBlocks = getFeedbackBlocks(slackPrompt, toolResults);
+        const viewInLightdashBlocks = agent
+            ? getViewInLightdashBlocks(
                   slackPrompt,
                   agent.uuid,
                   this.lightdashConfig.siteUrl,
@@ -4076,6 +4078,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ...referencedArtifactsBlocks,
             ...followUpToolBlocks,
             ...feedbackBlocks,
+            ...viewInLightdashBlocks,
             ...(historyBlocks || []),
         ];
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -179,7 +179,6 @@ import {
     getReferencedArtifactsBlocks,
     getTextBlocks,
     getThinkingBlocks,
-    getViewInLightdashBlocks,
 } from '../ai/utils/getSlackBlocks';
 import { llmAsAJudge } from '../ai/utils/llmAsAJudge';
 import { populateCustomMetricsSQL } from '../ai/utils/populateCustomMetricsSQL';
@@ -3995,10 +3994,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             slackPrompt.promptUuid,
         );
 
-        const feedbackBlocks = getFeedbackBlocks(slackPrompt, toolResults);
-        const viewInLightdashBlocks = agent
-            ? getViewInLightdashBlocks(
+        const feedbackBlocks = agent
+            ? getFeedbackBlocks(
                   slackPrompt,
+                  toolResults,
                   agent.uuid,
                   this.lightdashConfig.siteUrl,
               )
@@ -4078,7 +4077,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ...referencedArtifactsBlocks,
             ...followUpToolBlocks,
             ...feedbackBlocks,
-            ...viewInLightdashBlocks,
             ...(historyBlocks || []),
         ];
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -163,6 +163,7 @@ import {
     StoreToolCallFn,
     StoreToolResultsFn,
     UpdateProgressFn,
+    UpdateSlackMessageFn,
 } from '../ai/types/aiAgentDependencies';
 import { getUserFacingErrorMessage } from '../ai/utils/errorMessages';
 import {
@@ -3190,10 +3191,28 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 'AiAgent.sendSlackBlocks',
                 { channelId: args.channelId },
                 async () => {
-                    await this.slackClient.postMessage({
+                    const response = await this.slackClient.postMessage({
                         organizationUuid: args.organizationUuid,
                         channel: args.channelId,
                         thread_ts: args.threadTs,
+                        text: args.text,
+                        blocks: args.blocks,
+                    });
+                    return { ts: (response?.ts ?? '') as string };
+                },
+            );
+
+        const updateSlackMessage: UpdateSlackMessageFn = async (args) =>
+            wrapSentryTransaction(
+                'AiAgent.updateSlackMessage',
+                { channelId: args.channelId },
+                async () => {
+                    const webClient = await this.slackClient.getWebClient(
+                        args.organizationUuid,
+                    );
+                    await webClient.chat.update({
+                        channel: args.channelId,
+                        ts: args.ts,
                         text: args.text,
                         blocks: args.blocks,
                     });
@@ -3379,6 +3398,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             getSavedChart,
             sendFile,
             sendSlackBlocks,
+            updateSlackMessage,
             storeToolCall,
             storeToolResults,
             storeReasoning,
@@ -3459,6 +3479,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             getSavedChart,
             sendFile,
             sendSlackBlocks,
+            updateSlackMessage,
             storeToolCall,
             storeToolResults,
             storeReasoning,
@@ -3578,6 +3599,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             getPrompt,
             sendFile,
             sendSlackBlocks,
+            updateSlackMessage,
             storeToolCall,
             storeToolResults,
             storeReasoning,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -174,6 +174,7 @@ import {
     getDeepLinkBlocks,
     getFeedbackBlocks,
     getFollowUpToolBlocks,
+    getMarkdownBlocks,
     getProposeChangeBlocks,
     getReferencedArtifactsBlocks,
     getTextBlocks,
@@ -4052,17 +4053,18 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                   )
                 : [];
 
-        // ! This is needed because the markdownToBlocks escapes all characters and slack just needs &, <, > to be escaped
-        // ! https://api.slack.com/reference/surfaces/formatting#escaping
-        // Also strip trailing backslashes before newlines — slackifyMarkdown converts
-        // markdown hard line breaks (two trailing spaces) into `\` which Slack renders literally.
+        // Slack's `markdown` block renders GitHub-flavoured markdown natively,
+        // including tables — which the older mrkdwn-via-section path strips
+        // into pipe-text. We pass the agent's raw response straight through
+        // for the rich rendering, and keep slackifyMarkdown for the message-
+        // level `text` field that drives notifications + older client fallback.
         const slackifiedMarkdown = slackifyMarkdown(response).replace(
             /\\\n/g,
             '\n',
         );
 
         const blocks = [
-            ...getTextBlocks(slackifiedMarkdown),
+            ...getMarkdownBlocks(response),
             ...exploreBlocks,
             ...proposeChangeBlocks,
             ...referencedArtifactsBlocks,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -133,7 +133,6 @@ const getAgentTools = (
               runSqlJob: dependencies.runSqlJob,
               getPrompt: dependencies.getPrompt,
               sendFile: dependencies.sendFile,
-              sendSlackBlocks: dependencies.sendSlackBlocks,
               updateSlackMessage: dependencies.updateSlackMessage,
           })
         : null;

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -11,6 +11,7 @@ import {
 } from 'ai';
 import Logger from '../../../../logging/logger';
 import { getSystemPromptV2 } from '../prompts/systemV2';
+import { getDescribeWarehouseTable } from '../tools/describeWarehouseTable';
 import { getFindContent } from '../tools/findContent';
 import { getFindExplores } from '../tools/findExplores';
 import { getFindFields } from '../tools/findFields';
@@ -143,6 +144,12 @@ const getAgentTools = (
           })
         : null;
 
+    const describeWarehouseTable = args.canRunSql
+        ? getDescribeWarehouseTable({
+              describeWarehouseTable: dependencies.describeWarehouseTable,
+          })
+        : null;
+
     const generateDashboard = getGenerateDashboardV2({
         getPrompt: dependencies.getPrompt,
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
@@ -174,6 +181,7 @@ const getAgentTools = (
         ...(args.enableDataAccess ? { searchFieldValues } : {}),
         ...(runSql ? { runSql } : {}),
         ...(listWarehouseTables ? { listWarehouseTables } : {}),
+        ...(describeWarehouseTable ? { describeWarehouseTable } : {}),
     };
 
     logger(

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -133,6 +133,7 @@ const getAgentTools = (
               getPrompt: dependencies.getPrompt,
               sendFile: dependencies.sendFile,
               sendSlackBlocks: dependencies.sendSlackBlocks,
+              updateSlackMessage: dependencies.updateSlackMessage,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -134,6 +134,7 @@ const getAgentTools = (
               getPrompt: dependencies.getPrompt,
               sendFile: dependencies.sendFile,
               updateSlackMessage: dependencies.updateSlackMessage,
+              siteUrl: args.siteUrl,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/prompts/systemV2RunSql.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2RunSql.ts
@@ -49,11 +49,16 @@ You have access to a runSql tool that executes raw SELECT queries directly again
 
 Every \`runSql\` call costs the user an approval click. Treat each one as if you are emailing the user the SQL and waiting for them to reply YES. If you would not send this SQL to a busy human, do not call \`runSql\`.
 
-**1. ZERO \`information_schema\`.** The agent has access to \`findExplores\`, \`findFields\`, and \`listWarehouseTables\`. These return schema/columns/types directly from Lightdash's cached metadata. There is **no scenario** in which querying \`information_schema.columns\` or \`information_schema.tables\` is the right move.
+**1. ZERO \`information_schema\`.** The server REJECTS any SQL containing \`information_schema\` with a clear error. You have four discovery tools that cover every legitimate use case:
 
-- ❌ NEVER: \`SELECT column_name FROM information_schema.columns WHERE table_name = '...'\`
-- ❌ NEVER: \`SELECT table_name FROM information_schema.tables\`
-- ✅ INSTEAD: call \`findFields\` for explore-backed tables; \`listWarehouseTables\` for raw/staging tables. If neither returns what you need, **ASK THE USER**.
+- \`findExplores\` — list explores in the project
+- \`findFields\` — columns + types for an **explore-backed** table
+- \`listWarehouseTables\` — names of raw / staging / seed tables
+- \`describeWarehouseTable\` — columns + types for a **raw** warehouse table
+
+- ❌ NEVER: \`SELECT column_name FROM information_schema.columns WHERE table_name = '...'\` — use \`describeWarehouseTable({ table: '...' })\` instead
+- ❌ NEVER: \`SELECT table_name FROM information_schema.tables\` — use \`listWarehouseTables\` instead
+- ✅ INSTEAD: pick the right discovery tool above. If none of them returns what you need, **ASK THE USER**.
 
 **2. ZERO \`SELECT *\` sampling.** \`findFields\` already tells you the columns and types. Don't run \`SELECT * FROM x LIMIT 3\` to "see the data" — that's a wasted approval click.
 
@@ -66,11 +71,15 @@ Every \`runSql\` call costs the user an approval click. Treat each one as if you
 - ✅ GOOD: one query with 3 CTEs that produces the final answer
 - ❌ BAD: query 1 to "check the schema", query 2 to "sample rows", query 3 to actually answer
 
-**4. STOP after one failed query.** If a \`runSql\` returns "column does not exist", "relation not found", an empty result you didn't expect, or anything that suggests the data model doesn't match your assumption — **do not run another \`runSql\`**. Tell the user:
+**4. Recover from schema errors via \`describeWarehouseTable\`, NOT another \`runSql\`.** If your \`runSql\` failed with "column does not exist" or "relation not found":
 
-> "I expected \`X\` but the data model has \`Y\` instead. The relationship you're asking about isn't modelled here. Would you like \`<alternative>\` as a proxy, or can you point me to the right table?"
+1. Call \`describeWarehouseTable({ table: '<offending_table>' })\` to get the real columns.
+2. Rewrite the SQL once with the correct columns and submit it.
+3. If \`describeWarehouseTable\` shows the relationship you need genuinely doesn't exist (e.g. no foreign key, no junction table), STOP and tell the user:
 
-This is non-negotiable. Iterating on missing-schema errors burns the user's time and approval clicks.
+   > "I expected \`X\` but \`raw_parts\` actually has columns \`[...]\` — there's no \`work_order_id\`. The relationship you're asking about isn't modelled here. Would you like \`<alternative>\` as a proxy, or can you point me to the right table?"
+
+NEVER guess column names across multiple \`runSql\` calls. Discovery is free; SQL costs an approval click.
 
 **5. Schema qualification on the first attempt.** ${schemaLine}
 

--- a/packages/backend/src/ee/services/ai/tools/describeWarehouseTable.ts
+++ b/packages/backend/src/ee/services/ai/tools/describeWarehouseTable.ts
@@ -1,0 +1,51 @@
+import { toolDescribeWarehouseTableArgsSchema } from '@lightdash/common';
+import { tool } from 'ai';
+import type { DescribeWarehouseTableFn } from '../types/aiAgentDependencies';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+
+type Dependencies = {
+    describeWarehouseTable: DescribeWarehouseTableFn;
+};
+
+export const getDescribeWarehouseTable = ({
+    describeWarehouseTable,
+}: Dependencies) =>
+    tool({
+        description: toolDescribeWarehouseTableArgsSchema.description,
+        inputSchema: toolDescribeWarehouseTableArgsSchema,
+        execute: async ({ table, schema }) => {
+            try {
+                const { columns, resolvedSchema } =
+                    await describeWarehouseTable({ table, schema });
+
+                if (columns.length === 0) {
+                    return {
+                        result: `No columns found for \`${
+                            resolvedSchema ?? schema ?? '(default schema)'
+                        }.${table}\`. The table may not exist or may be empty of metadata. Confirm the name via listWarehouseTables or ask the user.`,
+                        metadata: { status: 'not_found' },
+                    };
+                }
+
+                const qualified = `${
+                    resolvedSchema ?? schema ?? '(default schema)'
+                }.${table}`;
+                const columnLines = columns
+                    .map((c) => `  - ${c.name}: ${c.type}`)
+                    .join('\n');
+
+                return {
+                    result: `Columns for \`${qualified}\` (${columns.length}):\n${columnLines}`,
+                    metadata: { status: 'success' },
+                };
+            } catch (e) {
+                return {
+                    result: toolErrorHandler(
+                        e,
+                        'Error describing warehouse table.',
+                    ),
+                    metadata: { status: 'error' },
+                };
+            }
+        },
+    });

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -17,10 +17,9 @@ import { serializeData } from '../utils/serializeData';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import {
     getAggregate,
-    renderAggregateBlocks,
+    renderBlocks,
     setAggregate,
-    upsertSection,
-    type AggregateSection,
+    setCurrentState,
     type SectionState,
 } from './slackSqlAggregate';
 import {
@@ -52,6 +51,8 @@ const FORBIDDEN_STATEMENTS =
 const INFORMATION_SCHEMA = /\binformation_schema\b/i;
 
 const PREVIEW_ROW_LIMIT = 50;
+const SLACK_INLINE_ROW_LIMIT = 10;
+const LARGE_RESULT_THRESHOLD = 25;
 
 const validateSelectOnly = (sql: string) => {
     const stripped = stripCommentsAndStrings(sql);
@@ -82,113 +83,95 @@ export const getRunSql = ({
         description: toolRunSqlArgsSchema.description,
         inputSchema: toolRunSqlArgsSchema,
         execute: async ({ sql, limit }, { toolCallId }) => {
+            // Pre-section errors (bad SQL shape) — no Slack message exists
+            // yet, just return the error to the agent.
             try {
                 validateSelectOnly(sql);
-
-                const prompt = await getPrompt();
-                const isSlack = isSlackPrompt(prompt);
-                const slackAutoApproved =
-                    isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
-
-                // Helper: push a new state for this section and re-render the
-                // aggregate Slack message. No-op when not in Slack.
-                const updateSection = async (state: SectionState) => {
-                    if (!isSlack) return;
-                    const section: AggregateSection = {
-                        toolCallId,
-                        threadUuid: prompt.threadUuid,
-                        state,
-                    };
-                    upsertSection(prompt.promptUuid, section);
-                    const agg = getAggregate(prompt.promptUuid);
-                    if (!agg) return;
-                    await updateSlackMessage({
-                        channelId: agg.channelId,
-                        organizationUuid: prompt.organizationUuid,
-                        ts: agg.messageTs,
-                        text: 'SQL execution',
-                        blocks: renderAggregateBlocks(agg),
-                    });
+            } catch (e) {
+                return {
+                    result: toolErrorHandler(e, 'Error running SQL query.'),
+                    metadata: { status: 'error' },
                 };
+            }
 
+            const prompt = await getPrompt();
+            const isSlack = isSlackPrompt(prompt);
+            const slackAutoApproved =
+                isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
+
+            // Push a state into the single living Slack message for this
+            // prompt. First call creates the message; subsequent calls
+            // (re-runs in the same turn) mutate it via chat.update.
+            const renderState = async (state: SectionState) => {
+                if (!isSlack) return;
+                const existing = getAggregate(prompt.promptUuid);
+                const blocks = renderBlocks(state);
+                if (!existing) {
+                    const { ts } = await sendSlackBlocks({
+                        channelId: prompt.slackChannelId,
+                        threadTs: prompt.slackThreadTs,
+                        organizationUuid: prompt.organizationUuid,
+                        text: 'SQL execution',
+                        blocks,
+                    });
+                    if (ts) {
+                        setAggregate(prompt.promptUuid, {
+                            channelId: prompt.slackChannelId,
+                            messageTs: ts,
+                            current: state,
+                        });
+                    }
+                    return;
+                }
+                setCurrentState(prompt.promptUuid, state);
+                await updateSlackMessage({
+                    channelId: existing.channelId,
+                    organizationUuid: prompt.organizationUuid,
+                    ts: existing.messageTs,
+                    text: 'SQL execution',
+                    blocks,
+                });
+            };
+
+            try {
                 if (slackAutoApproved) {
                     await updateProgress('Running SQL query...');
+                    await renderState({ kind: 'approved', sql });
                 } else {
                     await updateProgress('Awaiting approval to run SQL...');
+                    await renderState({
+                        kind: 'pending',
+                        sql,
+                        toolCallId,
+                        threadUuid: prompt.threadUuid,
+                    });
                 }
 
                 // Register the approval listener first, then trigger any
                 // auto-approval (the EventEmitter delivers synchronously, so
-                // the order matters).
+                // order matters).
                 const decisionPromise = waitForSqlApproval(toolCallId);
-
-                if (isSlack) {
-                    const initialState: SectionState = slackAutoApproved
-                        ? { kind: 'approved', sql }
-                        : { kind: 'pending', sql };
-                    const section: AggregateSection = {
-                        toolCallId,
-                        threadUuid: prompt.threadUuid,
-                        state: initialState,
-                    };
-                    const existing = getAggregate(prompt.promptUuid);
-                    if (!existing) {
-                        // First runSql in this turn — post a new aggregate
-                        // message and remember its ts so subsequent calls
-                        // can edit it in place.
-                        const { ts } = await sendSlackBlocks({
-                            channelId: prompt.slackChannelId,
-                            threadTs: prompt.slackThreadTs,
-                            organizationUuid: prompt.organizationUuid,
-                            text: 'SQL execution',
-                            blocks: renderAggregateBlocks({
-                                channelId: prompt.slackChannelId,
-                                messageTs: '',
-                                sections: [section],
-                            }),
-                        });
-                        if (ts) {
-                            setAggregate(prompt.promptUuid, {
-                                channelId: prompt.slackChannelId,
-                                messageTs: ts,
-                                sections: [section],
-                            });
-                        }
-                    } else {
-                        // Append a new section to the existing aggregate
-                        // message and update it in place.
-                        existing.sections.push(section);
-                        await updateSlackMessage({
-                            channelId: existing.channelId,
-                            organizationUuid: prompt.organizationUuid,
-                            ts: existing.messageTs,
-                            text: 'SQL execution',
-                            blocks: renderAggregateBlocks(existing),
-                        });
-                    }
-                }
-
                 if (slackAutoApproved) {
                     resolveSqlApproval(toolCallId, 'approved');
                 }
 
                 const decision = await decisionPromise;
                 if (decision === 'rejected') {
-                    await updateSection({ kind: 'rejected', sql });
+                    await renderState({ kind: 'rejected', sql });
                     return {
                         result: 'User rejected this SQL execution. Do not retry the same query; ask the user what they would like instead.',
                         metadata: { status: 'rejected' },
                     };
                 }
                 if (decision === 'timeout') {
-                    await updateSection({ kind: 'timeout', sql });
+                    await renderState({ kind: 'timeout', sql });
                     return {
                         result: 'SQL approval timed out after 5 minutes with no response. The user may have stepped away — acknowledge politely and wait for them to re-ask.',
                         metadata: { status: 'timeout' },
                     };
                 }
 
-                await updateSection({ kind: 'running', sql });
+                await renderState({ kind: 'running', sql });
                 await updateProgress('Running SQL query...');
 
                 const { rows, columns, rowCount } = await runSqlJob({
@@ -197,7 +180,7 @@ export const getRunSql = ({
                 });
 
                 if (rowCount === 0) {
-                    await updateSection({
+                    await renderState({
                         kind: 'success',
                         sql,
                         rowCount: 0,
@@ -221,18 +204,10 @@ export const getRunSql = ({
                             return acc;
                         }, {}),
                     ),
-                    {
-                        header: true,
-                        columns,
-                    },
+                    { header: true, columns },
                 );
 
-                // For Slack: collapse the prior approval section into an
-                // inline result preview. Only upload the full CSV file when
-                // the result is large enough to justify a separate attachment.
                 if (isSlack) {
-                    const SLACK_INLINE_ROW_LIMIT = 10;
-                    const LARGE_RESULT_THRESHOLD = 25;
                     const inlineRows = rows.slice(0, SLACK_INLINE_ROW_LIMIT);
                     const inlineCsv = stringify(
                         inlineRows.map((row) =>
@@ -247,7 +222,7 @@ export const getRunSql = ({
                         { header: true, columns },
                     );
 
-                    await updateSection({
+                    await renderState({
                         kind: 'success',
                         sql,
                         rowCount,
@@ -255,6 +230,8 @@ export const getRunSql = ({
                         truncated: rowCount > SLACK_INLINE_ROW_LIMIT,
                     });
 
+                    // Slack chat.update can't attach files, so the full CSV
+                    // for large results still goes as a separate message.
                     if (rowCount > LARGE_RESULT_THRESHOLD) {
                         await sendFile({
                             channelId: prompt.slackChannelId,
@@ -276,10 +253,7 @@ export const getRunSql = ({
                             return acc;
                         }, {}),
                     ),
-                    {
-                        header: true,
-                        columns,
-                    },
+                    { header: true, columns },
                 );
 
                 const truncatedNote =
@@ -294,6 +268,14 @@ export const getRunSql = ({
                     metadata: { status: 'success' },
                 };
             } catch (e) {
+                // Post-section errors (runSqlJob threw, Slack call failed,
+                // etc.). Reflect the error in the living Slack block so the
+                // state isn't stuck on "running" forever.
+                const message =
+                    e instanceof Error ? e.message : 'Unknown error';
+                await renderState({ kind: 'error', sql, message }).catch(() => {
+                    /* don't shadow the original error if rendering fails */
+                });
                 return {
                     result: toolErrorHandler(e, 'Error running SQL query.'),
                     metadata: { status: 'error' },

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -11,9 +11,18 @@ import type {
     SendFileFn,
     SendSlackBlocksFn,
     UpdateProgressFn,
+    UpdateSlackMessageFn,
 } from '../types/aiAgentDependencies';
 import { serializeData } from '../utils/serializeData';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
+import {
+    getAggregate,
+    renderAggregateBlocks,
+    setAggregate,
+    upsertSection,
+    type AggregateSection,
+    type SectionState,
+} from './slackSqlAggregate';
 import {
     isSlackThreadAutoApproved,
     resolveSqlApproval,
@@ -26,65 +35,13 @@ type Dependencies = {
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
     sendSlackBlocks: SendSlackBlocksFn;
+    updateSlackMessage: UpdateSlackMessageFn;
 };
-
-const truncateForSlack = (sql: string, maxLength = 2500) =>
-    sql.length > maxLength
-        ? `${sql.slice(0, maxLength)}\n... (truncated)`
-        : sql;
-
-const buildSlackApprovalBlocks = (
-    toolCallId: string,
-    threadUuid: string,
-    sql: string,
-) => [
-    {
-        type: 'section',
-        text: {
-            type: 'mrkdwn',
-            text: ':lock: *About to run SQL — approve to execute*',
-        },
-    },
-    {
-        type: 'section',
-        text: {
-            type: 'mrkdwn',
-            text: `\`\`\`sql\n${truncateForSlack(sql)}\n\`\`\``,
-        },
-    },
-    {
-        type: 'actions',
-        elements: [
-            {
-                type: 'button',
-                text: { type: 'plain_text', text: 'Approve' },
-                action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:approved`,
-                value: toolCallId,
-                style: 'primary',
-            },
-            {
-                type: 'button',
-                text: {
-                    type: 'plain_text',
-                    text: "Approve & don't ask again",
-                },
-                action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:approved_always`,
-                value: toolCallId,
-            },
-            {
-                type: 'button',
-                text: { type: 'plain_text', text: 'Reject' },
-                action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:rejected`,
-                value: toolCallId,
-                style: 'danger',
-            },
-        ],
-    },
-];
 
 const SELECT_OR_WITH = /^\s*(WITH|SELECT)\b/i;
 const FORBIDDEN_STATEMENTS =
     /\b(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|GRANT|REVOKE|MERGE|CALL|EXECUTE)\b/i;
+const INFORMATION_SCHEMA = /\binformation_schema\b/i;
 
 const PREVIEW_ROW_LIMIT = 50;
 
@@ -97,6 +54,11 @@ const validateSelectOnly = (sql: string) => {
             'SQL contains forbidden statements (INSERT/UPDATE/DELETE/DDL). Only SELECT queries are allowed.',
         );
     }
+    if (INFORMATION_SCHEMA.test(sql)) {
+        throw new Error(
+            'Querying information_schema is forbidden. Use findFields (for explore-backed tables) or listWarehouseTables (for raw tables) to discover schema. If neither returns what you need, ask the user — do not introspect via SQL.',
+        );
+    }
 };
 
 export const getRunSql = ({
@@ -105,6 +67,7 @@ export const getRunSql = ({
     getPrompt,
     sendFile,
     sendSlackBlocks,
+    updateSlackMessage,
 }: Dependencies) =>
     tool({
         description: toolRunSqlArgsSchema.description,
@@ -118,48 +81,105 @@ export const getRunSql = ({
                 const slackAutoApproved =
                     isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
 
+                // Helper: push a new state for this section and re-render the
+                // aggregate Slack message. No-op when not in Slack.
+                const updateSection = async (state: SectionState) => {
+                    if (!isSlack) return;
+                    const section: AggregateSection = {
+                        toolCallId,
+                        threadUuid: prompt.threadUuid,
+                        state,
+                    };
+                    upsertSection(prompt.promptUuid, section);
+                    const agg = getAggregate(prompt.promptUuid);
+                    if (!agg) return;
+                    await updateSlackMessage({
+                        channelId: agg.channelId,
+                        organizationUuid: prompt.organizationUuid,
+                        ts: agg.messageTs,
+                        text: 'SQL execution',
+                        blocks: renderAggregateBlocks(agg),
+                    });
+                };
+
                 if (slackAutoApproved) {
                     await updateProgress('Running SQL query...');
                 } else {
                     await updateProgress('Awaiting approval to run SQL...');
                 }
 
-                // Register the listener first, then trigger any auto-approval
-                // (the EventEmitter delivers synchronously, so the order matters).
+                // Register the approval listener first, then trigger any
+                // auto-approval (the EventEmitter delivers synchronously, so
+                // the order matters).
                 const decisionPromise = waitForSqlApproval(toolCallId);
+
+                if (isSlack) {
+                    const initialState: SectionState = slackAutoApproved
+                        ? { kind: 'approved', sql }
+                        : { kind: 'pending', sql };
+                    const section: AggregateSection = {
+                        toolCallId,
+                        threadUuid: prompt.threadUuid,
+                        state: initialState,
+                    };
+                    const existing = getAggregate(prompt.promptUuid);
+                    if (!existing) {
+                        // First runSql in this turn — post a new aggregate
+                        // message and remember its ts so subsequent calls
+                        // can edit it in place.
+                        const { ts } = await sendSlackBlocks({
+                            channelId: prompt.slackChannelId,
+                            threadTs: prompt.slackThreadTs,
+                            organizationUuid: prompt.organizationUuid,
+                            text: 'SQL execution',
+                            blocks: renderAggregateBlocks({
+                                channelId: prompt.slackChannelId,
+                                messageTs: '',
+                                sections: [section],
+                            }),
+                        });
+                        if (ts) {
+                            setAggregate(prompt.promptUuid, {
+                                channelId: prompt.slackChannelId,
+                                messageTs: ts,
+                                sections: [section],
+                            });
+                        }
+                    } else {
+                        // Append a new section to the existing aggregate
+                        // message and update it in place.
+                        existing.sections.push(section);
+                        await updateSlackMessage({
+                            channelId: existing.channelId,
+                            organizationUuid: prompt.organizationUuid,
+                            ts: existing.messageTs,
+                            text: 'SQL execution',
+                            blocks: renderAggregateBlocks(existing),
+                        });
+                    }
+                }
 
                 if (slackAutoApproved) {
                     resolveSqlApproval(toolCallId, 'approved');
-                } else if (isSlack) {
-                    // Post a separate message with Approve/Reject buttons so
-                    // the user can decide without leaving Slack.
-                    await sendSlackBlocks({
-                        channelId: prompt.slackChannelId,
-                        threadTs: prompt.slackThreadTs,
-                        organizationUuid: prompt.organizationUuid,
-                        text: 'About to run SQL — approve to execute',
-                        blocks: buildSlackApprovalBlocks(
-                            toolCallId,
-                            prompt.threadUuid,
-                            sql,
-                        ),
-                    });
                 }
 
                 const decision = await decisionPromise;
                 if (decision === 'rejected') {
+                    await updateSection({ kind: 'rejected', sql });
                     return {
                         result: 'User rejected this SQL execution. Do not retry the same query; ask the user what they would like instead.',
                         metadata: { status: 'rejected' },
                     };
                 }
                 if (decision === 'timeout') {
+                    await updateSection({ kind: 'timeout', sql });
                     return {
                         result: 'SQL approval timed out after 5 minutes with no response. The user may have stepped away — acknowledge politely and wait for them to re-ask.',
                         metadata: { status: 'timeout' },
                     };
                 }
 
+                await updateSection({ kind: 'running', sql });
                 await updateProgress('Running SQL query...');
 
                 const { rows, columns, rowCount } = await runSqlJob({
@@ -168,6 +188,13 @@ export const getRunSql = ({
                 });
 
                 if (rowCount === 0) {
+                    await updateSection({
+                        kind: 'success',
+                        sql,
+                        rowCount: 0,
+                        inlineCsv: '',
+                        truncated: false,
+                    });
                     return {
                         result: `Query returned 0 rows.${
                             columns.length > 0
@@ -191,11 +218,10 @@ export const getRunSql = ({
                     },
                 );
 
-                // For Slack: avoid the noisy auto-expanded CSV file preview by
-                // posting a collapsible code block of the first few rows. If
-                // the result is large, ALSO upload the full CSV file (Slack
-                // file previews are heavy, so we only do it when worth it).
-                if (isSlackPrompt(prompt)) {
+                // For Slack: collapse the prior approval section into an
+                // inline result preview. Only upload the full CSV file when
+                // the result is large enough to justify a separate attachment.
+                if (isSlack) {
                     const SLACK_INLINE_ROW_LIMIT = 10;
                     const LARGE_RESULT_THRESHOLD = 25;
                     const inlineRows = rows.slice(0, SLACK_INLINE_ROW_LIMIT);
@@ -211,26 +237,13 @@ export const getRunSql = ({
                         ),
                         { header: true, columns },
                     );
-                    const truncatedNote =
-                        rowCount > SLACK_INLINE_ROW_LIMIT
-                            ? ` _(showing first ${SLACK_INLINE_ROW_LIMIT})_`
-                            : '';
-                    await sendSlackBlocks({
-                        channelId: prompt.slackChannelId,
-                        threadTs: prompt.slackThreadTs,
-                        organizationUuid: prompt.organizationUuid,
-                        text: `Query returned ${rowCount} rows`,
-                        blocks: [
-                            {
-                                type: 'section',
-                                text: {
-                                    type: 'mrkdwn',
-                                    text: `*Query returned ${rowCount} row${
-                                        rowCount === 1 ? '' : 's'
-                                    }*${truncatedNote}\n\`\`\`\n${inlineCsv}\n\`\`\``,
-                                },
-                            },
-                        ],
+
+                    await updateSection({
+                        kind: 'success',
+                        sql,
+                        rowCount,
+                        inlineCsv,
+                        truncated: rowCount > SLACK_INLINE_ROW_LIMIT,
                     });
 
                     if (rowCount > LARGE_RESULT_THRESHOLD) {

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -27,6 +27,7 @@ type Dependencies = {
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
     updateSlackMessage: UpdateSlackMessageFn;
+    siteUrl: string;
 };
 
 // Strip --line and /* block */ comments + string literals so subsequent
@@ -69,6 +70,7 @@ export const getRunSql = ({
     getPrompt,
     sendFile,
     updateSlackMessage,
+    siteUrl,
 }: Dependencies) =>
     tool({
         description: toolRunSqlArgsSchema.description,
@@ -101,7 +103,7 @@ export const getRunSql = ({
                     organizationUuid: prompt.organizationUuid,
                     ts: prompt.response_slack_ts,
                     text: 'SQL execution',
-                    blocks: renderBlocks(state),
+                    blocks: renderBlocks(state, siteUrl),
                 });
             };
 

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -9,19 +9,12 @@ import type {
     GetPromptFn,
     RunSqlJobFn,
     SendFileFn,
-    SendSlackBlocksFn,
     UpdateProgressFn,
     UpdateSlackMessageFn,
 } from '../types/aiAgentDependencies';
 import { serializeData } from '../utils/serializeData';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import {
-    getAggregate,
-    renderBlocks,
-    setAggregate,
-    setCurrentState,
-    type SectionState,
-} from './slackSqlAggregate';
+import { renderBlocks, type SectionState } from './slackSqlAggregate';
 import {
     isSlackThreadAutoApproved,
     resolveSqlApproval,
@@ -33,7 +26,6 @@ type Dependencies = {
     runSqlJob: RunSqlJobFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
-    sendSlackBlocks: SendSlackBlocksFn;
     updateSlackMessage: UpdateSlackMessageFn;
 };
 
@@ -76,7 +68,6 @@ export const getRunSql = ({
     runSqlJob,
     getPrompt,
     sendFile,
-    sendSlackBlocks,
     updateSlackMessage,
 }: Dependencies) =>
     tool({
@@ -99,52 +90,33 @@ export const getRunSql = ({
             const slackAutoApproved =
                 isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
 
-            // Push a state into the single living Slack message for this
-            // prompt. First call creates the message; subsequent calls
-            // (re-runs in the same turn) mutate it via chat.update.
+            // Render a runSql state INTO the bot's existing progress message
+            // (the bolt-gif "Thinking…" message at response_slack_ts). One
+            // living block — pending → running → result. When the agent
+            // moves on, the next updateProgress overwrites with the bolt gif.
             const renderState = async (state: SectionState) => {
                 if (!isSlack) return;
-                const existing = getAggregate(prompt.promptUuid);
-                const blocks = renderBlocks(state);
-                if (!existing) {
-                    const { ts } = await sendSlackBlocks({
-                        channelId: prompt.slackChannelId,
-                        threadTs: prompt.slackThreadTs,
-                        organizationUuid: prompt.organizationUuid,
-                        text: 'SQL execution',
-                        blocks,
-                    });
-                    if (ts) {
-                        setAggregate(prompt.promptUuid, {
-                            channelId: prompt.slackChannelId,
-                            messageTs: ts,
-                            current: state,
-                        });
-                    }
-                    return;
-                }
-                setCurrentState(prompt.promptUuid, state);
                 await updateSlackMessage({
-                    channelId: existing.channelId,
+                    channelId: prompt.slackChannelId,
                     organizationUuid: prompt.organizationUuid,
-                    ts: existing.messageTs,
+                    ts: prompt.response_slack_ts,
                     text: 'SQL execution',
-                    blocks,
+                    blocks: renderBlocks(state),
                 });
             };
 
             try {
                 if (slackAutoApproved) {
-                    await updateProgress('Running SQL query...');
                     await renderState({ kind: 'approved', sql });
-                } else {
-                    await updateProgress('Awaiting approval to run SQL...');
+                } else if (isSlack) {
                     await renderState({
                         kind: 'pending',
                         sql,
                         toolCallId,
                         threadUuid: prompt.threadUuid,
                     });
+                } else {
+                    await updateProgress('Awaiting approval to run SQL...');
                 }
 
                 // Register the approval listener first, then trigger any
@@ -171,8 +143,11 @@ export const getRunSql = ({
                     };
                 }
 
-                await renderState({ kind: 'running', sql });
-                await updateProgress('Running SQL query...');
+                if (isSlack) {
+                    await renderState({ kind: 'running', sql });
+                } else {
+                    await updateProgress('Running SQL query...');
+                }
 
                 const { rows, columns, rowCount } = await runSqlJob({
                     sql,
@@ -230,8 +205,8 @@ export const getRunSql = ({
                         truncated: rowCount > SLACK_INLINE_ROW_LIMIT,
                     });
 
-                    // Slack chat.update can't attach files, so the full CSV
-                    // for large results still goes as a separate message.
+                    // chat.update can't attach files, so a full CSV for large
+                    // results still goes as a separate message.
                     if (rowCount > LARGE_RESULT_THRESHOLD) {
                         await sendFile({
                             channelId: prompt.slackChannelId,

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -38,7 +38,15 @@ type Dependencies = {
     updateSlackMessage: UpdateSlackMessageFn;
 };
 
-const SELECT_OR_WITH = /^\s*(WITH|SELECT)\b/i;
+// Strip --line and /* block */ comments + string literals so subsequent
+// keyword checks don't false-positive on text that's inside a comment or a
+// string. We don't execute the stripped version — it's used purely for
+// validation.
+const SQL_COMMENTS_AND_STRINGS = /--[^\n]*|\/\*[\s\S]*?\*\/|'(?:[^']|'')*'/g;
+const stripCommentsAndStrings = (sql: string): string =>
+    sql.replace(SQL_COMMENTS_AND_STRINGS, ' ');
+
+const STARTS_WITH_SELECT_OR_WITH = /^\s*(WITH|SELECT)\b/i;
 const FORBIDDEN_STATEMENTS =
     /\b(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|GRANT|REVOKE|MERGE|CALL|EXECUTE)\b/i;
 const INFORMATION_SCHEMA = /\binformation_schema\b/i;
@@ -46,17 +54,18 @@ const INFORMATION_SCHEMA = /\binformation_schema\b/i;
 const PREVIEW_ROW_LIMIT = 50;
 
 const validateSelectOnly = (sql: string) => {
-    if (!SELECT_OR_WITH.test(sql)) {
+    const stripped = stripCommentsAndStrings(sql);
+    if (!STARTS_WITH_SELECT_OR_WITH.test(stripped)) {
         throw new Error('Only SELECT or WITH queries are allowed.');
     }
-    if (FORBIDDEN_STATEMENTS.test(sql)) {
+    if (FORBIDDEN_STATEMENTS.test(stripped)) {
         throw new Error(
             'SQL contains forbidden statements (INSERT/UPDATE/DELETE/DDL). Only SELECT queries are allowed.',
         );
     }
-    if (INFORMATION_SCHEMA.test(sql)) {
+    if (INFORMATION_SCHEMA.test(stripped)) {
         throw new Error(
-            'Querying information_schema is forbidden. Use findFields (for explore-backed tables) or listWarehouseTables (for raw tables) to discover schema. If neither returns what you need, ask the user — do not introspect via SQL.',
+            'Querying information_schema is forbidden. Use describeWarehouseTable for column discovery on a raw table, or listWarehouseTables to find table names. If neither returns what you need, ask the user — do not introspect via SQL.',
         );
     }
 };

--- a/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
+++ b/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
@@ -1,12 +1,8 @@
-// Single living Slack message per prompt — when the agent calls runSql we
-// post a status block, then mutate it in place as the call progresses
-// (pending → approved → running → success/error/rejected/timeout). The next
-// runSql in the same prompt reuses the same message, replacing the body with
-// the new call's state. No section history is kept in Slack — past calls
-// remain in the DB + web thread for audit.
-//
-// Per-pod in-memory state, lost on pod restart (next runSql posts a fresh
-// message and we lose continuity — degrades gracefully).
+// Render the agent's runSql state as Slack blocks that get written INTO the
+// bot's existing progress message (the bolt-gif "Thinking…" message at
+// `slackPrompt.response_slack_ts`). One living message — pending → approved →
+// running → success / error / rejected / timeout. When the agent moves on,
+// the next updateProgress call overwrites with the bolt-gif again.
 
 import type { AnyType } from '@lightdash/common';
 
@@ -24,31 +20,6 @@ export type SectionState =
     | { kind: 'rejected'; sql: string }
     | { kind: 'timeout'; sql: string }
     | { kind: 'error'; sql: string; message: string };
-
-export type Aggregate = {
-    channelId: string;
-    messageTs: string;
-    current: SectionState;
-};
-
-const aggregates = new Map<string, Aggregate>();
-
-export const getAggregate = (promptUuid: string): Aggregate | undefined =>
-    aggregates.get(promptUuid);
-
-export const setAggregate = (promptUuid: string, agg: Aggregate): void => {
-    aggregates.set(promptUuid, agg);
-};
-
-export const setCurrentState = (
-    promptUuid: string,
-    state: SectionState,
-): Aggregate | undefined => {
-    const agg = aggregates.get(promptUuid);
-    if (!agg) return undefined;
-    agg.current = state;
-    return agg;
-};
 
 const truncateSql = (sql: string, maxLength = 2500) =>
     sql.length > maxLength
@@ -148,10 +119,7 @@ export const renderBlocks = (state: SectionState): AnyType[] => {
         case 'error':
             blocks.push({
                 type: 'section',
-                text: {
-                    type: 'mrkdwn',
-                    text: `_${state.message}_`,
-                },
+                text: { type: 'mrkdwn', text: `_${state.message}_` },
             });
             break;
         case 'rejected':

--- a/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
+++ b/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
@@ -1,10 +1,14 @@
-// Render the agent's runSql state as Slack blocks that get written INTO the
-// bot's existing progress message (the bolt-gif "Thinking…" message at
-// `slackPrompt.response_slack_ts`). One living message — pending → approved →
-// running → success / error / rejected / timeout. When the agent moves on,
-// the next updateProgress call overwrites with the bolt-gif again.
+// Render the agent's runSql state INTO the bot's existing progress message
+// (the bolt-gif "Thinking…" message at `slackPrompt.response_slack_ts`).
+//
+// Visual rule: every state except `pending` reuses the same subtle bolt-gif +
+// grey italic treatment that the rest of the agent's progress messages use,
+// so the SQL flow blends into the agent's normal "I'm working" stream. The
+// pending state is the one exception — it's a prominent section + buttons
+// because we need user action before going further.
 
 import type { AnyType } from '@lightdash/common';
+import { getThinkingBlocks } from '../utils/getSlackBlocks';
 
 export type SectionState =
     | { kind: 'pending'; sql: string; toolCallId: string; threadUuid: string }
@@ -26,47 +30,50 @@ const truncateSql = (sql: string, maxLength = 2500) =>
         ? `${sql.slice(0, maxLength)}\n... (truncated)`
         : sql;
 
-const header = (state: SectionState): string => {
+const subtleText = (state: SectionState): string | null => {
     switch (state.kind) {
-        case 'pending':
-            return ':lock: *Awaiting approval to run SQL*';
         case 'approved':
-            return ':hourglass_flowing_sand: *Approved — running…*';
+            return 'Approved — running SQL query…';
         case 'running':
-            return ':hourglass_flowing_sand: *Running SQL query…*';
+            return 'Running SQL query…';
         case 'success':
-            return `:white_check_mark: *${state.rowCount} row${
+            return `:white_check_mark: SQL query returned ${state.rowCount} row${
                 state.rowCount === 1 ? '' : 's'
-            }*${state.truncated ? ' _(preview)_' : ''}`;
+            }`;
         case 'rejected':
-            return ':no_entry_sign: *Rejected*';
+            return ':no_entry_sign: SQL execution rejected';
         case 'timeout':
-            return ':hourglass: *Approval timed out*';
+            return ':hourglass: SQL approval timed out';
         case 'error':
-            return ':x: *Error*';
+            return `:x: SQL error — ${state.message}`;
         default:
-            return '';
+            return null;
     }
 };
 
-export const renderBlocks = (state: SectionState): AnyType[] => {
-    const blocks: AnyType[] = [
-        {
-            type: 'section',
-            text: { type: 'mrkdwn', text: header(state) },
-        },
-    ];
-
-    switch (state.kind) {
-        case 'pending':
-            blocks.push({
+export const renderBlocks = (
+    state: SectionState,
+    siteUrl: string,
+): AnyType[] => {
+    if (state.kind === 'pending') {
+        // Prominent block — user action required, can't be a context block
+        // (Slack disallows buttons in context blocks).
+        return [
+            {
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: ':lock: *Awaiting approval to run SQL*',
+                },
+            },
+            {
                 type: 'section',
                 text: {
                     type: 'mrkdwn',
                     text: `\`\`\`sql\n${truncateSql(state.sql)}\n\`\`\``,
                 },
-            });
-            blocks.push({
+            },
+            {
                 type: 'actions',
                 elements: [
                     {
@@ -93,40 +100,12 @@ export const renderBlocks = (state: SectionState): AnyType[] => {
                         style: 'danger',
                     },
                 ],
-            });
-            break;
-        case 'approved':
-        case 'running':
-            blocks.push({
-                type: 'section',
-                text: {
-                    type: 'mrkdwn',
-                    text: `\`\`\`sql\n${truncateSql(state.sql)}\n\`\`\``,
-                },
-            });
-            break;
-        case 'success':
-            if (state.inlineCsv) {
-                blocks.push({
-                    type: 'section',
-                    text: {
-                        type: 'mrkdwn',
-                        text: `\`\`\`\n${state.inlineCsv}\n\`\`\``,
-                    },
-                });
-            }
-            break;
-        case 'error':
-            blocks.push({
-                type: 'section',
-                text: { type: 'mrkdwn', text: `_${state.message}_` },
-            });
-            break;
-        case 'rejected':
-        case 'timeout':
-        default:
-            break;
+            },
+        ];
     }
 
-    return blocks;
+    // Every other state: reuse the agent's existing bolt-gif + grey italic
+    // treatment via getThinkingBlocks so it blends with normal progress.
+    const text = subtleText(state) ?? '';
+    return getThinkingBlocks(text, siteUrl);
 };

--- a/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
+++ b/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
@@ -1,0 +1,228 @@
+// Aggregates all runSql interactions in a single Slack prompt into ONE message
+// that's updated in place via chat.update — instead of posting a fresh message
+// for every approval card + result. Per-pod in-memory state, lost on restart
+// (next runSql posts a new aggregate message; degrades gracefully).
+
+import type { AnyType } from '@lightdash/common';
+
+export type SectionState =
+    | { kind: 'pending'; sql: string }
+    | { kind: 'approved'; sql: string }
+    | { kind: 'running'; sql: string }
+    | {
+          kind: 'success';
+          sql: string;
+          rowCount: number;
+          inlineCsv: string;
+          truncated: boolean;
+      }
+    | { kind: 'rejected'; sql: string }
+    | { kind: 'timeout'; sql: string }
+    | { kind: 'error'; sql: string; message: string };
+
+export type AggregateSection = {
+    toolCallId: string;
+    threadUuid: string;
+    state: SectionState;
+};
+
+export type Aggregate = {
+    channelId: string;
+    messageTs: string;
+    sections: AggregateSection[];
+};
+
+const aggregates = new Map<string, Aggregate>();
+
+export const getAggregate = (promptUuid: string): Aggregate | undefined =>
+    aggregates.get(promptUuid);
+
+export const setAggregate = (promptUuid: string, agg: Aggregate): void => {
+    aggregates.set(promptUuid, agg);
+};
+
+export const upsertSection = (
+    promptUuid: string,
+    section: AggregateSection,
+): void => {
+    const agg = aggregates.get(promptUuid);
+    if (!agg) return;
+    const idx = agg.sections.findIndex(
+        (s) => s.toolCallId === section.toolCallId,
+    );
+    if (idx === -1) {
+        agg.sections.push(section);
+    } else {
+        agg.sections[idx] = section;
+    }
+};
+
+const truncateSql = (sql: string, maxLength = 2500) =>
+    sql.length > maxLength
+        ? `${sql.slice(0, maxLength)}\n... (truncated)`
+        : sql;
+
+const oneLineSql = (sql: string, maxLength = 120) => {
+    const flat = sql.replace(/\s+/g, ' ').trim();
+    return flat.length > maxLength ? `${flat.slice(0, maxLength)}…` : flat;
+};
+
+const sectionHeader = (idx: number, state: SectionState): string => {
+    const step = `*Step ${idx + 1}*`;
+    switch (state.kind) {
+        case 'pending':
+            return `:lock: ${step} — awaiting approval`;
+        case 'approved':
+            return `:hourglass_flowing_sand: ${step} — approved, running…`;
+        case 'running':
+            return `:hourglass_flowing_sand: ${step} — running…`;
+        case 'success':
+            return `:white_check_mark: ${step} — ${state.rowCount} row${
+                state.rowCount === 1 ? '' : 's'
+            }${state.truncated ? ' _(preview)_' : ''}`;
+        case 'rejected':
+            return `:no_entry_sign: ${step} — rejected`;
+        case 'timeout':
+            return `:hourglass: ${step} — approval timed out`;
+        case 'error':
+            return `:x: ${step} — error`;
+        default:
+            return step;
+    }
+};
+
+const renderActiveSection = (section: AggregateSection): AnyType[] => {
+    const { state, toolCallId, threadUuid } = section;
+    const blocks: AnyType[] = [];
+
+    switch (state.kind) {
+        case 'pending':
+            blocks.push({
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: `\`\`\`sql\n${truncateSql(state.sql)}\n\`\`\``,
+                },
+            });
+            blocks.push({
+                type: 'actions',
+                elements: [
+                    {
+                        type: 'button',
+                        text: { type: 'plain_text', text: 'Approve' },
+                        action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:approved`,
+                        value: toolCallId,
+                        style: 'primary',
+                    },
+                    {
+                        type: 'button',
+                        text: {
+                            type: 'plain_text',
+                            text: "Approve & don't ask again",
+                        },
+                        action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:approved_always`,
+                        value: toolCallId,
+                    },
+                    {
+                        type: 'button',
+                        text: { type: 'plain_text', text: 'Reject' },
+                        action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:rejected`,
+                        value: toolCallId,
+                        style: 'danger',
+                    },
+                ],
+            });
+            break;
+        case 'approved':
+        case 'running':
+            blocks.push({
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: `\`\`\`sql\n${truncateSql(state.sql)}\n\`\`\``,
+                },
+            });
+            break;
+        case 'success':
+            blocks.push({
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: `\`\`\`\n${state.inlineCsv}\n\`\`\``,
+                },
+            });
+            break;
+        case 'rejected':
+        case 'timeout':
+            blocks.push({
+                type: 'context',
+                elements: [
+                    {
+                        type: 'mrkdwn',
+                        text: `_${oneLineSql(state.sql)}_`,
+                    },
+                ],
+            });
+            break;
+        case 'error':
+            blocks.push({
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: `_${state.message}_\n\`\`\`sql\n${truncateSql(state.sql)}\n\`\`\``,
+                },
+            });
+            break;
+        default:
+            break;
+    }
+
+    return blocks;
+};
+
+const renderCollapsedSection = (section: AggregateSection): AnyType[] => [
+    {
+        type: 'context',
+        elements: [
+            {
+                type: 'mrkdwn',
+                text: `\`${oneLineSql(section.state.sql)}\``,
+            },
+        ],
+    },
+];
+
+// Slack hard-caps a message at 50 blocks. Keep the latest sections fully
+// rendered; older ones collapse to a single context line. If we still exceed
+// the cap, drop the oldest collapsed sections from rendering (state is kept
+// in the map but not shown — they were terminal anyway).
+const MAX_BLOCKS = 48;
+
+export const renderAggregateBlocks = (agg: Aggregate): AnyType[] => {
+    const blocks: AnyType[] = [];
+    const total = agg.sections.length;
+
+    agg.sections.forEach((section, idx) => {
+        const isLast = idx === total - 1;
+        blocks.push({
+            type: 'section',
+            text: { type: 'mrkdwn', text: sectionHeader(idx, section.state) },
+        });
+        if (isLast) {
+            blocks.push(...renderActiveSection(section));
+        } else {
+            blocks.push(...renderCollapsedSection(section));
+        }
+        if (!isLast) blocks.push({ type: 'divider' });
+    });
+
+    if (blocks.length <= MAX_BLOCKS) return blocks;
+
+    // Trim from the front (oldest collapsed sections) until we fit.
+    while (blocks.length > MAX_BLOCKS) blocks.shift();
+    blocks.unshift({
+        type: 'context',
+        elements: [{ type: 'mrkdwn', text: '_(earlier steps collapsed)_' }],
+    });
+    return blocks;
+};

--- a/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
+++ b/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
@@ -1,12 +1,17 @@
-// Aggregates all runSql interactions in a single Slack prompt into ONE message
-// that's updated in place via chat.update — instead of posting a fresh message
-// for every approval card + result. Per-pod in-memory state, lost on restart
-// (next runSql posts a new aggregate message; degrades gracefully).
+// Single living Slack message per prompt — when the agent calls runSql we
+// post a status block, then mutate it in place as the call progresses
+// (pending → approved → running → success/error/rejected/timeout). The next
+// runSql in the same prompt reuses the same message, replacing the body with
+// the new call's state. No section history is kept in Slack — past calls
+// remain in the DB + web thread for audit.
+//
+// Per-pod in-memory state, lost on pod restart (next runSql posts a fresh
+// message and we lose continuity — degrades gracefully).
 
 import type { AnyType } from '@lightdash/common';
 
 export type SectionState =
-    | { kind: 'pending'; sql: string }
+    | { kind: 'pending'; sql: string; toolCallId: string; threadUuid: string }
     | { kind: 'approved'; sql: string }
     | { kind: 'running'; sql: string }
     | {
@@ -20,16 +25,10 @@ export type SectionState =
     | { kind: 'timeout'; sql: string }
     | { kind: 'error'; sql: string; message: string };
 
-export type AggregateSection = {
-    toolCallId: string;
-    threadUuid: string;
-    state: SectionState;
-};
-
 export type Aggregate = {
     channelId: string;
     messageTs: string;
-    sections: AggregateSection[];
+    current: SectionState;
 };
 
 const aggregates = new Map<string, Aggregate>();
@@ -41,20 +40,14 @@ export const setAggregate = (promptUuid: string, agg: Aggregate): void => {
     aggregates.set(promptUuid, agg);
 };
 
-export const upsertSection = (
+export const setCurrentState = (
     promptUuid: string,
-    section: AggregateSection,
-): void => {
+    state: SectionState,
+): Aggregate | undefined => {
     const agg = aggregates.get(promptUuid);
-    if (!agg) return;
-    const idx = agg.sections.findIndex(
-        (s) => s.toolCallId === section.toolCallId,
-    );
-    if (idx === -1) {
-        agg.sections.push(section);
-    } else {
-        agg.sections[idx] = section;
-    }
+    if (!agg) return undefined;
+    agg.current = state;
+    return agg;
 };
 
 const truncateSql = (sql: string, maxLength = 2500) =>
@@ -62,38 +55,36 @@ const truncateSql = (sql: string, maxLength = 2500) =>
         ? `${sql.slice(0, maxLength)}\n... (truncated)`
         : sql;
 
-const oneLineSql = (sql: string, maxLength = 120) => {
-    const flat = sql.replace(/\s+/g, ' ').trim();
-    return flat.length > maxLength ? `${flat.slice(0, maxLength)}…` : flat;
-};
-
-const sectionHeader = (idx: number, state: SectionState): string => {
-    const step = `*Step ${idx + 1}*`;
+const header = (state: SectionState): string => {
     switch (state.kind) {
         case 'pending':
-            return `:lock: ${step} — awaiting approval`;
+            return ':lock: *Awaiting approval to run SQL*';
         case 'approved':
-            return `:hourglass_flowing_sand: ${step} — approved, running…`;
+            return ':hourglass_flowing_sand: *Approved — running…*';
         case 'running':
-            return `:hourglass_flowing_sand: ${step} — running…`;
+            return ':hourglass_flowing_sand: *Running SQL query…*';
         case 'success':
-            return `:white_check_mark: ${step} — ${state.rowCount} row${
+            return `:white_check_mark: *${state.rowCount} row${
                 state.rowCount === 1 ? '' : 's'
-            }${state.truncated ? ' _(preview)_' : ''}`;
+            }*${state.truncated ? ' _(preview)_' : ''}`;
         case 'rejected':
-            return `:no_entry_sign: ${step} — rejected`;
+            return ':no_entry_sign: *Rejected*';
         case 'timeout':
-            return `:hourglass: ${step} — approval timed out`;
+            return ':hourglass: *Approval timed out*';
         case 'error':
-            return `:x: ${step} — error`;
+            return ':x: *Error*';
         default:
-            return step;
+            return '';
     }
 };
 
-const renderActiveSection = (section: AggregateSection): AnyType[] => {
-    const { state, toolCallId, threadUuid } = section;
-    const blocks: AnyType[] = [];
+export const renderBlocks = (state: SectionState): AnyType[] => {
+    const blocks: AnyType[] = [
+        {
+            type: 'section',
+            text: { type: 'mrkdwn', text: header(state) },
+        },
+    ];
 
     switch (state.kind) {
         case 'pending':
@@ -110,8 +101,8 @@ const renderActiveSection = (section: AggregateSection): AnyType[] => {
                     {
                         type: 'button',
                         text: { type: 'plain_text', text: 'Approve' },
-                        action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:approved`,
-                        value: toolCallId,
+                        action_id: `actions.sql_approval:${state.toolCallId}:${state.threadUuid}:approved`,
+                        value: state.toolCallId,
                         style: 'primary',
                     },
                     {
@@ -120,14 +111,14 @@ const renderActiveSection = (section: AggregateSection): AnyType[] => {
                             type: 'plain_text',
                             text: "Approve & don't ask again",
                         },
-                        action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:approved_always`,
-                        value: toolCallId,
+                        action_id: `actions.sql_approval:${state.toolCallId}:${state.threadUuid}:approved_always`,
+                        value: state.toolCallId,
                     },
                     {
                         type: 'button',
                         text: { type: 'plain_text', text: 'Reject' },
-                        action_id: `actions.sql_approval:${toolCallId}:${threadUuid}:rejected`,
-                        value: toolCallId,
+                        action_id: `actions.sql_approval:${state.toolCallId}:${state.threadUuid}:rejected`,
+                        value: state.toolCallId,
                         style: 'danger',
                     },
                 ],
@@ -144,80 +135,30 @@ const renderActiveSection = (section: AggregateSection): AnyType[] => {
             });
             break;
         case 'success':
-            blocks.push({
-                type: 'section',
-                text: {
-                    type: 'mrkdwn',
-                    text: `\`\`\`\n${state.inlineCsv}\n\`\`\``,
-                },
-            });
-            break;
-        case 'rejected':
-        case 'timeout':
-            blocks.push({
-                type: 'context',
-                elements: [
-                    {
+            if (state.inlineCsv) {
+                blocks.push({
+                    type: 'section',
+                    text: {
                         type: 'mrkdwn',
-                        text: `_${oneLineSql(state.sql)}_`,
+                        text: `\`\`\`\n${state.inlineCsv}\n\`\`\``,
                     },
-                ],
-            });
+                });
+            }
             break;
         case 'error':
             blocks.push({
                 type: 'section',
                 text: {
                     type: 'mrkdwn',
-                    text: `_${state.message}_\n\`\`\`sql\n${truncateSql(state.sql)}\n\`\`\``,
+                    text: `_${state.message}_`,
                 },
             });
             break;
+        case 'rejected':
+        case 'timeout':
         default:
             break;
     }
 
-    return blocks;
-};
-
-// Past sections collapse to JUST the header line — no body. Keeps the
-// message scannable: one row per completed step.
-const renderCollapsedSection = (_section: AggregateSection): AnyType[] => [];
-
-// Slack hard-caps a message at 50 blocks. Keep the latest sections fully
-// rendered; older ones collapse to a single context line. If we still exceed
-// the cap, drop the oldest collapsed sections from rendering (state is kept
-// in the map but not shown — they were terminal anyway).
-const MAX_BLOCKS = 48;
-
-export const renderAggregateBlocks = (agg: Aggregate): AnyType[] => {
-    const blocks: AnyType[] = [];
-    const total = agg.sections.length;
-
-    agg.sections.forEach((section, idx) => {
-        const isLast = idx === total - 1;
-        const isLastBeforeActive = idx === total - 2;
-        blocks.push({
-            type: 'section',
-            text: { type: 'mrkdwn', text: sectionHeader(idx, section.state) },
-        });
-        if (isLast) {
-            blocks.push(...renderActiveSection(section));
-        } else {
-            blocks.push(...renderCollapsedSection(section));
-        }
-        // One divider, only between the past section stack and the active
-        // section — gives visual separation without cluttering the list.
-        if (isLastBeforeActive) blocks.push({ type: 'divider' });
-    });
-
-    if (blocks.length <= MAX_BLOCKS) return blocks;
-
-    // Trim from the front (oldest collapsed sections) until we fit.
-    while (blocks.length > MAX_BLOCKS) blocks.shift();
-    blocks.unshift({
-        type: 'context',
-        elements: [{ type: 'mrkdwn', text: '_(earlier steps collapsed)_' }],
-    });
     return blocks;
 };

--- a/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
+++ b/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
@@ -180,17 +180,9 @@ const renderActiveSection = (section: AggregateSection): AnyType[] => {
     return blocks;
 };
 
-const renderCollapsedSection = (section: AggregateSection): AnyType[] => [
-    {
-        type: 'context',
-        elements: [
-            {
-                type: 'mrkdwn',
-                text: `\`${oneLineSql(section.state.sql)}\``,
-            },
-        ],
-    },
-];
+// Past sections collapse to JUST the header line — no body. Keeps the
+// message scannable: one row per completed step.
+const renderCollapsedSection = (_section: AggregateSection): AnyType[] => [];
 
 // Slack hard-caps a message at 50 blocks. Keep the latest sections fully
 // rendered; older ones collapse to a single context line. If we still exceed
@@ -204,6 +196,7 @@ export const renderAggregateBlocks = (agg: Aggregate): AnyType[] => {
 
     agg.sections.forEach((section, idx) => {
         const isLast = idx === total - 1;
+        const isLastBeforeActive = idx === total - 2;
         blocks.push({
             type: 'section',
             text: { type: 'mrkdwn', text: sectionHeader(idx, section.state) },
@@ -213,7 +206,9 @@ export const renderAggregateBlocks = (agg: Aggregate): AnyType[] => {
         } else {
             blocks.push(...renderCollapsedSection(section));
         }
-        if (!isLast) blocks.push({ type: 'divider' });
+        // One divider, only between the past section stack and the active
+        // section — gives visual separation without cluttering the list.
+        if (isLastBeforeActive) blocks.push({ type: 'divider' });
     });
 
     if (blocks.length <= MAX_BLOCKS) return blocks;

--- a/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
+++ b/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
@@ -30,22 +30,25 @@ const truncateSql = (sql: string, maxLength = 2500) =>
         ? `${sql.slice(0, maxLength)}\n... (truncated)`
         : sql;
 
+const oneLineSql = (sql: string, maxLength = 140) => {
+    const flat = sql.replace(/\s+/g, ' ').trim();
+    return flat.length > maxLength ? `${flat.slice(0, maxLength)}…` : flat;
+};
+
 const subtleText = (state: SectionState): string | null => {
     switch (state.kind) {
         case 'approved':
-            return 'Approved — running SQL query…';
+            return `Running SQL: \`${oneLineSql(state.sql)}\``;
         case 'running':
-            return 'Running SQL query…';
+            return `Running SQL: \`${oneLineSql(state.sql)}\``;
         case 'success':
-            return `:white_check_mark: SQL query returned ${state.rowCount} row${
-                state.rowCount === 1 ? '' : 's'
-            }`;
+            return `Ran SQL: \`${oneLineSql(state.sql)}\``;
         case 'rejected':
-            return ':no_entry_sign: SQL execution rejected';
+            return `Rejected SQL: \`${oneLineSql(state.sql)}\``;
         case 'timeout':
-            return ':hourglass: SQL approval timed out';
+            return 'SQL approval timed out';
         case 'error':
-            return `:x: SQL error — ${state.message}`;
+            return `SQL error — ${state.message}`;
         default:
             return null;
     }

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -4,6 +4,7 @@ import { AiModel, AiProvider } from '../models/types';
 import {
     CreateChangeFn,
     CreateOrUpdateArtifactFn,
+    DescribeWarehouseTableFn,
     FindContentFn,
     FindExploresFn,
     FindFieldFn,
@@ -75,6 +76,7 @@ export type AiAgentDependencies = {
     runAsyncQuery: RunAsyncQueryFn;
     runSqlJob: RunSqlJobFn;
     listWarehouseTables: ListWarehouseTablesFn;
+    describeWarehouseTable: DescribeWarehouseTableFn;
     getSavedChart: GetSavedChartFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -25,6 +25,7 @@ import {
     TrackEventFn,
     UpdateProgressFn,
     UpdatePromptFn,
+    UpdateSlackMessageFn,
 } from './aiAgentDependencies';
 
 type AnyAiModel<P = AiProvider> = P extends AiProvider ? AiModel<P> : never;
@@ -78,6 +79,7 @@ export type AiAgentDependencies = {
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
     sendSlackBlocks: SendSlackBlocksFn;
+    updateSlackMessage: UpdateSlackMessageFn;
     updatePrompt: UpdatePromptFn;
     updateProgress: UpdateProgressFn;
     storeToolCall: StoreToolCallFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -116,6 +116,14 @@ export type SendSlackBlocksFn = (args: {
     organizationUuid: string;
     text: string;
     blocks: AnyType[];
+}) => Promise<{ ts: string }>;
+
+export type UpdateSlackMessageFn = (args: {
+    channelId: string;
+    organizationUuid: string;
+    ts: string;
+    text: string;
+    blocks: AnyType[];
 }) => Promise<void>;
 
 export type UpdatePromptFn = (

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -197,3 +197,11 @@ export type RunSqlJobFn = (args: { sql: string; limit: number }) => Promise<{
 }>;
 
 export type ListWarehouseTablesFn = () => Promise<WarehouseTablesCatalog>;
+
+export type DescribeWarehouseTableFn = (args: {
+    table: string;
+    schema?: string;
+}) => Promise<{
+    columns: Array<{ name: string; type: string }>;
+    resolvedSchema: string | null;
+}>;

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -239,9 +239,14 @@ const ANSWER_PRODUCING_TOOLS = new Set([
     'generateDashboard',
 ]);
 
+// One compact footer: small "How did I do?" header + a single row with
+// thumbs and the chat permalink. Only rendered when at least one
+// answer-producing tool succeeded for this prompt.
 export function getFeedbackBlocks(
     slackPrompt: SlackPrompt,
     toolResults: AiAgentToolResult[],
+    agentUuid: string,
+    siteUrl: string,
 ): (Block | KnownBlock)[] {
     const hasAnswer = toolResults.some(
         (r) =>
@@ -249,7 +254,13 @@ export function getFeedbackBlocks(
             (r.metadata as { status?: string } | null)?.status === 'success',
     );
     if (!hasAnswer) return [];
+
+    const threadUrl = `${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}`;
     return [
+        {
+            type: 'context',
+            elements: [{ type: 'mrkdwn', text: '🤖 _How did I do?_' }],
+        },
         {
             block_id: 'prompt_human_score',
             type: 'actions',
@@ -266,27 +277,14 @@ export function getFeedbackBlocks(
                     value: slackPrompt.promptUuid,
                     action_id: 'prompt_human_score.downvote',
                 },
-            ],
-        },
-    ];
-}
-
-// Subtle, always-on permalink to the thread in Lightdash. Rendered as a
-// dimmed context block (single italic line) so it doesn't compete with the
-// agent's answer or the feedback row.
-export function getViewInLightdashBlocks(
-    slackPrompt: SlackPrompt,
-    agentUuid: string,
-    siteUrl: string,
-): (Block | KnownBlock)[] {
-    const threadUrl = `${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}`;
-    return [
-        {
-            type: 'context',
-            elements: [
                 {
-                    type: 'mrkdwn',
-                    text: `<${threadUrl}|View chat in Lightdash> :zap:`,
+                    type: 'button',
+                    text: {
+                        type: 'plain_text',
+                        text: 'View chat in Lightdash',
+                    },
+                    url: threadUrl,
+                    action_id: 'view_chat_in_lightdash',
                 },
             ],
         },

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -78,6 +78,22 @@ export const getTextBlocks = (
     }));
 
 /**
+ * Converts standard markdown into Slack `markdown` blocks. Unlike `mrkdwn`
+ * inside a section block, the markdown block natively renders GitHub-flavoured
+ * markdown including tables, task lists, code blocks with language hints, etc.
+ *
+ * Pass the agent's raw markdown response here — no slackifyMarkdown needed.
+ */
+export const getMarkdownBlocks = (text: string): (Block | KnownBlock)[] =>
+    chunkSlackText(text).map(
+        (chunk) =>
+            ({
+                type: 'markdown',
+                text: chunk,
+            }) as unknown as Block,
+    );
+
+/**
  * Returns compact Slack blocks showing a "thinking" animation with a GIF.
  * Uses context block for smaller, dimmed text appearance.
  * Used while the AI agent is processing a request.

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -258,10 +258,6 @@ export function getFeedbackBlocks(
     const threadUrl = `${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}`;
     return [
         {
-            type: 'context',
-            elements: [{ type: 'mrkdwn', text: '🤖 _How did I do?_' }],
-        },
-        {
             block_id: 'prompt_human_score',
             type: 'actions',
             elements: [

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -230,36 +230,14 @@ export function getFollowUpToolBlocks(
 
 export function getFeedbackBlocks(
     slackPrompt: SlackPrompt,
-    artifacts?: AiArtifact[],
+    agentUuid: string,
+    siteUrl: string,
 ): (Block | KnownBlock)[] {
-    // TODO: Assuming each thread has just one artifact for now
-    // Show feedback blocks if we have artifacts with visualizations
-    if (!artifacts || artifacts.length === 0) {
-        return [];
-    }
-
-    // Check if any artifacts have chart or dashboard configs
-    const hasVisualization = artifacts.some(
-        (artifact) => artifact.chartConfig || artifact.dashboardConfig,
-    );
-
-    if (!hasVisualization) {
-        return [];
-    }
-
+    // One compact actions row: [View chat in Lightdash] [👍] [👎].
+    // Shown on every agent response — feedback applies regardless of whether
+    // the response produced a chart artifact.
+    const threadUrl = `${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}`;
     return [
-        {
-            type: 'divider',
-        },
-        {
-            type: 'context',
-            elements: [
-                {
-                    type: 'plain_text',
-                    text: `🤖 How did I do?`,
-                },
-            ],
-        },
         {
             block_id: 'prompt_human_score',
             type: 'actions',
@@ -268,19 +246,21 @@ export function getFeedbackBlocks(
                     type: 'button',
                     text: {
                         type: 'plain_text',
-                        text: '👍',
+                        text: '⚡ View in Lightdash',
                         emoji: true,
                     },
+                    url: threadUrl,
+                    action_id: 'view_chat_in_lightdash',
+                },
+                {
+                    type: 'button',
+                    text: { type: 'plain_text', text: '👍', emoji: true },
                     value: slackPrompt.promptUuid,
                     action_id: 'prompt_human_score.upvote',
                 },
                 {
                     type: 'button',
-                    text: {
-                        type: 'plain_text',
-                        text: '👎',
-                        emoji: true,
-                    },
+                    text: { type: 'plain_text', text: '👎', emoji: true },
                     value: slackPrompt.promptUuid,
                     action_id: 'prompt_human_score.downvote',
                 },
@@ -397,34 +377,17 @@ export function getDeepLinkBlocks(
     siteUrl: string,
     artifacts?: AiArtifact[],
 ): (Block | KnownBlock)[] {
-    // TODO: Assuming each thread has just one artifact for now
-    // Show debug link when there are artifacts to inspect
-    if (!artifacts || artifacts.length === 0) {
-        return [];
-    }
-
-    // Check if any artifacts have dashboard configs
+    // Prominent "View Dashboard" link only — the regular "View chat in
+    // Lightdash" link now lives inside the unified feedback row.
+    if (!artifacts || artifacts.length === 0) return [];
     const hasDashboard = artifacts.some((artifact) => artifact.dashboardConfig);
-
-    // Add prominent dashboard link if dashboard artifact exists
-    if (hasDashboard) {
-        return [
-            {
-                type: 'section',
-                text: {
-                    type: 'mrkdwn',
-                    text: `📊 <${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}|View Dashboard in Lightdash ⚡️>`,
-                },
-            },
-        ];
-    }
-
+    if (!hasDashboard) return [];
     return [
         {
             type: 'section',
             text: {
                 type: 'mrkdwn',
-                text: `<${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}|View chat in Lightdash ⚡️>`,
+                text: `📊 <${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}|View Dashboard in Lightdash ⚡️>`,
             },
         },
     ];

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -228,30 +228,32 @@ export function getFollowUpToolBlocks(
     ];
 }
 
+// Tool names whose successful results count as "an answer the user can score".
+// Discovery tools (findExplores, findFields, listWarehouseTables,
+// describeWarehouseTable) are deliberately excluded — they don't deliver a
+// final answer, only context for the agent.
+const ANSWER_PRODUCING_TOOLS = new Set([
+    'runQuery',
+    'runSql',
+    'runSavedChart',
+    'generateDashboard',
+]);
+
 export function getFeedbackBlocks(
     slackPrompt: SlackPrompt,
-    agentUuid: string,
-    siteUrl: string,
+    toolResults: AiAgentToolResult[],
 ): (Block | KnownBlock)[] {
-    // One compact actions row: [View chat in Lightdash] [👍] [👎].
-    // Shown on every agent response — feedback applies regardless of whether
-    // the response produced a chart artifact.
-    const threadUrl = `${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}`;
+    const hasAnswer = toolResults.some(
+        (r) =>
+            ANSWER_PRODUCING_TOOLS.has(r.toolName) &&
+            (r.metadata as { status?: string } | null)?.status === 'success',
+    );
+    if (!hasAnswer) return [];
     return [
         {
             block_id: 'prompt_human_score',
             type: 'actions',
             elements: [
-                {
-                    type: 'button',
-                    text: {
-                        type: 'plain_text',
-                        text: '⚡ View in Lightdash',
-                        emoji: true,
-                    },
-                    url: threadUrl,
-                    action_id: 'view_chat_in_lightdash',
-                },
                 {
                     type: 'button',
                     text: { type: 'plain_text', text: '👍', emoji: true },
@@ -263,6 +265,28 @@ export function getFeedbackBlocks(
                     text: { type: 'plain_text', text: '👎', emoji: true },
                     value: slackPrompt.promptUuid,
                     action_id: 'prompt_human_score.downvote',
+                },
+            ],
+        },
+    ];
+}
+
+// Subtle, always-on permalink to the thread in Lightdash. Rendered as a
+// dimmed context block (single italic line) so it doesn't compete with the
+// agent's answer or the feedback row.
+export function getViewInLightdashBlocks(
+    slackPrompt: SlackPrompt,
+    agentUuid: string,
+    siteUrl: string,
+): (Block | KnownBlock)[] {
+    const threadUrl = `${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}`;
+    return [
+        {
+            type: 'context',
+            elements: [
+                {
+                    type: 'mrkdwn',
+                    text: `<${threadUrl}|View chat in Lightdash> :zap:`,
                 },
             ],
         },

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -1,6 +1,7 @@
 import {
     isToolName,
     toolDashboardV2ArgsSchema,
+    toolDescribeWarehouseTableArgsSchema,
     toolFindChartsArgsSchema,
     toolFindContentArgsSchema,
     toolFindDashboardsArgsSchema,
@@ -42,6 +43,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     runSavedChart: 'run_saved_chart',
     runSql: 'run_sql',
     listWarehouseTables: 'list_warehouse_tables',
+    describeWarehouseTable: 'describe_warehouse_table',
     generateDashboard: 'generate_dashboard',
     improveContext: 'improve_context',
     proposeChange: 'propose_change',
@@ -67,6 +69,7 @@ const TOOL_SCHEMAS = {
     runSavedChart: toolRunSavedChartArgsSchema,
     runSql: toolRunSqlArgsSchema,
     listWarehouseTables: toolListWarehouseTablesArgsSchema,
+    describeWarehouseTable: toolDescribeWarehouseTableArgsSchema,
 } satisfies Record<ToolName, z.ZodSchema>;
 
 const getToolInfo = (toolName: string) => {

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -1,6 +1,7 @@
 export * from './mcpToolListExploresArgs';
 export * from './toolDashboardArgs';
 export * from './toolDashboardV2Args';
+export * from './toolDescribeWarehouseTableArgs';
 export * from './toolFindChartsArgs';
 export * from './toolFindContentArgs';
 export * from './toolFindDashboardsArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDescribeWarehouseTableArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDescribeWarehouseTableArgs.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { createToolSchema } from '../toolSchemaBuilder';
+
+const TOOL_DESCRIBE_WAREHOUSE_TABLE_DESCRIPTION = `Tool: describe_warehouse_table
+
+Purpose:
+Return the column names + types of a single raw warehouse table. Use this to learn the exact schema of a raw / staging / seed table that is NOT exposed via an explore, so you can write correct runSql on the first attempt.
+
+Returns: { columns: [{ name, type }, ...] }. Pulled from cached metadata, fast, NO user approval required.
+
+When to use:
+- You're about to write runSql against a raw table and need its columns (e.g. to confirm a join key exists).
+- A previous runSql failed with "column does not exist" or similar. Use this to recover, then retry the SQL ONCE.
+- The user asked about a raw table that isn't part of any explore.
+
+Do NOT use:
+- For columns of explore-backed tables — use findFields instead.
+- As a substitute for runSql — this returns schema only, not data.
+- For schema-wide listings — use listWarehouseTables to find table names first.
+
+Parameters:
+- table: Required. The unqualified table name (e.g. "raw_parts", not "jaffle.raw_parts").
+- schema: Optional. The schema name (e.g. "jaffle"). If omitted, the project's default schema is used.
+`;
+
+export const toolDescribeWarehouseTableArgsSchema = createToolSchema({
+    description: TOOL_DESCRIBE_WAREHOUSE_TABLE_DESCRIPTION,
+})
+    .extend({
+        table: z
+            .string()
+            .min(1)
+            .describe(
+                'The unqualified table name (e.g. "raw_parts"). Do not include schema/database here — use the schema parameter instead.',
+            ),
+        schema: z
+            .string()
+            .optional()
+            .describe(
+                "Optional schema name. Defaults to the project's default schema if omitted.",
+            ),
+    })
+    .build();
+
+export type ToolDescribeWarehouseTableArgs = z.infer<
+    typeof toolDescribeWarehouseTableArgsSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -27,6 +27,7 @@ export const ToolNameSchema = z.enum([
     'runSavedChart',
     'runSql',
     'listWarehouseTables',
+    'describeWarehouseTable',
 ]);
 
 export type ToolName = z.infer<typeof ToolNameSchema>;
@@ -54,6 +55,7 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     runSavedChart: 'Running saved chart',
     runSql: 'Running SQL query',
     listWarehouseTables: 'Listing warehouse tables',
+    describeWarehouseTable: 'Describing warehouse table',
 });
 
 // after-tool-call messages
@@ -75,6 +77,7 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         runSavedChart: 'Ran saved chart',
         runSql: 'Ran SQL query',
         listWarehouseTables: 'Listed warehouse tables',
+        describeWarehouseTable: 'Described warehouse table',
     });
 
 export const AVAILABLE_VISUALIZATION_TYPES = VisualizationTools;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/InlineToolCallCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/InlineToolCallCard.tsx
@@ -19,6 +19,7 @@ const TOOLS_WITHOUT_DESCRIPTION = new Set<ToolName>([
     'proposeChange',
     'runSavedChart',
     'listWarehouseTables',
+    'describeWarehouseTable',
 ]);
 
 type InlineToolCallCardProps = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -151,6 +151,7 @@ export const ToolCallDescription: FC<{
                 />
             );
         case 'listWarehouseTables':
+        case 'describeWarehouseTable':
         case 'improveContext':
         case 'proposeChange':
         case 'runSavedChart':

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -35,6 +35,7 @@ export const getToolIcon = (toolName: ToolName) => {
             runSavedChart: IconChartHistogram,
             runSql: IconTerminal2,
             listWarehouseTables: IconDatabase,
+            describeWarehouseTable: IconDatabase,
         };
 
     return iconMap[toolName];

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -196,6 +196,7 @@ export function useAiAgentThreadStreamMutation() {
                             case 'tool-runQuery':
                             case 'tool-runSql':
                             case 'tool-listWarehouseTables':
+                            case 'tool-describeWarehouseTable':
                             case 'tool-generateDashboard':
                                 if (part.state !== 'input-available') {
                                     // Whenever a runSql tool result lands


### PR DESCRIPTION
## Summary

Three changes that make the runSql experience less noisy in Slack and significantly more capable on raw tables.

### 1. Aggregate-message pattern for Slack
- All runSql interactions within one user prompt now collapse into **one Slack message** that updates in place via `chat.update`, instead of posting fresh messages for every approval card / result / CSV.
- Per-pod in-memory state (`slackSqlAggregate.ts`) keyed by `promptUuid` — same scoping as the approval bus. Pod restart → next runSql posts a new aggregate (degrades gracefully).
- Each runSql becomes a "section" inside the aggregate with state machine: `pending` → `approved`/`running` → `success`/`rejected`/`timeout`/`error`. Past sections collapse to a single-line preview; the active section stays fully expanded.
- New dependency `updateSlackMessage` (wraps `webClient.chat.update`); `sendSlackBlocks` now returns `{ ts }` so callers can edit the message they posted.
- Hits Slack's 50-block hard cap gracefully — oldest sections drop from rendering with a `_(earlier steps collapsed)_` header.

### 2. Server-side `information_schema` block
- `validateSelectOnly` now rejects any SQL containing `\binformation_schema\b` with a clear error pointing the agent at the right discovery tool.
- Belt-and-braces with the prompt rules — eval data showed the agent still reached for `information_schema.columns` despite the prompt forbidding it. Server-side rejection forces the right behaviour.

### 3. New `describeWarehouseTable` tool (closes the schema-discovery gap)
- The agent had no way to introspect columns of raw tables: `findFields` only works for explore-backed tables, `listWarehouseTables` only returns table names, `information_schema` is now blocked. Result: agent had to guess column names and then bail when `runSql` failed.
- New tool wraps `ProjectService.getWarehouseFields(table, schema)` — returns `{ columns: [{name, type}, ...] }` for one raw table. Same CASL gate as runSql (`manage:SqlRunner`). Falls back to the project's default schema when the agent doesn't pass one.
- Renders in the UI as a single dimmed one-liner (added to `TOOLS_WITHOUT_DESCRIPTION`) — the user doesn't need to think about it.
- Prompt Rule 4 updated: on `column does not exist` / `relation not found`, the agent now uses `describeWarehouseTable` to recover, then retries the SQL ONCE. No more "I cannot inspect columns" dead-ends.

## Regression analysis

- **Web prompts**: unchanged. The aggregate machinery is gated behind `isSlackPrompt(prompt)`. The web `SqlApprovalCard` flow is untouched. The new tool is invisible to users (no description rendering).
- **Slack with single runSql per turn**: visual diff is "1 unified message" vs "approval + result + maybe CSV file". Looks cleaner; no functional change.
- **Slack with multiple runSql per turn**: previously 2N+ messages; now 1 message that grows. The CSV file upload (when result > 25 rows) still happens as a separate message — Slack `chat.update` can't attach files. Acceptable noise reduction.
- **Pod restart mid-turn**: `getAggregate` returns undefined → runSql posts a fresh aggregate message instead of trying to update the lost `ts`. Previous one becomes orphaned but harmless.
- **`information_schema` queries**: legitimate SELECT/WITH that happens to *reference* the literal string `information_schema` (e.g. in a column comment) gets blocked. Probability ~0. Mitigation: error message is explicit.
- **`describeWarehouseTable` on non-existent table**: `getWarehouseFields` throws `NotFoundError` with a clear message → tool catches and returns `not_found` status. Agent can recover by asking the user.
- **Pre-existing `manage:SqlRunner` + flag + OAuth gating**: unchanged. New tool inherits all three.

## Test plan
- [ ] Slack prompt that triggers 3 consecutive runSql calls — confirm 1 aggregate message with 3 sections (past 2 collapsed, last expanded)
- [ ] Click Approve on the active section — confirm buttons swap to result preview within the same message
- [ ] runSql with `SELECT column_name FROM information_schema.columns` — confirm tool returns the corrective error and agent uses `describeWarehouseTable` instead
- [ ] Ask the median-completion-time-per-technician-plus-distinct-parts question — confirm agent now uses `describeWarehouseTable` to find the right column instead of guessing
- [ ] runSql fails with "column does not exist" — confirm agent calls `describeWarehouseTable` for that table and retries once
- [ ] Web prompt — confirm SqlApprovalCard still renders inline as before
- [ ] runSql result > 25 rows in Slack — confirm aggregate message updates AND a CSV file is uploaded as a separate message

## Stack

Stacked on top of #22942 (subtler streaming UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)