### PR TITLE
feat(ai-agent): per-thread SQL mode toggle (web)

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -21,6 +21,7 @@ import {
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
     ApiAiAgentThreadResponse,
+    ApiAiAgentThreadStreamRequest,
     ApiAiAgentThreadSummaryListResponse,
     ApiAiAgentVerifiedArtifactsResponse,
     ApiAiAgentVerifiedQuestionsResponse,
@@ -498,6 +499,7 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Path() threadUuid: string,
+        @Body() body?: ApiAiAgentThreadStreamRequest,
     ): Promise<void> {
         assertRegisteredAccount(req.account);
         const stream = await this.getAiAgentService().streamAgentThreadResponse(
@@ -505,6 +507,7 @@ export class AiAgentController extends BaseController {
             {
                 agentUuid,
                 threadUuid,
+                enableSqlMode: body?.enableSqlMode ?? false,
             },
         );
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1476,9 +1476,11 @@ export class AiAgentService extends BaseService {
         {
             agentUuid,
             threadUuid,
+            enableSqlMode,
         }: {
             agentUuid: string;
             threadUuid: string;
+            enableSqlMode: boolean;
         },
     ): Promise<ReturnType<typeof streamAgentResponse>> {
         try {
@@ -1514,6 +1516,7 @@ export class AiAgentService extends BaseService {
                     prompt,
                     stream: true,
                     canManageAgent,
+                    enableSqlMode,
                 },
             );
             return response;
@@ -1565,6 +1568,8 @@ export class AiAgentService extends BaseService {
                     prompt,
                     stream: false,
                     canManageAgent,
+                    // Non-stream callers (eval, etc.) preserve flag-only gating.
+                    enableSqlMode: true,
                 },
             );
             return response;
@@ -3460,6 +3465,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             prompt: AiWebAppPrompt;
             stream: true;
             canManageAgent: boolean;
+            enableSqlMode?: boolean;
         },
     ): Promise<ReturnType<typeof streamAgentResponse>>;
     async generateOrStreamAgentResponse(
@@ -3469,6 +3475,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             prompt: AiWebAppPrompt;
             stream: false;
             canManageAgent: boolean;
+            enableSqlMode?: boolean;
         },
     ): Promise<string>;
     async generateOrStreamAgentResponse(
@@ -3478,13 +3485,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             prompt: SlackPrompt;
             stream: false;
             canManageAgent: boolean;
+            enableSqlMode?: boolean;
         },
     ): Promise<string>;
     async generateOrStreamAgentResponse(
         user: SessionUser,
 
         messageHistory: ModelMessage[],
-        options: { canManageAgent: boolean } & (
+        options: {
+            canManageAgent: boolean;
+            enableSqlMode?: boolean;
+        } & (
             | {
                   prompt: AiWebAppPrompt;
                   stream: true;
@@ -3539,12 +3550,18 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             featureFlagId: CommercialFeatureFlags.AiAgentRunSql,
         });
 
+        const enableSqlMode = options.enableSqlMode ?? false;
+
         // For Slack prompts: only allow runSql when the org requires OAuth.
         // Without OAuth, Slack messages run as a workspace-default user, so
         // both the feature flag and the SqlRunner CASL check evaluate against
         // that default — meaning ANYONE in the Slack workspace could trigger
         // SQL execution under a different person's permissions. Fail-closed.
-        let canRunSql = canRunSqlFlag.enabled;
+        // Three-way gate: org-level flag, per-call CASL ability (added below),
+        // and per-thread toggle from the web client (default false for any
+        // caller that doesn't pass it — Slack/eval paths pass `true` to
+        // preserve their flag-only gating).
+        let canRunSql = canRunSqlFlag.enabled && enableSqlMode;
         if (canRunSql && isSlackPrompt(prompt) && user.organizationUuid) {
             const slackSettings =
                 await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
@@ -3939,6 +3956,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     prompt: slackPrompt,
                     stream: false,
                     canManageAgent,
+                    // Slack uses flag-only gating (no per-prompt toggle yet).
+                    enableSqlMode: true,
                 },
             );
         } catch (e) {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9389,6 +9389,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['runSavedChart'] },
                 { dataType: 'enum', enums: ['runSql'] },
                 { dataType: 'enum', enums: ['listWarehouseTables'] },
