### PR TITLE
feat(unfurl): support saved SQL Runner chart links in Slack (PROD-7166)

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -887,6 +887,7 @@ export class ServiceRepository
                     lightdashConfig: this.context.lightdashConfig,
                     dashboardModel: this.models.getDashboardModel(),
                     savedChartModel: this.models.getSavedChartModel(),
+                    savedSqlModel: this.models.getSavedSqlModel(),
                     shareModel: this.models.getShareModel(),
                     fileStorageClient: this.clients.getFileStorageClient(),
                     projectModel: this.models.getProjectModel(),

--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -1,4 +1,8 @@
-import { DownloadFileType, NotFoundError } from '@lightdash/common';
+import {
+    DownloadFileType,
+    LightdashPage,
+    NotFoundError,
+} from '@lightdash/common';
 import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { type SlackClient } from '../../clients/Slack/SlackClient';
@@ -7,6 +11,7 @@ import { type DashboardModel } from '../../models/DashboardModel/DashboardModel'
 import { type DownloadFileModel } from '../../models/DownloadFileModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { type SavedChartModel } from '../../models/SavedChartModel';
+import { type SavedSqlModel } from '../../models/SavedSqlModel';
 import { type ShareModel } from '../../models/ShareModel';
 import { type SlackAuthenticationModel } from '../../models/SlackAuthenticationModel';
 import { type SlackUnfurlImageModel } from '../../models/SlackUnfurlImageModel';
@@ -40,13 +45,22 @@ const mockDownloadFileModel = {
     getDownloadFile: jest.fn(),
 };
 
