### PR TITLE
feat: freeze columns in pivot tables (PROD-639)

### DIFF
--- a/docs/superpowers/plans/2026-05-12-prod-639-pivot-frozen-columns.md
+++ b/docs/superpowers/plans/2026-05-12-prod-639-pivot-frozen-columns.md
@@ -1,0 +1,1155 @@
+# PROD-639 — Freeze columns in pivot tables — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to freeze leftmost columns in a pivoted table chart so they stay visible while scrolling horizontally. Reuse the existing `ColumnProperties.frozen` field; render via CSS sticky positioning.
+
+**Architecture:**
+A new pure helper `getFrozenColumnLayout` walks the pivot's `pivotColumnInfo` left-to-right, computes cumulative `left` offsets for columns whose freeze key is marked frozen in `columnProperties`, and returns a `Map<fieldId, { left, isLast }>`. `PivotTable/index.tsx` consults that map when rendering header rows + body cells, applying inline sticky styles + CSS classes. The freeze toggle in `TableConfigPanel/ColumnConfiguration.tsx` is unhidden for non-pivoted dimensions and (when `metricsAsRows === false`) for metrics.
+
+**Tech Stack:** React 19, TanStack Table, Mantine v7 (existing PivotTable deps), CSS Modules, Vitest for unit tests, `renderWithProviders` from `testing/testUtils` for component tests.
+
+**Spec:** [docs/superpowers/specs/2026-05-11-prod-639-pivot-frozen-columns-design.md](../specs/2026-05-11-prod-639-pivot-frozen-columns-design.md)
+
+**Key constraints discovered while planning:**
+
+- `PivotTable/index.tsx:349-351` already sets `columnPinning.left: [ROW_NUMBER_COLUMN_ID]` in TanStack state but PivotTable does NOT consume `getIsPinned()` — it manually renders header cells via iteration over `data.headerValues` / `data.titleFields`. So we cannot use TanStack's pinning machinery for visual rendering; we apply sticky styles manually.
+- The existing non-pivoted Table reorders frozen columns to the left (`Table/TableProvider.tsx:115-141`). In pivot, column order is fixed by pivot semantics — we don't reorder. Sticky positioning is "best effort": frozen columns get a cumulative `left` offset based on their natural position. For dimension columns (which are naturally leftmost), this works perfectly. For pivoted metric columns, it's documented but not visually polished — see Task 6 caveat.
+- The freeze "key" in `columnProperties` follows the same rules as width: `widthKey = (col.columnType === 'indexValue' || col.columnType === 'label') ? col.fieldId : (col.underlyingId || col.baseId)` (see `index.tsx:228-235`). Setting `frozen` on a metric fieldId freezes ALL its pivot slices (consistent with how width works).
+
+---
+
+### Task 1: Test scaffold for `getFrozenColumnLayout`
+
+**Files:**
+- Create: `packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.test.ts`
+
+The helper takes `pivotColumnInfo` (the per-column metadata array from `PivotData.retrofitData.pivotColumnInfo`), a `columnProperties` map keyed by underlying field id, and a few sizing inputs. It returns a `Map<renderedFieldId, { left: number; isLast: boolean }>` — only the entries for columns that should be sticky.
+
+- [ ] **Step 1: Write the failing test file**
+
+```ts
+// packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.test.ts
+import { describe, expect, it } from 'vitest';
+import type { PivotColumn } from '@lightdash/common';
+import { getFrozenColumnLayout } from './getFrozenColumnLayout';
+
+const indexCol = (fieldId: string): PivotColumn => ({
+    fieldId,
+    baseId: undefined,
+    underlyingId: undefined,
+    columnType: 'indexValue',
+});
+
+const dataCol = (fieldId: string, baseId: string): PivotColumn => ({
+    fieldId,
+    baseId,
+    underlyingId: undefined,
+    columnType: undefined,
+});
+
+describe('getFrozenColumnLayout', () => {
+    it('returns an empty map when no columns are frozen', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [indexCol('orders_category')],
+            columnProperties: {},
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.size).toBe(0);
+    });
+
+    it('starts cumulative left at rowNumberWidth when row numbers are shown', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [indexCol('orders_category')],
+            columnProperties: { orders_category: { frozen: true } },
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 50,
+            isLast: true,
+        });
+    });
+
+    it('starts cumulative left at 0 when row numbers are hidden', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [indexCol('orders_category')],
+            columnProperties: { orders_category: { frozen: true } },
+            rowNumberWidth: 0,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 0,
+            isLast: true,
+        });
+    });
+
+    it('chains cumulative left across multiple frozen index columns', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                indexCol('orders_category'),
+                indexCol('orders_region'),
+            ],
+            columnProperties: {
+                orders_category: { frozen: true, width: 120 },
+                orders_region: { frozen: true, width: 80 },
+            },
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 50,
+            isLast: false,
+        });
+        expect(layout.get('orders_region')).toEqual({
+            left: 170,
+            isLast: true,
+        });
+    });
+
+    it('uses defaultColumnWidth when a frozen column has no explicit width', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                indexCol('orders_category'),
+                indexCol('orders_region'),
+            ],
+            columnProperties: {
+                orders_category: { frozen: true },
+                orders_region: { frozen: true, width: 80 },
+            },
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 50,
+            isLast: false,
+        });
+        expect(layout.get('orders_region')).toEqual({
+            left: 150,
+            isLast: true,
+        });
+    });
+
+    it('skips non-frozen columns but advances offset for frozen ones only', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                indexCol('orders_category'),
+                indexCol('orders_region'),
+                indexCol('orders_segment'),
+            ],
+            columnProperties: {
+                orders_category: { frozen: true, width: 120 },
+                orders_segment: { frozen: true, width: 80 },
+                // orders_region is NOT frozen — left offset for orders_segment
+                // is computed from orders_category only.
+            },
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 50,
+            isLast: false,
+        });
+        expect(layout.has('orders_region')).toBe(false);
+        expect(layout.get('orders_segment')).toEqual({
+            left: 170,
+            isLast: true,
+        });
+    });
+
+    it('uses underlyingId/baseId as the freeze key for data columns', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                indexCol('orders_category'),
+                dataCol('total_count__pivot_0', 'total_count'),
+                dataCol('total_count__pivot_1', 'total_count'),
+            ],
+            columnProperties: {
+                total_count: { frozen: true, width: 90 },
+            },
+            rowNumberWidth: 0,
+            defaultColumnWidth: 100,
+        });
+        // Both pivot slices of the same metric become sticky because the freeze
+        // key resolves to the metric's baseId.
+        expect(layout.get('total_count__pivot_0')).toEqual({
+            left: 0,
+            isLast: false,
+        });
+        expect(layout.get('total_count__pivot_1')).toEqual({
+            left: 90,
+            isLast: true,
+        });
+    });
+
+    it('marks only the rightmost frozen entry as isLast', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                indexCol('orders_category'),
+                indexCol('orders_region'),
+            ],
+            columnProperties: {
+                orders_category: { frozen: true },
+                orders_region: { frozen: true },
+            },
+            rowNumberWidth: 0,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')?.isLast).toBe(false);
+        expect(layout.get('orders_region')?.isLast).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm -F frontend exec vitest run src/components/common/PivotTable/getFrozenColumnLayout.test.ts
+```
+
+Expected: all 8 tests fail with module-not-found / import error for `./getFrozenColumnLayout`.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.test.ts
+git commit -m "test(frontend): add tests for pivot frozen column layout helper"
+```
+
+---
+
+### Task 2: Implement `getFrozenColumnLayout`
+
+**Files:**
+- Create: `packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts`
+
+- [ ] **Step 1: Write the helper**
+
+```ts
+// packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
+import type { ColumnProperties, PivotColumn } from '@lightdash/common';
+
+export type FrozenColumnEntry = {
+    left: number;
+    isLast: boolean;
+};
+
+type Args = {
+    pivotColumnInfo: PivotColumn[];
+    columnProperties: Record<string, ColumnProperties | undefined>;
+    rowNumberWidth: number;
+    defaultColumnWidth: number;
+};
+
+/**
+ * Resolves the column-properties key used for a given pivot column.
+ *
+ * Mirrors the rule used for column widths in PivotTable/index.tsx:
+ * - indexValue / label columns key on the column's own fieldId
+ * - data columns key on the underlying metric (or last pivot dim) baseId
+ *
+ * Returns undefined for columns that have no usable freeze key (e.g.
+ * the all-pivoted spacer).
+ */
+const getFreezeKey = (col: PivotColumn): string | undefined => {
+    if (col.columnType === 'indexValue' || col.columnType === 'label') {
+        return col.fieldId;
+    }
+    return col.underlyingId ?? col.baseId;
+};
+
+const getColumnWidth = (
+    freezeKey: string,
+    columnProperties: Record<string, ColumnProperties | undefined>,
+    defaultColumnWidth: number,
+): number => columnProperties[freezeKey]?.width ?? defaultColumnWidth;
+
+/**
+ * Walks the pivot column info left-to-right and computes cumulative `left`
+ * offsets for columns marked frozen in columnProperties. Returns a map
+ * keyed by the rendered fieldId (col.fieldId), so cell renderers can look
+ * up sticky positioning by the same id used in their TanStack column.
+ *
+ * Non-frozen columns are skipped entirely — their offsets do NOT contribute
+ * to the cumulative position of subsequent frozen columns. This matches the
+ * "all sticky columns sit flush to the left edge" behaviour users expect.
+ */
+export const getFrozenColumnLayout = ({
+    pivotColumnInfo,
+    columnProperties,
+    rowNumberWidth,
+    defaultColumnWidth,
+}: Args): Map<string, FrozenColumnEntry> => {
+    const layout = new Map<string, FrozenColumnEntry>();
+    let cumulativeLeft = rowNumberWidth;
+    let lastFrozenFieldId: string | undefined;
+
+    for (const col of pivotColumnInfo) {
+        const freezeKey = getFreezeKey(col);
+        if (!freezeKey) continue;
+
+        const isFrozen = columnProperties[freezeKey]?.frozen === true;
+        if (!isFrozen) continue;
+
+        const width = getColumnWidth(
+            freezeKey,
+            columnProperties,
+            defaultColumnWidth,
+        );
+
+        layout.set(col.fieldId, { left: cumulativeLeft, isLast: false });
+        lastFrozenFieldId = col.fieldId;
+        cumulativeLeft += width;
+    }
+
+    if (lastFrozenFieldId) {
+        const lastEntry = layout.get(lastFrozenFieldId);
+        if (lastEntry) {
+            layout.set(lastFrozenFieldId, { ...lastEntry, isLast: true });
+        }
+    }
+
+    return layout;
+};
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+```bash
+pnpm -F frontend exec vitest run src/components/common/PivotTable/getFrozenColumnLayout.test.ts
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+pnpm -F frontend typecheck
+```
+
+Expected: no errors related to the new file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
+git commit -m "feat(frontend): add getFrozenColumnLayout helper for pivot tables"
+```
+
+---
+
+### Task 3: Compute frozen layout in PivotTable and thread onto column meta
+
+**Files:**
+- Modify: `packages/frontend/src/components/common/Table/types.ts` (extend `meta`)
+- Modify: `packages/frontend/src/components/common/PivotTable/index.tsx` (add import; add top-level `frozenLayout` useMemo; stash entry on column meta)
+
+The layout must be reachable by both the `columns` useMemo (for column meta) and the JSX rendering header / body cells. So we compute it in its own top-level `useMemo` and consume it from both places.
+
+We extend `TableColumn.meta` with a separate `frozenLayout` field rather than reusing the existing `frozen?: boolean` (which the non-pivoted Table uses for its column-pinning logic). Keeping pivot-only data under `frozenLayout` avoids ambiguity.
+
+- [ ] **Step 1: Extend the meta type**
+
+Open `packages/frontend/src/components/common/Table/types.ts` and find the line `frozen?: boolean;` (currently around line 48). Add a sibling field directly below:
+
+```ts
+        frozen?: boolean;
+        frozenLayout?: { left: number; isLast: boolean };
+```
+
+- [ ] **Step 2: Add the import in PivotTable**
+
+In `packages/frontend/src/components/common/PivotTable/index.tsx`, locate the import block. Find the line `import pivotStyles from './PivotTable.module.css';` (currently line 64). Add immediately below it:
+
+```tsx
+import {
+    getFrozenColumnLayout,
+    type FrozenColumnEntry,
+} from './getFrozenColumnLayout';
+```
+
+- [ ] **Step 3: Add a top-level `frozenLayout` useMemo**
+
+In `index.tsx`, find the existing `hasCustomWidths` useMemo (currently lines 169-175):
+
+```tsx
+    const hasCustomWidths = useMemo(
+        () =>
+            Object.values(columnProperties).some(
+                (prop) => prop?.width !== undefined,
+            ),
+        [columnProperties],
+    );
+```
+
+Insert the new useMemo immediately AFTER it:
+
+```tsx
+    const frozenLayout = useMemo(
+        () =>
+            getFrozenColumnLayout({
+                pivotColumnInfo: data.retrofitData.pivotColumnInfo,
+                columnProperties,
+                rowNumberWidth: hideRowNumbers ? 0 : ROW_NUMBER_COL_WIDTH,
+                defaultColumnWidth: 100,
+            }),
+        [
+            data.retrofitData.pivotColumnInfo,
+            columnProperties,
+            hideRowNumbers,
+        ],
+    );
+```
+
+- [ ] **Step 4: Stash the frozen entry on each column's meta**
+
+Inside the `columns` useMemo (currently starts at line 177 returning `{ columns, columnOrder, colWidths }`), find the meta object inside `.map((col, colIndex) => { ... })`. Currently lines 244-252:
+
+```tsx
+                        meta: {
+                            item: item,
+                            width: colWidth,
+                            type: col.columnType,
+                            headerInfo:
+                                colIndex < finalHeaderInfoForColumns.length
+                                    ? finalHeaderInfoForColumns[colIndex]
+                                    : undefined,
+                        },
+```
+
+Replace with:
+
+```tsx
+                        meta: {
+                            item: item,
+                            width: colWidth,
+                            type: col.columnType,
+                            headerInfo:
+                                colIndex < finalHeaderInfoForColumns.length
+                                    ? finalHeaderInfoForColumns[colIndex]
+                                    : undefined,
+                            frozenLayout: frozenLayout.get(col.fieldId),
+                        },
+```
+
+- [ ] **Step 5: Add `frozenLayout` to the columns useMemo deps**
+
+The `columns` useMemo currently ends with `}, [data, hideRowNumbers, getField, columnProperties]);` (line 332). Add `frozenLayout`:
+
+```tsx
+    }, [data, hideRowNumbers, getField, columnProperties, frozenLayout]);
+```
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+pnpm -F frontend typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/frontend/src/components/common/PivotTable/index.tsx packages/frontend/src/components/common/Table/types.ts
+git commit -m "feat(frontend): thread frozen column layout into pivot column meta"
+```
+
+---
+
+### Task 4: Apply sticky styles to body cells
+
+**Files:**
+- Modify: `packages/frontend/src/components/common/PivotTable/PivotTable.module.css` (add sticky classes)
+- Modify: `packages/frontend/src/components/common/PivotTable/index.tsx` (helper + body cell patch around line 1089)
+
+- [ ] **Step 1: Add CSS classes**
+
+Open `packages/frontend/src/components/common/PivotTable/PivotTable.module.css`. The current file has 9 lines (the `.fixedLayout` block). Append at the end:
+
+```css
+.stickyColumn {
+    position: sticky;
+    z-index: 1;
+    background-color: var(--mantine-color-body, white);
+}
+
+.stickyHeaderColumn {
+    z-index: 2;
+}
+
+.stickyColumnLast {
+    box-shadow: 4px 0 4px -2px rgba(0, 0, 0, 0.1);
+}
+```
+
+The background overrides default cell transparency so scrolling content doesn't bleed through. The shadow on the last sticky column gives visual separation when scrolling. `stickyHeaderColumn` raises the z-index for header cells so they layer above sticky body cells.
+
+- [ ] **Step 2: Add the sticky-prop helpers near the top of PivotTable**
+
+In `packages/frontend/src/components/common/PivotTable/index.tsx`, find the existing const declarations near the top of the file (around line 68-69):
+
+```tsx
+const ROW_NUMBER_COL_WIDTH = 50;
+const MIN_AUTO_COL_WIDTH = 50;
+```
+
+Insert immediately AFTER the `MIN_AUTO_COL_WIDTH` line:
+
+```tsx
+const getStickyCellProps = (frozen: FrozenColumnEntry | undefined) => {
+    if (!frozen) return {};
+    return {
+        className: `${pivotStyles.stickyColumn}${
+            frozen.isLast ? ` ${pivotStyles.stickyColumnLast}` : ''
+        }`,
+        style: { left: frozen.left },
+    };
+};
+
+const getStickyHeaderProps = (frozen: FrozenColumnEntry | undefined) => {
+    if (!frozen) return {};
+    return {
+        className: `${pivotStyles.stickyColumn} ${pivotStyles.stickyHeaderColumn}${
+            frozen.isLast ? ` ${pivotStyles.stickyColumnLast}` : ''
+        }`,
+        style: { left: frozen.left },
+    };
+};
+```
+
+- [ ] **Step 3: Apply sticky props to the body cell render**
+
+In `index.tsx`, find the body cell render block. Currently lines 1089-1106 read:
+
+```tsx
+                                const cellWidth = meta?.width;
+
+                                const TableCellComponent = isRowTotal
+                                    ? Table.CellHead
+                                    : Table.Cell;
+                                return (
+                                    <TableCellComponent
+                                        key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
+                                        isMinimal={isMinimal}
+                                        withAlignRight={isNumericItem(item)}
+                                        w={cellWidth}
+                                        miw={cellWidth}
+                                        maw={cellWidth}
+                                        withColor={conditionalFormatting?.color}
+                                        withBoldFont={meta?.type === 'label'}
+                                        withBackground={
+                                            conditionalFormatting?.backgroundColor
+                                        }
+```
+
+Replace with (adds the `stickyCellProps` line and spreads `className` + `style` onto `TableCellComponent`):
+
+```tsx
+                                const cellWidth = meta?.width;
+
+                                const stickyCellProps = getStickyCellProps(
+                                    meta?.frozenLayout,
+                                );
+
+                                const TableCellComponent = isRowTotal
+                                    ? Table.CellHead
+                                    : Table.Cell;
+                                return (
+                                    <TableCellComponent
+                                        key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
+                                        className={stickyCellProps.className}
+                                        style={stickyCellProps.style}
+                                        isMinimal={isMinimal}
+                                        withAlignRight={isNumericItem(item)}
+                                        w={cellWidth}
+                                        miw={cellWidth}
+                                        maw={cellWidth}
+                                        withColor={conditionalFormatting?.color}
+                                        withBoldFont={meta?.type === 'label'}
+                                        withBackground={
+                                            conditionalFormatting?.backgroundColor
+                                        }
+```
+
+`Table.Cell` and `Table.CellHead` accept `className` and `style` via the underlying Mantine `BoxProps` — confirmed in `LightTable/index.tsx:217` (`className={cx(classes.root, rest.className)}`). When `stickyCellProps` is empty (the column isn't frozen) `className` and `style` are both `undefined`, which is harmless.
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+pnpm -F frontend typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/components/common/PivotTable/index.tsx packages/frontend/src/components/common/PivotTable/PivotTable.module.css
+git commit -m "feat(frontend): apply sticky positioning to frozen pivot body cells"
+```
+
+---
+
+### Task 5: Apply sticky styles to header rows
+
+**Files:**
+- Modify: `packages/frontend/src/components/common/PivotTable/index.tsx` (title-field cells around line 753, header-value cells around line 845)
+
+The header row rendering (currently lines 692-906) iterates `data.headerValues` and renders, per row: a row-number / placeholder cell, then `data.titleFields[headerRowIndex]` cells (title labels), then `headerValues.map(...)` cells (pivot dim values + label cells), then row-total cells. The leftmost columns (title fields and the first `numLabelCols` header values) correspond directly to the leftmost entries in `pivotColumnInfo` and may be frozen.
+
+For each header cell whose corresponding pivot column is in `frozenLayout`, apply sticky positioning via `getStickyHeaderProps`.
+
+- [ ] **Step 1: Apply sticky props to title-field header cells**
+
+In `index.tsx`, find the title-field cell render. Currently lines 745-803 read approximately:
+
+```tsx
+                                return isEmpty ? (
+                                    <Table.Cell
+                                        key={`title-${headerRowIndex}-${titleFieldIndex}`}
+                                        isMinimal={isMinimal}
+                                        withMinimalWidth={
+                                            !hasCustomWidths && !titleWidth
+                                        }
+                                    />
+                                ) : (
+                                    <Table.CellHead
+                                        key={`title-${headerRowIndex}-${titleFieldIndex}`}
+                                        withAlignRight={isHeaderTitle}
+                                        isMinimal={isMinimal}
+                                        withMinimalWidth={
+                                            !hasCustomWidths &&
+                                            (!isLastHeaderRow || !titleWidth)
+                                        }
+                                        withBoldFont
+                                        withTooltip={
+                                            isField(field)
+                                                ? field.description
+                                                : undefined
+                                        }
+                                        w={
+```
+
+Just before the `return isEmpty ? (` line, compute `titleStickyProps`. Insert:
+
+```tsx
+                                const titlePivotCol =
+                                    data.retrofitData.pivotColumnInfo[
+                                        titleFieldIndex
+                                    ];
+                                const titleStickyProps = titlePivotCol
+                                    ? getStickyHeaderProps(
+                                          frozenLayout.get(titlePivotCol.fieldId),
+                                      )
+                                    : {};
+```
+
+Then add `className={titleStickyProps.className}` and `style={titleStickyProps.style}` as the FIRST two props on BOTH the `<Table.Cell>` (empty title) and `<Table.CellHead>` (titled). Each render becomes:
+
+```tsx
+                                return isEmpty ? (
+                                    <Table.Cell
+                                        key={`title-${headerRowIndex}-${titleFieldIndex}`}
+                                        className={titleStickyProps.className}
+                                        style={titleStickyProps.style}
+                                        isMinimal={isMinimal}
+                                        withMinimalWidth={
+                                            !hasCustomWidths && !titleWidth
+                                        }
+                                    />
+                                ) : (
+                                    <Table.CellHead
+                                        key={`title-${headerRowIndex}-${titleFieldIndex}`}
+                                        className={titleStickyProps.className}
+                                        style={titleStickyProps.style}
+                                        withAlignRight={isHeaderTitle}
+                                        ...
+                                    >
+```
+
+(Don't overwrite the `style` if a future change adds another `style` prop — this is fine for now since neither current branch has `style` already.)
+
+- [ ] **Step 2: Apply sticky props to header-value cells**
+
+Find the header-value render. Currently lines 807-873 begin:
+
+```tsx
+                        {/* renders the header values or labels */}
+                        {headerValues.map((headerValue, headerColIndex) => {
+                            const isLabel = headerValue.type === 'label';
+                            const field = getField(headerValue.fieldId);
+
+                            const description =
+                                isLabel && isField(field)
+                                    ? field.description
+                                    : undefined;
+
+                            const isLastHeaderRow =
+                                headerRowIndex === data.headerValues.length - 1;
+
+                            // Look up saved width for this data column
+                            const colInfo =
+                                data.retrofitData.pivotColumnInfo[
+                                    numLabelCols + headerColIndex
+                                ];
+```
+
+Note the existing `colInfo` lookup. Below the `colInfo = ...` line, insert:
+
+```tsx
+                            const headerValueStickyProps = colInfo
+                                ? getStickyHeaderProps(
+                                      frozenLayout.get(colInfo.fieldId),
+                                  )
+                                : {};
+```
+
+Then locate the `<Table.CellHead key={\`header-${headerRowIndex}-${headerColIndex}\`}` render (currently around line 844-872) and add `className={headerValueStickyProps.className}` and `style={headerValueStickyProps.style}` as the first two props:
+
+```tsx
+                            return isLabel || headerValue.colSpan > 0 ? (
+                                <Table.CellHead
+                                    key={`header-${headerRowIndex}-${headerColIndex}`}
+                                    className={headerValueStickyProps.className}
+                                    style={headerValueStickyProps.style}
+                                    isMinimal={isMinimal}
+                                    withBoldFont={isLabel}
+                                    ...
+                                >
+```
+
+- [ ] **Step 3: Make the row-number header cell stick when any column is frozen**
+
+Find the row-number / placeholder cell at the start of each header row. Currently lines 703-718:
+
+```tsx
+                        {/* shows empty cell if row numbers are visible */}
+                        {hideRowNumbers ? null : headerRowIndex <
+                          data.headerValues.length - 1 ? (
+                            <Table.Cell
+                                isMinimal={isMinimal}
+                                withMinimalWidth={!hasCustomWidths}
+                            />
+                        ) : (
+                            <Table.CellHead
+                                isMinimal={isMinimal}
+                                withMinimalWidth={!hasCustomWidths}
+                                withBoldFont
+                            >
+                                #
+                            </Table.CellHead>
+                        )}
+```
+
+Above the `data.titleFields[headerRowIndex].map(...)` block (just inside the `<Table.Row ...>`), the row-number cell is the very first child. To anchor the freeze chain we make this cell sticky at `left: 0` whenever any column is frozen.
+
+First, just before the `{hideRowNumbers ? null :` line, add:
+
+```tsx
+                        const rowNumberSticky =
+                            frozenLayout.size > 0
+                                ? {
+                                      className: `${pivotStyles.stickyColumn} ${pivotStyles.stickyHeaderColumn}`,
+                                      style: { left: 0 },
+                                  }
+                                : ({} as { className?: string; style?: React.CSSProperties });
+```
+
+Then apply it to BOTH branches:
+
+```tsx
+                        {hideRowNumbers ? null : headerRowIndex <
+                          data.headerValues.length - 1 ? (
+                            <Table.Cell
+                                className={rowNumberSticky.className}
+                                style={rowNumberSticky.style}
+                                isMinimal={isMinimal}
+                                withMinimalWidth={!hasCustomWidths}
+                            />
+                        ) : (
+                            <Table.CellHead
+                                className={rowNumberSticky.className}
+                                style={rowNumberSticky.style}
+                                isMinimal={isMinimal}
+                                withMinimalWidth={!hasCustomWidths}
+                                withBoldFont
+                            >
+                                #
+                            </Table.CellHead>
+                        )}
+```
+
+- [ ] **Step 4: Body row-number cell — verify it's already pinned**
+
+In `index.tsx`, search for where the row-number column is rendered in the body (it's the column with `id: ROW_NUMBER_COLUMN_ID` defined at line 79-83). The body iterates `row.getVisibleCells()` — this includes the row-number column whose cell function returns `props.row.index + 1`. Because `columnPinning.left: [ROW_NUMBER_COLUMN_ID]` is set in TanStack state at line 350-351 BUT the body render does not consult `getIsPinned()`, the row-number column scrolls horizontally today.
+
+To make the body row-number cell sticky when any column is frozen, modify the body cell render to detect the row-number column and apply `rowNumberSticky` styles. Inside the `row.getVisibleCells().map((cell, colIndex) => {` block at line 929, add at the very top of the callback:
+
+```tsx
+                            if (cell.column.id === ROW_NUMBER_COLUMN_ID) {
+                                const rowNumberStickyBody =
+                                    frozenLayout.size > 0
+                                        ? {
+                                              className: pivotStyles.stickyColumn,
+                                              style: { left: 0 },
+                                          }
+                                        : {};
+                                return (
+                                    <Table.Cell
+                                        key={`row-number-${rowIndex}`}
+                                        className={rowNumberStickyBody.className}
+                                        style={rowNumberStickyBody.style}
+                                        isMinimal={isMinimal}
+                                    >
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </Table.Cell>
+                                );
+                            }
+```
+
+Place this BEFORE the existing `const meta = cell.column.columnDef.meta;` line. The early return short-circuits the cell processing for the row-number column.
+
+- [ ] **Step 5: Apply sticky props to footer (column totals) cells**
+
+Column totals render in `Table.Footer` starting at line 1220. The footer iterates the leftmost label cells (`columnTotalFields`), then total values. The label cells correspond to the leftmost pivot columns and need sticky styling for alignment with the frozen body cells.
+
+Find the footer block. Currently lines 1230-1255 read approximately:
+
+```tsx
+                                {/* shows empty cell if row numbers are visible */}
+                                {hideRowNumbers ? null : <Table.Cell />}
+
+                                {/* render the total label */}
+                                {data.columnTotalFields?.[totalRowIndex].map(
+                                    (totalLabel, totalColIndex) =>
+                                        totalLabel ? (
+                                            <Table.CellHead
+                                                key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                                isMinimal={isMinimal}
+                                                withAlignRight
+                                                withBoldFont
+                                            >
+                                                {totalLabel.fieldId
+                                                    ? `Total ${getFieldLabel(
+                                                          totalLabel.fieldId,
+                                                      )}`
+                                                    : `Total`}
+                                            </Table.CellHead>
+                                        ) : (
+                                            <Table.Cell
+                                                key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                                isMinimal={isMinimal}
+                                            />
+                                        ),
+                                )}
+```
+
+Replace the row-number placeholder + the label-cell map with sticky-aware versions. Above the `{hideRowNumbers ? null : <Table.Cell />}` line, add the row-number sticky helper (same shape as header):
+
+```tsx
+                                const footerRowNumberSticky =
+                                    frozenLayout.size > 0
+                                        ? {
+                                              className: pivotStyles.stickyColumn,
+                                              style: { left: 0 },
+                                          }
+                                        : ({} as { className?: string; style?: React.CSSProperties });
+```
+
+Update the row-number cell:
+
+```tsx
+                                {hideRowNumbers ? null : (
+                                    <Table.Cell
+                                        className={footerRowNumberSticky.className}
+                                        style={footerRowNumberSticky.style}
+                                    />
+                                )}
+```
+
+Then for each totalLabel cell, look up the matching pivot column. The label cells correspond to the first `numLabelCols` slots of `pivotColumnInfo`:
+
+```tsx
+                                {data.columnTotalFields?.[totalRowIndex].map(
+                                    (totalLabel, totalColIndex) => {
+                                        const footerPivotCol =
+                                            data.retrofitData.pivotColumnInfo[
+                                                totalColIndex
+                                            ];
+                                        const footerStickyProps = footerPivotCol
+                                            ? getStickyCellProps(
+                                                  frozenLayout.get(
+                                                      footerPivotCol.fieldId,
+                                                  ),
+                                              )
+                                            : {};
+                                        return totalLabel ? (
+                                            <Table.CellHead
+                                                key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                                className={footerStickyProps.className}
+                                                style={footerStickyProps.style}
+                                                isMinimal={isMinimal}
+                                                withAlignRight
+                                                withBoldFont
+                                            >
+                                                {totalLabel.fieldId
+                                                    ? `Total ${getFieldLabel(
+                                                          totalLabel.fieldId,
+                                                      )}`
+                                                    : `Total`}
+                                            </Table.CellHead>
+                                        ) : (
+                                            <Table.Cell
+                                                key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                                className={footerStickyProps.className}
+                                                style={footerStickyProps.style}
+                                                isMinimal={isMinimal}
+                                            />
+                                        );
+                                    },
+                                )}
+```
+
+Note the use of `getStickyCellProps` (not `getStickyHeaderProps`) — footer cells need z-index 1, not 2, because they're below the header.
+
+Total VALUE cells (the data totals to the right of the label cells, lines 1257+) do NOT need sticky styles — they're in the data area, not the leftmost frozen region.
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+pnpm -F frontend typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Run the existing PivotTable tests**
+
+```bash
+pnpm -F frontend exec vitest run src/components/common/PivotTable
+```
+
+Expected: all 8 `getFrozenColumnLayout` tests still pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/frontend/src/components/common/PivotTable/index.tsx
+git commit -m "feat(frontend): apply sticky positioning to frozen pivot header and footer cells"
+```
+
+---
+
+### Task 6: Show the freeze toggle in `ColumnConfiguration` for pivoted dimensions and metrics
+
+**Files:**
+- Modify: `packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx` (lines 1-220)
+
+Today the freeze toggle is hidden entirely when `pivotDimensions` is set (line 153: `{!pivotDimensions ? (...) : null}`). We replace that gate with finer-grained logic:
+
+- **Hide for pivoted dimensions** (the dim is being used as a column header, so freezing it makes no sense)
+- **Hide for metrics when `metricsAsRows === true`** (per the ticket's acceptance criteria)
+- **Show otherwise** (non-pivoted dimensions and, when `metricsAsRows === false`, metrics)
+
+- [ ] **Step 1: Read `metricsAsRows` from chartConfig**
+
+At the top of the `ColumnConfiguration` component (around line 75-83), expand the destructure to include `metricsAsRows` from chartConfig:
+
+```tsx
+    const {
+        updateColumnProperty,
+        isColumnVisible,
+        isColumnFrozen,
+        getField,
+        columnProperties,
+        metricsAsRows,
+    } = visualizationConfig.chartConfig;
+```
+
+`metricsAsRows` is exposed on the chart config (see `useTableConfig.ts:423`).
+
+- [ ] **Step 2: Compute whether to show the freeze toggle**
+
+Below the existing computed values at `ColumnConfiguration.tsx:85-88`, add:
+
+```tsx
+    const isMetric = field && !isDimension(field);
+    const shouldShowFreezeToggle = (() => {
+        if (isPivotingDimension) return false;
+        if (isMetric && metricsAsRows) return false;
+        return true;
+    })();
+```
+
+- [ ] **Step 3: Replace the existing visibility gate**
+
+Find the existing block at `ColumnConfiguration.tsx:153-188`:
+
+```tsx
+            {!pivotDimensions ? (
+                <Tooltip ...>
+                    ...freeze toggle...
+                </Tooltip>
+            ) : null}
+```
+
+Replace `!pivotDimensions` with `shouldShowFreezeToggle`:
+
+```tsx
+            {shouldShowFreezeToggle ? (
+                <Tooltip
+                    position="top"
+                    withinPortal
+                    opened={isFreezeTooltipVisible}
+                    label={
+                        isColumnFrozen(fieldId)
+                            ? 'Unfreeze column'
+                            : 'Freeze column'
+                    }
+                >
+                    {/* ...rest unchanged... */}
+                </Tooltip>
+            ) : null}
+```
+
+- [ ] **Step 4: Typecheck the panel**
+
+```bash
+pnpm -F frontend typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Lint the changed file**
+
+```bash
+pnpm -F frontend lint --fix packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+git commit -m "feat(frontend): show freeze toggle for pivoted dimensions and metrics
+
+Per PROD-639 acceptance criteria:
+- Show freeze toggle for non-pivoted (row) dimensions
+- Show for metrics when metricsAsRows = false
+- Hide for pivoted dimensions and for metrics when metricsAsRows = true"
+```
+
+---
+
+### Task 7: Manual smoke test in the browser
+
+**Files:** None modified — verification only.
+
+The dev server is assumed to be already running per `CLAUDE.md`.
+
+- [ ] **Step 1: Open a pivoted chart in the Explorer**
+
+In the browser, log in as `demo@lightdash.com` / `demo_password!`, open the demo project, and either find an existing pivoted table chart or create one quickly:
+1. New chart → Explore → orders
+2. Add dimension `Order date month`, dimension `Shipping method`, metric `Total order amount`
+3. Switch chart type to Table
+4. In the Configure panel, drag `Shipping method` to the Pivot section
+
+- [ ] **Step 2: Verify dimension freezing works**
+
+In the Configure panel → Columns tab, click the lock icon next to `Order date month`. The lock should turn solid.
+
+In the chart panel, scroll horizontally. The `Order date month` column should stay visible on the left while the pivoted columns scroll past it.
+
+If row totals are enabled (config panel → "Show row totals"), they remain on the right edge unaffected. ✅
+
+- [ ] **Step 3: Verify the toggle is hidden for the pivoted dimension**
+
+In Configure → Columns, the row for `Shipping method` (which is the pivoted dimension) should NOT show a lock icon. ✅
+
+- [ ] **Step 4: Verify metrics-as-rows hides the metric freeze toggle**
+
+In Configure → Display, toggle `Metrics as rows` to ON. Re-open Configure → Columns. The metric (`Total order amount`) row should NOT show a lock icon. The dimension rows (`Order date month`, `Shipping method`) should still behave per Steps 2-3. ✅
+
+- [ ] **Step 5: Verify multi-row header alignment**
+
+With a frozen dimension and pivoting active, the multi-row header (pivot dim values stacked above metric labels) should align correctly with its body column when scrolled. No horizontal tearing. ✅
+
+- [ ] **Step 6: Verify column totals (footer) alignment**
+
+Toggle "Show column totals" in Configure → Display. The footer row at the bottom should keep the leftmost label cells aligned with the frozen body cells while horizontally scrolling. ✅
+
+- [ ] **Step 7: Verify dashboard tile rendering**
+
+Add the chart to a dashboard, give the tile a narrow width that forces horizontal scroll, then horizontally scroll inside the tile. The frozen column should stay anchored. The dashboard tile re-uses the same PivotTable component, so this should work without further changes — the test confirms it. ✅
+
+- [ ] **Step 8: Take a screenshot of the working freeze**
+
+Use Chrome DevTools MCP to capture a screenshot showing the frozen column anchored on the left while the pivot columns are mid-scroll. Save it for the PR description.
+
+- [ ] **Step 9: No commit needed for manual verification**
+
+If the smoke test reveals an issue, fix it inline and commit per the standard pattern. If everything works, proceed to the next step.
+
+---
+
+### Task 8: Push the branch and open the PR
+
+**Files:** None modified.
+
+- [ ] **Step 1: Verify branch state**
+
+```bash
+git status
+git log --oneline origin/main..HEAD
+```
+
+Expected: clean working tree; commits include the spec doc + `getFrozenColumnLayout` test/impl + PivotTable rendering changes + ColumnConfiguration changes.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feature/prod-639
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "feat(frontend): freeze columns in pivot tables (PROD-639)" --body "$(cat <<'EOF'
+## Summary
+- Adds per-fieldId freeze support for pivoted table charts, reusing the existing `ColumnProperties.frozen` storage
+- Renders sticky leftmost columns via CSS `position: sticky` with cumulative `left` offsets computed by a new `getFrozenColumnLayout` helper
+- Lifts the existing pivot-mode hide on the freeze toggle in `ColumnConfiguration`, gated on dimension/metric type per PROD-639 acceptance criteria
+
+## Spec
+[docs/superpowers/specs/2026-05-11-prod-639-pivot-frozen-columns-design.md](../docs/superpowers/specs/2026-05-11-prod-639-pivot-frozen-columns-design.md)
+
+## Test plan
+- [ ] Unit tests pass (`pnpm -F frontend exec vitest run src/components/common/PivotTable/getFrozenColumnLayout.test.ts`)
+- [ ] Typecheck passes (`pnpm -F frontend typecheck`)
+- [ ] Lint passes (`pnpm -F frontend lint`)
+- [ ] Manual: pivoted chart, freeze a row dimension, scroll horizontally — column stays anchored
+- [ ] Manual: pivoted chart with `metricsAsRows = true` — no freeze toggle on metric rows
+- [ ] Manual: pivoted chart with row totals enabled — totals remain on the right edge
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 4: Capture the PR URL for handoff**
+
+Note the PR URL in your response so the user can review it.
+
+---
+
+## Caveat to flag in the PR description
+
+Pivoted **metric** columns are not naturally leftmost — they live across the data area, often after several index dimensions. Setting `frozen = true` on a metric still applies sticky positioning to all of its pivot slices (consistent with how width works), but the visual result is best when the user only freezes leftmost columns (typically row dimensions). Freezing a metric in a heavily pivoted table works mechanically but may look odd because non-frozen columns sit between the index dims and the frozen metric slices. This is documented behaviour, not a bug — the spec's acceptance criteria treat metric freezing as supported when `metricsAsRows === false`, and we honour that.

--- a/docs/superpowers/specs/2026-05-11-prod-639-pivot-frozen-columns-design.md
+++ b/docs/superpowers/specs/2026-05-11-prod-639-pivot-frozen-columns-design.md
@@ -1,0 +1,93 @@
+# PROD-639 — Freeze columns in pivot tables
+
+**Status:** Proposed
+**Linear:** [PROD-639](https://linear.app/lightdash/issue/PROD-639)
+**Branch:** `feature/prod-639`
+**Project:** Improving pivot tables
+
+## Goal
+
+Allow users to freeze leftmost columns in a pivoted table chart so they stay visible while horizontally scrolling, mirroring the existing behavior of non-pivoted table charts.
+
+Per ticket acceptance criteria:
+- Row dimensions can always be frozen.
+- Metric columns can be frozen when `metricsAsRows = false`.
+- When `metricsAsRows = true`, no metric-column freeze option (there are no metric columns to freeze).
+
+## Background
+
+Non-pivoted table charts already support per-column freezing via `ColumnProperties.frozen` (`packages/common/src/types/savedCharts.ts:391-403`). Storage is a per-fieldId boolean inside `TableChart.columns`. Rendering uses CSS sticky positioning (`position: sticky; left: cumulativeLeft`) computed in `Table/TableProvider.tsx:85-113`.
+
+The pivoted table is a separate component (`packages/frontend/src/components/common/PivotTable/index.tsx`, ~1300 lines) that currently does not read `frozen` or apply sticky positioning. It uses TanStack Table with a multi-row header derived from `PivotData.titleFields` and `PivotData.headerValues` (see `PivotTable/CLAUDE.md` for the data structure).
+
+## Architecture
+
+### Type changes
+
+**None.** Reuses the existing `ColumnProperties.frozen?: boolean` field on `TableChart.columns`. No schema migration, no API change.
+
+### Frontend — `PivotTable/index.tsx`
+
+1. **Compute frozen columns**. In the `useMemo` that builds columns (around line 220), inspect `columnProperties[itemId]?.frozen` for each pivot column. Build two arrays:
+    - `frozenColumns` (kept in original order)
+    - `otherColumns`
+2. **Compute cumulative left offsets** for frozen columns, mirroring `Table/TableProvider.tsx:85-113`. Each frozen column's style is `{ position: sticky, left: cumulativeLeft, zIndex: <higher than scrolling cells> }`.
+3. **Apply sticky styles to all cell rows** for the frozen columns:
+    - Body cells (`dataValues` rows)
+    - Multi-row header cells (`titleFields` rows + `headerValues` rows) — each row gets the same sticky styles so the entire frozen column visually moves together.
+    - Subtotal rows if applicable.
+4. **CSS module** — extend `PivotTable.module.css` with `.sticky-column` / `.last-sticky-column` rules (drop shadow on the right edge of the last frozen column, opaque background to layer over scrolling content). Reuse the pattern from the non-pivoted Table module.
+5. **Z-index ordering** — frozen body cells must layer over scrolling body cells; frozen header cells must layer over scrolling header cells AND non-frozen body cells.
+
+### Frontend — `TableConfigPanel/ColumnConfiguration.tsx`
+
+Already has a "Freeze column" toggle (line 73, `setFreezeTooltipVisible`) for the non-pivoted Table. Extend it for the pivoted-mode rendering:
+
+- For each row dimension column → show the toggle (always allowed).
+- For each metric column when `metricsAsRows === false` → show the toggle.
+- When `metricsAsRows === true` → omit the freeze toggle entirely from metric rows (no toggle, no disabled+tooltip — cleaner UI).
+- Row totals column → no toggle (row totals always sit on the right edge; freezing isn't meaningful).
+
+The toggle writes to the same `TableChart.columns[fieldId].frozen` field that non-pivoted tables use. Save / load is automatic.
+
+### Edge cases
+
+- **Row totals**: stay on the right edge. Don't conflict with left-edge freeze.
+- **Column totals**: render below the body. Sticky `left` applies the same way.
+- **`metricsAsRows = true`**: only row dimensions exist on the left. The leftmost dimension column is the natural freeze target; freezing it works the same as any other dimension column. Acceptance criteria met by simply hiding the metric-row freeze toggle.
+- **`hideRowNumbers = false`**: the row-number column is always leftmost. It implicitly behaves frozen today (see `Table/TableProvider.tsx:119-135` `stickyRowColumn`). Mirror that for the pivoted table — the row-number column should always be sticky, with frozen columns starting at its right edge.
+- **No frozen columns selected**: zero overhead, layout unchanged.
+- **Horizontal scroll container**: PivotTable's existing scroll wrapper handles the sticky positioning; verify the ancestor has the right `overflow-x` and no clipping that breaks `position: sticky`.
+
+## Data flow
+
+```
+User opens TableConfigPanel → ColumnConfiguration row for dimension X
+  → toggles "Freeze column"
+  → writes TableChart.columns['dim_x'].frozen = true
+  → chart config update propagates
+  → PivotTable/index.tsx useMemo re-computes columns
+  → frozen column gets sticky positioning + cumulative left
+  → CSS sticky keeps it visible during horizontal scroll
+```
+
+## Backend
+
+**No changes.** This is purely a rendering + config-panel change.
+
+## Testing
+
+- Manual: pivoted chart, freeze leftmost dim, scroll horizontally — column stays put.
+- Manual: pivoted chart with `metricsAsRows = true` — confirm no freeze toggle on metric rows.
+- Manual: pivoted chart with row totals enabled — confirm right-edge totals + left-edge freeze coexist.
+- Manual: freeze multiple dimensions — verify cumulative left offsets line up correctly with no gaps.
+- Visual regression: header alignment with multi-row pivot headers.
+
+## Hidden gotchas
+
+- **Multi-row header alignment**: each row of the header (`titleFields`, `headerValues`) needs the same `left` value applied or the column will visibly tear during scroll. Easy to miss with TanStack's per-row rendering.
+- **Sticky parent containers**: `position: sticky` silently breaks if any ancestor has `overflow: hidden` or `overflow-x: hidden` set incorrectly. Verify the existing PivotTable scroll wrapper is compatible.
+- **Z-index stacking**: frozen header cells need higher z-index than frozen body cells, which need higher z-index than scrolling cells. Use the existing pattern from `Table/ScrollableTable/TableBody.tsx:146`.
+- **Dashboard tile rendering**: pivoted charts on dashboards use the same component — verify freeze behaves correctly inside dashboard tiles (smaller widths, more horizontal scroll).
+- **Conditional formatting**: cells already iterate via `cell.column.columnDef.meta?.headerInfo` (`PivotTable/index.tsx:465-489`). Sticky positioning is a style concern only — doesn't disturb conditional formatting lookup.
+- **Column resizing** (if present in pivoted tables): if widths change, cumulative left offsets need recomputing. Verify whether the existing `useColumnResize` hook is wired into the pivoted path or only the non-pivoted one.

--- a/docs/superpowers/specs/2026-05-11-prod-6986-pivot-column-sort-design.md
+++ b/docs/superpowers/specs/2026-05-11-prod-6986-pivot-column-sort-design.md
@@ -1,0 +1,122 @@
+# PROD-6986 — Sort by pivoted column slice
+
+**Status:** Proposed
+**Linear:** [PROD-6986](https://linear.app/lightdash/issue/PROD-6986)
+**Branch:** `feature/prod-6986`
+**Project:** Improving pivot tables
+
+## Goal
+
+Let users sort the rows of a pivoted table chart by clicking a pivoted column header. The sort key is "this metric's value at this specific pivot-column slice" (e.g. "sort rows by `Total count` at `Category=1`"), not just "this metric" (which today silently anchors to the first pivot slice).
+
+Out of scope for this ticket — split into a follow-up issue:
+- Sort by row totals
+- Sort by column totals
+- Multi-key sort
+
+## Background
+
+Lightdash pivots tables exclusively in SQL via `PivotQueryBuilder` (`packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts`). The frontend in-memory pivot path is dead code. The pivot pipeline tags rows with `row_index` / `column_index` via DENSE_RANK CTEs and the values are spread into `{field}_{agg}_{groupByValue}` columns downstream in `AsyncQueryService.runQueryAndTransformRows`.
+
+`PivotQueryBuilder` already supports a sort by metric value, but the anchor is hard-coded to `col_idx = 1` — i.e. it sorts rows by the metric's value in the **first** pivot slice. That's invisible to users, who want to pick the slice explicitly.
+
+In the Explorer, pivot sort is sourced from `metricQuery.sorts` via `getSortByForPivotConfiguration` in `packages/common/src/pivot/derivePivotConfigFromChart.ts:32-83`. SQL Runner builds `PivotConfiguration` directly and does not use `metricQuery.sorts`. Both surfaces share the downstream `PivotQueryBuilder`. **This ticket extends Explorer only.** The shared backend lift means SQL Runner could opt in later with its own UI work.
+
+## Architecture
+
+### Type changes
+
+Extend `SortField` (the entry shape inside `metricQuery.sorts`) with an optional pivot-slice key:
+
+```ts
+// packages/common/src/types/field.ts
+export type PivotSliceKey = Array<{
+    referenceField: string;
+    value: string | number | boolean | null;
+}>;
+
+export type SortField = {
+    fieldId: string;
+    descending: boolean;
+    nullsFirst?: boolean;
+    pivotValues?: PivotSliceKey; // NEW — only consumed by the pivot path
+};
+```
+
+`pivotValues` is metadata that only the pivot path consumes. `MetricQueryBuilder` ignores it. The non-pivoted Results table ignores it. No DB migration — `pivotValues` is optional and existing pivoted charts keep their current behavior (anchor = first slice when no `pivotValues`).
+
+Mirror the field on `PivotConfiguration.sortBy` entries (typed in `packages/common/src/types/sqlRunner.ts`) so the slice survives through to the SQL builder.
+
+### Backend — `PivotQueryBuilder.ts`
+
+Today: the `anchor_column` CTE picks the column where `col_idx = 1` to drive row-anchor metric values for sort.
+
+Change: when a `sortBy` entry has `pivotValues`, the `anchor_column` CTE filters by the dim equalities from `pivotValues` instead of `col_idx = 1`. The downstream `row_anchor` / `row_ranking` chain is unchanged.
+
+Concretely the change is localized to the methods that produce the `column_anchor` → `anchor_column` chain. No new CTE — just a different `WHERE` clause when slice info is present. Existing tests for `col_idx = 1` continue to pass; new tests cover slice-anchor cases per warehouse dialect (Postgres, BigQuery, Snowflake, Databricks). Databricks' precomputed-rankings path (`row_ranking` + `column_ranking` as self-contained CTEs) needs the same treatment — verify in `PivotQueryBuilder.test.ts`.
+
+Cache key: `PivotConfiguration` is hashed into the query cache key; `pivotValues` is part of the structure so cache invalidation is automatic.
+
+### Backend — `derivePivotConfigFromChart.ts`
+
+In `getSortByForPivotConfiguration` (lines 32-83), preserve the new optional `pivotValues` field when mapping each `SortField` into the corresponding `PivotConfiguration.sortBy` entry. Single line addition alongside `reference`, `direction`, `nullsFirst`.
+
+### Frontend — Explorer
+
+1. **New component**: `PivotColumnHeaderMenu.tsx` next to `ValueCellMenu.tsx` / `TotalCellMenu.tsx` in `packages/frontend/src/components/common/PivotTable/`. Mantine Menu opened from the pivoted column header. Items: "Sort asc / Sort desc / Clear sort", with check icons indicating active state. Mirrors the structure of `ColumnHeaderSortMenuOptions.tsx`.
+
+2. **Wire-up in `PivotTable/index.tsx`**: render the menu on header cells. The slice key is built from `column.columnDef.meta.headerInfo` (already populated, see `PivotTable/CLAUDE.md:347-369` for the structure — it's the per-column map of pivot-dimension fieldId → value).
+
+3. **Dispatch**: clicking "Sort asc/desc" dispatches `explorerActions.setSortFields([newSort])` where `newSort` is a `SortField` with `pivotValues` populated from `headerInfo`. This **replaces** existing sorts (single-sort model, matching `ColumnHeaderSortMenuOptions.tsx:42`).
+
+4. **Sort indicator**: small directional arrow on the pivoted column header when that header's `headerInfo` matches the active sort's `pivotValues`. Cheap, do it in this PR.
+
+### Frontend — SQL Runner
+
+No changes in this PR. SQL Runner pivot Visualization tab keeps its current behavior. The shared backend capability (`PivotConfiguration.sortBy` with optional `pivotValues`) is available for a future SQL Runner UI extension.
+
+## Data flow
+
+```
+User clicks "Sort desc" on pivoted column "Total count / Category=1"
+  → PivotColumnHeaderMenu builds SortField {
+        fieldId: 'orders_total_count',
+        descending: true,
+        pivotValues: [{ referenceField: 'orders_category', value: '1' }]
+    }
+  → dispatch explorerActions.setSortFields([newSort])
+  → metricQuery.sorts = [newSort]
+  → next query execution
+  → derivePivotConfigurationFromChart → getSortByForPivotConfiguration
+  → PivotConfiguration.sortBy = [{ reference, direction, nullsFirst, pivotValues }]
+  → PivotQueryBuilder.anchor_column CTE filters by dim equalities
+  → row_anchor picks metric value at the chosen slice
+  → row_ranking sorts rows by that anchor value
+  → results stream back, pivoted table re-renders sorted
+```
+
+## Compatibility
+
+- `pivotValues` is optional everywhere — existing saved charts deserialize unchanged.
+- Pivoted charts with no `pivotValues` continue to anchor on the first slice (`col_idx = 1`). No behavior change for them.
+- The Results panel keeps showing "Sorted by N fields" — the `pivotValues` metadata is invisible to it but harmless.
+- TSOA: regenerate API spec since `SortField` shape changes.
+
+## Testing
+
+- `PivotQueryBuilder.test.ts` — new cases for slice-anchor SQL across Postgres, BigQuery, Snowflake, Databricks. Verify the `anchor_column` CTE filter and that downstream `row_ranking` is unchanged.
+- `derivePivotConfigFromChart.test.ts` — verify `pivotValues` carries through `getSortByForPivotConfiguration`.
+- Frontend unit test for `PivotColumnHeaderMenu` (active state, dispatch payload).
+- Manual: open a pivoted chart in the Explorer, sort by a non-first slice, verify both the Chart panel order and the underlying SQL.
+
+## Hidden gotchas
+
+- **Coupled sort surface**: clicking a pivot column header writes to `metricQuery.sorts`, which is shared with the Results panel. Results panel will display "Sorted by `metric`" with no slice indicator. This matches today's coupling — not a regression — but worth flagging in the PR description.
+- **Conditional formatting** depends on `headerInfo` per column (`PivotTable/index.tsx:465-489`). Since slice-sort is backend-driven and column ordering is unchanged, this is unaffected.
+- **Subtotals** (`groupedSubtotals`) are a parallel API. Slice-sort doesn't change how they're requested or matched.
+- **Row limit + sort interaction**: row count is enforced by `row_index <= limit`. Changing the anchor changes which rows survive — correct behavior, but visually different from non-slice sort.
+- **Cache invalidation**: covered automatically since `pivotValues` lives inside `PivotConfiguration` which is hashed.
+
+## Open follow-up
+
+- New issue: "Sort by row total in pivot tables" — needs a separate code path (top-level `ORDER BY total_columns.row_total`) and a sentinel in `pivotValues` (or a dedicated boolean) to indicate "this is a row-total sort." Click-handler / menu plumbing built in this PR is reusable.

--- a/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.test.ts
+++ b/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.test.ts
@@ -1,0 +1,204 @@
+import type { PivotColumn } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getFrozenColumnLayout } from './getFrozenColumnLayout';
+
+const indexCol = (fieldId: string): PivotColumn => ({
+    fieldId,
+    baseId: undefined,
+    underlyingId: undefined,
+    columnType: 'indexValue',
+});
+
+const dataCol = (fieldId: string, baseId: string): PivotColumn => ({
+    fieldId,
+    baseId,
+    underlyingId: undefined,
+    columnType: undefined,
+});
+
+const labelCol = (fieldId: string): PivotColumn => ({
+    fieldId,
+    baseId: undefined,
+    underlyingId: undefined,
+    columnType: 'label',
+});
+
+describe('getFrozenColumnLayout', () => {
+    it('returns an empty map when no columns are frozen', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [indexCol('orders_category')],
+            columnProperties: {},
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.size).toBe(0);
+    });
+
+    it('starts cumulative left at rowNumberWidth when row numbers are shown', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [indexCol('orders_category')],
+            columnProperties: { orders_category: { frozen: true } },
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 50,
+            isLast: true,
+        });
+    });
+
+    it('starts cumulative left at 0 when row numbers are hidden', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [indexCol('orders_category')],
+            columnProperties: { orders_category: { frozen: true } },
+            rowNumberWidth: 0,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 0,
+            isLast: true,
+        });
+    });
+
+    it('chains cumulative left across multiple frozen index columns', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                indexCol('orders_category'),
+                indexCol('orders_region'),
+            ],
+            columnProperties: {
+                orders_category: { frozen: true, width: 120 },
+                orders_region: { frozen: true, width: 80 },
+            },
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 50,
+            isLast: false,
+        });
+        expect(layout.get('orders_region')).toEqual({
+            left: 170,
+            isLast: true,
+        });
+    });
+
+    it('uses defaultColumnWidth when a frozen column has no explicit width', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                indexCol('orders_category'),
+                indexCol('orders_region'),
+            ],
+            columnProperties: {
+                orders_category: { frozen: true },
+                orders_region: { frozen: true, width: 80 },
+            },
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 50,
+            isLast: false,
+        });
+        expect(layout.get('orders_region')).toEqual({
+            left: 150,
+            isLast: true,
+        });
+    });
+
+    it('skips non-frozen columns but advances offset for frozen ones only', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                indexCol('orders_category'),
+                indexCol('orders_region'),
+                indexCol('orders_segment'),
+            ],
+            columnProperties: {
+                orders_category: { frozen: true, width: 120 },
+                orders_segment: { frozen: true, width: 80 },
+                // orders_region is NOT frozen — left offset for orders_segment
+                // is computed from orders_category only.
+            },
+            rowNumberWidth: 50,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_category')).toEqual({
+            left: 50,
+            isLast: false,
+        });
+        expect(layout.has('orders_region')).toBe(false);
+        expect(layout.get('orders_segment')).toEqual({
+            left: 170,
+            isLast: true,
+        });
+    });
+
+    it('uses underlyingId/baseId as the freeze key for data columns', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                indexCol('orders_category'),
+                dataCol('total_count__pivot_0', 'total_count'),
+                dataCol('total_count__pivot_1', 'total_count'),
+            ],
+            columnProperties: {
+                total_count: { frozen: true, width: 90 },
+            },
+            rowNumberWidth: 0,
+            defaultColumnWidth: 100,
+        });
+        // Both pivot slices of the same metric become sticky because the freeze
+        // key resolves to the metric's baseId.
+        expect(layout.get('total_count__pivot_0')).toEqual({
+            left: 0,
+            isLast: false,
+        });
+        expect(layout.get('total_count__pivot_1')).toEqual({
+            left: 90,
+            isLast: true,
+        });
+    });
+
+    it('treats label columns the same as indexValue columns for freeze keys', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                labelCol('orders_metric_label'),
+                dataCol('total_count__pivot_0', 'total_count'),
+            ],
+            columnProperties: {
+                orders_metric_label: { frozen: true, width: 60 },
+            },
+            rowNumberWidth: 0,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_metric_label')).toEqual({
+            left: 0,
+            isLast: true,
+        });
+        expect(layout.has('total_count__pivot_0')).toBe(false);
+    });
+
+    it('prefers underlyingId over baseId as the freeze key for data columns', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [
+                {
+                    fieldId: 'orders_total_count__pivot_0',
+                    baseId: 'orders_shipping_method',
+                    underlyingId: 'orders_total_count',
+                    columnType: undefined,
+                },
+            ],
+            columnProperties: {
+                orders_total_count: { frozen: true, width: 90 },
+                // baseId match would also resolve to frozen, but underlyingId
+                // takes priority — this property has frozen: false to prove it.
+                orders_shipping_method: { frozen: false },
+            },
+            rowNumberWidth: 0,
+            defaultColumnWidth: 100,
+        });
+        expect(layout.get('orders_total_count__pivot_0')).toEqual({
+            left: 0,
+            isLast: true,
+        });
+    });
+});

