### PR TITLE
feat: frozen columns support for pivot table

### DIFF
--- a/packages/frontend/src/components/common/LightTable/styles.ts
+++ b/packages/frontend/src/components/common/LightTable/styles.ts
@@ -157,14 +157,14 @@ export const useTableSectionStyles = createStyles<
                 return {
                     top: 0,
                     position: 'sticky',
-                    zIndex: 1,
+                    zIndex: 110,
                 } as const;
 
             case SectionType.Footer:
                 return {
                     bottom: 0,
                     position: 'sticky',
-                    zIndex: 1,
+                    zIndex: 110,
                 } as const;
 
             case SectionType.Body:

--- a/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
+++ b/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
@@ -10,7 +10,7 @@
 
 .stickyColumn {
     position: sticky;
-    z-index: 1;
+    z-index: 0;
     background-color: var(--mantine-color-body, white);
 }
 

--- a/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
+++ b/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
@@ -14,6 +14,10 @@
     background-color: var(--mantine-color-body, white);
 }
 
+.stickyHeaderColumn {
+    z-index: 2;
+}
+
 .stickyColumnLast {
     box-shadow: 4px 0 4px -2px rgba(0, 0, 0, 0.1);
 }

--- a/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
+++ b/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
@@ -7,3 +7,13 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.stickyColumn {
+    position: sticky;
+    z-index: 1;
+    background-color: var(--mantine-color-body, white);
+}
+
+.stickyColumnLast {
+    box-shadow: 4px 0 4px -2px rgba(0, 0, 0, 0.1);
+}

--- a/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
+++ b/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
@@ -8,14 +8,23 @@
     text-overflow: ellipsis;
 }
 
+/* Stacking order:
+ *   100 — sticky body cells (above non-sticky body, below thead)
+ *   110 — <thead>/<tfoot> from LightTable (vertical sticky sections)
+ *   120 — sticky header cells (the frozen corner: above everything)
+ * Big gaps so later additions don't have to renumber.
+ */
 .stickyColumn {
-    position: sticky;
-    z-index: 0;
-    background-color: var(--mantine-color-body, white);
+    position: sticky !important;
+    z-index: 100;
+    background-color: light-dark(
+        var(--mantine-color-background-0),
+        var(--mantine-color-ldGray-0)
+    ) !important;
 }
 
 .stickyHeaderColumn {
-    z-index: 2;
+    z-index: 120;
 }
 
 .stickyColumnLast {

--- a/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.test.ts
+++ b/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.test.ts
@@ -158,23 +158,36 @@ describe('getFrozenColumnLayout', () => {
         });
     });
 
