### PR TITLE
feat(ai-agent): indigo halo on chat input when SQL mode is active

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -146,6 +146,33 @@
     padding: var(--mantine-spacing-sm);
 }
 
+/* ------------------------------------------------------------------ *
+ *  SQL mode active state — slow, smooth indigo border + halo. No      *
+ *  animation; relies on a long CSS transition so toggling on/off      *
+ *  reads as a calm fade rather than a snap.                            *
+ * ------------------------------------------------------------------ */
+.sqlModeActive {
+    border-color: var(--mantine-color-indigo-4) !important;
+    box-shadow: 0 0 0 1px var(--mantine-color-indigo-3),
+        0 0 24px -8px var(--mantine-color-indigo-5),
+        0 0 0 4px color-mix(in srgb, var(--mantine-color-indigo-5) 10%, transparent);
+}
+
+/* Long, gentle ease applies both when toggling on *and* off. */
+.minimalInputWrapper,
+.inputCard {
+    transition: border-color 520ms cubic-bezier(0.4, 0, 0.2, 1),
+        box-shadow 520ms cubic-bezier(0.4, 0, 0.2, 1),
+        background-color 150ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .minimalInputWrapper,
+    .inputCard {
+        transition: none;
+    }
+}
+
 .minimalInputWrapper {
     position: relative;
     display: flex;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -169,7 +169,12 @@ export const AgentChatInput = ({
                     </Paper>
                 )}
 
-                <Box className={styles.minimalInputWrapper} pos="relative">
+                <Box
+                    className={`${styles.minimalInputWrapper} ${
+                        sqlMode ? styles.sqlModeActive : ''
+                    }`}
+                    pos="relative"
+                >
                     <Textarea
                         autoFocus
                         w="100%"
@@ -265,7 +270,11 @@ export const AgentChatInput = ({
             } ${showDisabledBanner ? styles.disabledBannerVisible : ''}`}
         >
             {/* Main input card */}
-            <Box className={styles.inputCard}>
+            <Box
+                className={`${styles.inputCard} ${
+                    sqlMode ? styles.sqlModeActive : ''
+                }`}
+            >
                 {/* Textarea */}
                 <Textarea
                     autoFocus


### PR DESCRIPTION
## Summary
Adds a subtle indigo halo + soft border-color transition on the chat input when SQL mode is toggled on — gives users a clear visual cue that the agent will reach for raw SQL.

### What changed
- New `.sqlModeActive` class applied to both the full and minimal input wrappers in `AgentChatInput`.
- Indigo border + 3-layer halo (`box-shadow: 0 0 0 1px indigo-3, 0 0 24px -8px indigo-5, 0 0 0 4px color-mix(...) 10%`).
- Long 520ms `cubic-bezier(0.4, 0, 0.2, 1)` transition on `border-color` + `box-shadow` so toggling on **and** off fades smoothly (no snap).
- `prefers-reduced-motion` turns the transition off.

### Regression analysis
- Pure CSS, single new class applied conditionally on `sqlMode`.
- No behavior changes — visual cue only.

## Test plan
- [x] Type-check clean
- [x] Visual: indigo glow fades in when SQL mode toggle flips on, fades out when off
- [x] Both full-thread and minimal-thread input variants get the effect