### PR TITLE
feat(data-apps): add data app dashboard tile

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -51,6 +51,8 @@ import {
     DashboardTabsTableName,
     DashboardTileChartTable,
     DashboardTileChartTableName,
+    DashboardTileDataAppsTable,
+    DashboardTileDataAppsTableName,
     DashboardTileHeadingsTable,
     DashboardTileHeadingsTableName,
     DashboardTileLoomsTable,
@@ -414,6 +416,7 @@ declare module 'knex/types/tables' {
         [DashboardTileLoomsTableName]: DashboardTileLoomsTable;
         [DashboardTileMarkdownsTableName]: DashboardTileMarkdownsTable;
         [DashboardTileHeadingsTableName]: DashboardTileHeadingsTable;
+        [DashboardTileDataAppsTableName]: DashboardTileDataAppsTable;
         [OnboardingTableName]: OnboardingTable;
         [OpenIdIdentitiesTableName]: OpenIdIdentitiesTable;
         [OrganizationMembershipsTableName]: OrganizationMembershipsTable;

--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -16,6 +16,7 @@ export const DashboardTileSqlChartTableName = 'dashboard_tile_sql_charts';
 export const DashboardTileMarkdownsTableName = 'dashboard_tile_markdowns';
 export const DashboardTileLoomsTableName = 'dashboard_tile_looms';
 export const DashboardTileHeadingsTableName = 'dashboard_tile_headings';
+export const DashboardTileDataAppsTableName = 'dashboard_tile_data_apps';
 export const DashboardTabsTableName = 'dashboard_tabs';
 
 export type DbDashboard = {
@@ -147,6 +148,17 @@ type DbDashboardTileHeadings = {
 
 export type DashboardTileHeadingsTable =
     Knex.CompositeTableType<DbDashboardTileHeadings>;
+
+type DbDashboardTileDataApps = {
+    dashboard_version_id: number;
+    dashboard_tile_uuid: string;
+    app_uuid: string;
+    title: string | null;
+    hide_title: boolean | null;
+};
+
+export type DashboardTileDataAppsTable =
+    Knex.CompositeTableType<DbDashboardTileDataApps>;
 
 export type DbDashboardTabs = {
     name: string;

--- a/packages/backend/src/database/migrations/20260512140520_add_data_app_dashboard_tile.ts
+++ b/packages/backend/src/database/migrations/20260512140520_add_data_app_dashboard_tile.ts
@@ -1,0 +1,55 @@
+import { Knex } from 'knex';
+
+const DashboardTilesTable = 'dashboard_tiles';
+const DashboardTileTypesTable = 'dashboard_tile_types';
+const DashboardTileDataAppsTable = 'dashboard_tile_data_apps';
+const AppsTable = 'apps';
+
+const dataAppType = 'data_app';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex(DashboardTileTypesTable)
+        .insert({ dashboard_tile_type: dataAppType })
+        .onConflict('dashboard_tile_type')
+        .ignore();
+
+    if (!(await knex.schema.hasTable(DashboardTileDataAppsTable))) {
+        await knex.schema.createTable(DashboardTileDataAppsTable, (table) => {
+            table.integer('dashboard_version_id').notNullable();
+            table
+                .uuid('dashboard_tile_uuid')
+                .notNullable()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+
+            // Composite FK back to dashboard_tiles so dashboard version
+            // deletes don't leave orphans. Mirrors the loom/markdown/heading/
+            // chart tile tables — sql_chart skipped this and is the outlier.
+            table
+                .foreign(['dashboard_version_id', 'dashboard_tile_uuid'])
+                .references(['dashboard_version_id', 'dashboard_tile_uuid'])
+                .inTable(DashboardTilesTable)
+                .onDelete('CASCADE');
+
+            table
+                .uuid('app_uuid')
+                .references('app_id')
+                .inTable(AppsTable)
+                .notNullable()
+                .onDelete('CASCADE')
+                .index();
+
+            table.text('title').nullable();
+            table.boolean('hide_title').defaultTo(false);
+
+            table.primary(['dashboard_version_id', 'dashboard_tile_uuid']);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex(DashboardTilesTable).delete().where('type', dataAppType);
+    await knex(DashboardTileTypesTable)
+        .delete()
+        .where('dashboard_tile_type', dataAppType);
+    await knex.schema.dropTableIfExists(DashboardTileDataAppsTable);
+}

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -373,6 +373,7 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
             case DashboardTileTypes.MARKDOWN:
             case DashboardTileTypes.LOOM:
             case DashboardTileTypes.HEADING:
+            case DashboardTileTypes.DATA_APP:
                 return {
                     status: 'ineligible',
                     tileUuid: tile.uuid,

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -3,12 +3,14 @@ import {
     ContentType,
     CreateDashboard,
     CreateDashboardChartTile,
+    CreateDashboardDataAppTile,
     CreateDashboardHeadingTile,
     CreateDashboardLoomTile,
     CreateDashboardMarkdownTile,
     CreateDashboardSqlChartTile,
     DashboardChartTile,
     DashboardDAO,
+    DashboardDataAppTile,
     DashboardHeadingTile,
     DashboardLoomTile,
     DashboardMarkdownTile,
@@ -19,6 +21,7 @@ import {
     DashboardVersionedFields,
     HTML_SANITIZE_MARKDOWN_TILE_RULES,
     isDashboardChartTileType,
+    isDashboardDataAppTileType,
     isDashboardHeadingTileType,
     isDashboardLoomTileType,
     isDashboardMarkdownTileType,
@@ -37,12 +40,14 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
+import { AppsTableName } from '../../database/entities/apps';
 import {
     DashboardsTableName,
     DashboardTable,
     DashboardTabsTableName,
     DashboardTileChartTable,
     DashboardTileChartTableName,
+    DashboardTileDataAppsTableName,
     DashboardTileHeadingsTableName,
     DashboardTileLoomsTableName,
     DashboardTileMarkdownsTableName,
@@ -196,6 +201,7 @@ export class DashboardModel {
             | (CreateDashboardLoomTile & { uuid: string })
             | (CreateDashboardSqlChartTile & { uuid: string })
             | (CreateDashboardHeadingTile & { uuid: string })
+            | (CreateDashboardDataAppTile & { uuid: string })
         > = version.tiles.map((tile) => ({
             ...tile,
             uuid: tile.uuid || uuidv4(),
@@ -322,6 +328,19 @@ export class DashboardModel {
                     saved_sql_uuid: properties.savedSqlUuid,
                     hide_title: properties.hideTitle,
                     title: properties.title,
+                })),
+            );
+        }
+
+        const dataAppTiles = tilesWithUuids.filter(isDashboardDataAppTileType);
+        if (dataAppTiles.length > 0) {
+            await trx(DashboardTileDataAppsTableName).insert(
+                dataAppTiles.map(({ uuid, properties }) => ({
+                    dashboard_version_id: versionId.dashboard_version_id,
+                    dashboard_tile_uuid: uuid,
+                    app_uuid: properties.appUuid,
+                    title: properties.title ?? null,
+                    hide_title: properties.hideTitle ?? false,
                 })),
             );
         }
@@ -898,6 +917,8 @@ export class DashboardModel {
                     last_version_chart_kind: string | null;
                     tab_uuid: string;
                     chart_slug: string;
+                    app_uuid: string | null;
+                    data_app_deleted_at: Date | null;
                 }[]
             >(
                 `${DashboardTilesTableName}.x_offset`,
@@ -930,14 +951,16 @@ export class DashboardModel {
                         ${DashboardTileChartTableName}.title,
                         ${DashboardTileLoomsTableName}.title,
                         ${DashboardTileMarkdownsTableName}.title,
-                        ${DashboardTileSqlChartTableName}.title
+                        ${DashboardTileSqlChartTableName}.title,
+                        ${DashboardTileDataAppsTableName}.title
                     ) AS title`,
                 ),
                 this.database.raw(
                     `COALESCE(
                         ${DashboardTileLoomsTableName}.hide_title,
                         ${DashboardTileChartTableName}.hide_title,
-                        ${DashboardTileSqlChartTableName}.hide_title
+                        ${DashboardTileSqlChartTableName}.hide_title,
+                        ${DashboardTileDataAppsTableName}.hide_title
                     ) AS hide_title`,
                 ),
                 `${DashboardTileLoomsTableName}.url`,
@@ -945,6 +968,10 @@ export class DashboardModel {
                 `${DashboardTileMarkdownsTableName}.hide_frame`,
                 `${DashboardTileHeadingsTableName}.text`,
                 `${DashboardTileHeadingsTableName}.show_divider`,
+                `${DashboardTileDataAppsTableName}.app_uuid`,
+                this.database.raw(
+                    `${AppsTableName}.deleted_at AS data_app_deleted_at`,
+                ),
             )
             .leftJoin(DashboardTileChartTableName, function chartsJoin() {
                 this.on(
@@ -1020,6 +1047,27 @@ export class DashboardModel {
                     `${SavedChartsTableName}.saved_query_id`,
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
+            .leftJoin(DashboardTileDataAppsTableName, function dataAppsJoin() {
+                this.on(
+                    `${DashboardTileDataAppsTableName}.dashboard_tile_uuid`,
+                    '=',
+                    `${DashboardTilesTableName}.dashboard_tile_uuid`,
+                );
+                this.andOn(
+                    `${DashboardTileDataAppsTableName}.dashboard_version_id`,
+                    '=',
+                    `${DashboardTilesTableName}.dashboard_version_id`,
+                );
+            })
+            // Intentionally does NOT filter `apps.deleted_at IS NULL`. We
+            // need to surface soft-deleted apps so the frontend can render a
+            // "this app no longer exists" placeholder instead of a broken
+            // iframe.
+            .leftJoin(
+                AppsTableName,
+                `${DashboardTileDataAppsTableName}.app_uuid`,
+                `${AppsTableName}.app_id`,
+            )
             .where(
                 `${DashboardTilesTableName}.dashboard_version_id`,
                 dashboard.dashboard_version_id,
@@ -1092,6 +1140,8 @@ export class DashboardModel {
                     last_version_chart_kind,
                     tab_uuid,
                     chart_slug,
+                    app_uuid,
+                    data_app_deleted_at,
                 }) => {
                     const base: Omit<
                         DashboardDAO['tiles'][number],
@@ -1161,6 +1211,18 @@ export class DashboardModel {
                                 properties: {
                                     text: text || '',
                                     showDivider: show_divider ?? false,
+                                },
+                            };
+                        case DashboardTileTypes.DATA_APP:
+                            return <DashboardDataAppTile>{
+                                ...base,
+                                type: DashboardTileTypes.DATA_APP,
+                                properties: {
+                                    ...commonProperties,
+                                    appUuid: app_uuid ?? '',
+                                    appDeletedAt:
+                                        data_app_deleted_at?.toISOString() ??
+                                        null,
                                 },
                             };
                         default: {
@@ -1895,6 +1957,8 @@ export class DashboardModel {
                     last_version_chart_kind: string | null;
                     tab_uuid: string;
                     chart_slug: string;
+                    app_uuid: string | null;
+                    data_app_deleted_at: Date | null;
                 }[]
             >(
                 `${DashboardTilesTableName}.x_offset`,
@@ -1927,14 +1991,16 @@ export class DashboardModel {
                         ${DashboardTileChartTableName}.title,
                         ${DashboardTileLoomsTableName}.title,
                         ${DashboardTileMarkdownsTableName}.title,
-                        ${DashboardTileSqlChartTableName}.title
+                        ${DashboardTileSqlChartTableName}.title,
+                        ${DashboardTileDataAppsTableName}.title
                     ) AS title`,
                 ),
                 this.database.raw(
                     `COALESCE(
                         ${DashboardTileLoomsTableName}.hide_title,
                         ${DashboardTileChartTableName}.hide_title,
-                        ${DashboardTileSqlChartTableName}.hide_title
+                        ${DashboardTileSqlChartTableName}.hide_title,
+                        ${DashboardTileDataAppsTableName}.hide_title
                     ) AS hide_title`,
                 ),
                 `${DashboardTileLoomsTableName}.url`,
@@ -1942,6 +2008,10 @@ export class DashboardModel {
                 `${DashboardTileMarkdownsTableName}.hide_frame`,
                 `${DashboardTileHeadingsTableName}.text`,
                 `${DashboardTileHeadingsTableName}.show_divider`,
+                `${DashboardTileDataAppsTableName}.app_uuid`,
+                this.database.raw(
+                    `${AppsTableName}.deleted_at AS data_app_deleted_at`,
+                ),
             )
             .leftJoin(DashboardTileChartTableName, function chartsJoin() {
                 this.on(
@@ -2012,6 +2082,23 @@ export class DashboardModel {
                 SavedChartsTableName,
                 `${DashboardTileChartTableName}.saved_chart_id`,
                 `${SavedChartsTableName}.saved_query_id`,
+            )
+            .leftJoin(DashboardTileDataAppsTableName, function dataAppsJoin() {
+                this.on(
+                    `${DashboardTileDataAppsTableName}.dashboard_tile_uuid`,
+                    '=',
+                    `${DashboardTilesTableName}.dashboard_tile_uuid`,
+                );
+                this.andOn(
+                    `${DashboardTileDataAppsTableName}.dashboard_version_id`,
+                    '=',
+                    `${DashboardTilesTableName}.dashboard_version_id`,
+                );
+            })
+            .leftJoin(
+                AppsTableName,
+                `${DashboardTileDataAppsTableName}.app_uuid`,
+                `${AppsTableName}.app_id`,
             )
             .where(
                 `${DashboardTilesTableName}.dashboard_version_id`,
@@ -2085,6 +2172,8 @@ export class DashboardModel {
                     last_version_chart_kind,
                     tab_uuid,
                     chart_slug,
+                    app_uuid,
+                    data_app_deleted_at,
                 }) => {
                     const base: Omit<
                         DashboardDAO['tiles'][number],
@@ -2154,6 +2243,18 @@ export class DashboardModel {
                                 properties: {
                                     text: text || '',
                                     showDivider: show_divider ?? false,
+                                },
+                            };
+                        case DashboardTileTypes.DATA_APP:
+                            return <DashboardDataAppTile>{
+                                ...base,
+                                type: DashboardTileTypes.DATA_APP,
+                                properties: {
+                                    ...commonProperties,
+                                    appUuid: app_uuid ?? '',
+                                    appDeletedAt:
+                                        data_app_deleted_at?.toISOString() ??
+                                        null,
                                 },
                             };
                         default: {

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -21,6 +21,7 @@ export enum DashboardTileTypes {
     MARKDOWN = 'markdown',
     LOOM = 'loom',
     HEADING = 'heading',
+    DATA_APP = 'data_app',
 }
 
 type CreateDashboardTileBase = {
@@ -86,6 +87,19 @@ export type DashboardHeadingTileProperties = {
     };
 };
 
+export type DashboardDataAppTileProperties = {
+    type: DashboardTileTypes.DATA_APP;
+    properties: {
+        title: string;
+        hideTitle?: boolean;
+        appUuid: string;
+        // Set by the backend when the referenced app has been soft-deleted,
+        // so the frontend can render a placeholder instead of trying to load
+        // a missing iframe.
+        appDeletedAt?: string | null;
+    };
+};
+
 export type CreateDashboardMarkdownTile = CreateDashboardTileBase &
     DashboardMarkdownTileProperties;
 export type DashboardMarkdownTile = DashboardTileBase &
@@ -110,6 +124,11 @@ export type CreateDashboardHeadingTile = CreateDashboardTileBase &
 export type DashboardHeadingTile = DashboardTileBase &
     DashboardHeadingTileProperties;
 
+export type CreateDashboardDataAppTile = CreateDashboardTileBase &
+    DashboardDataAppTileProperties;
+export type DashboardDataAppTile = DashboardTileBase &
+    DashboardDataAppTileProperties;
+
 export type CreateDashboard = {
     name: string;
     description?: string;
@@ -119,6 +138,7 @@ export type CreateDashboard = {
         | CreateDashboardLoomTile
         | CreateDashboardSqlChartTile
         | CreateDashboardHeadingTile
+        | CreateDashboardDataAppTile
     >;
     filters?: DashboardFilters;
     parameters?: DashboardParameters;
@@ -135,7 +155,8 @@ export type DashboardTile =
     | DashboardMarkdownTile
     | DashboardLoomTile
     | DashboardSqlChartTile
-    | DashboardHeadingTile;
+    | DashboardHeadingTile
+    | DashboardDataAppTile;
 
 export const isDashboardChartTileType = (
     tile: DashboardTile,
@@ -156,6 +177,10 @@ export const isDashboardSqlChartTile = (
 export const isDashboardHeadingTileType = (
     tile: DashboardTile,
 ): tile is DashboardHeadingTile => tile.type === DashboardTileTypes.HEADING;
+
+export const isDashboardDataAppTileType = (
+    tile: DashboardTile,
+): tile is DashboardDataAppTile => tile.type === DashboardTileTypes.DATA_APP;
 
 export type DashboardTab = {
     uuid: string;

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -390,7 +390,11 @@ export const matchFieldByTypeAndName = (a: Field) => (b: Field) =>
 export const matchFieldByType = (a: Field) => (b: Field) => a.type === b.type;
 
 export const isTileFilterable = (tile: DashboardTile) =>
-    ![DashboardTileTypes.MARKDOWN, DashboardTileTypes.LOOM].includes(tile.type);
+    ![
+        DashboardTileTypes.MARKDOWN,
+        DashboardTileTypes.LOOM,
+        DashboardTileTypes.DATA_APP,
+    ].includes(tile.type);
 
 const getDefaultTileTargets = (
     field: FilterableDimension | Metric | Field,

--- a/packages/common/src/utils/i18n/dashboardAsCode.ts
+++ b/packages/common/src/utils/i18n/dashboardAsCode.ts
@@ -42,6 +42,12 @@ const dashboardAsCodeSchema = z.object({
                     text: z.string(),
                 }),
             }),
+            z.object({
+                type: z.literal(DashboardTileTypes.DATA_APP),
+                properties: z.object({
+                    title: z.string(),
+                }),
+            }),
         ]),
     ),
 });

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -1,4 +1,8 @@
-import { DashboardTileTypes, type Dashboard } from '@lightdash/common';
+import {
+    DashboardTileTypes,
+    FeatureFlags,
+    type Dashboard,
+} from '@lightdash/common';
 import {
     Button,
     Group,
@@ -8,6 +12,7 @@ import {
     type ButtonProps,
 } from '@mantine-8/core';
 import {
+    IconAppWindow,
     IconChartBar,
     IconHeading,
     IconInfoCircle,
@@ -19,6 +24,7 @@ import {
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import MantineIcon from '../common/MantineIcon';
@@ -52,6 +58,8 @@ const AddTileButton: FC<Props> = ({
     const { storeDashboard } = useDashboardStorage();
     const navigate = useNavigate();
     const { health } = useApp();
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const dataAppsEnabled = dataAppsFlag.data?.enabled === true;
 
     // Calculate current tiles in the active tab
     const currentTabTilesCount = useMemo(() => {
@@ -150,6 +158,19 @@ const AddTileButton: FC<Props> = ({
                             </Group>
                         </Menu.Item>
 
+                        {dataAppsEnabled && (
+                            <Menu.Item
+                                onClick={() =>
+                                    setAddTileType(DashboardTileTypes.DATA_APP)
+                                }
+                                leftSection={
+                                    <MantineIcon icon={IconAppWindow} />
+                                }
+                            >
+                                Data app
+                            </Menu.Item>
+                        )}
+
                         <Menu.Item
                             onClick={() =>
                                 setAddTileType(DashboardTileTypes.MARKDOWN)
@@ -228,7 +249,8 @@ const AddTileButton: FC<Props> = ({
 
             {addTileType === DashboardTileTypes.MARKDOWN ||
             addTileType === DashboardTileTypes.LOOM ||
-            addTileType === DashboardTileTypes.HEADING ? (
+            addTileType === DashboardTileTypes.HEADING ||
+            addTileType === DashboardTileTypes.DATA_APP ? (
                 <TileAddModal
                     opened={!!addTileType}
                     type={addTileType}

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -1,0 +1,175 @@
+import { subject } from '@casl/ability';
+import { type DashboardDataAppTile } from '@lightdash/common';
+import { Box, Loader, Stack, Text } from '@mantine-8/core';
+import { IconAppsOff, IconPencil } from '@tabler/icons-react';
+import React, { useMemo, useState, type FC } from 'react';
+import { useParams } from 'react-router';
+import AppIframePreview from '../../features/apps/AppIframePreview';
+import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken';
+import { useGetApp } from '../../features/apps/hooks/useGetApp';
+import { usePreviewOrigin } from '../../features/apps/previewOrigin';
+import { DashboardTileComments } from '../../features/comments';
+import { useSpaceSummaries } from '../../hooks/useSpaces';
+import useApp from '../../providers/App/useApp';
+import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
+import LinkMenuItem from '../common/LinkMenuItem';
+import MantineIcon from '../common/MantineIcon';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
+import TileBase from './TileBase/index';
+
+type Props = Pick<
+    React.ComponentProps<typeof TileBase>,
+    'tile' | 'onEdit' | 'onDelete' | 'isEditMode'
+> & { tile: DashboardDataAppTile };
+
+const DataAppTile: FC<Props> = (props) => {
+    const {
+        tile: {
+            properties: { title, appUuid, appDeletedAt },
+            uuid,
+        },
+    } = props;
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+
+    const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);
+    const showComments = useDashboardContext(
+        (c) => c.dashboardCommentsCheck?.canViewDashboardComments,
+    );
+    const tileHasComments = useDashboardContext((c) => c.hasTileComments(uuid));
+    const dashboardComments = useMemo(
+        () =>
+            !!showComments && (
+                <DashboardTileComments
+                    opened={isCommentsMenuOpen}
+                    onOpen={() => setIsCommentsMenuOpen(true)}
+                    onClose={() => setIsCommentsMenuOpen(false)}
+                    dashboardTileUuid={uuid}
+                />
+            ),
+        [showComments, isCommentsMenuOpen, uuid],
+    );
+
+    const previewOrigin = usePreviewOrigin();
+    // Skip the network calls when the backend already told us the app is
+    // gone — `useGetApp` would 404 anyway, but bypassing the request avoids
+    // a noisy log entry and a wasted round trip on every dashboard load.
+    const shouldFetch = !!projectUuid && !!appUuid && !appDeletedAt;
+    const appQuery = useGetApp(
+        shouldFetch ? projectUuid : undefined,
+        shouldFetch ? appUuid : undefined,
+    );
+
+    const latestReadyVersion = appQuery.data?.pages[0]?.versions.find(
+        (v) => v.status === 'ready',
+    )?.version;
+
+    // Mirror the "Continue building" affordance from the app preview page
+    // (AppPreviewTest.tsx) — same space-aware ability check.
+    const { user } = useApp();
+    const appSpaceUuid = appQuery.data?.pages[0]?.spaceUuid ?? null;
+    const appCreatedByUserUuid =
+        appQuery.data?.pages[0]?.createdByUserUuid ?? null;
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
+    const userSpaceAccess = appSpaceUuid
+        ? spaces.find((s) => s.uuid === appSpaceUuid)?.userAccess
+        : undefined;
+    const canEditApp =
+        !!appQuery.data &&
+        user.data?.ability?.can(
+            'manage',
+            subject('DataApp', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+                access: userSpaceAccess ? [userSpaceAccess] : [],
+                createdByUserUuid: appCreatedByUserUuid,
+            }),
+        ) === true;
+
+    const editMenuItem = canEditApp ? (
+        <LinkMenuItem
+            leftSection={<MantineIcon icon={IconPencil} />}
+            href={`/projects/${projectUuid}/apps/${appUuid}`}
+        >
+            Continue building
+        </LinkMenuItem>
+    ) : null;
+
+    const {
+        data: token,
+        isLoading: isTokenLoading,
+        error: tokenError,
+    } = useAppPreviewToken(projectUuid, appUuid, latestReadyVersion);
+
+    const previewUrl =
+        token && latestReadyVersion
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
+            : undefined;
+
+    const isForbidden =
+        appQuery.error?.error?.statusCode === 403 ||
+        tokenError?.error?.statusCode === 403;
+    const isNotFound =
+        appDeletedAt ||
+        appQuery.error?.error?.statusCode === 404 ||
+        tokenError?.error?.statusCode === 404;
+    const hasNoReadyVersion =
+        !appQuery.isLoading && !appQuery.error && !latestReadyVersion;
+    const isLoading =
+        appQuery.isLoading ||
+        (latestReadyVersion !== undefined && isTokenLoading);
+    const otherError =
+        !isForbidden && !isNotFound && (appQuery.error || tokenError);
+
+    return (
+        <TileBase
+            title={title}
+            lockHeaderVisibility={isCommentsMenuOpen}
+            visibleHeaderElement={
+                tileHasComments ? dashboardComments : undefined
+            }
+            extraHeaderElement={tileHasComments ? undefined : dashboardComments}
+            extraMenuItems={editMenuItem}
+            {...props}
+        >
+            <Box className="non-draggable" style={{ flex: 1, minHeight: 0 }}>
+                {isNotFound ? (
+                    <SuboptimalState
+                        icon={IconAppsOff}
+                        title="Data app not found"
+                        description="This data app no longer exists. Edit the tile to pick another app."
+                    />
+                ) : isForbidden ? (
+                    <SuboptimalState
+                        icon={IconAppsOff}
+                        title="No access"
+                        description="You don't have permission to view this data app."
+                    />
+                ) : hasNoReadyVersion ? (
+                    <SuboptimalState
+                        icon={IconAppsOff}
+                        title="No ready version"
+                        description="This data app hasn't finished building yet."
+                    />
+                ) : otherError ? (
+                    <Stack align="center" justify="center" h="100%">
+                        <Text c="red" size="sm">
+                            Failed to load app
+                        </Text>
+                    </Stack>
+                ) : isLoading || !previewUrl ? (
+                    <Stack align="center" justify="center" h="100%">
+                        <Loader size="sm" />
+                    </Stack>
+                ) : (
+                    <AppIframePreview
+                        src={previewUrl}
+                        expectedPreviewOrigin={previewOrigin}
+                        identityKey={`${appUuid}:${latestReadyVersion}`}
+                    />
+                )}
+            </Box>
+        </TileBase>
+    );
+};
+
+export default DataAppTile;

--- a/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileEditForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileEditForm.tsx
@@ -1,0 +1,40 @@
+import { type DashboardDataAppTileProperties } from '@lightdash/common';
+import { ActionIcon, Flex, Stack, TextInput } from '@mantine-8/core';
+import { type UseFormReturnType } from '@mantine/form';
+import { IconEye, IconEyeOff } from '@tabler/icons-react';
+import MantineIcon from '../../common/MantineIcon';
+
+interface DataAppTileEditFormProps {
+    form: UseFormReturnType<DashboardDataAppTileProperties['properties']>;
+}
+
+const DataAppTileEditForm = ({ form }: DataAppTileEditFormProps) => (
+    <Stack gap="md">
+        <Flex
+            align={form.getInputProps('title').error ? 'center' : 'flex-end'}
+            gap="xs"
+        >
+            <TextInput
+                label="Title"
+                placeholder="Tile title"
+                flex={1}
+                required
+                disabled={form.values.hideTitle}
+                {...form.getInputProps('title')}
+            />
+            <ActionIcon
+                variant="subtle"
+                size="lg"
+                onClick={() => {
+                    form.setFieldValue('hideTitle', !form.values.hideTitle);
+                }}
+            >
+                <MantineIcon
+                    icon={form.values.hideTitle ? IconEyeOff : IconEye}
+                />
+            </ActionIcon>
+        </Flex>
+    </Stack>
+);
+
+export default DataAppTileEditForm;

--- a/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileForm.tsx
@@ -1,0 +1,101 @@
+import {
+    ContentType,
+    type ApiContentResponse,
+    type ApiError,
+    type DashboardDataAppTileProperties,
+} from '@lightdash/common';
+import { Loader, Select, Stack, Text, TextInput } from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
+import { type UseFormReturnType } from '@mantine/form';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { useParams } from 'react-router';
+import { lightdashApi } from '../../../api';
+
+interface DataAppTileFormProps {
+    form: UseFormReturnType<DashboardDataAppTileProperties['properties']>;
+}
+
+const DATA_APP_PICKER_PAGE_SIZE = 100;
+
+const fetchDataAppContent = (projectUuid: string, search: string) => {
+    const searchParam = search ? `&search=${encodeURIComponent(search)}` : '';
+    return lightdashApi<ApiContentResponse['results']>({
+        version: 'v2',
+        url: `/content?projectUuids=${projectUuid}&contentTypes=${ContentType.DATA_APP}&pageSize=${DATA_APP_PICKER_PAGE_SIZE}&page=1${searchParam}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+const useProjectDataApps = (projectUuid: string | undefined, search: string) =>
+    useQuery<ApiContentResponse['results'], ApiError>({
+        queryKey: ['data-app-picker', projectUuid, search],
+        queryFn: () => fetchDataAppContent(projectUuid!, search),
+        enabled: !!projectUuid,
+        keepPreviousData: true,
+    });
+
+const DataAppTileForm = ({ form }: DataAppTileFormProps) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const [searchValue, setSearchValue] = useState('');
+    const [debouncedSearch] = useDebouncedValue(searchValue, 300);
+    const { data, isLoading, isFetching, error } = useProjectDataApps(
+        projectUuid,
+        debouncedSearch,
+    );
+
+    const options = useMemo(() => {
+        if (!data) return [];
+        return data.data
+            .filter((item) => item.contentType === ContentType.DATA_APP)
+            .map((item) => ({
+                value: item.uuid,
+                label: item.name || 'Untitled app',
+            }));
+    }, [data]);
+
+    return (
+        <Stack gap="md">
+            <TextInput
+                label="Title"
+                placeholder="Tile title"
+                required
+                {...form.getInputProps('title')}
+            />
+
+            <Select
+                label="Data app"
+                description="Only apps that were moved to a space can be added to a dashboard."
+                placeholder={isLoading ? 'Loading apps...' : 'Pick a data app'}
+                searchable
+                required
+                data={options}
+                disabled={isLoading || !!error}
+                searchValue={searchValue}
+                onSearchChange={setSearchValue}
+                rightSection={
+                    isLoading || isFetching ? <Loader size="xs" /> : undefined
+                }
+                nothingFoundMessage="No matching data apps"
+                // Spreading `form.getInputProps('appUuid')` here breaks the
+                // controlled `searchValue` — Mantine's Select forcibly syncs
+                // the search input to the selected option's label whenever
+                // its `value` prop ticks, which on every render erases what
+                // the user typed before the debounce can fire. Wire the
+                // form props by hand so Mantine sees a stable `value`.
+                value={form.values.appUuid || null}
+                onChange={(value) => form.setFieldValue('appUuid', value ?? '')}
+                error={form.errors.appUuid}
+            />
+
+            {error && (
+                <Text c="red" size="sm">
+                    Failed to load apps
+                </Text>
+            )}
+        </Stack>
+    );
+};
+
+export default DataAppTileForm;

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
@@ -3,6 +3,7 @@ import {
     DashboardTileTypes,
     defaultTileSize,
     type Dashboard,
+    type DashboardDataAppTileProperties,
     type DashboardHeadingTileProperties,
     type DashboardLoomTileProperties,
     type DashboardMarkdownTile,
@@ -10,10 +11,16 @@ import {
 } from '@lightdash/common';
 import { Button, Stack, Text } from '@mantine-8/core';
 import { useForm, type UseFormReturnType } from '@mantine/form';
-import { IconHeading, IconMarkdown, IconVideo } from '@tabler/icons-react';
+import {
+    IconAppWindow,
+    IconHeading,
+    IconMarkdown,
+    IconVideo,
+} from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { v4 as uuid4 } from 'uuid';
 import MantineModal from '../../common/MantineModal';
+import DataAppTileForm from './DataAppTileForm';
 import HeadingTileForm from './HeadingTileForm';
 import LoomTileForm from './LoomTileForm';
 import MarkdownTileForm from './MarkdownTileForm';
@@ -28,7 +35,8 @@ type AddProps = {
     type:
         | DashboardTileTypes.LOOM
         | DashboardTileTypes.MARKDOWN
-        | DashboardTileTypes.HEADING;
+        | DashboardTileTypes.HEADING
+        | DashboardTileTypes.DATA_APP;
     onConfirm: (tile: Tile) => void;
 };
 
@@ -53,9 +61,15 @@ export const TileAddModal: FC<AddProps> = ({
             text: (value: string | undefined) =>
                 !value || !value.length ? 'Required field' : null,
         };
+        const appUuidValidator = {
+            appUuid: (value: string | undefined) =>
+                !value || !value.length ? 'Required field' : null,
+        };
         if (type === DashboardTileTypes.LOOM)
             return { ...urlValidator, ...titleValidator };
         if (type === DashboardTileTypes.HEADING) return textValidator;
+        if (type === DashboardTileTypes.DATA_APP)
+            return { ...titleValidator, ...appUuidValidator };
     };
 
     const form = useForm<TileProperties>({
@@ -80,6 +94,8 @@ export const TileAddModal: FC<AddProps> = ({
                 return IconVideo;
             case DashboardTileTypes.HEADING:
                 return IconHeading;
+            case DashboardTileTypes.DATA_APP:
+                return IconAppWindow;
             default:
                 return assertUnreachable(type, 'Tile type not supported');
         }
@@ -93,6 +109,8 @@ export const TileAddModal: FC<AddProps> = ({
                 return 'Add loom tile';
             case DashboardTileTypes.HEADING:
                 return 'Add heading tile';
+            case DashboardTileTypes.DATA_APP:
+                return 'Add data app tile';
             default:
                 return assertUnreachable(type, 'Tile type not supported');
         }
@@ -181,6 +199,14 @@ export const TileAddModal: FC<AddProps> = ({
                             form={
                                 form as UseFormReturnType<
                                     DashboardHeadingTileProperties['properties']
+                                >
+                            }
+                        />
+                    ) : type === DashboardTileTypes.DATA_APP ? (
+                        <DataAppTileForm
+                            form={
+                                form as UseFormReturnType<
+                                    DashboardDataAppTileProperties['properties']
                                 >
                             }
                         />

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     DashboardTileTypes,
     type Dashboard,
+    type DashboardDataAppTileProperties,
     type DashboardHeadingTileProperties,
     type DashboardLoomTileProperties,
     type DashboardMarkdownTile,
@@ -9,10 +10,16 @@ import {
 } from '@lightdash/common';
 import { Button, Stack, type ModalProps } from '@mantine-8/core';
 import { useForm, type UseFormReturnType } from '@mantine/form';
-import { IconHeading, IconMarkdown, IconVideo } from '@tabler/icons-react';
+import {
+    IconAppWindow,
+    IconHeading,
+    IconMarkdown,
+    IconVideo,
+} from '@tabler/icons-react';
 import { produce } from 'immer';
 import { useMemo } from 'react';
 import MantineModal from '../../common/MantineModal';
+import DataAppTileEditForm from './DataAppTileEditForm';
 import HeadingTileForm from './HeadingTileForm';
 import LoomTileForm from './LoomTileForm';
 import MarkdownTileForm from './MarkdownTileForm';
@@ -54,6 +61,7 @@ const TileUpdateModal = <T extends Tile>({
         if (tile.type === DashboardTileTypes.LOOM)
             return { ...urlValidator, ...titleValidator };
         if (tile.type === DashboardTileTypes.HEADING) return textValidator;
+        if (tile.type === DashboardTileTypes.DATA_APP) return titleValidator;
     };
 
     const form = useForm<TileProperties>({
@@ -88,6 +96,8 @@ const TileUpdateModal = <T extends Tile>({
                 return IconVideo;
             case DashboardTileTypes.HEADING:
                 return IconHeading;
+            case DashboardTileTypes.DATA_APP:
+                return IconAppWindow;
             case DashboardTileTypes.SAVED_CHART:
                 return undefined;
             case DashboardTileTypes.SQL_CHART:
@@ -106,6 +116,8 @@ const TileUpdateModal = <T extends Tile>({
                 return 'Edit loom tile';
             case DashboardTileTypes.HEADING:
                 return 'Edit heading tile';
+            case DashboardTileTypes.DATA_APP:
+                return 'Edit data app tile';
             case DashboardTileTypes.SAVED_CHART:
                 return 'Edit saved_chart tile';
             case DashboardTileTypes.SQL_CHART:
@@ -160,6 +172,14 @@ const TileUpdateModal = <T extends Tile>({
                             form={
                                 form as UseFormReturnType<
                                     DashboardHeadingTileProperties['properties']
+                                >
+                            }
+                        />
+                    ) : tile.type === DashboardTileTypes.DATA_APP ? (
+                        <DataAppTileEditForm
+                            form={
+                                form as UseFormReturnType<
+                                    DashboardDataAppTileProperties['properties']
                                 >
                             }
                         />

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -123,6 +123,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
             case DashboardTileTypes.LOOM:
             case DashboardTileTypes.MARKDOWN:
             case DashboardTileTypes.HEADING:
+            case DashboardTileTypes.DATA_APP:
                 throw new Error(
                     `not implemented for chart tile type: ${dashboardTileType}`,
                 );

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -129,6 +129,12 @@ const EmbedDashboardGrid: FC<{
                                 tileIndex={index}
                                 dashboardSlug={dashboard.slug}
                             />
+                        ) : tile.type === DashboardTileTypes.DATA_APP ? (
+                            <SuboptimalState
+                                key={tile.uuid}
+                                title="Data app tile"
+                                description="Data apps cannot be rendered in embedded dashboards yet."
+                            />
                         ) : (
                             assertUnreachable(
                                 tile,

--- a/packages/frontend/src/features/dashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/features/dashboardTabs/GridTile.tsx
@@ -7,6 +7,7 @@ import {
 import { Box } from '@mantine-8/core';
 import { memo, type FC } from 'react';
 import ChartTile from '../../components/DashboardTiles/DashboardChartTile';
+import DataAppTile from '../../components/DashboardTiles/DashboardDataAppTile';
 import HeadingTile from '../../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../../components/DashboardTiles/DashboardMarkdownTile';
@@ -28,7 +29,7 @@ const GridTileInner: FC<GridTileProps> = memo((props) => {
     const { tile } = props;
 
     if (props.locked) {
-        // Allow markdown, loom, and heading tiles to show even when locked since they are not filterable
+        // Allow non-filterable tiles to show even when locked.
         if (tile.type === DashboardTileTypes.MARKDOWN) {
             return <MarkdownTile {...props} tile={tile} />;
         }
@@ -37,6 +38,9 @@ const GridTileInner: FC<GridTileProps> = memo((props) => {
         }
         if (tile.type === DashboardTileTypes.HEADING) {
             return <HeadingTile {...props} tile={tile} />;
+        }
+        if (tile.type === DashboardTileTypes.DATA_APP) {
+            return <DataAppTile {...props} tile={tile} />;
         }
 
         return (
@@ -57,6 +61,8 @@ const GridTileInner: FC<GridTileProps> = memo((props) => {
             return <SqlChartTile {...props} tile={tile} />;
         case DashboardTileTypes.HEADING:
             return <HeadingTile {...props} tile={tile} />;
+        case DashboardTileTypes.DATA_APP:
+            return <DataAppTile {...props} tile={tile} />;
         default: {
             return assertUnreachable(
                 tile,

--- a/packages/frontend/src/pages/DashboardVersionComparison.tsx
+++ b/packages/frontend/src/pages/DashboardVersionComparison.tsx
@@ -4,6 +4,7 @@ import {
     getFilterTypeFromItemType,
     isDashboardChartTileType,
     isDashboardHeadingTileType,
+    isDashboardDataAppTileType,
     isDashboardLoomTileType,
     isDashboardMarkdownTileType,
     isDashboardSqlChartTile,
@@ -1008,6 +1009,12 @@ const DashboardVersionComparison = ({
         const versionHeadingTiles = version.tiles.filter(
             isDashboardHeadingTileType,
         );
+        const currentDataAppTiles = current.tiles.filter(
+            isDashboardDataAppTileType,
+        );
+        const versionDataAppTiles = version.tiles.filter(
+            isDashboardDataAppTileType,
+        );
 
         // Prepare tiles data for table
         const tilesData = [
@@ -1042,6 +1049,13 @@ const DashboardVersionComparison = ({
                 selected: versionHeadingTiles.length,
                 difference:
                     versionHeadingTiles.length - currentHeadingTiles.length,
+            },
+            {
+                tileType: 'Data App',
+                current: currentDataAppTiles.length,
+                selected: versionDataAppTiles.length,
+                difference:
+                    versionDataAppTiles.length - currentDataAppTiles.length,
             },
             {
                 tileType: 'Total',

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -19,6 +19,7 @@ import ScreenshotProgressIndicator from '../components/common/ScreenshotProgress
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ChartTile from '../components/DashboardTiles/DashboardChartTile';
+import DataAppTile from '../components/DashboardTiles/DashboardDataAppTile';
 import HeadingTile from '../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../components/DashboardTiles/DashboardMarkdownTile';
@@ -168,6 +169,14 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
                                 />
                             ) : tile.type === DashboardTileTypes.HEADING ? (
                                 <HeadingTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={false}
+                                    onDelete={() => {}}
+                                    onEdit={() => {}}
+                                />
+                            ) : tile.type === DashboardTileTypes.DATA_APP ? (
+                                <DataAppTile
                                     key={tile.uuid}
                                     tile={tile}
                                     isEditMode={false}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7533/i-want-to-use-a-data-app-as-a-tile-on-a-dashbaord

### Description:
Embed a Data App as a dashboard tile via a sandboxed iframe. The tile references an app by uuid only; rendering resolves the latest ready version at view time. Picker reuses the /content endpoint (contentTypes=data_app) — no new backend list endpoint needed.

Schema: new dashboard_tile_data_apps table (FK to apps.app_id, ON DELETE CASCADE). Hydration intentionally LEFT JOINs apps without filtering deleted_at so the frontend can render a "deleted" placeholder instead of a broken iframe.

Embed dashboards render a not-supported placeholder (preview-token mint needs a session user, not an embed JWT).

### Testing

- [x] feature flag
- [x] permissions
- [x] tile deletion
- [x] tile resizing
- [x] tile dragging
- [x] app deletion while inside dashboard

Here's a dashboard with a data app and chart side-by-side:
<img width="2561" height="1361" alt="image" src="https://github.com/user-attachments/assets/cfe4562b-ae76-4233-aec7-15fdaf34b31d" />
