### PR TITLE
fix(echarts): scope continuousDateRange to the actual X axis

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -14,6 +14,7 @@ import {
     getCategoryDateAxisConfig,
     getMinAndMaxValues,
     padDatasetForContinuousAxis,
+    selectContinuousDateRange,
 } from './useEchartsCartesianConfig';
 
 vi.mock('./../../providers/TrackingProvider');
@@ -753,6 +754,52 @@ describe('padDatasetForContinuousAxis', () => {
 
         const result = padDatasetForContinuousAxis(data, range, xField);
         expect(result).toEqual(data);
+    });
+});
+
+describe('selectContinuousDateRange', () => {
+    const range = ['2024-01-01T00:00:00Z', '2024-01-08T00:00:00Z'];
+
+    test('non-flipped reads from bottom (X axis)', () => {
+        expect(
+            selectContinuousDateRange(
+                false,
+                { data: range },
+                { data: undefined },
+            ),
+        ).toEqual(range);
+    });
+
+    test('flipped reads from left (X axis)', () => {
+        expect(
+            selectContinuousDateRange(
+                true,
+                { data: undefined },
+                { data: range },
+            ),
+        ).toEqual(range);
+    });
+
+    // Regression: date dim on Y leaked into X-axis padding via the old
+    // bottom ?? top ?? left ?? right fallback chain.
+    test('non-flipped ignores left-axis data (Y-axis leak guard)', () => {
+        expect(
+            selectContinuousDateRange(
+                false,
+                { data: undefined },
+                { data: range },
+            ),
+        ).toBeUndefined();
+    });
+
+    test('flipped ignores bottom-axis data (Y-axis leak guard)', () => {
+        expect(
+            selectContinuousDateRange(
+                true,
+                { data: range },
+                { data: undefined },
+            ),
+        ).toBeUndefined();
     });
 });
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1577,6 +1577,15 @@ export const getCategoryDateAxisConfig = (
     return {};
 };
 
+// Read from the axis holding the X field — bottom (normal) or left (flipped).
+// Top/right hold Y-field metrics; leaking them corrupts the X field column.
+export const selectContinuousDateRange = (
+    flipAxes: boolean | undefined,
+    bottomAxisExtraConfig: CategoryDateAxisConfig,
+    leftAxisExtraConfig: CategoryDateAxisConfig,
+): string[] | undefined =>
+    flipAxes ? leftAxisExtraConfig.data : bottomAxisExtraConfig.data;
+
 const getEchartAxes = ({
     itemsMap,
     validCartesianConfig,
@@ -2258,12 +2267,11 @@ const getEchartAxes = ({
                 ...rightAxisExtraConfig,
             },
         ],
-        continuousDateRange:
-            bottomAxisExtraConfig.data ??
-            topAxisExtraConfig.data ??
-            leftAxisExtraConfig.data ??
-            rightAxisExtraConfig.data ??
-            undefined,
+        continuousDateRange: selectContinuousDateRange(
+            validCartesianConfig.layout.flipAxes,
+            bottomAxisExtraConfig,
+            leftAxisExtraConfig,
+        ),
     };
 };
 


### PR DESCRIPTION
Closes: GLITCH-439

## Summary

Fixes a chart rendering bug where the axes display `1970-01-01` (epoch zero) when a date dimension is placed on the Y axis, in both flipped and non-flipped layouts.

## Root cause

`continuousDateRange` was computed via an unconditional fallback chain:

```ts
bottomAxisExtraConfig.data ?? topAxisExtraConfig.data ?? leftAxisExtraConfig.data ?? rightAxisExtraConfig.data
```

introduced in #21480. The left/right fallbacks were intended to handle **flipped** (horizontal bar) layouts, where the X field visually sits on the left axis. But the fallback fired unconditionally — so in a normal layout, a date dim on Y would leak into the chain via `leftAxisExtraConfig.data`. The same problem mirrored in flipped layouts via `rightAxisExtraConfig.data` (the secondary Y-field metric).

That value then flowed into `padDatasetForContinuousAxis(rows, range, xField)`, which rewrote every row's `xField` column with date strings from the range — corrupting `dataset.source` and producing the epoch-zero signature in ECharts.

PR #22952 did not introduce the corruption, but unmasked it by routing stack decorations (rounded corners, stack totals) through the padded dataset instead of the un-padded `rows` source.

## Fix

`continuousDateRange` now reads only from the axis that actually holds the X field:

- `flipAxes === false` → `bottomAxisExtraConfig.data`
- `flipAxes === true` → `leftAxisExtraConfig.data`

The top/right secondary axes are dropped from the chain — `topAxisXId` is `undefined` in non-flipped (so `topAxisExtraConfig.data` was always `undefined` there anyway), and `rightAxisYId` in flipped falls back to `layout.yField?.[1]` which is a Y-field metric, not the X field.

**Before**
<img width="2109" height="950" alt="CleanShot 2026-05-13 at 10 46 38" src="https://github.com/user-attachments/assets/f76ea36c-e671-4052-87ce-a997a5d6c211" />

Flipped
<img width="2112" height="954" alt="CleanShot 2026-05-13 at 10 46 50" src="https://github.com/user-attachments/assets/1cf09297-3378-4f5a-85dd-5c716c1e0558" />


**After**

<img width="2112" height="947" alt="CleanShot 2026-05-13 at 10 46 13" src="https://github.com/user-attachments/assets/b87a76dc-351d-4a0a-bf96-8f36259988d4" />

Flipped
<img width="2110" height="949" alt="CleanShot 2026-05-13 at 10 45 05" src="https://github.com/user-attachments/assets/9c6ec66e-759e-4ef1-bf3e-f8a8b18604d0" />