--- a/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
+++ b/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
@@ -1,0 +1,62 @@
+import type { ColumnProperties, PivotColumn } from '@lightdash/common';
+
+export type FrozenColumnEntry = {
+    left: number;
+    isLast: boolean;
+};
+
+type Args = {
+    pivotColumnInfo: PivotColumn[];
+    columnProperties: Record<string, ColumnProperties | undefined>;
+    rowNumberWidth: number;
+    defaultColumnWidth: number;
+};
+
+const getFreezeKey = (col: PivotColumn): string | undefined => {
+    if (col.columnType === 'indexValue' || col.columnType === 'label') {
+        return col.fieldId;
+    }
+    return col.underlyingId ?? col.baseId;
+};
+
+const getColumnWidth = (
+    freezeKey: string,
+    columnProperties: Record<string, ColumnProperties | undefined>,
+    defaultColumnWidth: number,
+): number => columnProperties[freezeKey]?.width ?? defaultColumnWidth;
+
+export const getFrozenColumnLayout = ({
+    pivotColumnInfo,
+    columnProperties,
+    rowNumberWidth,
+    defaultColumnWidth,
+}: Args): Map<string, FrozenColumnEntry> => {
+    const layout = new Map<string, FrozenColumnEntry>();
+    let cumulativeLeft = rowNumberWidth;
+    let lastFrozenFieldId: string | undefined;
+
+    for (const col of pivotColumnInfo) {
+        const freezeKey = getFreezeKey(col);
+        if (!freezeKey) continue;
+
+        const isFrozen = columnProperties[freezeKey]?.frozen === true;
+        if (!isFrozen) continue;
+
+        const width = getColumnWidth(
+            freezeKey,
+            columnProperties,
+            defaultColumnWidth,
+        );
+
+        layout.set(col.fieldId, { left: cumulativeLeft, isLast: false });
+        lastFrozenFieldId = col.fieldId;
+        cumulativeLeft += width;
+    }
+
+    if (lastFrozenFieldId !== undefined) {
+        const lastEntry = layout.get(lastFrozenFieldId)!;
+        layout.set(lastFrozenFieldId, { ...lastEntry, isLast: true });
+    }
+
+    return layout;
+};


