### PR TITLE
feat: sync freeze toggle across metrics in `metricsAsRows` mode

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -69,7 +69,6 @@ type ColumnConfigurationProps = {
      * When provided, the freeze toggle controls all listed fieldIds together.
      */
     syncFreezeWith?: string[];
-
 };
 
 const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
@@ -95,7 +94,6 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
     const columnWidth = columnProperties[fieldId]?.width;
     const isPivotingDimension = pivotDimensions?.includes(fieldId);
     const disableHidingDimensions = !!(pivotDimensions && isDimension(field));
-
 
     // Pivoted dimensions become column headers and can't be frozen.
     const shouldShowFreezeToggle = !isPivotingDimension;

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -96,15 +96,13 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
     const isPivotingDimension = pivotDimensions?.includes(fieldId);
     const disableHidingDimensions = !!(pivotDimensions && isDimension(field));
 
-    // Hide freeze for pivoted dimensions (they become column headers and can't
-    // be frozen). Everything else is freezable: non-pivoted dimensions act as
-    // row labels, metrics with metricsAsRows=true become the leftmost metric-
-    // label column, and metrics with metricsAsRows=false freeze every pivot
-    // slice of that metric (widths are measured at runtime so they line up).
+
+    // Pivoted dimensions become column headers and can't be frozen.
     const shouldShowFreezeToggle = !isPivotingDimension;
 
     // When syncFreezeWith is set, the lock visually reflects "any sibling
     // frozen" and clicking flips the entire group in lockstep.
