### PR TITLE
fix(leave-org): delete the user on leave to match admin-remove cleanup

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -173,14 +173,6 @@ type UserJoinOrganizationEvent = BaseTrack & {
     };
 };
 
-type UserLeaveOrganizationEvent = BaseTrack & {
-    event: 'user.left_organization';
-    properties: {
-        organizationId: string;
-        role: OrganizationMemberRole;
-    };
-};
-
 export const getContextFromHeader = (req: Request) => {
     const method = getRequestMethod(req.header(LightdashRequestMethodHeader));
     switch (method) {
@@ -1949,7 +1941,6 @@ type TypedEvent =
     | DeleteUserEvent
     | VerifiedUserEvent
     | UserJoinOrganizationEvent
-    | UserLeaveOrganizationEvent
     | QueryExecutionEvent
     | QueryReadyEvent
     | QueryErrorEvent

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -440,28 +440,6 @@ export class OrganizationMemberProfileModel {
         });
     }
 
-    async deleteOrganizationMembershipByUuid({
-        organizationUuid,
-        userUuid,
-    }: {
-        organizationUuid: string;
-        userUuid: string;
-    }): Promise<void> {
-        const userIdSubquery = this.database
-            .select('user_id')
-            .from(UserTableName)
-            .where('user_uuid', userUuid);
-        const organizationIdSubquery = this.database
-            .select('organization_id')
-            .from(OrganizationTableName)
-            .where('organization_uuid', organizationUuid);
-
-        await this.database(OrganizationMembershipsTableName)
-            .where('user_id', userIdSubquery)
-            .andWhere('organization_id', organizationIdSubquery)
-            .delete();
-    }
-
     async getOrganizationMemberByUuid(
         organizationUuid: string,
         userUuid: string,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -449,6 +449,44 @@ export class UserService extends BaseService {
         return user;
     }
 
+    /**
+     * Destroys a user's sessions, their `users` row (cascading every
+     * user-scoped table — sessions, personal_access_tokens, schedulers,
+     * project_memberships, space_user_access, …), and emits the
+     * `user.deleted` analytics event with the supplied context.
+     *
+     * Shared by the admin-remove path (`delete`) and the self-serve leave
+     * path (`leaveOrganization`); each owns its own authorization + business
+     * rule checks and calls this helper once it has decided the user is
+     * going to be removed.
+     */
+    private async destroyUser({
+        actor,
+        userToDelete,
+        context,
+    }: {
+        actor: SessionUser;
+        userToDelete: NonNullable<
+            Awaited<ReturnType<UserModel['getUserDetailsByUuid']>>
+        >;
+        context: 'delete_self' | 'delete_org_member' | 'leave_organization';
+    }): Promise<void> {
+        await this.sessionModel.deleteAllByUserUuid(userToDelete.userUuid);
+        await this.userModel.delete(userToDelete.userUuid);
+        this.analytics.track({
+            event: 'user.deleted',
+            userId: actor.userUuid,
+            properties: {
+                context,
+                firstName: userToDelete.firstName,
+                lastName: userToDelete.lastName,
+                email: userToDelete.email,
+                organizationId: userToDelete.organizationUuid,
+                deletedUserId: userToDelete.userUuid,
+            },
+        });
+    }
+
     async delete(user: SessionUser, userUuidToDelete: string): Promise<void> {
         const auditedAbility = this.createAuditedAbility(user);
         const userToDelete =
@@ -484,23 +522,21 @@ export class UserService extends BaseService {
             }
         }
 
-        await this.sessionModel.deleteAllByUserUuid(userUuidToDelete);
+        if (!userToDelete) {
+            // Pre-org "Cancel registration" path: there is no org-scoped state
+            // to clean up, just remove the row. Fall back to a direct delete.
+            await this.sessionModel.deleteAllByUserUuid(userUuidToDelete);
+            await this.userModel.delete(userUuidToDelete);
+            return;
+        }
 
-        await this.userModel.delete(userUuidToDelete);
-        this.analytics.track({
-            event: 'user.deleted',
-            userId: user.userUuid,
-            properties: {
-                context:
-                    user.userUuid !== userUuidToDelete
-                        ? 'delete_org_member'
-                        : 'delete_self',
-                firstName: userToDelete.firstName,
-                lastName: userToDelete.lastName,
-                email: userToDelete.email,
-                organizationId: userToDelete.organizationUuid,
-                deletedUserId: userUuidToDelete,
-            },
+        await this.destroyUser({
+            actor: user,
+            userToDelete,
+            context:
+                user.userUuid !== userUuidToDelete
+                    ? 'delete_org_member'
+                    : 'delete_self',
         });
     }
 
@@ -1838,14 +1874,23 @@ export class UserService extends BaseService {
             );
         }
 
-        await this.organizationMemberProfileModel.deleteOrganizationMembershipByUuid(
-            {
-                organizationUuid,
-                userUuid: user.userUuid,
-            },
+        // Leaving an organization deletes the user record entirely. The
+        // single-org-per-user invariant means there is no other org for the
+        // user to remain a member of, and deleting the `users` row CASCADEs
+        // through every user-scoped table — matching the cleanup that admin
+        // remove-user already performs. If the leaver is later invited
+        // again, the invite flow creates a fresh `users` row.
+        const userToDelete = await this.userModel.getUserDetailsByUuid(
+            user.userUuid,
         );
-
-        await this.sessionModel.deleteAllByUserUuid(user.userUuid);
+        if (!userToDelete) {
+            throw new NotFoundError(`User ${user.userUuid} not found`);
+        }
+        await this.destroyUser({
+            actor: user,
+            userToDelete,
+            context: 'leave_organization',
+        });
 
         this.logger.info('User left organization', {
             userUuid: user.userUuid,
@@ -1861,15 +1906,6 @@ export class UserService extends BaseService {
             organizationUuid,
             metadata: { role: member.role },
             context,
-        });
-
-        this.analytics.track({
-            userId: user.userUuid,
-            event: 'user.left_organization',
-            properties: {
-                organizationId: organizationUuid,
-                role: member.role,
-            },
         });
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #22915. Audits after the original leave-organization PR landed showed that the lean implementation (delete the `organization_memberships` row + the user's sessions, leave the rest) left a long trail of org-scoped state behind that the existing admin remove-user path wipes via FK CASCADE.

This PR closes the gap by making the leave path call the **same DB primitive** the admin-remove path uses: `userModel.delete(userUuid)`. PostgreSQL's CASCADE rules then handle every user-scoped table in one shot. The user record itself is removed; if the leaver is invited back later, `UserService.createPendingUserAndInviteLink` already handles "no existing user with this email" by creating a fresh `users` row, so the round-trip is identical to onboarding a new person.

## Side-effects this fixes

Each was reproduced live against `main` before the change:

| Side-effect | Severity | Before | After |
|---|---|---|---|
| `project_memberships` survives → re-inviting at a lower org role silently re-grants the prior project role | HIGH (privilege escalation) | Bob = project-editor → leaves → re-invited as org-viewer → API reports project role=editor and UI shows Edit chart button | Row CASCADEs on user delete; no ghost grant on rejoin |
| `space_user_access` survives → metadata leak ("editor on Parent Space 1" reported by API even after leaving as viewer) | MEDIUM | API metadata returns wrong role | CASCADEd |
| `scheduler` keeps firing → cron worker continues materializing delivery jobs for the leaver's schedulers, emails arrive with "Failed to export" body forever | MEDIUM (recurring noise + admin has no signal) | Reproduced: Bob's scheduler delivered an error email to his inbox after he left | CASCADEd on `scheduler.created_by` FK |
| `personal_access_tokens` outlives org change → a PAT minted in org A keeps working after the user joins org B | LOW (security-relevant) | Reproduced: same PAT switched orgs silently | CASCADEd |
| `user_favorites`, `user_warehouse_credentials` linger | COSMETIC | DB rows for left orgs persist | CASCADEd |

## Refactor

- Extracted a private `destroyUser({ actor, userToDelete, context })` helper on `UserService`. The admin-remove `delete()` and the new `leaveOrganization()` both call it after their own authorization / business-rule checks. Single place for sessions delete + `userModel.delete` + analytics.
- Dropped the redundant `user.left_organization` analytics event in favor of `user.deleted` with `context: 'leave_organization'` — same pattern already used for `delete_self` / `delete_org_member`.
- Removed the now-unused `OrganizationMemberProfileModel.deleteOrganizationMembershipByUuid` primitive (added in #22915 specifically for the lean leave path; no other callers).

## Cleanup behaviour shared with admin-remove

Because `leaveOrganization` now calls the same `userModel.delete(userUuid)` primitive as the admin-remove path, the leave flow inherits the existing Postgres FK rules. These behaviours are **not new** — they have been admin-remove's behaviour all along — but worth being explicit about now that they are also user-self-triggered:

| Table | FK rule | Effect on leave / admin-remove |
|---|---|---|
| `dashboard_tile_comments.user_uuid` | `CASCADE` | The leaver's comments on shared dashboards are **deleted**, not anonymized. Reply threads other org members were reading may lose context. |
| `saved_queries_versions.updated_by_user_uuid`, `dashboard_versions.updated_by_user_uuid`, `saved_sql_versions.created_by_user_uuid` | `SET NULL` | Old chart/dashboard versions render with no author. The list view's "Last updated by" gracefully falls back to `saved_queries.last_version_updated_by_user_uuid` (also nullable). |
| `slack_auth_tokens.created_by_user_id` | `SET NULL` | The org-level Slack integration keeps working but loses attribution to its installer. This is the intentional design — otherwise the installer leaving would break Slack for the whole org. |
| `projects.created_by_user_uuid`, `spaces.created_by_user_id`, `groups.created_by_user_uuid`, `slack_auth_tokens.created_by_user_id`, `roles.created_by`, `tags.created_by_user_uuid`, … | `SET NULL` | Artifact survives, "created by" attribution drops. Standard pattern across the schema for content the leaver authored. |
| `analytics_app_views.user_uuid`, `analytics_chart_views.user_uuid`, `analytics_dashboard_views.user_uuid` | `SET NULL` | View counters preserved; the row is no longer attributable to the deleted user. |

The complete `users` FK audit (every child table + delete rule) was verified before merging this PR. No `RESTRICT` / `NO ACTION` rules exist on `users`, so the delete is guaranteed not to fail mid-cascade.

If we ever want to change one of these behaviours (e.g. anonymize comments rather than delete them), the fix belongs in the schema (FK rule change) and would apply to both admin-remove and leave automatically — they cannot drift again.

## Test plan

- [x] `pnpm -F backend typecheck` clean
- [x] `pnpm -F backend lint` clean
- [x] Manual side-effect repro:
  - Plant Bob in Jaffle Shop as editor + a planted PAT, project_membership, space_user_access, user_favorite, user_warehouse_credentials, scheduler (7 rows total across 7 tables).
  - Trigger `DELETE /api/v1/user/me/leaveOrganization` as Bob.
  - All 7 rows go to 0, including Bob's own `users` and `emails` rows. Audit log records `leave_organization` `(allowed)` as before.
- [ ] Reviewer to verify the squash-merged docs PR (lightdash/mintlify-docs#609) is still accurate after this change — the page describes the user-facing behavior, which is unchanged.

## Behavioural note for the docs

The docs in `lightdash/mintlify-docs#609` say "your user account is preserved" was already removed in earlier review — good, because that's no longer true with this PR. From the user's perspective the experience is the same: they hit Leave, type the org name, get signed out, can be invited back later. The DB just does the right cleanup underneath.

Refs lightdash/lightdash#22211
Follow-up to lightdash/lightdash#22915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