-function createService() {
+function createService(
+    overrides: Partial<{
+        savedSqlModel: Partial<SavedSqlModel>;
+    }> = {},
+) {
     return new UnfurlService({
         lightdashConfig: {
             siteUrl: 'https://app.lightdash.cloud',
+            headlessBrowser: {
+                internalLightdashHost: 'http://headless-browser:8080',
+            },
         } as unknown as LightdashConfig,
         dashboardModel: {} as unknown as DashboardModel,
         savedChartModel: {} as unknown as SavedChartModel,
+        savedSqlModel: (overrides.savedSqlModel ??
+            {}) as unknown as SavedSqlModel,
         shareModel: {} as unknown as ShareModel,
         fileStorageClient:
             mockFileStorageClient as unknown as FileStorageClient,
@@ -205,6 +219,128 @@ describe('UnfurlService', () => {
             expect(result.imageUrl).toMatch(
                 /^https:\/\/app\.lightdash\.cloud\/api\/v1\/slack\/image\//,
             );
+        });
+    });
+
+    describe('parseUrl - SQL Runner charts', () => {
+        const PROJECT_UUID = '21eef0b9-5bae-40f3-851e-9554588e71a6';
+        const SQL_CHART_UUID = '11111111-2222-3333-4444-555555555555';
+
+        it('recognizes a saved SQL Runner URL and rewrites to a minimal URL', async () => {
+            const getBySlug = jest.fn().mockResolvedValue({
+                savedSqlUuid: SQL_CHART_UUID,
+                name: 'my chart',
+                description: null,
+            });
+            const service = createService({
+                savedSqlModel: { getBySlug } as Partial<SavedSqlModel>,
+            });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_UUID}/sql-runner/my-saved-chart`,
+            );
+
+            expect(result.isValid).toBe(true);
+            expect(result.lightdashPage).toBe('sql_chart');
+            expect(result.projectUuid).toBe(PROJECT_UUID);
+            expect(result.savedSqlUuid).toBe(SQL_CHART_UUID);
+            expect(result.minimalUrl).toBe(
+                `http://headless-browser:8080/minimal/projects/${PROJECT_UUID}/sql-runner/${SQL_CHART_UUID}`,
+            );
+            expect(getBySlug).toHaveBeenCalledWith(
+                PROJECT_UUID,
+                'my-saved-chart',
+            );
+        });
+
+        it('also recognizes `/sql-runner/<slug>/edit` and resolves to the same minimal URL', async () => {
+            const getBySlug = jest.fn().mockResolvedValue({
+                savedSqlUuid: SQL_CHART_UUID,
+                name: 'my chart',
+                description: null,
+            });
+            const service = createService({
+                savedSqlModel: { getBySlug } as Partial<SavedSqlModel>,
+            });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_UUID}/sql-runner/my-saved-chart/edit`,
+            );
+
+            expect(result.isValid).toBe(true);
+            expect(result.savedSqlUuid).toBe(SQL_CHART_UUID);
+            expect(getBySlug).toHaveBeenCalledWith(
+                PROJECT_UUID,
+                'my-saved-chart',
+            );
+        });
+
+        it('returns isValid: false when the slug does not resolve to a saved chart', async () => {
+            const getBySlug = jest
+                .fn()
+                .mockRejectedValue(new Error('not found'));
+            const service = createService({
+                savedSqlModel: { getBySlug } as Partial<SavedSqlModel>,
+            });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_UUID}/sql-runner/missing-chart`,
+            );
+
+            expect(result.isValid).toBe(false);
+        });
+
+        it('returns isValid: false for `/sql-runner` with no slug (unsaved chart)', async () => {
+            const getBySlug = jest.fn();
+            const service = createService({
+                savedSqlModel: { getBySlug } as Partial<SavedSqlModel>,
+            });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_UUID}/sql-runner`,
+            );
+
+            expect(result.isValid).toBe(false);
+            expect(getBySlug).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getTitleAndDescription - SQL_CHART', () => {
+        const PROJECT_UUID = '21eef0b9-5bae-40f3-851e-9554588e71a6';
+        const SQL_CHART_UUID = '11111111-2222-3333-4444-555555555555';
+
+        it('returns chart name + description + organizationUuid from saved_sql', async () => {
+            const getByUuid = jest.fn().mockResolvedValue({
+                savedSqlUuid: SQL_CHART_UUID,
+                name: 'Prompts created over time',
+                description: 'A monthly trend of AI prompts',
+                organization: {
+                    organizationUuid: '00000000-0000-0000-0000-000000000aaa',
+                },
+            });
+            const service = createService({
+                savedSqlModel: { getByUuid } as Partial<SavedSqlModel>,
+            });
+
+            const result = await service.getTitleAndDescription(
+                {
+                    isValid: true,
+                    lightdashPage: LightdashPage.SQL_CHART,
+                    url: 'irrelevant',
+                    minimalUrl: 'irrelevant',
+                    projectUuid: PROJECT_UUID,
+                    savedSqlUuid: SQL_CHART_UUID,
+                },
+                null,
+            );
+
+            expect(result.title).toBe('Prompts created over time');
+            expect(result.description).toBe('A monthly trend of AI prompts');
+            expect(result.organizationUuid).toBe(
+                '00000000-0000-0000-0000-000000000aaa',
+            );
+            expect(result.resourceUuid).toBe(SQL_CHART_UUID);
+            expect(getByUuid).toHaveBeenCalledWith(SQL_CHART_UUID);
         });
     });
 });

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -56,6 +56,7 @@ import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { DownloadFileModel } from '../../models/DownloadFileModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
+import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { ShareModel } from '../../models/ShareModel';
 import { SlackAuthenticationModel } from '../../models/SlackAuthenticationModel';
 import { SlackUnfurlImageModel } from '../../models/SlackUnfurlImageModel';
@@ -237,6 +238,7 @@ export type ParsedUrl = {
     dashboardUuid?: string;
     projectUuid?: string;
     chartUuid?: string;
+    savedSqlUuid?: string;
     exploreModel?: string;
 };
 
@@ -271,6 +273,7 @@ type UnfurlServiceArguments = {
     lightdashConfig: LightdashConfig;
     dashboardModel: DashboardModel;
     savedChartModel: SavedChartModel;
+    savedSqlModel: SavedSqlModel;
     shareModel: ShareModel;
     fileStorageClient: FileStorageClient;
     slackClient: SlackClient;
@@ -288,6 +291,8 @@ export class UnfurlService extends BaseService {
     dashboardModel: DashboardModel;
 
     savedChartModel: SavedChartModel;
+
+    savedSqlModel: SavedSqlModel;
 
     shareModel: ShareModel;
 
@@ -311,6 +316,7 @@ export class UnfurlService extends BaseService {
         lightdashConfig,
         dashboardModel,
         savedChartModel,
+        savedSqlModel,
         shareModel,
         fileStorageClient,
         projectModel,
@@ -325,6 +331,7 @@ export class UnfurlService extends BaseService {
         this.lightdashConfig = lightdashConfig;
         this.dashboardModel = dashboardModel;
         this.savedChartModel = savedChartModel;
+        this.savedSqlModel = savedSqlModel;
         this.shareModel = shareModel;
         this.fileStorageClient = fileStorageClient;
         this.slackClient = slackClient;
@@ -421,6 +428,20 @@ export class UnfurlService extends BaseService {
                     organizationUuid: chart.organizationUuid,
                     chartType: chart.chartType,
                     resourceUuid: chart.uuid,
+                };
+            case LightdashPage.SQL_CHART:
+                if (!parsedUrl.savedSqlUuid)
+                    throw new Error(
+                        `Missing savedSqlUuid when unfurling SQL Runner URL ${parsedUrl.url}`,
+                    );
+                const sqlChart = await this.savedSqlModel.getByUuid(
+                    parsedUrl.savedSqlUuid,
+                );
+                return {
+                    title: sqlChart.name,
+                    description: sqlChart.description ?? undefined,
+                    organizationUuid: sqlChart.organization.organizationUuid,
+                    resourceUuid: sqlChart.savedSqlUuid,
                 };
             case LightdashPage.EXPLORE:
                 const project = await this.projectModel.getSummary(
@@ -1704,6 +1725,9 @@ export class UnfurlService extends BaseService {
         const dashboardUrl = new RegExp(`/projects/${uuid}/dashboards/${uuid}`);
         const chartUrl = new RegExp(`/projects/${uuid}/saved/${uuid}`);
         const exploreUrl = new RegExp(`/projects/${uuid}/tables/`);
+        const sqlChartUrl = new RegExp(
+            `/projects/(${uuid})/sql-runner/([^/?#]+)`,
+        );
 
         if (url.match(dashboardUrl) !== null) {
             const [projectUuid, dashboardUuid] = url.match(uuidRegex) || [];
@@ -1751,6 +1775,35 @@ export class UnfurlService extends BaseService {
                 projectUuid,
                 exploreModel,
             };
+        }
+        const sqlChartMatch = url.match(sqlChartUrl);
+        if (sqlChartMatch !== null) {
+            const [, projectUuid, slug] = sqlChartMatch;
+            try {
+                const sqlChart = await this.savedSqlModel.getBySlug(
+                    projectUuid,
+                    slug,
+                );
+                return {
+                    isValid: true,
+                    lightdashPage: LightdashPage.SQL_CHART,
+                    url,
+                    minimalUrl: new URL(
+                        `/minimal/projects/${projectUuid}/sql-runner/${sqlChart.savedSqlUuid}`,
+                        this.lightdashConfig.headlessBrowser
+                            .internalLightdashHost,
+                    ).href,
+                    projectUuid,
+                    savedSqlUuid: sqlChart.savedSqlUuid,
+                };
+            } catch (e) {
+                this.logger.debug(
+                    `SQL chart slug ${slug} did not resolve in project ${projectUuid}: ${getErrorMessage(
+                        e,
+                    )}`,
+                );
+                // fall through to isValid: false
+            }
         }
 
         this.logger.debug(`URL to unfurl ${url} is not valid`);

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -431,7 +431,7 @@ export class UnfurlService extends BaseService {
                 };
             case LightdashPage.SQL_CHART:
                 if (!parsedUrl.savedSqlUuid)
-                    throw new Error(
+                    throw new ParameterError(
                         `Missing savedSqlUuid when unfurling SQL Runner URL ${parsedUrl.url}`,
                     );
                 const sqlChart = await this.savedSqlModel.getByUuid(

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -532,6 +532,7 @@ export enum LightdashPage {
     DASHBOARD = 'dashboard',
     CHART = 'chart',
     EXPLORE = 'explore',
+    SQL_CHART = 'sql_chart',
 }
 
 export type NotificationPayloadBase = {

--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -263,7 +263,11 @@ const MINIMAL_ROUTES: RouteObject[] = [
             },
             {
                 path: '/minimal/projects/:projectUuid/sql-runner/:savedSqlUuid',
-                element: <MinimalSqlChart />,
+                element: (
+                    <Stack p="lg" h="90vh">
+                        <MinimalSqlChart />
+                    </Stack>
+                ),
             },
         ],
     },

--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -46,6 +46,7 @@ import AuthPopupResult, {
 import Login from './pages/Login';
 import MinimalDashboard from './pages/MinimalDashboard';
 import MinimalSavedExplorer from './pages/MinimalSavedExplorer';
+import MinimalSqlChart from './pages/MinimalSqlChart';
 import MobileCharts from './pages/MobileCharts';
 import MobileDashboards from './pages/MobileDashboards';
 import MobileHome from './pages/MobileHome';
@@ -259,6 +260,10 @@ const MINIMAL_ROUTES: RouteObject[] = [
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid/view/tabs/:tabUuid',
                 element: <MinimalDashboard />,
+            },
+            {
+                path: '/minimal/projects/:projectUuid/sql-runner/:savedSqlUuid',
+                element: <MinimalSqlChart />,
             },
         ],
     },

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -27,6 +27,7 @@ import Login from './pages/Login';
 import MetricsCatalog from './pages/MetricsCatalog';
 import MinimalDashboard from './pages/MinimalDashboard';
 import MinimalSavedExplorer from './pages/MinimalSavedExplorer';
+import MinimalSqlChart from './pages/MinimalSqlChart';
 import PasswordRecovery from './pages/PasswordRecovery';
 import PasswordReset from './pages/PasswordReset';
 import Projects from './pages/Projects';
@@ -134,6 +135,14 @@ const MINIMAL_ROUTES: RouteObject[] = [
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid/view/tabs/:tabUuid',
                 element: <MinimalDashboard />,
+            },
+            {
+                path: '/minimal/projects/:projectUuid/sql-runner/:savedSqlUuid',
+                element: (
+                    <Stack p="lg" h="100vh">
+                        <MinimalSqlChart />
+                    </Stack>
+                ),
             },
         ],
     },