+
     const isFrozenForDisplay = syncFreezeWith
         ? syncFreezeWith.some((id) => isColumnFrozen(id))
         : isColumnFrozen(fieldId);

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -64,13 +64,12 @@ const ColumnConfigurationInput: FC<ColumnConfigurationInputProps> = ({
 
 type ColumnConfigurationProps = {
     fieldId: string;
+
     /**
-     * When provided, the freeze toggle controls all listed fieldIds together
-     * instead of just this one. Used in metricsAsRows mode where the leftmost
-     * column is a single label column shared across all metrics — toggling
-     * any metric should keep all the lock icons in sync.
+     * When provided, the freeze toggle controls all listed fieldIds together.
      */
     syncFreezeWith?: string[];
+
 };
 
 const ColumnConfiguration: FC<ColumnConfigurationProps> = ({

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -80,12 +80,20 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({ fieldId }) => {
         isColumnFrozen,
         getField,
         columnProperties,
+        metricsAsRows,
     } = visualizationConfig.chartConfig;
 
     const field = getField(fieldId);
     const columnWidth = columnProperties[fieldId]?.width;
     const isPivotingDimension = pivotDimensions?.includes(fieldId);
     const disableHidingDimensions = !!(pivotDimensions && isDimension(field));
+
+    const isMetric = field && !isDimension(field);
+    const shouldShowFreezeToggle = (() => {
+        if (isPivotingDimension) return false;
+        if (isMetric && metricsAsRows) return false;
+        return true;
+    })();
 
     return (
         <Group spacing="xs" noWrap style={{ flexGrow: 1 }}>
@@ -150,7 +158,7 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({ fieldId }) => {
                 </Box>
             </Tooltip>
 
-            {!pivotDimensions ? (
+            {shouldShowFreezeToggle ? (
                 <Tooltip
                     position="top"
                     withinPortal

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -64,9 +64,19 @@ const ColumnConfigurationInput: FC<ColumnConfigurationInputProps> = ({
 
 type ColumnConfigurationProps = {
     fieldId: string;
+    /**
+     * When provided, the freeze toggle controls all listed fieldIds together
+     * instead of just this one. Used in metricsAsRows mode where the leftmost
+     * column is a single label column shared across all metrics — toggling
+     * any metric should keep all the lock icons in sync.
+     */
+    syncFreezeWith?: string[];
 };
 
-const ColumnConfiguration: FC<ColumnConfigurationProps> = ({ fieldId }) => {
+const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
+    fieldId,
+    syncFreezeWith,
+}) => {
     const { pivotDimensions, visualizationConfig } = useVisualizationContext();
 
     const [isShowTooltipVisible, setShowTooltipVisible] = useState(false);
@@ -80,7 +90,6 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({ fieldId }) => {
         isColumnFrozen,
         getField,
         columnProperties,
-        metricsAsRows,
     } = visualizationConfig.chartConfig;
 
     const field = getField(fieldId);
@@ -88,12 +97,28 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({ fieldId }) => {
     const isPivotingDimension = pivotDimensions?.includes(fieldId);
     const disableHidingDimensions = !!(pivotDimensions && isDimension(field));
 
-    const isMetric = field && !isDimension(field);
-    const shouldShowFreezeToggle = (() => {
-        if (isPivotingDimension) return false;
-        if (isMetric && metricsAsRows) return false;
-        return true;
-    })();
+    // Hide freeze for pivoted dimensions (they become column headers and can't
+    // be frozen). Everything else is freezable: non-pivoted dimensions act as
+    // row labels, metrics with metricsAsRows=true become the leftmost metric-
+    // label column, and metrics with metricsAsRows=false freeze every pivot
+    // slice of that metric (widths are measured at runtime so they line up).
+    const shouldShowFreezeToggle = !isPivotingDimension;
+
+    // When syncFreezeWith is set, the lock visually reflects "any sibling
+    // frozen" and clicking flips the entire group in lockstep.
+    const isFrozenForDisplay = syncFreezeWith
+        ? syncFreezeWith.some((id) => isColumnFrozen(id))
+        : isColumnFrozen(fieldId);
+    const handleFreezeToggle = () => {
+        const next = !isFrozenForDisplay;
+        if (syncFreezeWith) {
+            syncFreezeWith.forEach((id) =>
+                updateColumnProperty(id, { frozen: next }),
+            );
+        } else {
+            updateColumnProperty(fieldId, { frozen: next });
+        }
+    };
 
     return (
         <Group spacing="xs" noWrap style={{ flexGrow: 1 }}>
@@ -164,9 +189,7 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({ fieldId }) => {
                     withinPortal
                     opened={isFreezeTooltipVisible}
                     label={
-                        isColumnFrozen(fieldId)
-                            ? 'Unfreeze column'
-                            : 'Freeze column'
+                        isFrozenForDisplay ? 'Unfreeze column' : 'Freeze column'
                     }
                 >
                     <Box
@@ -178,16 +201,12 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({ fieldId }) => {
                             onClick={() => {
                                 // Close the tooltip. See comment above.
                                 setFreezeTooltipVisible(false);
-                                updateColumnProperty(fieldId, {
-                                    frozen: !isColumnFrozen(fieldId),
-                                });
+                                handleFreezeToggle();
                             }}
                         >
                             <MantineIcon
                                 icon={
-                                    isColumnFrozen(fieldId)
-                                        ? IconLock
-                                        : IconLockOpen
+                                    isFrozenForDisplay ? IconLock : IconLockOpen
                                 }
                             />
                         </ActionIcon>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -227,7 +227,13 @@ const GeneralSettings: FC = () => {
 
             <Config.Section>
                 {metrics.map((itemId) => (
-                    <ColumnConfiguration key={itemId} fieldId={itemId} />
+                    <ColumnConfiguration
+                        key={itemId}
+                        fieldId={itemId}
+                        // metricsAsRows: there's one shared label column for
+                        // all metrics, so freeze lock icons should sync.
+                        syncFreezeWith={metricsAsRows ? metrics : undefined}
+                    />
                 ))}
             </Config.Section>
 

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -459,18 +459,19 @@ const useTableConfig = (
 
     const updateColumnProperty = useCallback(
         (field: string, properties: Partial<ColumnProperties>) => {
-            const newProperties =
-                field in columnProperties
-                    ? { ...columnProperties[field], ...properties }
-                    : {
-                          ...properties,
-                      };
-            setColumnProperties({
-                ...columnProperties,
-                [field]: newProperties,
-            });
+            // Use the functional setter so consecutive calls (e.g. the sync
+            // freeze toggle that updates several metrics in one click) compose
+            // correctly instead of stomping on each other's closure-captured
+            // snapshot of columnProperties.
+            setColumnProperties((prev) => ({
+                ...prev,
+                [field]:
+                    field in prev
+                        ? { ...prev[field], ...properties }
+                        : { ...properties },
+            }));
         },
-        [columnProperties],
+        [],
     );
 
     const handleSetConditionalFormattings = useCallback(

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -459,7 +459,6 @@ const useTableConfig = (
 
     const updateColumnProperty = useCallback(
         (field: string, properties: Partial<ColumnProperties>) => {
-
             // functional setter so consecutive calls compose correctly
 
             setColumnProperties((prev) => ({

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -459,10 +459,9 @@ const useTableConfig = (
 
     const updateColumnProperty = useCallback(
         (field: string, properties: Partial<ColumnProperties>) => {
-            // Use the functional setter so consecutive calls (e.g. the sync
-            // freeze toggle that updates several metrics in one click) compose
-            // correctly instead of stomping on each other's closure-captured
-            // snapshot of columnProperties.
+
+            // functional setter so consecutive calls compose correctly
+
             setColumnProperties((prev) => ({
                 ...prev,
                 [field]:


### PR DESCRIPTION
Related to: [PROD-639](https://linear.app/lightdash/issue/PROD-639)

### Description:

In `metricsAsRows` mode, all metric rows share a single leftmost label column, so freezing one metric should freeze all of them together. Previously, each metric's freeze toggle acted independently, causing the lock icons to fall out of sync.

This PR introduces a `syncFreezeWith` prop on `ColumnConfiguration` that accepts a list of field IDs. When provided, the freeze toggle reflects whether **any** of the listed columns is frozen, and clicking it applies the frozen state to **all** of them simultaneously. In `GeneralSettings`, the full `metrics` array is passed as `syncFreezeWith` when `metricsAsRows` is enabled.

The freeze toggle visibility logic was also updated: previously the toggle was hidden whenever any pivot dimensions existed, but it now only hides for the specific column that is itself a pivoting dimension. This allows metrics and non-pivoted dimensions to remain freezable even when pivot dimensions are present.

Additionally, `updateColumnProperty` was updated to use the functional form of `setColumnProperties` so that multiple consecutive calls within the same event (e.g. syncing all metrics at once) correctly compose on top of each other rather than overwriting based on a stale closure snapshot.