### PR DESCRIPTION
Closes: [PROD-639](https://linear.app/lightdash/issue/PROD-639)

### Description:

Adds support for freezing leftmost columns in pivoted table charts so they remain visible during horizontal scrolling, mirroring the existing freeze behavior in non-pivoted tables.

A new `getFrozenColumnLayout` helper walks the pivot's `pivotColumnInfo` left-to-right, computes cumulative `left` offsets for columns marked as frozen in `columnProperties`, and returns a `Map<fieldId, { left, isLast }>`. This map is consumed by `PivotTable/index.tsx` to apply CSS `position: sticky` inline styles to header rows, body cells, and footer cells. The row-number column is also made sticky whenever any column is frozen.

The freeze toggle in `ColumnConfiguration` is now shown for non-pivoted (row) dimensions and for metrics when `metricsAsRows === false`. It remains hidden for pivoted dimensions and for metrics when `metricsAsRows === true`.

The existing `ColumnProperties.frozen` field is reused — no schema changes or API changes are required.

**Note:** Freezing metric columns is supported when `metricsAsRows === false`, but works best when those metrics are naturally leftmost. Freezing a metric in a heavily pivoted table applies sticky positioning to all of its pivot slices, which may look unexpected if non-frozen columns sit between the index dimensions and the frozen metric slices. This is documented behavior consistent with how column widths work for metrics.