### PR TITLE
fix(cli): show correct project in log when --project overrides config

### DIFF
--- a/packages/cli/src/handlers/selectProject.test.ts
+++ b/packages/cli/src/handlers/selectProject.test.ts
@@ -1,7 +1,7 @@
 import { ProjectType } from '@lightdash/common';
 import { Config } from '../config';
 import { lightdashApi } from './dbt/apiClient';
-import { selectProject } from './selectProject';
+import { logSelectedProject, selectProject } from './selectProject';
 
 jest.mock('inquirer');
 jest.mock('../analytics/analytics');
@@ -71,5 +71,83 @@ describe('selectProject', () => {
             isPreview: false,
         });
         expect(mockLightdashApi).not.toHaveBeenCalled();
+    });
+});
+
+describe('logSelectedProject', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        consoleErrorSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    const getLoggedMessage = (): string =>
+        consoleErrorSpy.mock.calls.map((call) => String(call[0])).join('\n');
+
+    it('shows the config project name when the selected UUID matches the config project', () => {
+        const config: Config = {
+            context: {
+                project: MAIN_UUID,
+                projectName: 'main',
+            },
+        };
+
+        logSelectedProject(
+            { projectUuid: MAIN_UUID, isPreview: false },
+            config,
+            'Uploading to',
+        );
+
+        const output = getLoggedMessage();
+        expect(output).toContain('Uploading to project:');
+        expect(output).toContain('"main"');
+    });
+
+    it('shows the UUID (not the config project name) when --project overrides to a different project', () => {
+        const OVERRIDE_UUID = '00000000-0000-0000-0000-000000000099';
+        const config: Config = {
+            context: {
+                project: MAIN_UUID,
+                projectName: 'main',
+            },
+        };
+
+        logSelectedProject(
+            { projectUuid: OVERRIDE_UUID, isPreview: false },
+            config,
+            'Uploading to',
+        );
+
+        const output = getLoggedMessage();
+        expect(output).toContain('Uploading to project:');
+        expect(output).toContain(OVERRIDE_UUID);
+        expect(output).not.toContain('"main"');
+    });
+
+    it('shows the preview name when selection is a preview', () => {
+        const config: Config = {
+            context: {
+                project: MAIN_UUID,
+                projectName: 'main',
+                previewProject: PREVIEW_UUID,
+                previewName: 'my-preview',
+            },
+        };
+
+        logSelectedProject(
+            { projectUuid: PREVIEW_UUID, isPreview: true },
+            config,
+            'Uploading to',
+        );
+
+        const output = getLoggedMessage();
+        expect(output).toContain('Uploading to preview project:');
+        expect(output).toContain('"my-preview"');
     });
 });

--- a/packages/cli/src/handlers/selectProject.ts
+++ b/packages/cli/src/handlers/selectProject.ts
@@ -148,6 +148,7 @@ export const logSelectedProject = (
     const { projectUuid, isPreview } = selection;
     const previewName = config.context?.previewName;
     const mainProjectName = config.context?.projectName;
+    const mainProjectUuid = config.context?.project;
 
     if (isPreview) {
         const name = previewName ? `"${previewName}"` : projectUuid;
@@ -155,7 +156,14 @@ export const logSelectedProject = (
             `\n${styles.success(`${action} preview project:`)} ${name}\n`,
         );
     } else {
-        const name = mainProjectName ? `"${mainProjectName}"` : projectUuid;
+        // Only use the cached project name when the selection actually points
+        // at the config-set project. With --project, the UUID can differ and
+        // the cached name would be misleading.
+        const isConfigProject = mainProjectUuid === projectUuid;
+        const name =
+            isConfigProject && mainProjectName
+                ? `"${mainProjectName}"`
+                : projectUuid;
         GlobalState.log(`\n${styles.success(`${action} project:`)} ${name}\n`);
     }
 };


### PR DESCRIPTION
## Summary

Fixes [PROD-7536](https://linear.app/lightdash/issue/PROD-7536/project-flag-shows-wrong-project-name-in-log-output).

`lightdash upload --project <uuid>` (and `download`) logged the wrong project: the cached name from `lightdash config set-project` instead of the override target. The upload/download itself targeted the correct project — only the log line was misleading.

`logSelectedProject` now compares the selected `projectUuid` against `config.context.project`. The cached `projectName` is only used when they match; otherwise the UUID is logged.

## Test plan

- [x] New tests in `selectProject.test.ts` cover the override, match, and preview cases
- [x] `pnpm -F cli lint` clean
- [x] `pnpm -F cli typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)