### PR TITLE
fix(ai-agent): persist SQL approvals in DB so they survive pod restarts + cross-pod requests

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -312,6 +312,8 @@ import {
     AiSlackPromptTableName,
     AiSlackThreadTable,
     AiSlackThreadTableName,
+    AiSqlApprovalTable,
+    AiSqlApprovalTableName,
     AiThreadTable,
     AiThreadTableName,
     AiWebAppPromptTable,
@@ -479,6 +481,7 @@ declare module 'knex/types/tables' {
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;
         [AiAgentToolResultTableName]: AiAgentToolResultTable;
+        [AiSqlApprovalTableName]: AiSqlApprovalTable;
         [DashboardTabsTableName]: DashboardTabsTable;
         [NotificationsTableName]: NotificationsTable;
         [DashboardSummariesTableName]: DashboardSummariesTable;

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -229,3 +229,21 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
     Pick<DbAiOrganizationSettings, 'organization_uuid' | 'ai_agents_visible'>,
     Partial<Pick<DbAiOrganizationSettings, 'ai_agents_visible'>>
 >;
+
+export const AiSqlApprovalTableName = 'ai_sql_approval';
+
+export type AiSqlApprovalDecision = 'approved' | 'rejected';
+
+export type DbAiSqlApproval = {
+    tool_call_id: string;
+    decision: AiSqlApprovalDecision;
+    decided_by_user_uuid: string | null;
+    decided_at: Date;
+};
+
+export type AiSqlApprovalTable = Knex.CompositeTableType<
+    DbAiSqlApproval,
+    Pick<DbAiSqlApproval, 'tool_call_id' | 'decision'> &
+        Partial<Pick<DbAiSqlApproval, 'decided_by_user_uuid'>>,
+    never
+>;

--- a/packages/backend/src/ee/database/migrations/20260513091146_add_ai_sql_approval.ts
+++ b/packages/backend/src/ee/database/migrations/20260513091146_add_ai_sql_approval.ts
@@ -1,0 +1,37 @@
+import { Knex } from 'knex';
+
+const AiSqlApprovalTableName = 'ai_sql_approval';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AiSqlApprovalTableName, (table) => {
+        // Tool call id from the agent run is the natural primary key —
+        // each call is decided at most once.
+        table.text('tool_call_id').primary();
+        table.text('decision').notNullable();
+        table.uuid('decided_by_user_uuid').nullable();
+        table
+            .timestamp('decided_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        // Audit trail FK — null on user deletion so we don't lose the row.
+        table
+            .foreign('decided_by_user_uuid')
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+
+        // Index for periodic cleanup of stale rows.
+        table.index('decided_at', 'ai_sql_approval_decided_at_idx');
+    });
+
+    await knex.raw(`
+        ALTER TABLE ${AiSqlApprovalTableName}
+        ADD CONSTRAINT ai_sql_approval_decision_check
+        CHECK (decision IN ('approved', 'rejected'))
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AiSqlApprovalTableName);
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -85,6 +85,7 @@ import {
     AiPromptTableName,
     AiSlackPromptTableName,
     AiSlackThreadTableName,
+    AiSqlApprovalTableName,
     AiThreadTableName,
     AiWebAppPromptTableName,
     AiWebAppThreadTableName,
@@ -94,8 +95,10 @@ import {
     DbAiPromptContext,
     DbAiSlackPrompt,
     DbAiSlackThread,
+    DbAiSqlApproval,
     DbAiThread,
     DbAiWebAppPrompt,
+    type AiSqlApprovalDecision,
 } from '../database/entities/ai';
 import {
     AiAgentGroupAccessTableName,
@@ -132,6 +135,7 @@ import {
     DbAiEvalRunResult,
     DbAiEvalRunResultAssessment,
 } from '../database/entities/aiEvals';
+import { type SqlApprovalDecision } from '../services/ai/tools/sqlApprovals';
 
 type Dependencies = {
     database: Knex;
@@ -3298,6 +3302,69 @@ export class AiAgentModel {
             toolName: row.toolName,
             hasResult: row.resultUuid !== null,
         };
+    }
+
+    // ---------------------------------------------------------------
+    // SQL approval bus — DB-backed so it works across pods and
+    // survives restarts. See `ai_sql_approval` migration.
+    // ---------------------------------------------------------------
+
+    /**
+     * Records a user's decision for a pending SQL approval. First write
+     * wins — `ON CONFLICT (tool_call_id) DO NOTHING` means double-clicks
+     * (or a race between Slack and the web UI) are safely ignored.
+     *
+     * @returns `true` if this call recorded the decision; `false` if a
+     *   decision was already in place.
+     */
+    async recordSqlApproval(
+        toolCallId: string,
+        decision: AiSqlApprovalDecision,
+        decidedByUserUuid: string | null,
+    ): Promise<boolean> {
+        const inserted = await this.database<DbAiSqlApproval>(
+            AiSqlApprovalTableName,
+        )
+            .insert({
+                tool_call_id: toolCallId,
+                decision,
+                decided_by_user_uuid: decidedByUserUuid,
+            })
+            .onConflict('tool_call_id')
+            .ignore()
+            .returning('tool_call_id');
+        return inserted.length > 0;
+    }
+
+    /**
+     * Polls `ai_sql_approval` for a decision keyed by `toolCallId`.
+     * Resolves to the decision once one is recorded, or `'timeout'`
+     * after `timeoutMs` of no activity.
+     */
+    async waitForSqlApproval(
+        toolCallId: string,
+        timeoutMs: number = 5 * 60 * 1000,
+        pollIntervalMs: number = 500,
+    ): Promise<SqlApprovalDecision> {
+        const deadline = Date.now() + timeoutMs;
+        /* eslint-disable no-await-in-loop -- polling is intentional and
+           sequential; we want to wait between queries, not fire in parallel. */
+        while (Date.now() < deadline) {
+            const row = await this.database<DbAiSqlApproval>(
+                AiSqlApprovalTableName,
+            )
+                .where({ tool_call_id: toolCallId })
+                .select('decision')
+                .first();
+            if (row) return row.decision;
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) break;
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, Math.min(pollIntervalMs, remaining));
+            });
+        }
+        /* eslint-enable no-await-in-loop */
+        return 'timeout';
     }
 
     async getToolResultsForPrompt(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -138,10 +138,7 @@ import { evaluateAgentReadiness } from '../ai/agents/readinessScorer';
 import { generateThreadTitle as generateTitleFromMessages } from '../ai/agents/titleGenerator';
 import { getAvailableModels, getDefaultModel, getModel } from '../ai/models';
 import { matchesPreset } from '../ai/models/presets';
-import {
-    markSlackThreadAutoApproved,
-    resolveSqlApproval,
-} from '../ai/tools/sqlApprovals';
+import { markSlackThreadAutoApproved } from '../ai/tools/sqlApprovals';
 import { AiAgentArgs, AiAgentDependencies } from '../ai/types/aiAgent';
 import {
     CreateChangeFn,
@@ -1043,16 +1040,17 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        const delivered = resolveSqlApproval(toolCallId, decision);
-        if (!delivered) {
-            // Approval was registered in DB sense (no result yet) but the
-            // backend pod awaiting the decision is gone — likely a restart.
-            // The 5-min timeout in waitForSqlApproval will fire, returning
-            // a 'timeout' result to the agent. We still record the user's
-            // intent by completing the request — let the timeout path
-            // handle the rest.
-            this.logger.warn(
-                `SQL approval for ${toolCallId} could not be delivered to any in-flight listener (possible pod restart).`,
+        const recorded = await this.aiAgentModel.recordSqlApproval(
+            toolCallId,
+            decision,
+            user.userUuid,
+        );
+        if (!recorded) {
+            // A decision was already in place for this tool call — likely a
+            // double-click or a race between Slack and the web UI. First
+            // write wins; subsequent calls are a no-op.
+            this.logger.info(
+                `SQL approval for ${toolCallId} was already recorded; ignoring duplicate.`,
             );
         }
 
@@ -3685,6 +3683,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 return artifact;
             },
 
+            waitForSqlApproval: (toolCallId, timeoutMs) =>
+                this.aiAgentModel.waitForSqlApproval(toolCallId, timeoutMs),
+            recordSqlApproval: (toolCallId, decision, decidedByUserUuid) =>
+                this.aiAgentModel.recordSqlApproval(
+                    toolCallId,
+                    decision,
+                    decidedByUserUuid,
+                ),
+
             perf: {
                 measureGenerateResponseTime: (durationMs) => {
                     this.prometheusMetrics?.aiAgentGenerateResponseDurationHistogram?.observe(
@@ -4371,14 +4378,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     markSlackThreadAutoApproved(threadUuid);
                 }
 
-                const delivered = resolveSqlApproval(toolCallId, decision);
-                if (!delivered) {
-                    await respond({
-                        text: ':warning: Could not deliver approval — the agent run may have already timed out.',
-                        replace_original: false,
-                    });
-                    return;
-                }
+                // We don't reverse-map Slack user IDs → Lightdash user UUIDs
+                // here (no direct join exists), so the audit trail records
+                // the decision without a user reference. The Slack user id
+                // is available via body.user.id if we want to enrich later.
+                await this.aiAgentModel.recordSqlApproval(
+                    toolCallId,
+                    decision,
+                    null,
+                );
 
                 const emoji =
                     decision === 'approved'

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -135,6 +135,8 @@ const getAgentTools = (
               sendFile: dependencies.sendFile,
               updateSlackMessage: dependencies.updateSlackMessage,
               siteUrl: args.siteUrl,
+              waitForSqlApproval: dependencies.waitForSqlApproval,
+              recordSqlApproval: dependencies.recordSqlApproval,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -7,19 +7,17 @@ import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
 import type {
     GetPromptFn,
+    RecordSqlApprovalFn,
     RunSqlJobFn,
     SendFileFn,
     UpdateProgressFn,
     UpdateSlackMessageFn,
+    WaitForSqlApprovalFn,
 } from '../types/aiAgentDependencies';
 import { serializeData } from '../utils/serializeData';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import { renderBlocks, type SectionState } from './slackSqlAggregate';
-import {
-    isSlackThreadAutoApproved,
-    resolveSqlApproval,
-    waitForSqlApproval,
-} from './sqlApprovals';
+import { isSlackThreadAutoApproved } from './sqlApprovals';
 
 type Dependencies = {
     updateProgress: UpdateProgressFn;
@@ -28,6 +26,8 @@ type Dependencies = {
     sendFile: SendFileFn;
     updateSlackMessage: UpdateSlackMessageFn;
     siteUrl: string;
+    waitForSqlApproval: WaitForSqlApprovalFn;
+    recordSqlApproval: RecordSqlApprovalFn;
 };
 
 // Strip --line and /* block */ comments + string literals so subsequent
@@ -71,6 +71,8 @@ export const getRunSql = ({
     sendFile,
     updateSlackMessage,
     siteUrl,
+    waitForSqlApproval,
+    recordSqlApproval,
 }: Dependencies) =>
     tool({
         description: toolRunSqlArgsSchema.description,
@@ -121,15 +123,14 @@ export const getRunSql = ({
                     await updateProgress('Awaiting approval to run SQL...');
                 }
 
-                // Register the approval listener first, then trigger any
-                // auto-approval (the EventEmitter delivers synchronously, so
-                // order matters).
-                const decisionPromise = waitForSqlApproval(toolCallId);
+                // Auto-approval: pre-record the decision so the poller in
+                // waitForSqlApproval picks it up on its first poll. Approvals
+                // are DB-backed (ai_sql_approval) so this works across pods
+                // and survives restarts.
                 if (slackAutoApproved) {
-                    resolveSqlApproval(toolCallId, 'approved');
+                    await recordSqlApproval(toolCallId, 'approved', null);
                 }
-
-                const decision = await decisionPromise;
+                const decision = await waitForSqlApproval(toolCallId);
                 if (decision === 'rejected') {
                     await renderState({ kind: 'rejected', sql });
                     return {

--- a/packages/backend/src/ee/services/ai/tools/sqlApprovals.ts
+++ b/packages/backend/src/ee/services/ai/tools/sqlApprovals.ts
@@ -1,15 +1,23 @@
-import { EventEmitter } from 'events';
+import { type AiSqlApprovalDecision } from '../../../database/entities/ai';
 
-const bus = new EventEmitter();
-bus.setMaxListeners(100);
+// ---------------------------------------------------------------------------
+// SQL approval — in-memory UX flag for Slack "approve & don't ask again"
+//
+// The decision itself (approved / rejected) is persisted in the
+// `ai_sql_approval` table via `AiAgentModel.waitForSqlApproval` /
+// `recordSqlApproval`. That part is the one that has to survive pod
+// restarts / cross-pod requests.
+//
+// What's left here is session-scoped UX state: when the user clicks
+// "Approve & don't ask again" from a Slack approval message, we remember
+// that thread for the lifetime of this pod so subsequent runSql calls in
+// the same thread skip the approval flow. It's a UX nicety, not a
+// correctness primitive, so the in-memory Set is fine.
+// ---------------------------------------------------------------------------
 
-// Threads (Lightdash AI thread UUIDs) where the user clicked "Approve & don't
-// ask again" from a Slack approval message. Subsequent runSql calls in the
-// same thread skip the approval flow. In-memory, session-scoped — lost on
-// pod restart, same as the approval bus itself.
 const slackAutoApprovedThreads = new Set<string>();
 
-export type SqlApprovalDecision = 'approved' | 'rejected' | 'timeout';
+export type SqlApprovalDecision = AiSqlApprovalDecision | 'timeout';
 
 export const markSlackThreadAutoApproved = (threadUuid: string): void => {
     slackAutoApprovedThreads.add(threadUuid);
@@ -17,26 +25,3 @@ export const markSlackThreadAutoApproved = (threadUuid: string): void => {
 
 export const isSlackThreadAutoApproved = (threadUuid: string): boolean =>
     slackAutoApprovedThreads.has(threadUuid);
-
-export const waitForSqlApproval = (
-    toolCallId: string,
-    timeoutMs: number = 5 * 60 * 1000,
-): Promise<SqlApprovalDecision> =>
-    new Promise((resolve) => {
-        let settled = false;
-        let timer: ReturnType<typeof setTimeout>;
-        const onDecision = (decision: SqlApprovalDecision) => {
-            if (settled) return;
-            settled = true;
-            bus.off(toolCallId, onDecision);
-            clearTimeout(timer);
-            resolve(decision);
-        };
-        bus.on(toolCallId, onDecision);
-        timer = setTimeout(() => onDecision('timeout'), timeoutMs);
-    });
-
-export const resolveSqlApproval = (
-    toolCallId: string,
-    decision: SqlApprovalDecision,
-): boolean => bus.emit(toolCallId, decision);

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -15,6 +15,7 @@ import {
     GetSavedChartFn,
     ListExploresFn,
     ListWarehouseTablesFn,
+    RecordSqlApprovalFn,
     RunAsyncQueryFn,
     RunSqlJobFn,
     SearchFieldValuesFn,
@@ -27,6 +28,7 @@ import {
     UpdateProgressFn,
     UpdatePromptFn,
     UpdateSlackMessageFn,
+    WaitForSqlApprovalFn,
 } from './aiAgentDependencies';
 
 type AnyAiModel<P = AiProvider> = P extends AiProvider ? AiModel<P> : never;
@@ -91,6 +93,8 @@ export type AiAgentDependencies = {
     trackEvent: TrackEventFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     createChange: CreateChangeFn;
+    waitForSqlApproval: WaitForSqlApprovalFn;
+    recordSqlApproval: RecordSqlApprovalFn;
     perf: PerformanceMetrics;
 };
 

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -205,3 +205,14 @@ export type DescribeWarehouseTableFn = (args: {
     columns: Array<{ name: string; type: string }>;
     resolvedSchema: string | null;
 }>;
+
+export type WaitForSqlApprovalFn = (
+    toolCallId: string,
+    timeoutMs?: number,
+) => Promise<'approved' | 'rejected' | 'timeout'>;
+
+export type RecordSqlApprovalFn = (
+    toolCallId: string,
+    decision: 'approved' | 'rejected',
+    decidedByUserUuid: string | null,
+) => Promise<boolean>;


### PR DESCRIPTION
## Summary
Fixes the recurring **":warning: Could not deliver approval — the agent run may have already timed out"** message in Slack (and the equivalent silent miss on the web UI).

### Root cause
`waitForSqlApproval` / `resolveSqlApproval` (`packages/backend/src/ee/services/ai/tools/sqlApprovals.ts`) were an **in-process `EventEmitter`**:

- The agent run holding the wait promise lives on whichever API pod handled the original stream request.
- When the user clicks **Approve** in Slack, the action POST is load-balanced to a *random* API pod.
- If the LB lands the click on a different pod than the one running the stream, `bus.emit(toolCallId, decision)` has zero listeners → returns `false` → user sees the warning.

In a multi-replica deployment this misfired roughly `1 - 1/N` of the time — exactly what we were seeing in prod.

### Fix
Replaced the EventEmitter with a tiny DB table (`ai_sql_approval`) + polling:

- **Migration** `20260513091146_add_ai_sql_approval.ts` — `(tool_call_id PK, decision, decided_by_user_uuid, decided_at)` plus a CHECK constraint on `decision IN ('approved', 'rejected')`.
- **`AiAgentModel.recordSqlApproval`** does `INSERT … ON CONFLICT (tool_call_id) DO NOTHING` — first write wins, double-clicks safe, race-free across pods.
- **`AiAgentModel.waitForSqlApproval`** polls every ~500ms until a row appears or `timeoutMs` (default 5 min) elapses.
- `sqlApprovals.ts` now only houses the in-memory `slackAutoApprovedThreads` Set (session-scoped UX state, not correctness-critical).
- Tools/services receive the new methods via the existing `AiAgentDependencies` bag (`waitForSqlApproval`, `recordSqlApproval`).
- Removed the "Could not deliver approval" Slack response — with `ON CONFLICT DO NOTHING`, the only "not recorded" case is a duplicate decision (e.g. Slack + web at the same instant). That's not a user error worth surfacing.

### Why DB-backed + polling over PG LISTEN/NOTIFY
LISTEN/NOTIFY is in-process too — if the listener pod restarts while waiting, the broadcast is lost. DB polling survives any pod restart: a new poller can pick up the decision on the next cycle. It also gives us an audit trail (who approved what, when).

### Regression analysis
- **Single-pod / dev**: identical user-visible behavior. Latency goes from ~0ms to ≤500ms between click and agent resume — invisible since the user is waiting on an LLM anyway.
- **Multi-pod**: now correct. Previously this was the broken case.
- **Slack auto-approve ("don't ask again")**: unchanged. Still in-memory, session-scoped per pod — by design (it's a UX nicety, not a correctness primitive). If a pod restarts, users get re-asked, which is acceptable.
- **Web UI approve path**: now passes `user.userUuid` for the audit trail.
- **Slack action handler**: records the decision without a user reference (no direct Slack-user → Lightdash-user join exists). We can enrich this later if needed.
- **System/admin roles / service accounts / custom roles**: unaffected — no permission changes. The existing `manage:SqlRunner` CASL check on `decideSqlApproval` is untouched.

### Audit trail
The new table doubles as an audit log. Periodic cleanup of stale rows can be a follow-up scheduler task (e.g. delete decisions older than 24h). Not in this PR.

## Test plan
- [x] Migration applies cleanly on local DB
- [x] Backend type-check + lint pass
- [x] Slack approval click → agent resumes (manual test in local dev)
- [x] Web UI approval click → agent resumes
- [x] Double-click in Slack → second click is silently ignored
- [ ] Multi-pod staging deploy: verify Slack click on pod B reaches an agent run on pod A