### PR TITLE
feat: migrate results cache flag to per-org feature flag with env fallback

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -381,6 +381,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     queryHistoryModel: models.getQueryHistoryModel(),
                     lightdashConfig: context.lightdashConfig,
                     storageClient: clients.getResultsFileStorageClient(),
+                    featureFlagModel: models.getFeatureFlagModel(),
                 }),
             mcpService: ({ context, repository, models }) =>
                 new McpService({

--- a/packages/backend/src/ee/services/CommercialCacheService.ts
+++ b/packages/backend/src/ee/services/CommercialCacheService.ts
@@ -1,13 +1,19 @@
+import { FeatureFlags } from '@lightdash/common';
 import { type S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import type { LightdashConfig } from '../../config/parseConfig';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
-import type { ICacheService } from '../../services/CacheService/ICacheService';
+import type {
+    CacheServiceUser,
+    ICacheService,
+} from '../../services/CacheService/ICacheService';
 import { type CacheHitCacheResult } from '../../services/CacheService/types';
 
 type CacheServiceDependencies = {
     queryHistoryModel: QueryHistoryModel;
     lightdashConfig: LightdashConfig;
     storageClient: S3ResultsFileStorageClient;
+    featureFlagModel: FeatureFlagModel;
 };
 
 // Buffer time to ensure cache doesn't expire while being fetched
@@ -19,28 +25,41 @@ export class CommercialCacheService implements ICacheService {
 
     private readonly lightdashConfig: LightdashConfig;
 
+    private readonly featureFlagModel: FeatureFlagModel;
+
     storageClient: S3ResultsFileStorageClient;
 
     constructor({
         queryHistoryModel,
         lightdashConfig,
         storageClient,
+        featureFlagModel,
     }: CacheServiceDependencies) {
         this.queryHistoryModel = queryHistoryModel;
         this.lightdashConfig = lightdashConfig;
         this.storageClient = storageClient;
+        this.featureFlagModel = featureFlagModel;
     }
 
-    get isEnabled() {
-        return this.lightdashConfig.results.cacheEnabled;
+    async isResultsCacheEnabled(
+        user: CacheServiceUser | undefined,
+    ): Promise<boolean> {
+        const { enabled } = await this.featureFlagModel.get({
+            user,
+            featureFlagId: FeatureFlags.ResultsCacheEnabled,
+        });
+        return enabled;
     }
 
     async findCachedResultsFile(
         projectUuid: string,
         cacheKey: string,
+        user: CacheServiceUser,
     ): Promise<CacheHitCacheResult | null> {
-        // If caching is disabled, return null
-        if (!this.isEnabled) {
+        // Self-protect: gate every cache lookup on the FF, regardless of how
+        // the caller arrived here. Belt-and-suspenders for embed and any
+        // future caller that might forget the outer gate.
+        if (!(await this.isResultsCacheEnabled(user))) {
             return null;
         }
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -925,6 +925,11 @@ export class EmbedService extends BaseService {
             await this.projectService.getResultsFromCacheOrWarehouse({
                 projectUuid,
                 userUuid: null,
+                user: {
+                    userUuid: account.user.id,
+                    organizationUuid: account.organization.organizationUuid,
+                    organizationName: account.organization.name,
+                },
                 context: QueryExecutionContext.EMBED,
                 warehouseClient,
                 metricQuery,

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -7,6 +7,9 @@ import {
 } from '../../database/entities/featureFlags';
 import Logger from '../../logging/logger';
 
+const UUID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export type FeatureFlagLogicArgs = {
     user?: Pick<
         LightdashUser,
@@ -35,6 +38,11 @@ export class FeatureFlagModel {
                 this.getEnableTimezoneSupportEnabled.bind(this),
             [FeatureFlags.EnableDataApps]:
                 this.getEnableDataAppsEnabled.bind(this),
+            [FeatureFlags.ResultsCacheEnabled]: (flagArgs) =>
+                this.getWithEnvFallback(
+                    flagArgs,
+                    this.lightdashConfig.results.cacheEnabled,
+                ),
         };
     }
 
@@ -97,6 +105,17 @@ export class FeatureFlagModel {
         return dbResult ?? { id: args.featureFlagId, enabled: false };
     }
 
+    // DB value (user override → org override → flag default) wins. Falls
+    // back to the env-derived value when the flag has no DB row and no
+    // override applies.
+    private async getWithEnvFallback(
+        args: FeatureFlagLogicArgs,
+        envFallback: boolean,
+    ): Promise<FeatureFlag> {
+        const dbResult = await this.tryGetFromDatabase(args);
+        return dbResult ?? { id: args.featureFlagId, enabled: envFallback };
+    }
+
     protected async tryGetFromDatabase(
         args: FeatureFlagLogicArgs,
     ): Promise<FeatureFlag | null> {
@@ -122,7 +141,11 @@ export class FeatureFlagModel {
         }
 
         // Priority: user override > org override > flag default
-        if (args.user?.userUuid) {
+        // Skip the user-override lookup unless the userUuid is a real UUID.
+        // Anonymous (embed/JWT) accounts use a non-UUID externalId for
+        // `user.userUuid`; passing it to a `uuid` column raises a Postgres
+        // type error and would prevent the org-override lookup below.
+        if (args.user?.userUuid && UUID_REGEX.test(args.user.userUuid)) {
             const userOverride = await this.database(
                 FeatureFlagOverridesTableName,
             )

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -5,6 +5,7 @@ import {
     DimensionType,
     ExecuteAsyncQueryRequestParams,
     ExploreType,
+    FeatureFlags,
     FilterOperator,
     ForbiddenError,
     NotFoundError,
@@ -253,7 +254,20 @@ const getMockedAsyncQueryService = (
             })),
         } as unknown as S3ResultsFileStorageClient,
         featureFlagModel: {
-            get: jest.fn(async () => ({ enabled: false })),
+            // Mirror production behaviour: ResultsCacheEnabled resolves from
+            // the env-derived lightdashConfig.results.cacheEnabled when there
+            // is no DB row.
+            get: jest.fn(
+                async ({ featureFlagId }: { featureFlagId: string }) => {
+                    if (featureFlagId === FeatureFlags.ResultsCacheEnabled) {
+                        return {
+                            id: featureFlagId,
+                            enabled: lightdashConfig.results.cacheEnabled,
+                        };
+                    }
+                    return { id: featureFlagId, enabled: false };
+                },
+            ),
         } as unknown as FeatureFlagModel,
         projectParametersModel: {
             find: jest.fn(async () => []),
@@ -292,7 +306,10 @@ describe('AsyncQueryService', () => {
         beforeEach(() => {
             // clear in memory cache so new mock is applied
             serviceWithCache.warehouseClients = {};
-            serviceWithCache.cacheService = {} as ICacheService;
+            serviceWithCache.cacheService = {
+                isResultsCacheEnabled: jest.fn(async () => true),
+                findCachedResultsFile: jest.fn(async () => null),
+            } as unknown as ICacheService;
 
             jest.clearAllMocks();
 
@@ -565,10 +582,11 @@ describe('AsyncQueryService', () => {
                 { query: metricQueryMock },
             );
 
-            // THEN: findResultsCache called with invalidate flag (third parameter: true)
+            // THEN: findResultsCache called with invalidate flag (last parameter: true)
             expect(serviceWithCache.findResultsCache).toHaveBeenCalledWith(
                 projectUuid,
                 expect.any(String),
+                expect.any(Object), // account
                 true,
             );
 
@@ -622,6 +640,7 @@ describe('AsyncQueryService', () => {
             // Clear cache and mocks for this service
             serviceWithoutCache.warehouseClients = {};
             serviceWithoutCache.cacheService = {
+                isResultsCacheEnabled: jest.fn(async () => false),
                 findCachedResultsFile: jest.fn(),
             } as unknown as ICacheService;
 
@@ -666,6 +685,7 @@ describe('AsyncQueryService', () => {
             expect(findResultsCacheSpy).toHaveBeenCalledWith(
                 projectUuid,
                 expect.any(String), // cache key
+                expect.any(Object), // account
                 false, // invalidateCache
             );
 
@@ -1193,7 +1213,10 @@ describe('AsyncQueryService', () => {
         beforeEach(() => {
             // clear in memory cache so new mock is applied
             serviceWithCache.warehouseClients = {};
-            serviceWithCache.cacheService = {} as ICacheService;
+            serviceWithCache.cacheService = {
+                isResultsCacheEnabled: jest.fn(async () => true),
+                findCachedResultsFile: jest.fn(async () => null),
+            } as unknown as ICacheService;
 
             jest.clearAllMocks();
         });
@@ -1658,7 +1681,10 @@ describe('AsyncQueryService', () => {
 
         beforeEach(() => {
             serviceWithCache.warehouseClients = {};
-            serviceWithCache.cacheService = {} as ICacheService;
+            serviceWithCache.cacheService = {
+                isResultsCacheEnabled: jest.fn(async () => true),
+                findCachedResultsFile: jest.fn(async () => null),
+            } as unknown as ICacheService;
             jest.clearAllMocks();
 
             serviceWithCache.findResultsCache = jest

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -504,16 +504,22 @@ export class AsyncQueryService extends ProjectService {
     async findResultsCache(
         projectUuid: string,
         cacheKey: string,
+        account: Account,
         invalidateCache: boolean = false,
     ): Promise<CreateCacheResult> {
         if (!invalidateCache) {
-            // Check if cache already exists
+            // CommercialCacheService gates internally on the
+            // ResultsCacheEnabled feature flag (DB → env fallback).
             const existingCache =
                 await this.cacheService?.findCachedResultsFile(
                     projectUuid,
                     cacheKey,
+                    {
+                        userUuid: account.user.id,
+                        organizationUuid: account.organization.organizationUuid,
+                        organizationName: account.organization.name,
+                    },
                 );
-            // Valid cache exists and not being invalidated
             if (existingCache) {
                 return existingCache;
             }
@@ -836,13 +842,20 @@ export class AsyncQueryService extends ProjectService {
                 displayTimezone ?? undefined,
             );
 
+        const resultsCacheEnabled =
+            (await this.cacheService?.isResultsCacheEnabled({
+                userUuid: account.user.id,
+                organizationUuid: account.organization.organizationUuid,
+                organizationName: account.organization.name,
+            })) ?? false;
+
         const {
             result: { rows },
             durationMs,
         } = await measureTime(
             () =>
                 this.getResultsStorageClientForContext(queryHistory.context)
-                    .isEnabled || this.cacheService?.isEnabled
+                    .isEnabled || resultsCacheEnabled
                     ? this.getResultsPageFromS3(
                           queryUuid,
                           resultsFileName,
@@ -3117,6 +3130,7 @@ export class AsyncQueryService extends ProjectService {
                     const resultsCache = await this.findResultsCache(
                         projectUuid,
                         cacheKey,
+                        account,
                         args.invalidateCache,
                     );
                     const cacheCheckMs = Date.now() - cacheCheckStart;

--- a/packages/backend/src/services/CacheService/ICacheService.ts
+++ b/packages/backend/src/services/CacheService/ICacheService.ts
@@ -1,9 +1,24 @@
+import { LightdashUser } from '@lightdash/common';
 import { CacheHitCacheResult } from './types';
 
+export type CacheServiceUser = Pick<
+    LightdashUser,
+    'userUuid' | 'organizationUuid' | 'organizationName'
+>;
+
 export interface ICacheService {
-    isEnabled: boolean;
+    /**
+     * Resolve whether results caching is enabled for the given user/org. The
+     * implementation reads the ResultsCacheEnabled feature flag (DB value
+     * with env fallback). Pass `undefined` for callers that don't have a
+     * user (rare — e.g. background jobs) — only the env fallback applies.
+     */
+    isResultsCacheEnabled: (
+        user: CacheServiceUser | undefined,
+    ) => Promise<boolean>;
     findCachedResultsFile: (
         projectUuid: string,
         cacheKey: string,
+        user: CacheServiceUser,
     ) => Promise<CacheHitCacheResult | null>;
 }

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -105,7 +105,6 @@ export const BaseResponse: HealthState = {
         profilesSampleRate: 0,
     },
     hasCacheAutocompleResults: false,
-    hasResultsCaching: false,
     appearance: {
         overrideColorPalette: undefined,
         overrideColorPaletteName: undefined,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -184,7 +184,6 @@ export class HealthService extends BaseService {
                 this.lightdashConfig.extendedUsageAnalytics.enabled,
             hasCacheAutocompleResults:
                 this.lightdashConfig.results.autocompleteEnabled,
-            hasResultsCaching: this.lightdashConfig.results.cacheEnabled,
             appearance: {
                 overrideColorPalette:
                     this.lightdashConfig.appearance.overrideColorPalette,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1,6 +1,7 @@
 import { Ability } from '@casl/ability';
 import {
     defineUserAbility,
+    FeatureFlags,
     FilterOperator,
     ForbiddenError,
     MetricType,
@@ -246,10 +247,20 @@ const getMockedProjectService = (
         encryptionUtil: {} as EncryptionUtil,
         userModel: {} as UserModel,
         featureFlagModel: {
-            get: jest.fn(async () => ({
-                id: '',
-                enabled: false,
-            })),
+            // Mirror production behaviour: ResultsCacheEnabled resolves from
+            // the env-derived lightdashConfig.results.cacheEnabled when there
+            // is no DB row.
+            get: jest.fn(
+                async ({ featureFlagId }: { featureFlagId: string }) => {
+                    if (featureFlagId === FeatureFlags.ResultsCacheEnabled) {
+                        return {
+                            id: featureFlagId,
+                            enabled: lightdashConfig.results.cacheEnabled,
+                        };
+                    }
+                    return { id: featureFlagId, enabled: false };
+                },
+            ),
         } as unknown as FeatureFlagModel,
         projectParametersModel: {
             find: jest.fn(async () => []),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -102,6 +102,7 @@ import {
     JobType,
     LightdashError,
     LightdashProjectConfig,
+    LightdashUser,
     maybeOverrideDbtConnection,
     maybeOverrideWarehouseConnection,
     maybeReplaceFieldsInChartVersion,
@@ -4195,6 +4196,7 @@ export class ProjectService extends BaseService {
     async getResultsFromCacheOrWarehouse({
         projectUuid,
         userUuid,
+        user,
         context,
         warehouseClient,
         query,
@@ -4204,6 +4206,10 @@ export class ProjectService extends BaseService {
     }: {
         projectUuid: string;
         userUuid: string | null;
+        user: Pick<
+            LightdashUser,
+            'userUuid' | 'organizationUuid' | 'organizationName'
+        >;
         context: QueryExecutionContext;
         warehouseClient: WarehouseClient;
         query: AnyType;
@@ -4225,10 +4231,13 @@ export class ProjectService extends BaseService {
                 span.setAttribute('queryHash', queryHash);
                 span.setAttribute('cacheHit', false);
 
-                if (
-                    this.lightdashConfig.results.cacheEnabled &&
-                    !invalidateCache
-                ) {
+                const { enabled: resultsCacheEnabled } =
+                    await this.featureFlagModel.get({
+                        user,
+                        featureFlagId: FeatureFlags.ResultsCacheEnabled,
+                    });
+
+                if (resultsCacheEnabled && !invalidateCache) {
                     const cacheEntryMetadata = await this.s3CacheClient
                         .getResultsMetadata(queryHash)
                         .catch((e) => undefined); // ignore since error is tracked in fileStorageClient
@@ -4313,7 +4322,7 @@ export class ProjectService extends BaseService {
                     },
                 );
 
-                if (this.lightdashConfig.results.cacheEnabled) {
+                if (resultsCacheEnabled) {
                     this.logger.debug(
                         `Writing data to cache with key ${queryHash}`,
                     );
@@ -4543,6 +4552,12 @@ export class ProjectService extends BaseService {
                         await this.getResultsFromCacheOrWarehouse({
                             projectUuid,
                             userUuid,
+                            user: {
+                                userUuid: account.user.id,
+                                organizationUuid:
+                                    account.organization.organizationUuid,
+                                organizationName: account.organization.name,
+                            },
                             context,
                             warehouseClient,
                             metricQuery: metricQueryWithLimit,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -477,7 +477,6 @@ export type HealthState = {
     hasHeadlessBrowser: boolean;
     hasExtendedUsageAnalytics: boolean;
     hasCacheAutocompleResults: boolean;
-    hasResultsCaching: boolean;
     appearance: {
         overrideColorPalette: string[] | undefined;
         overrideColorPaletteName: string | undefined;

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -129,6 +129,14 @@ export enum FeatureFlags {
      * per-org if it causes operational issues.
      */
     LeaveOrganization = 'leave-organization',
+
+    /**
+     * Enable query results caching. DB value (user/org override or flag
+     * default) takes precedence; falls back to the RESULTS_CACHE_ENABLED env
+     * var when no DB row is set. Lets shared-instance customers (eu1/app)
+     * opt in per-org without a redeploy.
+     */
+    ResultsCacheEnabled = 'results-cache-enabled',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     getFilterRulesFromGroup,
     getItemId,
     isField,
@@ -17,7 +18,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDebounce } from 'react-use';
 import { lightdashApi } from '../api';
 import useEmbed from '../ee/providers/Embed/useEmbed';
-import useHealth from './health/useHealth';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
 
 export const MAX_AUTOCOMPLETE_RESULTS = 50;
 
@@ -212,8 +213,10 @@ export const useFieldValues = (
     parameterValues?: ParametersValuesMap,
 ) => {
     const { embedToken } = useEmbed();
-    const { data: healthData } = useHealth();
-    const useAsyncPath = healthData?.hasResultsCaching === true;
+    const { data: resultsCacheFlag } = useServerFeatureFlag(
+        FeatureFlags.ResultsCacheEnabled,
+    );
+    const useAsyncPath = resultsCacheFlag?.enabled === true;
     const [fieldName, setFieldName] = useState<string>(field.name);
     const [debouncedSearch, setDebouncedSearch] = useState<string>(search);
     const [searches, setSearches] = useState(new Set<string>());

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -101,7 +101,6 @@ export default function mockHealthResponse(
         hasGithub: false,
         hasGitlab: false,
         hasCacheAutocompleResults: false,
-        hasResultsCaching: false,
         hasMicrosoftTeams: false,
         appearance: {
             overrideColorPalette: undefined,


### PR DESCRIPTION
### Closes: [https://linear.app/lightdash/issue/PROD-7496/replace-query-results-caching-env-var-with-database-value](https://linear.app/lightdash/issue/PROD-7496/replace-query-results-caching-env-var-with-database-value)  
  


### Description

Converts `RESULTS_CACHE_ENABLED` from a static environment-variable check into a feature flag (`ResultsCacheEnabled`) backed by `FeatureFlagModel`. The DB value (user override → org override → flag default) takes precedence; if no DB row exists, falls back to the existing `RESULTS_CACHE_ENABLED` env var. This unblocks shared-instance customers (eu1/app) who currently can't opt in to caching without a redeploy.

### Resolution priority

`user override → org override → flag default → RESULTS_CACHE_ENABLED env → false`

### Compatibility matrix

| DB state | ENV | Result | Who this is |
| --- | --- | --- | --- |
| no row | `true` | cache **on** | self-hosters and existing cloud (today's behavior) |
| no row | unset/`false` | cache **off** | self-hosters and shared instances (today's behavior) |
| `default_enabled=false`, no override | anything | cache **off** | shared instances opting in per-org |
| `default_enabled=false`, org override `=true` | anything | cache **on** for that org only | shared-instance customer enabled |
| `default_enabled=true` | anything | cache **on** | DB-enforced "always on" |

Existing customers with the env var set keep working with no DB changes.

### Backend changes

- New `ResultsCacheEnabled` flag + `getWithEnvFallback` helper in `FeatureFlagModel` (reusable for any future DB-first/env-fallback flag).
- `FeatureFlagModel.getFromDatabase` now skips the user-override lookup when `userUuid` isn't a valid UUID. Embed accounts use a non-UUID `external::…` ID; without this guard the user query raises a Postgres uuid type error and the catch silently swallows the org-override lookup too.
- `CommercialCacheService.findCachedResultsFile(projectUuid, cacheKey, user)` self-protects: gates internally on the FF, and exposes `isResultsCacheEnabled(user)` for the pagination path that previously read the sync `isEnabled` getter.
- `ICacheService.isEnabled` (sync boolean) replaced with `isResultsCacheEnabled(user)` (async). `findCachedResultsFile` now requires a `user` arg.
- `ProjectService.getResultsFromCacheOrWarehouse` widened to accept the user context. The embed path (`EmbedService._runEmbedQuery`) and the regular path both pass `account.user` / `account.organization` through.
- `AsyncQueryService.findResultsCache` accepts the `Account` and forwards user context to the cache service.

### Frontend changes

- `useFieldValues` reads the flag via `useServerFeatureFlag(ResultsCacheEnabled)` instead of `useHealth().hasResultsCaching`.
- `hasResultsCaching` removed from `HealthState` and `/api/v1/health` (it can't carry per-org values; the flag endpoint already exists).

### Breaking change

- `/api/v1/health` no longer returns `hasResultsCaching`. Anything scraping that field should switch to `GET /api/v2/feature-flag/results-cache-enabled`.

### Tested

- PAT path: flag on → cache hit on second run; flag off → no hit even with prior matching row.
- Embed path: with org override `=false` → no cache; remove override → cache hits resume. Confirms the UUID-skip fix is required for embed.
- Env-fallback: DB row deleted with env unset → resolves false (env fallback works).

### Out of scope

- `AUTOCOMPLETE_CACHE_ENABLED` and the autocomplete cache path are unchanged from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)