### PR TITLE
fix(logging): own uncaughtException/unhandledRejection logging via Winston

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -7,11 +7,10 @@ import Logger from './logging/logger';
 
 // trigger BE tests
 
-process.on('unhandledRejection', (reason, p) => {
-    Logger.error('Unhandled Rejection at Promise', reason, p);
-});
-process.on('uncaughtException', (err) => {
-    Logger.error('Uncaught Exception thrown', err);
+// Winston (handleExceptions/handleRejections in winston.ts) owns structured logging
+// for both events. Logger uses exitOnError: false so rejections are tolerated.
+// We still want uncaught exceptions to terminate — process state may be corrupt.
+process.on('uncaughtException', () => {
     process.exit(1);
 });
 

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -124,6 +124,8 @@ if (lightdashConfig.logging.outputs.includes('console')) {
             level:
                 lightdashConfig.logging.consoleLevel ||
                 lightdashConfig.logging.level,
+            handleExceptions: true,
+            handleRejections: true,
         }),
     );
 }
@@ -145,6 +147,7 @@ if (lightdashConfig.logging.outputs.includes('file')) {
 export const winstonLogger = winston.createLogger({
     levels,
     transports,
+    exitOnError: false,
 });
 
 const PAST_TENSE_ACTIONS: Record<string, string> = {

--- a/packages/backend/src/natsWorker.ts
+++ b/packages/backend/src/natsWorker.ts
@@ -21,14 +21,12 @@ const parseStreams = (): NatsWorkerStream[] => {
     return streams.length > 0 ? streams : getRegisteredStreams();
 };
 
-process
-    .on('unhandledRejection', (reason, p) => {
-        Logger.error('Unhandled Rejection at Promise', reason, p);
-    })
-    .on('uncaughtException', (err) => {
-        Logger.error('Uncaught Exception thrown', err);
-        process.exit(1);
-    });
+// Winston (handleExceptions/handleRejections in winston.ts) owns structured logging
+// for both events. Logger uses exitOnError: false so rejections are tolerated.
+// We still want uncaught exceptions to terminate — process state may be corrupt.
+process.on('uncaughtException', () => {
+    process.exit(1);
+});
 
 (async () => {
     if (process.env.CI !== 'true') {

--- a/packages/backend/src/scheduler.ts
+++ b/packages/backend/src/scheduler.ts
@@ -4,14 +4,12 @@ import knexConfig from './knexfile';
 import Logger from './logging/logger';
 import SchedulerApp from './SchedulerApp';
 
-process
-    .on('unhandledRejection', (reason, p) => {
-        Logger.error('Unhandled Rejection at Promise', reason, p);
-    })
-    .on('uncaughtException', (err) => {
-        Logger.error('Uncaught Exception thrown', err);
-        process.exit(1);
-    });
+// Winston (handleExceptions/handleRejections in winston.ts) owns structured logging
+// for both events. Logger uses exitOnError: false so rejections are tolerated.
+// We still want uncaught exceptions to terminate — process state may be corrupt.
+process.on('uncaughtException', () => {
+    process.exit(1);
+});
 
 (async () => {
     if (process.env.CI !== 'true') {


### PR DESCRIPTION
Closes: #22824
Alternative shape for #22880.

### Description

Adds `handleExceptions: true` + `handleRejections: true` on the Winston Console transport so uncaught exceptions and unhandled rejections produce a single structured JSON entry instead of raw stack lines on stderr (the goal of #22880).

The straight-up version of that change (PR #22880 as written) was tested locally and crashes the backend ~3s after every unhandled rejection — rejections are tolerated today, so that's a real regression. Root cause: with Winston's transport-level rejection handling enabled, the logger's `exitOnError: true` default takes effect on the rejection path (despite Winston's docs suggesting otherwise) and exits the process. This PR neutralises that and removes the duplicate logging from the existing handlers.

### Changes

- `packages/backend/src/logging/winston.ts`: `handleExceptions: true` + `handleRejections: true` on the Console transport; `exitOnError: false` on the logger so Winston never calls `process.exit` itself.
- `packages/backend/src/index.ts`, `scheduler.ts`, `natsWorker.ts`: remove the manual `process.on('unhandledRejection' | 'uncaughtException')` handlers that were also logging. Keep a bare `process.on('uncaughtException', () => process.exit(1))` so uncaught exceptions still terminate the process and trip the container-restart alarm.

### Behaviour comparison

| Event | Before this PR | After this PR |
|---|---|---|
| Unhandled rejection | Tolerated; logged via custom handler | Tolerated; **single** structured Winston log entry |
| Uncaught exception | Exits 1; logged via custom handler | Exits 1; structured Winston log entry, then bare exit handler runs |

Container lifecycle is identical to today. GCP restart-count alerts still fire on exceptions.

### Sentry / monitoring

- Sentry's `onUnhandledRejection` listener is registered independently (default mode `'warn'`) and still fires — error reporting to Sentry SaaS is preserved.
- Cloud audit confirmed no GCP alert or dashboard filters on the old log message strings (`"Unhandled Rejection at Promise"`, `"Uncaught Exception thrown"`), so the message-format change is invisible to monitoring.
- Lightdash doesn't ship logs to Datadog despite the original PR's framing — logs go to GCP Cloud Logging via stdout.

### Test plan

- [x] Locally trigger unhandled rejection via temporary debug endpoint → backend stays up, single structured log entry emitted
- [x] Locally trigger uncaught exception → backend exits, container would be restarted by k8s
- [ ] CI: typecheck/lint pass (this PR)
- [ ] Verify a scheduler-worker / NATS-worker crash in staging emits a single structured entry to GCP Cloud Logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)