-    it('treats label columns the same as indexValue columns for freeze keys', () => {
+    it('freezes the label column when labelColumnFrozen is true', () => {
+        // In metricsAsRows mode the label column has a synthetic fieldId
+        // ("label-0") that does not exist in columnProperties — the caller
+        // bridges the metric's freeze flag via labelColumnFrozen.
         const layout = getFrozenColumnLayout({
             pivotColumnInfo: [
-                labelCol('orders_metric_label'),
+                labelCol('label-0'),
                 dataCol('total_count__pivot_0', 'total_count'),
             ],
-            columnProperties: {
-                orders_metric_label: { frozen: true, width: 60 },
-            },
+            columnProperties: {},
             rowNumberWidth: 0,
             defaultColumnWidth: 100,
+            labelColumnFrozen: true,
         });
-        expect(layout.get('orders_metric_label')).toEqual({
+        expect(layout.get('label-0')).toEqual({
             left: 0,
             isLast: true,
         });
         expect(layout.has('total_count__pivot_0')).toBe(false);
+    });
+
+    it('does NOT freeze the label column when labelColumnFrozen is false', () => {
+        const layout = getFrozenColumnLayout({
+            pivotColumnInfo: [labelCol('label-0')],
+            columnProperties: {},
+            rowNumberWidth: 0,
+            defaultColumnWidth: 100,
+            labelColumnFrozen: false,
+        });
+        expect(layout.size).toBe(0);
     });
 
     it('prefers underlyingId over baseId as the freeze key for data columns', () => {

--- a/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
+++ b/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
@@ -10,6 +10,13 @@ type Args = {
     columnProperties: Record<string, ColumnProperties | undefined>;
     rowNumberWidth: number;
     defaultColumnWidth: number;
+    /**
+     * Actual rendered widths keyed by pivot col.fieldId, populated at runtime
+     * via ResizeObserver. When present for a column, this takes precedence
+     * over columnProperties[freezeKey].width — keeps frozen offsets aligned
+     * with the real cell width even for auto-sized columns.
+     */
+    measuredWidths?: Map<string, number>;
 };
 
 const getFreezeKey = (col: PivotColumn): string | undefined => {
@@ -20,16 +27,23 @@ const getFreezeKey = (col: PivotColumn): string | undefined => {
 };
 
 const getColumnWidth = (
+    col: PivotColumn,
     freezeKey: string,
     columnProperties: Record<string, ColumnProperties | undefined>,
     defaultColumnWidth: number,
-): number => columnProperties[freezeKey]?.width ?? defaultColumnWidth;
+    measuredWidths?: Map<string, number>,
+): number => {
+    const measured = measuredWidths?.get(col.fieldId);
+    if (measured !== undefined) return measured;
+    return columnProperties[freezeKey]?.width ?? defaultColumnWidth;
+};
 
 export const getFrozenColumnLayout = ({
     pivotColumnInfo,
     columnProperties,
     rowNumberWidth,
     defaultColumnWidth,
+    measuredWidths,
 }: Args): Map<string, FrozenColumnEntry> => {
     const layout = new Map<string, FrozenColumnEntry>();
     let cumulativeLeft = rowNumberWidth;
@@ -43,9 +57,11 @@ export const getFrozenColumnLayout = ({
         if (!isFrozen) continue;
 
         const width = getColumnWidth(
+            col,
             freezeKey,
             columnProperties,
             defaultColumnWidth,
+            measuredWidths,
         );
 
         layout.set(col.fieldId, { left: cumulativeLeft, isLast: false });

--- a/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
+++ b/packages/frontend/src/components/common/PivotTable/getFrozenColumnLayout.ts
@@ -17,6 +17,15 @@ type Args = {
      * with the real cell width even for auto-sized columns.
      */
     measuredWidths?: Map<string, number>;
+    /**
+     * When metricsAsRows is true, the leftmost label column holds metric
+     * names like "Total order amount". Its synthetic fieldId (e.g. "label-0")
+     * isn't a key in columnProperties — instead the freeze toggle writes to
+     * the underlying metric fieldId. The caller pre-computes "is any metric
+     * shown as a row-label frozen?" and passes it here so the layout can
+     * treat the label column as frozen.
+     */
+    labelColumnFrozen?: boolean;
 };
 
 const getFreezeKey = (col: PivotColumn): string | undefined => {
@@ -44,6 +53,7 @@ export const getFrozenColumnLayout = ({
     rowNumberWidth,
     defaultColumnWidth,
     measuredWidths,
+    labelColumnFrozen = false,
 }: Args): Map<string, FrozenColumnEntry> => {
     const layout = new Map<string, FrozenColumnEntry>();
     let cumulativeLeft = rowNumberWidth;
@@ -53,7 +63,10 @@ export const getFrozenColumnLayout = ({
         const freezeKey = getFreezeKey(col);
         if (!freezeKey) continue;
 
-        const isFrozen = columnProperties[freezeKey]?.frozen === true;
+        const isFrozen =
+            col.columnType === 'label'
+                ? labelColumnFrozen
+                : columnProperties[freezeKey]?.frozen === true;
         if (!isFrozen) continue;
 
         const width = getColumnWidth(

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -61,6 +61,7 @@ import { getGroupedRowModelLightdash } from '../Table/getGroupedRowModelLightdas
 import { columnHelper, type TableColumn } from '../Table/types';
 import { useColumnResize } from '../Table/useColumnResize';
 import { countSubRows } from '../Table/utils';
+import { getFrozenColumnLayout } from './getFrozenColumnLayout';
 import pivotStyles from './PivotTable.module.css';
 import TotalCellMenu from './TotalCellMenu';
 import ValueCellMenu from './ValueCellMenu';
@@ -174,6 +175,17 @@ const PivotTable: FC<PivotTableProps> = ({
         [columnProperties],
     );
 
+    const frozenLayout = useMemo(
+        () =>
+            getFrozenColumnLayout({
+                pivotColumnInfo: data.retrofitData.pivotColumnInfo,
+                columnProperties,
+                rowNumberWidth: hideRowNumbers ? 0 : ROW_NUMBER_COL_WIDTH,
+                defaultColumnWidth: 100,
+            }),
+        [data.retrofitData.pivotColumnInfo, columnProperties, hideRowNumbers],
+    );
+
     const { columns, columnOrder, colWidths } = useMemo(() => {
         // Pivoting all dimensions requires a spacer column under the pivoted headers.
         const allDimensionsPivoted =
@@ -249,6 +261,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 colIndex < finalHeaderInfoForColumns.length
                                     ? finalHeaderInfoForColumns[colIndex]
                                     : undefined,
+                            frozenLayout: frozenLayout.get(col.fieldId),
                         },
                         aggregatedCell: (info) => {
                             if (info.row.getIsGrouped()) {
@@ -329,7 +342,7 @@ const PivotTable: FC<PivotTableProps> = ({
             columnOrder: newColumnOrder,
             colWidths: newColWidths,
         };
-    }, [data, hideRowNumbers, getField, columnProperties]);
+    }, [data, hideRowNumbers, getField, columnProperties, frozenLayout]);
 
     // Minimum table width so auto columns don't get squeezed to zero
     const minTableWidth = useMemo(() => {

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -61,13 +61,26 @@ import { getGroupedRowModelLightdash } from '../Table/getGroupedRowModelLightdas
 import { columnHelper, type TableColumn } from '../Table/types';
 import { useColumnResize } from '../Table/useColumnResize';
 import { countSubRows } from '../Table/utils';
-import { getFrozenColumnLayout } from './getFrozenColumnLayout';
+import {
+    getFrozenColumnLayout,
+    type FrozenColumnEntry,
+} from './getFrozenColumnLayout';
 import pivotStyles from './PivotTable.module.css';
 import TotalCellMenu from './TotalCellMenu';
 import ValueCellMenu from './ValueCellMenu';
 
 const ROW_NUMBER_COL_WIDTH = 50;
 const MIN_AUTO_COL_WIDTH = 50;
+
+const getStickyCellProps = (frozen: FrozenColumnEntry | undefined) => {
+    if (!frozen) return {};
+    return {
+        className: `${pivotStyles.stickyColumn}${
+            frozen.isLast ? ` ${pivotStyles.stickyColumnLast}` : ''
+        }`,
+        style: { left: frozen.left },
+    };
+};
 
 type MenuCallbackProps = {
     isOpen: boolean;
@@ -1101,12 +1114,18 @@ const PivotTable: FC<PivotTableProps> = ({
 
                                 const cellWidth = meta?.width;
 
+                                const stickyCellProps = getStickyCellProps(
+                                    meta?.frozenLayout,
+                                );
+
                                 const TableCellComponent = isRowTotal
                                     ? Table.CellHead
                                     : Table.Cell;
                                 return (
                                     <TableCellComponent
                                         key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
+                                        className={stickyCellProps.className}
+                                        style={stickyCellProps.style}
                                         isMinimal={isMinimal}
                                         withAlignRight={isNumericItem(item)}
                                         w={cellWidth}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -69,7 +69,6 @@ import pivotStyles from './PivotTable.module.css';
 import TotalCellMenu from './TotalCellMenu';
 import ValueCellMenu from './ValueCellMenu';
 
-const ROW_NUMBER_COL_WIDTH = 50;
 const MIN_AUTO_COL_WIDTH = 50;
 
 const getStickyCellProps = (frozen: FrozenColumnEntry | undefined) => {
@@ -198,15 +197,24 @@ const PivotTable: FC<PivotTableProps> = ({
         [columnProperties],
     );
 
+    // Width of the leftmost row-number column. Mirrors the formula used by
+    // the non-pivoted Table (see Table/TableProvider.tsx) so freeze offsets
+    // line up with the actual rendered column width.
+    const rowNumberWidth = useMemo(() => {
+        if (hideRowNumbers) return 0;
+        const rowCount = data.retrofitData.allCombinedData.length;
+        return `${rowCount}`.length * 10 + 20;
+    }, [hideRowNumbers, data.retrofitData.allCombinedData.length]);
+
     const frozenLayout = useMemo(
         () =>
             getFrozenColumnLayout({
                 pivotColumnInfo: data.retrofitData.pivotColumnInfo,
                 columnProperties,
-                rowNumberWidth: hideRowNumbers ? 0 : ROW_NUMBER_COL_WIDTH,
+                rowNumberWidth,
                 defaultColumnWidth: 100,
             }),
-        [data.retrofitData.pivotColumnInfo, columnProperties, hideRowNumbers],
+        [data.retrofitData.pivotColumnInfo, columnProperties, rowNumberWidth],
     );
 
     const { columns, columnOrder, colWidths } = useMemo(() => {
@@ -245,7 +253,7 @@ const PivotTable: FC<PivotTableProps> = ({
         const newColWidths: (number | undefined)[] = [];
         if (!hideRowNumbers) {
             newColumnOrder.push(ROW_NUMBER_COLUMN_ID);
-            newColWidths.push(ROW_NUMBER_COL_WIDTH);
+            newColWidths.push(rowNumberWidth);
         }
         if (allDimensionsPivoted) {
             newColumnOrder.push(allPivotedSpacerColumn.id);
@@ -365,7 +373,14 @@ const PivotTable: FC<PivotTableProps> = ({
             columnOrder: newColumnOrder,
             colWidths: newColWidths,
         };
-    }, [data, hideRowNumbers, getField, columnProperties, frozenLayout]);
+    }, [
+        data,
+        hideRowNumbers,
+        getField,
+        columnProperties,
+        frozenLayout,
+        rowNumberWidth,
+    ]);
 
     // Minimum table width so auto columns don't get squeezed to zero
     const minTableWidth = useMemo(() => {
@@ -756,14 +771,18 @@ const PivotTable: FC<PivotTableProps> = ({
                                           className={rowNumberSticky.className}
                                           style={rowNumberSticky.style}
                                           isMinimal={isMinimal}
-                                          withMinimalWidth={!hasCustomWidths}
+                                          w={rowNumberWidth}
+                                          miw={rowNumberWidth}
+                                          maw={rowNumberWidth}
                                       />
                                   ) : (
                                       <Table.CellHead
                                           className={rowNumberSticky.className}
                                           style={rowNumberSticky.style}
                                           isMinimal={isMinimal}
-                                          withMinimalWidth={!hasCustomWidths}
+                                          w={rowNumberWidth}
+                                          miw={rowNumberWidth}
+                                          maw={rowNumberWidth}
                                           withBoldFont
                                       >
                                           #
@@ -1025,6 +1044,9 @@ const PivotTable: FC<PivotTableProps> = ({
                                             }
                                             style={rowNumberStickyBody.style}
                                             isMinimal={isMinimal}
+                                            w={rowNumberWidth}
+                                            miw={rowNumberWidth}
+                                            maw={rowNumberWidth}
                                         >
                                             {flexRender(
                                                 cell.column.columnDef.cell,
@@ -1363,6 +1385,9 @@ const PivotTable: FC<PivotTableProps> = ({
                                                   style={
                                                       footerRowNumberSticky.style
                                                   }
+                                                  w={rowNumberWidth}
+                                                  miw={rowNumberWidth}
+                                                  maw={rowNumberWidth}
                                               />
                                           );
                                       })()}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -260,6 +260,25 @@ const PivotTable: FC<PivotTableProps> = ({
         return `${rowCount}`.length * 10 + 20;
     }, [hideRowNumbers, data.retrofitData.allCombinedData.length]);
 
+    // In metricsAsRows mode the leftmost label column shows metric names
+    // (Total order amount / Total completed order amount). Its synthetic
+    // fieldId in pivotColumnInfo isn't a key in columnProperties — the
+    // freeze toggle writes to the underlying metric fieldId instead. Map
+    // the metric flags to a single "is the label column frozen?" signal.
+    const isLabelColumnFrozen = useMemo(() => {
+        if (!data.pivotConfig.metricsAsRows) return false;
+        const labelMetricIds = new Set<string>();
+        for (const row of data.indexValues) {
+            for (const entry of row) {
+                if (entry.type === 'label') labelMetricIds.add(entry.fieldId);
+            }
+        }
+        for (const id of labelMetricIds) {
+            if (columnProperties[id]?.frozen === true) return true;
+        }
+        return false;
+    }, [data.indexValues, data.pivotConfig.metricsAsRows, columnProperties]);
+
     const frozenLayout = useMemo(
         () =>
             getFrozenColumnLayout({
@@ -268,12 +287,14 @@ const PivotTable: FC<PivotTableProps> = ({
                 rowNumberWidth,
                 defaultColumnWidth: 100,
                 measuredWidths: measuredColumnWidths,
+                labelColumnFrozen: isLabelColumnFrozen,
             }),
         [
             data.retrofitData.pivotColumnInfo,
             columnProperties,
             rowNumberWidth,
             measuredColumnWidths,
+            isLabelColumnFrozen,
         ],
     );
 

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -39,7 +39,14 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import isEqual from 'lodash/isEqual';
 import last from 'lodash/last';
 import { readableColor } from 'polished';
-import React, { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import {
     getGroupingValuesAndSubtotalKey,
     getSubtotalValueFromGroup,
@@ -174,6 +181,53 @@ const PivotTable: FC<PivotTableProps> = ({
         onColumnWidthChange,
     });
 
+    // Track actual rendered widths of body cells by column id, used to keep
+    // frozen-column offsets aligned with reality. Without measurement, the
+    // layout has to guess (defaultColumnWidth) and offsets visibly drift
+    // when auto-sized cells differ from the guess.
+    const [measuredColumnWidths, setMeasuredColumnWidths] = useState<
+        Map<string, number>
+    >(() => new Map());
+    const cellObserversRef = useRef<Map<string, ResizeObserver>>(new Map());
+
+    useEffect(
+        () => () => {
+            cellObserversRef.current.forEach((obs) => obs.disconnect());
+            cellObserversRef.current.clear();
+        },
+        [],
+    );
+
+    const measureCellRef = useCallback(
+        (columnId: string) => (el: HTMLTableCellElement | null) => {
+            const existing = cellObserversRef.current.get(columnId);
+            if (existing) {
+                existing.disconnect();
+                cellObserversRef.current.delete(columnId);
+            }
+            if (!el) return;
+            const obs = new ResizeObserver(() => {
+                const width = el.getBoundingClientRect().width;
+                if (width === 0) return;
+                setMeasuredColumnWidths((prev) => {
+                    const current = prev.get(columnId);
+                    if (
+                        current !== undefined &&
+                        Math.abs(current - width) < 0.5
+                    ) {
+                        return prev;
+                    }
+                    const next = new Map(prev);
+                    next.set(columnId, width);
+                    return next;
+                });
+            });
+            obs.observe(el);
+            cellObserversRef.current.set(columnId, obs);
+        },
+        [],
+    );
+
     // Count label/index columns to compute offset from headerColIndex to pivotColumnInfo
     const numLabelCols = useMemo(
         () =>
@@ -213,8 +267,14 @@ const PivotTable: FC<PivotTableProps> = ({
                 columnProperties,
                 rowNumberWidth,
                 defaultColumnWidth: 100,
+                measuredWidths: measuredColumnWidths,
             }),
-        [data.retrofitData.pivotColumnInfo, columnProperties, rowNumberWidth],
+        [
+            data.retrofitData.pivotColumnInfo,
+            columnProperties,
+            rowNumberWidth,
+            measuredColumnWidths,
+        ],
     );
 
     const { columns, columnOrder, colWidths } = useMemo(() => {
@@ -1024,6 +1084,13 @@ const PivotTable: FC<PivotTableProps> = ({
                             index={rowIndex}
                         >
                             {row.getVisibleCells().map((cell, colIndex) => {
+                                // Measure body cell widths in the first row only.
+                                // Column widths are uniform across rows (CSS table
+                                // layout), so one measurement per column is enough.
+                                const measureRef =
+                                    virtualRow.index === 0
+                                        ? measureCellRef(cell.column.id)
+                                        : undefined;
                                 if (cell.column.id === ROW_NUMBER_COLUMN_ID) {
                                     const rowNumberStickyBody =
                                         frozenLayout.size > 0
@@ -1039,6 +1106,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                     return (
                                         <Table.Cell
                                             key={`row-number-${rowIndex}`}
+                                            ref={measureRef}
                                             className={
                                                 rowNumberStickyBody.className
                                             }
@@ -1227,6 +1295,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 return (
                                     <TableCellComponent
                                         key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
+                                        ref={measureRef}
                                         className={stickyCellProps.className}
                                         style={stickyCellProps.style}
                                         isMinimal={isMinimal}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -82,6 +82,16 @@ const getStickyCellProps = (frozen: FrozenColumnEntry | undefined) => {
     };
 };
 
+const getStickyHeaderProps = (frozen: FrozenColumnEntry | undefined) => {
+    if (!frozen) return {};
+    return {
+        className: `${pivotStyles.stickyColumn} ${pivotStyles.stickyHeaderColumn}${
+            frozen.isLast ? ` ${pivotStyles.stickyColumnLast}` : ''
+        }`,
+        style: { left: frozen.left },
+    };
+};
+
 type MenuCallbackProps = {
     isOpen: boolean;
     onClose: () => void;
@@ -727,21 +737,39 @@ const PivotTable: FC<PivotTableProps> = ({
                         index={headerRowIndex}
                     >
                         {/* shows empty cell if row numbers are visible */}
-                        {hideRowNumbers ? null : headerRowIndex <
-                          data.headerValues.length - 1 ? (
-                            <Table.Cell
-                                isMinimal={isMinimal}
-                                withMinimalWidth={!hasCustomWidths}
-                            />
-                        ) : (
-                            <Table.CellHead
-                                isMinimal={isMinimal}
-                                withMinimalWidth={!hasCustomWidths}
-                                withBoldFont
-                            >
-                                #
-                            </Table.CellHead>
-                        )}
+                        {hideRowNumbers
+                            ? null
+                            : (() => {
+                                  const rowNumberSticky =
+                                      frozenLayout.size > 0
+                                          ? {
+                                                className: `${pivotStyles.stickyColumn} ${pivotStyles.stickyHeaderColumn}`,
+                                                style: { left: 0 },
+                                            }
+                                          : ({} as {
+                                                className?: string;
+                                                style?: React.CSSProperties;
+                                            });
+                                  return headerRowIndex <
+                                      data.headerValues.length - 1 ? (
+                                      <Table.Cell
+                                          className={rowNumberSticky.className}
+                                          style={rowNumberSticky.style}
+                                          isMinimal={isMinimal}
+                                          withMinimalWidth={!hasCustomWidths}
+                                      />
+                                  ) : (
+                                      <Table.CellHead
+                                          className={rowNumberSticky.className}
+                                          style={rowNumberSticky.style}
+                                          isMinimal={isMinimal}
+                                          withMinimalWidth={!hasCustomWidths}
+                                          withBoldFont
+                                      >
+                                          #
+                                      </Table.CellHead>
+                                  );
+                              })()}
                         {/* renders the title labels */}
                         {data.titleFields[headerRowIndex].map(
                             (titleField, titleFieldIndex) => {
@@ -768,9 +796,23 @@ const PivotTable: FC<PivotTableProps> = ({
                                     !isMinimal &&
                                     titleWidthKey;
 
+                                const titlePivotCol =
+                                    data.retrofitData.pivotColumnInfo[
+                                        titleFieldIndex
+                                    ];
+                                const titleStickyProps = titlePivotCol
+                                    ? getStickyHeaderProps(
+                                          frozenLayout.get(
+                                              titlePivotCol.fieldId,
+                                          ),
+                                      )
+                                    : {};
+
                                 return isEmpty ? (
                                     <Table.Cell
                                         key={`title-${headerRowIndex}-${titleFieldIndex}`}
+                                        className={titleStickyProps.className}
+                                        style={titleStickyProps.style}
                                         isMinimal={isMinimal}
                                         withMinimalWidth={
                                             !hasCustomWidths && !titleWidth
@@ -779,6 +821,8 @@ const PivotTable: FC<PivotTableProps> = ({
                                 ) : (
                                     <Table.CellHead
                                         key={`title-${headerRowIndex}-${titleFieldIndex}`}
+                                        className={titleStickyProps.className}
+                                        style={titleStickyProps.style}
                                         withAlignRight={isHeaderTitle}
                                         isMinimal={isMinimal}
                                         withMinimalWidth={
@@ -867,9 +911,17 @@ const PivotTable: FC<PivotTableProps> = ({
                                     ? colWidth
                                     : undefined;
 
+                            const headerValueStickyProps = colInfo
+                                ? getStickyHeaderProps(
+                                      frozenLayout.get(colInfo.fieldId),
+                                  )
+                                : {};
+
                             return isLabel || headerValue.colSpan > 0 ? (
                                 <Table.CellHead
                                     key={`header-${headerRowIndex}-${headerColIndex}`}
+                                    className={headerValueStickyProps.className}
+                                    style={headerValueStickyProps.style}
                                     isMinimal={isMinimal}
                                     withBoldFont={isLabel}
                                     withTooltip={description}
@@ -953,6 +1005,35 @@ const PivotTable: FC<PivotTableProps> = ({
                             index={rowIndex}
                         >
                             {row.getVisibleCells().map((cell, colIndex) => {
+                                if (cell.column.id === ROW_NUMBER_COLUMN_ID) {
+                                    const rowNumberStickyBody =
+                                        frozenLayout.size > 0
+                                            ? {
+                                                  className:
+                                                      pivotStyles.stickyColumn,
+                                                  style: { left: 0 },
+                                              }
+                                            : ({} as {
+                                                  className?: string;
+                                                  style?: React.CSSProperties;
+                                              });
+                                    return (
+                                        <Table.Cell
+                                            key={`row-number-${rowIndex}`}
+                                            className={
+                                                rowNumberStickyBody.className
+                                            }
+                                            style={rowNumberStickyBody.style}
+                                            isMinimal={isMinimal}
+                                        >
+                                            {flexRender(
+                                                cell.column.columnDef.cell,
+                                                cell.getContext(),
+                                            )}
+                                        </Table.Cell>
+                                    );
+                                }
+
                                 const meta = cell.column.columnDef.meta;
                                 const isRowTotal = meta?.type === 'rowTotal';
                                 const isDataColumn =
@@ -1260,14 +1341,53 @@ const PivotTable: FC<PivotTableProps> = ({
                                 index={stickyIndex}
                             >
                                 {/* shows empty cell if row numbers are visible */}
-                                {hideRowNumbers ? null : <Table.Cell />}
+                                {hideRowNumbers
+                                    ? null
+                                    : (() => {
+                                          const footerRowNumberSticky =
+                                              frozenLayout.size > 0
+                                                  ? {
+                                                        className:
+                                                            pivotStyles.stickyColumn,
+                                                        style: { left: 0 },
+                                                    }
+                                                  : ({} as {
+                                                        className?: string;
+                                                        style?: React.CSSProperties;
+                                                    });
+                                          return (
+                                              <Table.Cell
+                                                  className={
+                                                      footerRowNumberSticky.className
+                                                  }
+                                                  style={
+                                                      footerRowNumberSticky.style
+                                                  }
+                                              />
+                                          );
+                                      })()}
 
                                 {/* render the total label */}
                                 {data.columnTotalFields?.[totalRowIndex].map(
-                                    (totalLabel, totalColIndex) =>
-                                        totalLabel ? (
+                                    (totalLabel, totalColIndex) => {
+                                        const footerPivotCol =
+                                            data.retrofitData.pivotColumnInfo[
+                                                totalColIndex
+                                            ];
+                                        const footerStickyProps = footerPivotCol
+                                            ? getStickyCellProps(
+                                                  frozenLayout.get(
+                                                      footerPivotCol.fieldId,
+                                                  ),
+                                              )
+                                            : {};
+                                        return totalLabel ? (
                                             <Table.CellHead
                                                 key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                                className={
+                                                    footerStickyProps.className
+                                                }
+                                                style={footerStickyProps.style}
                                                 isMinimal={isMinimal}
                                                 withAlignRight
                                                 withBoldFont
@@ -1281,9 +1401,14 @@ const PivotTable: FC<PivotTableProps> = ({
                                         ) : (
                                             <Table.Cell
                                                 key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                                className={
+                                                    footerStickyProps.className
+                                                }
+                                                style={footerStickyProps.style}
                                                 isMinimal={isMinimal}
                                             />
-                                        ),
+                                        );
+                                    },
                                 )}
 
                                 {row.map((total, totalColIndex) => {

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -46,6 +46,7 @@ export type TableColumn = ColumnDef<ResultRow, ResultRow[0]> & {
         className?: string;
         style?: CSSProperties;
         frozen?: boolean;
+        frozenLayout?: { left: number; isLast: boolean };
         isVisible?: boolean;
         isReadOnly?: boolean; // For computed/derived columns like period-over-period
     };

--- a/packages/frontend/src/types/@tanstack-react-table.d.ts
+++ b/packages/frontend/src/types/@tanstack-react-table.d.ts
@@ -20,6 +20,7 @@ declare module '@tanstack/react-table' {
         className?: string;
         style?: CSSProperties;
         frozen?: boolean;
+        frozenLayout?: { left: number; isLast: boolean };
         isVisible?: boolean;
         isReadOnly?: boolean; // For computed/derived columns like period-over-period
         onHeaderClick?: MouseEventHandler<HTMLTableHeaderCellElement>;


### PR DESCRIPTION
Related to: [PROD-639](https://linear.app/lightdash/issue/PROD-639)

### Description:

Adds frozen (sticky) column support to the PivotTable component, allowing columns to remain fixed while scrolling horizontally.

A `getFrozenColumnLayout` utility computes the `left` offset for each frozen column based on cumulative widths. To keep these offsets accurate for auto-sized columns, a `ResizeObserver` measures actual rendered cell widths at runtime (sampling the first body row) and feeds them back into the layout calculation.

The `metricsAsRows` label column is handled as a special case: its synthetic `fieldId` (e.g. `label-0`) has no entry in `columnProperties`, so a `labelColumnFrozen` flag is derived by checking whether any of the underlying metric field IDs have `frozen: true`, and passed directly to the layout function.

A z-index layering scheme is established to ensure correct stacking:
- `100` — sticky body cells (above non-sticky body)
- `110` — `<thead>`/`<tfoot>` sections (above body)
- `120` — sticky header cells in frozen columns (above everything, including the sticky header row)

The row-number column width is now computed dynamically based on row count (matching the non-pivoted table's formula) so freeze offsets stay aligned. Sticky styles are applied consistently across header, body, and footer cells, including the row-number column, with a subtle drop shadow on the last frozen column to visually indicate the freeze boundary.