### PR TITLE
fix(palette-picker): compact stacked swatches with truncated names

### DIFF
--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.module.css
@@ -1,10 +1,30 @@
+.options {
+    overflow-x: hidden;
+}
+
+.options * {
+    min-width: 0;
+    max-width: 100%;
+}
+
+.options > div {
+    overflow-x: hidden !important;
+}
+
+.option {
+    width: 100%;
+    overflow: hidden;
+}
+
 .row {
     width: 100%;
+    min-width: 0;
     justify-content: space-between;
 }
 
 .name {
     flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -12,6 +32,20 @@
 
 .swatches {
     flex-shrink: 0;
+}
+
+.swatchStack {
+    display: flex;
+    align-items: center;
+}
+
+.stackedSwatch {
+    --cs-size: calc(0.85rem * var(--mantine-scale));
+    border: 1px solid var(--mantine-color-body);
+}
+
+.stackedSwatch:not(:first-child) {
+    margin-left: -0.4rem;
 }
 
 .miniChartCardLight,

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -42,16 +42,18 @@ const SwatchInline: FC<{
     limit: number;
 }> = ({ icon, label, colors, limit }) => (
     <Tooltip label={label} position="top" withinPortal>
-        <Group gap={4} wrap="nowrap">
+        <Group gap={2} wrap="nowrap">
             <MantineIcon icon={icon} size={14} color="gray" />
-            {colors.slice(0, limit).map((color, index) => (
-                <ColorSwatch
-                    key={`${color}-${index}`}
-                    size={12}
-                    color={color}
-                    withShadow={false}
-                />
-            ))}
+            <div className={classes.swatchStack}>
+                {colors.slice(0, limit).map((color, index) => (
+                    <ColorSwatch
+                        key={`${color}-${index}`}
+                        color={color}
+                        withShadow={false}
+                        className={classes.stackedSwatch}
+                    />
+                ))}
+            </div>
         </Group>
     </Tooltip>
 );
@@ -65,7 +67,7 @@ const PaletteOptionRow: FC<{ name: string; swatches: SwatchSet | null }> = ({
             {name}
         </Text>
         {swatches && (
-            <Group gap="xs" wrap="nowrap" className={classes.swatches}>
+            <Group gap={4} wrap="nowrap" className={classes.swatches}>
                 <SwatchInline
                     icon={IconSun}
                     label="Light mode"
@@ -197,6 +199,10 @@ export const PalettePicker: FC<Props> = ({
                 }
                 disabled={disabled}
                 allowDeselect={false}
+                classNames={{
+                    option: classes.option,
+                    options: classes.options,
+                }}
                 renderOption={({ option }) => (
                     <PaletteOptionRow
                         name={option.label}


### PR DESCRIPTION
Related: https://github.com/lightdash/lightdash/issues/14089

### Description:

Tightens the `PalettePicker` Select dropdown rows: light/dark palette swatches are now overlapped like an avatar stack (smaller `--cs-size`, negative left margin, 1px border) instead of laid out with gaps, the sun/moon icons sit closer to the swatches, and the slash separator uses a tighter gap. Palette names now truncate with ellipsis so very long names no longer expand the dropdown and produce a horizontal scrollbar — achieved by cascading `min-width: 0` through the Mantine combobox descendants and overriding the internal scroll wrapper's `overflow-x`.

### Demos

<img width="796" height="768" alt="CleanShot 2026-05-13 at 13 21 24@2x" src="https://github.com/user-attachments/assets/655ebc48-d40e-469f-a036-4a2406531b55" />

<img width="1314" height="758" alt="CleanShot 2026-05-13 at 13 23 51@2x" src="https://github.com/user-attachments/assets/60e31caa-ea47-47f2-b2ae-b2b871d86625" />