--- a/packages/frontend/src/pages/MinimalSqlChart.tsx
+++ b/packages/frontend/src/pages/MinimalSqlChart.tsx
@@ -1,0 +1,155 @@
+import {
+    ChartKind,
+    isVizCartesianChartConfig,
+    isVizPieChartConfig,
+    isVizTableConfig,
+} from '@lightdash/common';
+import { Box, MantineProvider, type MantineThemeOverride } from '@mantine/core';
+import { memo, useEffect, useRef, useState, type FC } from 'react';
+import { useParams } from 'react-router';
+import ScreenshotProgressIndicator from '../components/common/ScreenshotProgressIndicator';
+import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
+import ChartView from '../components/DataViz/visualizations/ChartView';
+import { Table } from '../components/DataViz/visualizations/Table';
+import { useSavedSqlChartResults } from '../features/sqlRunner/hooks/useSavedSqlChartResults';
+
+const themeOverride: MantineThemeOverride = {
+    globalStyles: () => ({
+        'html, body': {
+            backgroundColor: 'white',
+        },
+    }),
+};
+
+const MinimalSqlChartContent = memo(
+    ({
+        projectUuid,
+        savedSqlUuid,
+    }: {
+        projectUuid: string;
+        savedSqlUuid: string;
+    }) => {
+        const {
+            chartQuery: {
+                data: chartData,
+                isLoading: isChartLoading,
+                error: chartError,
+            },
+            chartResultsQuery: {
+                data: chartResultsData,
+                isLoading: isChartResultsLoading,
+                isFetching: isChartResultsFetching,
+                error: chartResultsError,
+            },
+        } = useSavedSqlChartResults({
+            projectUuid,
+            savedSqlUuid,
+        });
+
+        const hasError = !!chartError || !!chartResultsError;
+        const isReady =
+            !isChartLoading &&
+            !isChartResultsLoading &&
+            !!chartData &&
+            !!chartResultsData;
+        const [hasSignaled, setHasSignaled] = useState(false);
+        const hasSignaledRef = useRef(false);
+
+        useEffect(() => {
+            if (hasSignaledRef.current) return;
+            if (!isReady && !hasError) return;
+            hasSignaledRef.current = true;
+            setHasSignaled(true);
+        }, [isReady, hasError]);
+
+        if (!chartData || !chartResultsData) {
+            if (hasError) {
+                const errorMessage =
+                    chartError?.error?.message ??
+                    chartResultsError?.error?.message ??
+                    'Error loading SQL chart';
+                return (
+                    <>
+                        <span>{errorMessage}</span>
+                        <ScreenshotReadyIndicator
+                            tilesTotal={1}
+                            tilesReady={0}
+                            tilesErrored={1}
+                        />
+                    </>
+                );
+            }
+            return null;
+        }
+
+        return (
+            <MantineProvider inherit theme={themeOverride}>
+                <Box mih="inherit" h="100%" data-testid="visualization">
+                    {chartData.config.type === ChartKind.TABLE &&
+                        isVizTableConfig(chartData.config) && (
+                            <Box w="100%" h="100%" style={{ overflow: 'auto' }}>
+                                <Table
+                                    resultsRunner={
+                                        chartResultsData.resultsRunner
+                                    }
+                                    columnsConfig={chartData.config.columns}
+                                    flexProps={{ mah: '100%' }}
+                                />
+                            </Box>
+                        )}
+                    {(isVizCartesianChartConfig(chartData.config) ||
+                        isVizPieChartConfig(chartData.config)) && (
+                        <ChartView
+                            config={chartData.config}
+                            spec={chartResultsData.chartSpec}
+                            isLoading={isChartResultsFetching}
+                            error={undefined}
+                            style={{
+                                minHeight: 'inherit',
+                                height: '100%',
+                                width: '100%',
+                            }}
+                        />
+                    )}
+                </Box>
+
+                <ScreenshotProgressIndicator
+                    expectedTileUuids={[savedSqlUuid]}
+                    readyTileUuids={
+                        hasSignaled && !hasError ? [savedSqlUuid] : []
+                    }
+                    erroredTileUuids={
+                        hasSignaled && hasError ? [savedSqlUuid] : []
+                    }
+                />
+                {hasSignaled && (
+                    <ScreenshotReadyIndicator
+                        tilesTotal={1}
+                        tilesReady={hasError ? 0 : 1}
+                        tilesErrored={hasError ? 1 : 0}
+                    />
+                )}
+            </MantineProvider>
+        );
+    },
+);
+
+const MinimalSqlChart: FC = () => {
+    const params = useParams<{
+        projectUuid: string;
+        savedSqlUuid: string;
+    }>();
+
+    if (!params.projectUuid || !params.savedSqlUuid) {
+        return null;
+    }
+
+    return (
+        <MinimalSqlChartContent
+            projectUuid={params.projectUuid}
+            savedSqlUuid={params.savedSqlUuid}
+        />
+    );
+};
+
+export default MinimalSqlChart;