+                { dataType: 'enum', enums: ['describeWarehouseTable'] },
             ],
             validators: {},
         },
@@ -10517,6 +10518,15 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadStreamRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { enableSqlMode: { dataType: 'boolean' } },
             validators: {},
         },
     },
@@ -36843,6 +36853,11 @@ export function RegisterRoutes(app: Router) {
             name: 'threadUuid',
             required: true,
             dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            ref: 'ApiAiAgentThreadStreamRequest',
         },
     };
     app.post(

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10856,7 +10856,8 @@
                     "runQuery",
                     "runSavedChart",
                     "runSql",
-                    "listWarehouseTables"
+                    "listWarehouseTables",
+                    "describeWarehouseTable"
                 ],
                 "description": "Exclude from T those types that are assignable to U"
             },
@@ -11575,6 +11576,15 @@
                     }
                 },
                 "required": ["decision"],
+                "type": "object"
+            },
+            "ApiAiAgentThreadStreamRequest": {
+                "properties": {
+                    "enableSqlMode": {
+                        "type": "boolean",
+                        "description": "Per-thread toggle that decides whether the agent gets access to the\nrunSql / listWarehouseTables / describeWarehouseTable tools for this\nstream. Frontend tracks the toggle in its slice; passed in on every\nstream call. Falls back to `false` when omitted (e.g. older clients,\nAPI callers) so the safer \"semantic layer only\" mode is the default."
+                    }
+                },
                 "type": "object"
             },
             "ApiAiAgentThreadGenerateResponse": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -291,6 +291,17 @@ export type ApiAiAgentSqlApprovalRequest = {
     decision: 'approved' | 'rejected';
 };
 
