### PR TITLE
fix: dedupe identical SCIM roles before validation to handle Entra PATCH Add duplicates

### DIFF
--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -853,6 +853,92 @@ describe('ScimService', () => {
             );
         });
 
+        test('should dedupe identical organization roles (Entra PATCH Add on top of existing role)', () => {
+            const roles = [
+                {
+                    value: 'admin',
+                    display: 'Admin',
+                    type: 'Organization',
+                    primary: true,
+                },
+                {
+                    value: 'admin',
+                    display: 'Admin',
+                    type: 'Organization',
+                    primary: false,
+                },
+            ];
+
+            const result = ScimService.validateRolesArray(
+                roles,
+                validRoleValues,
+            );
+            expect(result).toHaveLength(1);
+            expect(result[0].value).toBe('admin');
+        });
+
+        test('should dedupe identical project roles', () => {
+            const roles = [
+                {
+                    value: 'admin',
+                    display: 'Admin',
+                    type: 'Organization',
+                    primary: true,
+                },
+                {
+                    value: 'project-1-uuid:viewer',
+                    display: 'Project 1 - Viewer',
+                    type: 'Project - Project 1',
+                    primary: false,
+                },
+                {
+                    value: 'project-1-uuid:viewer',
+                    display: 'Project 1 - Viewer',
+                    type: 'Project - Project 1',
+                    primary: false,
+                },
+            ];
+
+            const result = ScimService.validateRolesArray(
+                roles,
+                validRoleValues,
+            );
+            expect(result).toHaveLength(2);
+            expect(result.map((r) => r.value)).toEqual([
+                'admin',
+                'project-1-uuid:viewer',
+            ]);
+        });
+
+        test('should still throw for two different organization roles after dedupe', () => {
+            const roles = [
+                {
+                    value: 'admin',
+                    display: 'Admin',
+                    type: 'Organization',
+                    primary: true,
+                },
+                {
+                    value: 'admin',
+                    display: 'Admin',
+                    type: 'Organization',
+                    primary: false,
+                },
+                {
+                    value: 'editor',
+                    display: 'Editor',
+                    type: 'Organization',
+                    primary: false,
+                },
+            ];
+
+            expect(() => {
+                ScimService.validateRolesArray(roles, validRoleValues);
+            }).toThrow(
+                'Roles array must contain exactly one organization role, found 2',
+            );
+        });
+
         test('should allow roles ending with NO_ROLE_KEYWORD', () => {
             const roles = [
                 {

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -502,10 +502,14 @@ export class ScimService extends BaseService {
             }
             // Validate roles if provided
             const { allScimRoles } = await this.getAllRoles(organizationUuid);
+            let dedupedRoles: ScimUserRole[] | undefined;
             if (user.roles !== undefined) {
                 const validRoleValues = allScimRoles.map((role) => role.value);
-                // Throws error if roles are not valid
-                ScimService.validateRolesArray(user.roles, validRoleValues);
+                // Throws error if roles are not valid; returns deduped roles
+                dedupedRoles = ScimService.validateRolesArray(
+                    user.roles,
+                    validRoleValues,
+                );
             }
             const email = ScimService.getScimUserEmail(user);
 
@@ -580,7 +584,7 @@ export class ScimService extends BaseService {
             await this.upsertUserRoles({
                 organizationUuid,
                 userUuid: dbUser.userUuid,
-                roles: user.roles,
+                roles: dedupedRoles,
             });
 
             // verify user email on create if coming from scim
@@ -678,13 +682,17 @@ export class ScimService extends BaseService {
                 throw new ForbiddenError();
             }
             // Validate roles if provided
+            let dedupedRoles: ScimUserRole[] | undefined;
             if (user.roles !== undefined) {
                 const { allScimRoles } =
                     await this.getAllRoles(organizationUuid);
                 const validRoleValues = allScimRoles.map((role) => role.value);
 
-                // Throws error if roles are not valid
-                ScimService.validateRolesArray(user.roles, validRoleValues);
+                // Throws error if roles are not valid; returns deduped roles
+                dedupedRoles = ScimService.validateRolesArray(
+                    user.roles,
+                    validRoleValues,
+                );
             }
             const emailToUpdate = ScimService.getScimUserEmail(user);
             // get existing user (and make sure user is in the organization)
@@ -734,7 +742,7 @@ export class ScimService extends BaseService {
             await this.upsertUserRoles({
                 organizationUuid,
                 userUuid,
-                roles: user.roles,
+                roles: dedupedRoles,
             });
 
             // If active status changes, either true or false
@@ -1839,10 +1847,10 @@ export class ScimService extends BaseService {
     static validateRolesArray(
         roles: ScimUserRole[],
         validRoleValues: string[],
-    ): void {
+    ): ScimUserRole[] {
         // For backwards compatibility, when array is empty, skip validation and let caller skip updates
         if (roles.length === 0) {
-            return;
+            return roles;
         }
 
         // Check for invalid role values
@@ -1860,8 +1868,18 @@ export class ScimService extends BaseService {
             );
         }
 
+        // Dedupe roles by value. Entra "Update changed user" jobs sometimes emit
+        // a PATCH `Add` for `roles` on top of a user's existing role; without
+        // this, identical duplicates would trip "found 2" / "duplicate project"
+        // errors. Conflicting org roles or conflicting per-project roles still
+        // throw below.
+        const dedupedRoles = roles.filter(
+            (role, index, arr) =>
+                arr.findIndex((r) => r.value === role.value) === index,
+        );
+
         // Parse roles and categorize them
-        const parsedRoles = roles.map((role) => ({
+        const parsedRoles = dedupedRoles.map((role) => ({
             ...role,
             parsed: ScimService.parseRoleId(role.value),
         }));
@@ -1893,6 +1911,8 @@ export class ScimService extends BaseService {
                 ].join(', ')}`,
             );
         }
+
+        return dedupedRoles;
     }
 
     private convertLightdashRoleToScimRole(


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/23037

### Description:

When Microsoft Entra runs "Update changed user" sync jobs, it sometimes emits a SCIM PATCH `Add` operation for `roles` on top of a user's already-assigned role. This caused identical duplicate role entries to appear in the roles array, which would incorrectly trigger validation errors like "found 2 organization roles" or "duplicate project roles".

`validateRolesArray` now deduplicates roles by value before running validation, silently collapsing identical duplicates. Conflicting organization roles (e.g. both `admin` and `editor`) or conflicting per-project roles still throw as expected. The method now returns the deduped roles array, which is then passed through to `upsertUserRoles` in both the create and update user flows.