### PR TITLE
feat(ai-agents): add Anthropic cache control to system prompt and remove time from context

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -13,7 +13,6 @@ export const getSystemPromptV2 = (args: {
     instructions?: string;
     agentName?: string;
     date?: string;
-    time?: string;
     enableDataAccess?: boolean;
     enableSelfImprovement?: boolean;
     canRunSql?: boolean;
@@ -24,7 +23,6 @@ export const getSystemPromptV2 = (args: {
         instructions,
         agentName = 'Lightdash AI Analyst',
         date = moment().utc().format('YYYY-MM-DD'),
-        time = moment().utc().format('HH:mm'),
         enableDataAccess = false,
         enableSelfImprovement = false,
         canRunSql = false,
@@ -62,7 +60,6 @@ export const getSystemPromptV2 = (args: {
             instructions ? `Special instructions: ${instructions}` : '',
         )
         .replace('{{date}}', date)
-        .replace('{{time}}', time)
         .replace(
             '{{available_explores}}',
             renderAvailableExplores(args.availableExplores).toString(),
@@ -71,5 +68,8 @@ export const getSystemPromptV2 = (args: {
     return {
         role: 'system',
         content,
+        providerOptions: {
+            anthropic: { cacheControl: { type: 'ephemeral' } },
+        },
     };
 };

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -475,6 +475,6 @@ Adhere to these guidelines to ensure your responses are clear, informative, and 
 
 Your name is "{{agent_name}}".
 {{instructions}}
-Today is {{date}} and the time is {{time}} in UTC.
+Today is {{date}}.
 You have access to the following explores:
 {{available_explores}}`;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #22128<!-- reference the related issue e.g. #150 -->

### Description:

Enable Anthropic prompt caching on AI agent requests by adding a `cache_control` breakpoint on the system prompt, and stabilize the system prompt so the cache key holds for a full day.

The system prompt is ~65k tokens and was being re-sent on every agent turn and every multi-step tool call. For Anthropic, that's the largest single cost lever

<details>
<summary>Some logs for testing</summary>

```
[AiAgent][Usage] model=claude-sonnet-4-6 prompt=a615889e-54fb-458f-8f38-114ea132874d input=74088 output=134 cacheRead=65532 total=74222
[AiAgent][Usage] model=claude-sonnet-4-6 prompt=5b2825ee-f526-4bed-bb8c-681e1f3e668f input=69435 output=167 cacheRead=65206 total=69602 steps=2
[AiAgent][Usage] model=claude-sonnet-4-6 prompt=37dac46f-d435-405f-8731-412351be52c6 input=69787 output=341 cacheRead=65206 total=70128 steps=2
```

</details>