+export type ApiAiAgentThreadStreamRequest = {
+    /**
+     * Per-thread toggle that decides whether the agent gets access to the
+     * runSql / listWarehouseTables / describeWarehouseTable tools for this
+     * stream. Frontend tracks the toggle in its slice; passed in on every
+     * stream call. Falls back to `false` when omitted (e.g. older clients,
+     * API callers) so the safer "semantic layer only" mode is the default.
+     */
+    enableSqlMode?: boolean;
+};
+
 export type ApiAiAgentSqlApprovalResponse = ApiSuccess<{
     decision: 'approved' | 'rejected';
 }>;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -212,7 +212,7 @@ export const AgentChatInput = ({
                     with typed text. Right-aligned so it visually anchors to
                     the submit button above. Only renders when parent passes
                     a handler (flag + permission gated). */}
-                {onSqlModeChange && (
+                {onSqlModeChange && !disabled && (
                     <Group justify="flex-end" px="xs" pt="xs">
                         <Tooltip
                             multiline
@@ -348,7 +348,7 @@ export const AgentChatInput = ({
                             has confirmed flag + permission, so visibility
                             here is the visibility contract. Sits next to
                             submit because it's a per-prompt intent toggle. */}
-                        {onSqlModeChange && (
+                        {onSqlModeChange && !disabled && (
                             <Tooltip
                                 multiline
                                 w={260}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -7,10 +7,12 @@ import {
     Divider,
     Group,
     Paper,
+    Switch,
     Text,
     Textarea,
+    Tooltip,
 } from '@mantine-8/core';
-import { IconArrowUp, IconBrain } from '@tabler/icons-react';
+import { IconArrowUp, IconBrain, IconTerminal2 } from '@tabler/icons-react';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -33,6 +35,8 @@ interface AgentChatInputProps {
     onModelChange?: (modelId: string) => void;
     extendedThinking?: boolean;
     onExtendedThinkingChange?: (enabled: boolean) => void;
+    sqlMode?: boolean;
+    onSqlModeChange?: (enabled: boolean) => void;
     defaultValue?: string;
     onValueChange?: (value: string) => void;
 }
@@ -51,6 +55,8 @@ export const AgentChatInput = ({
     onModelChange,
     extendedThinking = false,
     onExtendedThinkingChange,
+    sqlMode = false,
+    onSqlModeChange,
     defaultValue,
     onValueChange,
 }: AgentChatInputProps) => {
@@ -202,6 +208,46 @@ export const AgentChatInput = ({
                     </ActionIcon>
                 </Box>
 
+                {/* SQL mode switch — sits below the input so it never collides
+                    with typed text. Right-aligned so it visually anchors to
+                    the submit button above. Only renders when parent passes
+                    a handler (flag + permission gated). */}
+                {onSqlModeChange && (
+                    <Group justify="flex-end" px="xs" pt="xs">
+                        <Tooltip
+                            multiline
+                            w={260}
+                            withArrow
+                            position="top"
+                            label="Let the agent reach for raw SQL when the question can't be answered from the semantic layer alone. Each query still asks for your approval before running."
+                        >
+                            <Group gap={6} align="center" wrap="nowrap">
+                                <MantineIcon
+                                    icon={IconTerminal2}
+                                    size={14}
+                                    color={sqlMode ? 'indigo.5' : 'ldGray.6'}
+                                />
+                                <Text
+                                    size="xs"
+                                    c={sqlMode ? 'indigo.5' : 'dimmed'}
+                                    fw={500}
+                                >
+                                    SQL mode
+                                </Text>
+                                <Switch
+                                    size="xs"
+                                    color="indigo"
+                                    checked={sqlMode}
+                                    onChange={(e) =>
+                                        onSqlModeChange(e.currentTarget.checked)
+                                    }
+                                    aria-label="Toggle SQL mode"
+                                />
+                            </Group>
+                        </Tooltip>
+                    </Group>
+                )}
+
                 {showDisabledBanner && (
                     <Text size="xs" c="dimmed" ta="right" mt="xs" px="sm">
                         {disabledReason}
@@ -297,23 +343,67 @@ export const AgentChatInput = ({
                         )}
                     </Box>
 
-                    {/* Submit button */}
-                    <ActionIcon
-                        variant="filled"
-                        size="lg"
-                        className={styles.submitButton}
-                        disabled={disabled || isComposing || !hasValue}
-                        loading={loading}
-                        onClick={handleSubmit}
-                        aria-label="Send message"
-                    >
-                        <MantineIcon
-                            icon={IconArrowUp}
-                            color="ldGray.0"
-                            size={20}
-                            stroke={2}
-                        />
-                    </ActionIcon>
+                    <Group gap="md" align="center" wrap="nowrap">
+                        {/* SQL mode switch — only rendered when the parent
+                            has confirmed flag + permission, so visibility
+                            here is the visibility contract. Sits next to
+                            submit because it's a per-prompt intent toggle. */}
+                        {onSqlModeChange && (
+                            <Tooltip
+                                multiline
+                                w={260}
+                                withArrow
+                                position="top"
+                                label="Let the agent reach for raw SQL when the question can't be answered from the semantic layer alone. Each query still asks for your approval before running."
+                            >
+                                <Group gap={6} align="center" wrap="nowrap">
+                                    <MantineIcon
+                                        icon={IconTerminal2}
+                                        size={14}
+                                        color={
+                                            sqlMode ? 'indigo.5' : 'ldGray.6'
+                                        }
+                                    />
+                                    <Text
+                                        size="xs"
+                                        c={sqlMode ? 'indigo.5' : 'dimmed'}
+                                        fw={500}
+                                    >
+                                        SQL mode
+                                    </Text>
+                                    <Switch
+                                        size="xs"
+                                        color="indigo"
+                                        checked={sqlMode}
+                                        onChange={(e) =>
+                                            onSqlModeChange(
+                                                e.currentTarget.checked,
+                                            )
+                                        }
+                                        aria-label="Toggle SQL mode"
+                                    />
+                                </Group>
+                            </Tooltip>
+                        )}
+
+                        {/* Submit button */}
+                        <ActionIcon
+                            variant="filled"
+                            size="lg"
+                            className={styles.submitButton}
+                            disabled={disabled || isComposing || !hasValue}
+                            loading={loading}
+                            onClick={handleSubmit}
+                            aria-label="Send message"
+                        >
+                            <MantineIcon
+                                icon={IconArrowUp}
+                                color="ldGray.0"
+                                size={20}
+                                stroke={2}
+                            />
+                        </ActionIcon>
+                    </Group>
                 </Box>
             </Box>
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -1,8 +1,9 @@
 import { type AiAgentSummary } from '@lightdash/common';
 import { Center, Group, Loader, Stack, Text } from '@mantine-8/core';
-import { type CSSProperties, type FC } from 'react';
+import { useState, type CSSProperties, type FC } from 'react';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import useApp from '../../../../../providers/App/useApp';
+import { useAiAgentSqlModeAvailable } from '../../hooks/useAiAgentSqlModeAvailable';
 import { usePendingThreadRefetch } from '../../hooks/usePendingThreadRefetch';
 import { usePinnedContext } from '../../hooks/usePinnedContext';
 import {
@@ -11,6 +12,10 @@ import {
     useCreateAgentThreadMutation,
 } from '../../hooks/useProjectAiAgents';
 import { openPanel } from '../../store/aiAgentLauncherSlice';
+import {
+    selectThreadSqlMode,
+    setThreadSqlMode,
+} from '../../store/aiAgentThreadModeSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -96,6 +101,9 @@ const NewThreadPanel: FC<{
 
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
         useCreateAgentThreadMutation(agent.uuid, projectUuid, {
+            // Launcher does its own routing via panels/dock — skip the default
+            // page navigation that other surfaces want.
+            skipNavigation: true,
             onCreated: (thread) => {
                 addDockItem({
                     threadId: thread.uuid,
@@ -108,8 +116,22 @@ const NewThreadPanel: FC<{
                         agentUuid: agent.uuid,
                     }),
                 );
+                // Seed the per-thread mode slice with the user's choice so
+                // subsequent prompts in this thread default to the same.
+                dispatchToStore(
+                    setThreadSqlMode({
+                        threadUuid: thread.uuid,
+                        enabled: sqlModeAvailable && sqlMode,
+                    }),
+                );
             },
         });
+
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    // New threads have no uuid yet — keep the toggle in local state and seed
+    // the per-thread slice entry once the thread is created.
+    const [sqlMode, setSqlMode] = useState(false);
+    const dispatchToStore = useAiAgentStoreDispatch();
 
     const handleSubmit = (prompt: string) => {
         void createAgentThread({
@@ -117,6 +139,7 @@ const NewThreadPanel: FC<{
             context: contextInput.length > 0 ? contextInput : undefined,
             optimisticContext:
                 previewItems.length > 0 ? previewItems : undefined,
+            enableSqlMode: sqlModeAvailable && sqlMode,
         });
     };
 
@@ -177,6 +200,8 @@ const NewThreadPanel: FC<{
                     placeholder={`Ask ${agent.name} anything...`}
                     projectUuid={projectUuid}
                     agentUuid={agent.uuid}
+                    sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                    onSqlModeChange={sqlModeAvailable ? setSqlMode : undefined}
                 />
             </div>
         </div>
@@ -208,6 +233,10 @@ const ExistingThreadPanel: FC<{
         isLoading: isCreatingMessage,
     } = useCreateAgentThreadMessageMutation(projectUuid, agent.uuid, threadId);
 
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    const sqlMode = useAiAgentStoreSelector(selectThreadSqlMode(threadId));
+    const dispatchToStore = useAiAgentStoreDispatch();
+
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
 
     const handleSubmit = (prompt: string) => {
@@ -215,7 +244,11 @@ const ExistingThreadPanel: FC<{
             (m) => m.role === 'assistant',
         );
         const modelConfig = firstAssistantMessage?.modelConfig ?? undefined;
-        void createAgentThreadMessage({ prompt, modelConfig });
+        void createAgentThreadMessage({
+            prompt,
+            modelConfig,
+            enableSqlMode: sqlModeAvailable && sqlMode,
+        });
     };
 
     const headerTitle =
@@ -268,6 +301,18 @@ const ExistingThreadPanel: FC<{
                         messageCount={thread.messages?.length || 0}
                         projectUuid={projectUuid}
                         agentUuid={agent.uuid}
+                        sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                        onSqlModeChange={
+                            sqlModeAvailable
+                                ? (enabled) =>
+                                      dispatchToStore(
+                                          setThreadSqlMode({
+                                              threadUuid: threadId,
+                                              enabled,
+                                          }),
+                                      )
+                                : undefined
+                        }
                     />
                 </AgentChatDisplay>
             </div>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentSqlModeAvailable.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentSqlModeAvailable.ts
@@ -1,0 +1,30 @@
+// True when the per-prompt "SQL mode" toggle should be visible: the
+// `ai-agent-run-sql` feature flag is on AND the user holds the same
+// `manage:SqlRunner` CASL ability the SQL Runner page requires. Without
+// both, the toggle never renders and the agent stays in the semantic
+// layer regardless.
+
+import { subject } from '@casl/ability';
+import { CommercialFeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../../providers/App/useApp';
+
+export const useAiAgentSqlModeAvailable = (
+    projectUuid: string | undefined,
+): boolean => {
+    const { user } = useApp();
+    const flag = useServerFeatureFlag(CommercialFeatureFlags.AiAgentRunSql);
+
+    if (!projectUuid || !user.data) return false;
+    if (flag.isLoading || !flag.data?.enabled) return false;
+
+    return (
+        user.data.ability.can(
+            'manage',
+            subject('SqlRunner', {
+                organizationUuid: user.data.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -500,6 +500,9 @@ export const useCreateAgentThreadMutation = (
     projectUuid: string,
     options?: {
         onCreated?: (thread: ApiAiAgentThreadCreateResponse['results']) => void;
+        // Skip the default `navigate(...)` to the thread page. The launcher
+        // uses this because it routes via its own panel/dock instead.
+        skipNavigation?: boolean;
     },
 ) => {
     const navigate = useNavigate();
@@ -516,9 +519,14 @@ export const useCreateAgentThreadMutation = (
         ApiError,
         ApiAiAgentThreadCreateRequest & {
             optimisticContext?: AiPromptContext;
+            enableSqlMode?: boolean;
         }
     >({
-        mutationFn: ({ optimisticContext: _optimisticContext, ...data }) =>
+        mutationFn: ({
+            optimisticContext: _optimisticContext,
+            enableSqlMode: _enableSqlMode,
+            ...data
+        }) =>
             agentUuid
                 ? createAgentThread(projectUuid, agentUuid, data)
                 : Promise.reject(),
@@ -572,6 +580,7 @@ export const useCreateAgentThreadMutation = (
                 agentUuid: thread.agentUuid,
                 threadUuid: thread.uuid,
                 messageUuid: thread.firstMessage.uuid,
+                enableSqlMode: variables.enableSqlMode,
                 onFinish: () =>
                     queryClient.invalidateQueries({
                         queryKey: [
@@ -594,14 +603,12 @@ export const useCreateAgentThreadMutation = (
                     }),
             });
 
-            if (options?.onCreated) {
-                options.onCreated(thread);
-            } else {
+            options?.onCreated?.(thread);
+
+            if (!options?.skipNavigation) {
                 void navigate(
                     `/projects/${projectUuid}/ai-agents/${agentUuid}/threads/${thread.uuid}`,
-                    {
-                        viewTransition: true,
-                    },
+                    { viewTransition: true },
                 );
             }
         },
@@ -649,10 +656,15 @@ export const useCreateAgentThreadMessageMutation = (
         ApiError,
         ApiAiAgentThreadMessageCreateRequest & {
             optimisticContext?: AiPromptContext;
+            enableSqlMode?: boolean;
         },
         { messageUuid: string }
     >({
-        mutationFn: ({ optimisticContext: _optimisticContext, ...data }) =>
+        mutationFn: ({
+            optimisticContext: _optimisticContext,
+            enableSqlMode: _enableSqlMode,
+            ...data
+        }) =>
             agentUuid && threadUuid
                 ? createAgentThreadMessage(
                       projectUuid,
@@ -696,7 +708,7 @@ export const useCreateAgentThreadMessageMutation = (
 
             return { messageUuid };
         },
-        onSuccess: (data, _vars, context) => {
+        onSuccess: (data, vars, context) => {
             queryClient.setQueryData(
                 [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', threadUuid],
                 (
@@ -727,6 +739,7 @@ export const useCreateAgentThreadMessageMutation = (
                 agentUuid: agentUuid!,
                 threadUuid: threadUuid!,
                 messageUuid: data.uuid,
+                enableSqlMode: vars.enableSqlMode,
                 onFinish: () =>
                     queryClient.invalidateQueries([
                         AI_AGENTS_KEY,
@@ -774,14 +787,22 @@ export const useRetryAiAgentThreadMessageMutation = () => {
             agentUuid: string;
             threadUuid: string;
             messageUuid: string;
+            enableSqlMode?: boolean;
         }
     >({
-        mutationFn: ({ projectUuid, agentUuid, threadUuid, messageUuid }) =>
+        mutationFn: ({
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            messageUuid,
+            enableSqlMode,
+        }) =>
             streamMessage({
                 projectUuid,
                 agentUuid: agentUuid,
                 threadUuid: threadUuid,
                 messageUuid: messageUuid,
+                enableSqlMode,
                 refetchThread: () =>
                     queryClient.invalidateQueries({
                         queryKey: [

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.ts
@@ -1,0 +1,41 @@
+// Per-thread UI mode state that needs to persist across streaming sessions
+// (the existing aiAgentThreadStreamSlice wipes its entry on each new stream,
+// which would reset the toggle every prompt).
+//
+// Currently holds the SQL-mode toggle: when ON, the user is asking the
+// agent to use runSql + warehouse-introspection tools for this prompt.
+// Frontend state only — backend treats `enableSqlMode` as a request-time
+// parameter on each stream call, no DB persistence.
+
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+type ThreadMode = {
+    sqlMode: boolean;
+};
+
+type State = Record<string, ThreadMode>;
+
+const initialState: State = {};
+
+const DEFAULT_SQL_MODE = false;
+
+export const aiAgentThreadModeSlice = createSlice({
+    name: 'aiAgentThreadMode',
+    initialState,
+    reducers: {
+        setThreadSqlMode: (
+            state,
+            action: PayloadAction<{ threadUuid: string; enabled: boolean }>,
+        ) => {
+            const { threadUuid, enabled } = action.payload;
+            state[threadUuid] = { ...state[threadUuid], sqlMode: enabled };
+        },
+    },
+});
+
+export const { setThreadSqlMode } = aiAgentThreadModeSlice.actions;
+
+export const selectThreadSqlMode =
+    (threadUuid: string) =>
+    (state: { aiAgentThreadMode: State }): boolean =>
+        state.aiAgentThreadMode[threadUuid]?.sqlMode ?? DEFAULT_SQL_MODE;

--- a/packages/frontend/src/ee/features/aiCopilot/store/index.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/index.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { aiAgentLauncherSlice } from './aiAgentLauncherSlice';
+import { aiAgentThreadModeSlice } from './aiAgentThreadModeSlice';
 import { aiAgentThreadStreamSlice } from './aiAgentThreadStreamSlice';
 import { aiArtifactSlice } from './aiArtifactSlice';
 
 export const store = configureStore({
     reducer: {
         aiAgentThreadStream: aiAgentThreadStreamSlice.reducer,
+        aiAgentThreadMode: aiAgentThreadModeSlice.reducer,
         aiArtifact: aiArtifactSlice.reducer,
         aiAgentLauncher: aiAgentLauncherSlice.reducer,
     },

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -32,6 +32,7 @@ export interface AiAgentThreadStreamOptions {
     agentUuid: string;
     threadUuid: string;
     messageUuid: string;
+    enableSqlMode?: boolean;
     onFinish?: () => void;
     onError?: (error: string) => void;
     refetchThread?: () => void;
@@ -41,12 +42,13 @@ const getAgentThreadReadableStream = async (
     projectUuid: string,
     agentUuid: string,
     threadUuid: string,
+    enableSqlMode: boolean,
     { signal }: { signal: AbortSignal },
 ) => {
     const res = await lightdashApiStream({
         url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/stream`,
         method: 'POST',
-        body: JSON.stringify({ threadUuid }),
+        body: JSON.stringify({ enableSqlMode }),
         signal,
     });
 
@@ -95,6 +97,7 @@ export function useAiAgentThreadStreamMutation() {
             agentUuid,
             threadUuid,
             messageUuid,
+            enableSqlMode = false,
             onFinish,
             onError,
             refetchThread,
@@ -109,6 +112,7 @@ export function useAiAgentThreadStreamMutation() {
                     projectUuid,
                     agentUuid,
                     threadUuid,
+                    enableSqlMode,
                     {
                         signal: abortController.signal,
                     },

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -4,6 +4,7 @@ import useApp from '../../../providers/App/useApp';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useAiAgentThreadArtifact } from '../../features/aiCopilot/hooks/useAiAgentThreadArtifact';
 import { usePendingThreadRefetch } from '../../features/aiCopilot/hooks/usePendingThreadRefetch';
 import {
@@ -11,6 +12,14 @@ import {
     useAiAgentThread,
     useCreateAgentThreadMessageMutation,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import {
+    selectThreadSqlMode,
+    setThreadSqlMode,
+} from '../../features/aiCopilot/store/aiAgentThreadModeSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../features/aiCopilot/store/hooks';
 import { type AgentContext } from './AgentPage';
 
 const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
@@ -56,6 +65,12 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         refetch,
     );
 
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    const sqlMode = useAiAgentStoreSelector(
+        selectThreadSqlMode(threadUuid ?? ''),
+    );
+    const dispatch = useAiAgentStoreDispatch();
+
     const handleSubmit = (prompt: string) => {
         // Use modelConfig from first assistant message for follow-up messages
         const firstAssistantMessage = thread?.messages?.find(
@@ -63,7 +78,11 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         );
         const modelConfig = firstAssistantMessage?.modelConfig ?? undefined;
 
-        void createAgentThreadMessage({ prompt, modelConfig });
+        void createAgentThreadMessage({
+            prompt,
+            modelConfig,
+            enableSqlMode: sqlModeAvailable && sqlMode,
+        });
     };
 
     if (isLoadingThread || !thread || agentQuery.isLoading) {
@@ -96,6 +115,18 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 messageCount={thread.messages?.length || 0}
                 projectUuid={projectUuid}
                 agentUuid={agentUuid}
+                sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                onSqlModeChange={
+                    sqlModeAvailable && threadUuid
+                        ? (enabled) =>
+                              dispatch(
+                                  setThreadSqlMode({
+                                      threadUuid,
+                                      enabled,
+                                  }),
+                              )
+                        : undefined
+                }
             />
         </AgentChatDisplay>
     );

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -21,12 +21,15 @@ import { DefaultAgentButton } from '../../features/aiCopilot/components/DefaultA
 import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { PinnedContextCard } from '../../features/aiCopilot/components/PinnedContextCard/PinnedContextCard';
 import { SuggestedQuestions } from '../../features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions';
+import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
 import {
     useCreateAgentThreadMutation,
     useVerifiedQuestions,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import { setThreadSqlMode } from '../../features/aiCopilot/store/aiAgentThreadModeSlice';
+import { useAiAgentStoreDispatch } from '../../features/aiCopilot/store/hooks';
 import { type AgentContext } from './AgentPage';
 
 const AiAgentNewThreadPage: FC = () => {
@@ -41,8 +44,23 @@ const AiAgentNewThreadPage: FC = () => {
         dashboardUuid,
     });
 
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    const [sqlMode, setSqlMode] = useState(false);
+    const dispatch = useAiAgentStoreDispatch();
+
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
-        useCreateAgentThreadMutation(agentUuid, projectUuid!);
+        useCreateAgentThreadMutation(agentUuid, projectUuid!, {
+            // Seed the per-thread slice with the user's choice so subsequent
+            // prompts in this thread default to the same state. Navigation
+            // still happens (we only override the slice, not the routing).
+            onCreated: (thread) =>
+                dispatch(
+                    setThreadSqlMode({
+                        threadUuid: thread.uuid,
+                        enabled: sqlModeAvailable && sqlMode,
+                    }),
+                ),
+        });
     const { agent } = useOutletContext<AgentContext>();
     const { data: verifiedQuestions } = useVerifiedQuestions(
         projectUuid,
@@ -95,6 +113,7 @@ const AiAgentNewThreadPage: FC = () => {
                 context: contextInput.length > 0 ? contextInput : undefined,
                 optimisticContext:
                     previewItems.length > 0 ? previewItems : undefined,
+                enableSqlMode: sqlModeAvailable && sqlMode,
                 modelConfig: selectedModel
                     ? {
                           modelName: selectedModel.name,
@@ -111,6 +130,8 @@ const AiAgentNewThreadPage: FC = () => {
             createAgentThread,
             contextInput,
             previewItems,
+            sqlModeAvailable,
+            sqlMode,
             selectedModel,
             showExtendedThinking,
             extendedThinking,
@@ -238,6 +259,10 @@ const AiAgentNewThreadPage: FC = () => {
                             showExtendedThinking
                                 ? setExtendedThinking
                                 : undefined
+                        }
+                        sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                        onSqlModeChange={
+                            sqlModeAvailable ? setSqlMode : undefined
                         }
                         defaultValue={pendingPrompt}
                         onValueChange={setPendingPrompt}


### PR DESCRIPTION
## Summary

Adds a per-thread **SQL mode** switch to the web prompt composer so users can opt into the runSql / listWarehouseTables / describeWarehouseTable tools on a per-thread basis. Customer-driven (Mo at The Collecting Group asked for a per-prompt toggle, ChatGPT "Thinking"-mode style).

## Behavior

- **Visibility gate**: toggle only renders when **both** `ai-agent-run-sql` feature flag is enabled AND the user holds `manage:SqlRunner` CASL permission. Without either, no toggle.
- **Default**: OFF. Users opt in per-thread.
- **Scope**: per-thread. Toggling persists across prompts within a thread; new threads start at the default (OFF).
- **Tooltip**: explains what flipping it on means + reminds the user every query still asks for approval.
- **No DB changes**: state lives in a new `aiAgentThreadModeSlice` Redux slice keyed by `threadUuid`. Backend treats `enableSqlMode` as a request-time parameter on each stream call.

## Backend

- `POST /threads/{threadUuid}/stream` accepts an optional `enableSqlMode` in the body (new `ApiAiAgentThreadStreamRequest` type).
- `generateOrStreamAgentResponse` adds a third clause to `canRunSql` resolution: `flag AND CASL AND enableSqlMode`.
- Slack and non-stream callers pass `enableSqlMode: true` to preserve their flag-only gating (no behavioural change for those surfaces).

## Frontend

- New `useAiAgentSqlModeAvailable(projectUuid)` hook — composes the flag + CASL checks.
- New `aiAgentThreadModeSlice` — per-thread `sqlMode` boolean. Default `false`.
- `AgentChatInput` extended with `sqlMode` + `onSqlModeChange` props. Renders a Mantine `Switch` (xs, indigo) next to the submit button in full-mode toolbar; renders as a separate right-aligned row below the input in minimal mode (so it can't collide with the user's typed text).
- All four consumers wired: `AiAgentNewThreadPage`, `AgentThreadPage`, `LauncherPanel.NewThreadPanel`, `LauncherPanel.ExistingThreadPanel`. New-thread surfaces use local `useState` (no thread UUID yet) and seed the slice in the mutation's `onCreated`; in-thread surfaces read/write the slice directly.
- `useCreateAgentThreadMutation` callback contract clarified: `onCreated` now runs **in addition to** the default navigation. New `skipNavigation: true` option for the launcher, which routes via panels instead.

## Regression analysis

- **Slack**: unchanged. Callers pass `enableSqlMode: true` so runSql tools register exactly as before (flag + OAuth + CASL).
- **Web users without the flag/permission**: no toggle visible, agent behaves identically to today (semantic layer only).
- **Web users with the flag/permission but toggle off**: agent stays in the semantic layer. Tools not registered with the model. Default-off matches the current pre-toggle gating.
- **Web users with the flag/permission and toggle on**: agent gets `runSql` + warehouse-introspection tools. Each runSql still requires per-call approval via the existing card.
- **`useCreateAgentThreadMutation` callers**: the contract change is backwards-compatible — old callers that passed `onCreated` to *suppress* navigation must now pass `skipNavigation: true`. Updated the only such caller (launcher) in this PR.
- **Page refresh**: slice is in-memory only → toggle resets to default OFF. Acceptable since default is "safer" and existing per-call approvals catch anything unexpected.

## Test plan
- [ ] User without `ai-agent-run-sql` flag → no toggle visible anywhere
- [ ] User with flag but without `manage:SqlRunner` → no toggle visible
- [ ] User with both → toggle visible on new-thread page + in-thread page + launcher new + launcher in-thread
- [ ] Hover toggle → tooltip explains the behaviour
- [ ] Toggle off + send prompt → agent stays in semantic layer (no runSql tools registered)
- [ ] Toggle on + send prompt → agent can use runSql + each call shows approval card
- [ ] Toggle on, send first prompt → after thread creation, navigate succeeds, in-thread input shows toggle reflecting same state
- [ ] Toggle on, send first prompt, in new thread page flip toggle off → next prompt stays in semantic layer
- [ ] Refresh thread page → toggle resets to default OFF (in-memory state)
- [ ] Slack prompt unaffected — runSql works exactly as on the previous PR in the stack

## Stack

Stacked on top of #22960. Web-only — Slack toggle is a future workstream (the customer-driven flow + Slack ergonomics are different problems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)