### PR TITLE
fix(cli): only count compiled external models in --combine-manifest

### DIFF
--- a/packages/cli/src/dbt/manifest.test.ts
+++ b/packages/cli/src/dbt/manifest.test.ts
@@ -5,6 +5,7 @@ const modelNode = (uniqueId: string, extra: Record<string, unknown> = {}) =>
     ({
         unique_id: uniqueId,
         resource_type: 'model',
+        compiled: true,
         ...extra,
     }) as unknown as DbtNode;
 
@@ -64,6 +65,31 @@ describe('combineManifests', () => {
         };
         expect(mergedA.tag).toBe('primary');
         expect(addedModelIds).toEqual(['model.proj.b']);
+    });
+
+    test('external model nodes that were not compiled are merged but not reported as added', () => {
+        const primary = buildManifest({
+            'model.proj.a': modelNode('model.proj.a'),
+        });
+        const external = buildManifest({
+            'model.proj.compiled': modelNode('model.proj.compiled', {
+                compiled: true,
+            }),
+            'model.proj.uncompiled': modelNode('model.proj.uncompiled', {
+                compiled: false,
+            }),
+            'model.proj.missing': modelNode('model.proj.missing', {
+                compiled: undefined,
+            }),
+        });
+
+        const { manifest, addedModelIds } = combineManifests(primary, external);
+
+        // All external nodes are merged (so joins by name still resolve)
+        expect(manifest.nodes['model.proj.uncompiled']).toBeDefined();
+        expect(manifest.nodes['model.proj.missing']).toBeDefined();
+        // ...but only the compiled one is reported as added
+        expect(addedModelIds).toEqual(['model.proj.compiled']);
     });
 
     test('non-model external nodes are merged into nodes but not reported as added', () => {

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -1,4 +1,9 @@
-import { DbtManifest, DbtNode, getErrorMessage } from '@lightdash/common';
+import {
+    DbtManifest,
+    DbtNode,
+    DbtRawModelNode,
+    getErrorMessage,
+} from '@lightdash/common';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import globalState from '../globalState';
@@ -43,6 +48,10 @@ export type CombineManifestsResult = {
  * combined manifest and the unique_ids of model nodes pulled in from the
  * external manifest, so callers can mark them as compiled.
  *
+ * Only external models with `compiled === true` are reported in
+ * `addedModelIds` — non-compiled nodes are still merged into `nodes` so join
+ * lookups by name keep working, but they are not turned into explores.
+ *
  * Metrics, docs, and metadata are taken from `primary` only.
  */
 export const combineManifests = (
@@ -54,7 +63,11 @@ export const combineManifests = (
 
     const addedModelIds: string[] = [];
     Object.entries(external.nodes).forEach(([id, node]) => {
-        if (!(id in primary.nodes) && node.resource_type === 'model') {
+        if (
+            !(id in primary.nodes) &&
+            node.resource_type === 'model' &&
+            (node as DbtRawModelNode).compiled === true
+        ) {
             addedModelIds.push(id);
         }
     });


### PR DESCRIPTION
Refs: PROD-7535

### Description

Follow-up to #22955. `combineManifests` was reporting every external model node in `addedModelIds`, regardless of whether dbt had actually compiled it. Those ids feed into `effectiveCompiledModelIds`, which `getCompiledModels` then filters by inclusion only (it doesn't re-check the `compiled` flag when a list is passed) — so uncompiled nodes were getting turned into explores and uploaded.

A customer running `lightdash preview -s tag:lightdash-migrated --combine-manifest=...` against a 15k-node prod manifest where only ~2.6k were actually compiled ended up sending all 15k explores to the backend, which then 500'd at finalize.

Fix: only push external model ids into `addedModelIds` when `compiled === true`. `mergedNodes` still carries every external node so join lookups by name keep resolving — they just no longer become explores. Added a regression test for `compiled: false` and missing-`compiled` external nodes.