--- a/packages/frontend/src/pages/MinimalSqlChart.tsx
+++ b/packages/frontend/src/pages/MinimalSqlChart.tsx
@@ -1,11 +1,11 @@
 import {
-    ChartKind,
+    assertUnreachable,
     isVizCartesianChartConfig,
     isVizPieChartConfig,
     isVizTableConfig,
 } from '@lightdash/common';
 import { Box, MantineProvider, type MantineThemeOverride } from '@mantine/core';
-import { memo, useEffect, useRef, useState, type FC } from 'react';
+import { memo, useEffect, useRef, useState, type FC, type JSX } from 'react';
 import { useParams } from 'react-router';
 import ScreenshotProgressIndicator from '../components/common/ScreenshotProgressIndicator';
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
@@ -82,35 +82,47 @@ const MinimalSqlChartContent = memo(
             return null;
         }
 
+        let visualization: JSX.Element;
+        if (isVizTableConfig(chartData.config)) {
+            visualization = (
+                <Box w="100%" h="100%" style={{ overflow: 'auto' }}>
+                    <Table
+                        resultsRunner={chartResultsData.resultsRunner}
+                        columnsConfig={chartData.config.columns}
+                        flexProps={{ mah: '100%' }}
+                    />
+                </Box>
+            );
+        } else if (
+            isVizCartesianChartConfig(chartData.config) ||
+            isVizPieChartConfig(chartData.config)
+        ) {
+            visualization = (
+                <ChartView
+                    config={chartData.config}
+                    spec={chartResultsData.chartSpec}
+                    isLoading={isChartResultsFetching}
+                    error={undefined}
+                    style={{
+                        minHeight: 'inherit',
+                        height: '100%',
+                        width: '100%',
+                    }}
+                />
+            );
+        } else {
+            return assertUnreachable(
+                chartData.config,
+                `Unsupported SQL chart config: ${
+                    (chartData.config as { type: unknown }).type
+                }`,
+            );
+        }
+
         return (
             <MantineProvider inherit theme={themeOverride}>
                 <Box mih="inherit" h="100%" data-testid="visualization">
-                    {chartData.config.type === ChartKind.TABLE &&
-                        isVizTableConfig(chartData.config) && (
-                            <Box w="100%" h="100%" style={{ overflow: 'auto' }}>
-                                <Table
-                                    resultsRunner={
-                                        chartResultsData.resultsRunner
-                                    }
-                                    columnsConfig={chartData.config.columns}
-                                    flexProps={{ mah: '100%' }}
-                                />
-                            </Box>
-                        )}
-                    {(isVizCartesianChartConfig(chartData.config) ||
-                        isVizPieChartConfig(chartData.config)) && (
-                        <ChartView
-                            config={chartData.config}
-                            spec={chartResultsData.chartSpec}
-                            isLoading={isChartResultsFetching}
-                            error={undefined}
-                            style={{
-                                minHeight: 'inherit',
-                                height: '100%',
-                                width: '100%',
-                            }}
-                        />
-                    )}
+                    {visualization}
                 </Box>
 
                 <ScreenshotProgressIndicator

--- a/packages/frontend/src/pages/MinimalSqlChart.tsx
+++ b/packages/frontend/src/pages/MinimalSqlChart.tsx
@@ -5,7 +5,7 @@ import {
     isVizTableConfig,
 } from '@lightdash/common';
 import { Box, MantineProvider, type MantineThemeOverride } from '@mantine/core';
-import { memo, useEffect, useRef, useState, type FC, type JSX } from 'react';
+import { memo, type FC, type JSX } from 'react';
 import { useParams } from 'react-router';
 import ScreenshotProgressIndicator from '../components/common/ScreenshotProgressIndicator';
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
@@ -52,15 +52,7 @@ const MinimalSqlChartContent = memo(
             !isChartResultsLoading &&
             !!chartData &&
             !!chartResultsData;
-        const [hasSignaled, setHasSignaled] = useState(false);
-        const hasSignaledRef = useRef(false);
-
-        useEffect(() => {
-            if (hasSignaledRef.current) return;
-            if (!isReady && !hasError) return;
-            hasSignaledRef.current = true;
-            setHasSignaled(true);
-        }, [isReady, hasError]);
+        const hasSignaled = isReady || hasError;
 
         if (!chartData || !chartResultsData) {
             if (hasError) {

--- a/packages/frontend/src/pages/MinimalSqlChart.tsx
+++ b/packages/frontend/src/pages/MinimalSqlChart.tsx
@@ -54,6 +54,14 @@ const MinimalSqlChartContent = memo(
             !!chartResultsData;
         const hasSignaled = isReady || hasError;
 
+        const progressIndicator = (
+            <ScreenshotProgressIndicator
+                expectedTileUuids={[savedSqlUuid]}
+                readyTileUuids={hasSignaled && !hasError ? [savedSqlUuid] : []}
+                erroredTileUuids={hasSignaled && hasError ? [savedSqlUuid] : []}
+            />
+        );
+
         if (!chartData || !chartResultsData) {
             if (hasError) {
                 const errorMessage =
@@ -63,6 +71,7 @@ const MinimalSqlChartContent = memo(
                 return (
                     <>
                         <span>{errorMessage}</span>
+                        {progressIndicator}
                         <ScreenshotReadyIndicator
                             tilesTotal={1}
                             tilesReady={0}
@@ -71,7 +80,7 @@ const MinimalSqlChartContent = memo(
                     </>
                 );
             }
-            return null;
+            return progressIndicator;
         }
 
         let visualization: JSX.Element;
@@ -117,15 +126,7 @@ const MinimalSqlChartContent = memo(
                     {visualization}
                 </Box>
 
-                <ScreenshotProgressIndicator
-                    expectedTileUuids={[savedSqlUuid]}
-                    readyTileUuids={
-                        hasSignaled && !hasError ? [savedSqlUuid] : []
-                    }
-                    erroredTileUuids={
-                        hasSignaled && hasError ? [savedSqlUuid] : []
-                    }
-                />
+                {progressIndicator}
                 {hasSignaled && (
                     <ScreenshotReadyIndicator
                         tilesTotal={1}


### PR DESCRIPTION
## Summary

Saved SQL Runner chart URLs now unfurl in Slack with the same title + description + screenshot preview that saved explore charts and dashboards already produce. Backend adds a fourth `parseUrl` branch matching `/projects/<uuid>/sql-runner/<slug>`, resolves the slug to a `savedSqlUuid` via `SavedSqlModel`, and rewrites it to a new `/minimal/projects/<uuid>/sql-runner/<savedSqlUuid>` minimal URL. Frontend adds the matching route + `MinimalSqlChart.tsx` page that renders the saved chart and signals readiness via `ScreenshotReadyIndicator` — completing the screenshot contract used by `MinimalSavedExplorer` and `MinimalDashboard`.

Scope: **saved** SQL charts only. Unsaved SQL Runner URLs are explicitly out of scope per the customer's actual workflow (Phantom saves the chart before sharing).

Resolves [PROD-7166](https://linear.app/lightdash/issue/PROD-7166/unfurl-not-working-for-sql-runner-chart-links).

## Test plan

- [x] Backend unit tests — 4 new \`parseUrl\` cases (happy / \`/edit\` variant / unknown slug / unsaved chart) + 1 \`getTitleAndDescription\` case; 11/11 pass.
- [x] \`pnpm -F backend typecheck\` and \`pnpm -F frontend typecheck\` exit 0; exhaustiveness on \`LightdashPage\` enforces the new case.
- [x] Manual E2E on local dev: saved a SQL chart, opened \`/minimal/projects/<uuid>/sql-runner/<savedSqlUuid>\` → chart renders alone on white, \`#lightdash-ready-indicator\` mounts with \`data-status="ready" data-tiles-total="1" data-tiles-ready="1"\`, \`#lightdash-screenshot-progress\` has matching expected/ready arrays.
- [ ] Post-merge: paste a saved SQL Runner chart URL into Slack and confirm the unfurl preview renders with title + description + screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)