### PR TITLE
feat(leave-org): surface Leave button on Profile page for discoverability

### DIFF
--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -210,7 +210,7 @@ const Settings: FC = () => {
                         </SettingsGridCard>
                         {isLeaveOrganizationEnabled && (
                             <SettingsGridCard>
-                                <div>
+                                <Box>
                                     <Title order={4}>Danger zone</Title>
                                     <Text c="ldGray.6" fz="xs">
                                         Leave the organization to remove
@@ -218,7 +218,7 @@ const Settings: FC = () => {
                                         you are the only admin). This action is
                                         not reversible.
                                     </Text>
-                                </div>
+                                </Box>
                                 <LeaveOrganizationPanel />
                             </SettingsGridCard>
                         )}

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -203,10 +203,26 @@ const Settings: FC = () => {
             {
                 path: '/profile',
                 element: (
-                    <SettingsGridCard>
-                        <Title order={4}>Profile settings</Title>
-                        <ProfilePanel />
-                    </SettingsGridCard>
+                    <Stack gap="xl">
+                        <SettingsGridCard>
+                            <Title order={4}>Profile settings</Title>
+                            <ProfilePanel />
+                        </SettingsGridCard>
+                        {isLeaveOrganizationEnabled && (
+                            <SettingsGridCard>
+                                <div>
+                                    <Title order={4}>Danger zone</Title>
+                                    <Text c="ldGray.6" fz="xs">
+                                        Leave the organization to remove
+                                        yourself from it (you cannot leave if
+                                        you are the only admin). This action is
+                                        not reversible.
+                                    </Text>
+                                </div>
+                                <LeaveOrganizationPanel />
+                            </SettingsGridCard>
+                        )}
+                    </Stack>
                 ),
             },
             {


### PR DESCRIPTION
## Summary

Follow-up to #22970 / #22915. The "Leave organization" button only lived on `/generalSettings/organization`, whose sidebar entry is gated by `manage Organization` (admin-only). Non-admins could reach the page by typing the URL but had no clickable path from anywhere in the app — i.e. the exact users most likely to want to leave couldn't find the feature.

This PR drops the existing `LeaveOrganizationPanel` into a Danger zone card on the **Profile** route (`/generalSettings/profile`), which every role already has a permanent sidebar link to.

## Why Profile and not a new sidebar entry

- Profile is in `Your settings`, which fits a user-self-service action like "remove yourself from the org" better than a new top-level entry would.
- The card only renders when the `leave-organization` feature flag is enabled — no UI noise for instances that haven't opted in.
- `LeaveOrganizationPanel` already self-handles the only-admin disabled state and the feature flag check, so no new gating logic is introduced here.

## Behaviour summary

| Role | Sees Leave on Profile? | Sees Leave on Org settings page? |
|---|---|---|
| Viewer | ✅ (new) | n/a — sidebar link hidden |
| Editor | ✅ (new) | n/a — sidebar link hidden |
| Developer | ✅ (new) | n/a — sidebar link hidden |
| Admin | ✅ (new) | ✅ (unchanged) |

Admins now see the button in two places (Profile and the Org settings Danger zone). This is intentional and matches how other "Danger zone" actions sit alongside self-service settings — the duplication is low-cost and removes any question of where to look.

## Test plan

- [x] `pnpm -F frontend typecheck` clean
- [x] `pnpm -F frontend lint` clean (no new warnings)
- [x] Manual: signed in as a viewer (no admin permissions), navigated to **Settings → Profile** via the sidebar — Danger zone card appears with `Leave 'Jaffle Shop'` button. No URL guessing required.
- [x] Manual: panel correctly hidden when `leave-organization` feature flag is off.
- [ ] Reviewer: confirm admin experience on the Org settings page is unchanged (Danger zone still shows both Leave and Delete Organization).

## Out of scope

- The route gate on `/generalSettings/organization` is currently `manage PersonalAccessToken` (i.e. effectively unrestricted). Tightening that to a sensible Org-permission check is a separate cleanup — not blocking this PR and unrelated to the discoverability gap.

Refs lightdash/lightdash#22211
Follow-up to lightdash/lightdash#22970 and lightdash/lightdash#22915

🤖 Generated with [Claude Code](https://claude.com/claude-code)