### PR TITLE
fix(frontend): allow Databricks OAuth re-auth from preview projects

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -356,7 +356,11 @@ const DatabricksForm: FC<{
                 ) : (
                     <DatabricksSSOInput
                         isAuthenticated={isAuthenticated}
-                        disabled={disabled || !isServerHostNameProvided}
+                        // OAuth re-auth writes to the current user's own credentials,
+                        // not the project's warehouse config — so it must stay
+                        // available even when the rest of the form is locked
+                        // (preview projects, missing update permission, mid-save).
+                        disabled={!isServerHostNameProvided}
                         disabledTooltip={databricksSsoDisabledTooltip}
                         openLoginPopup={openLoginPopup}
                     />


### PR DESCRIPTION
Closes: #20620

### Description

Preview projects intentionally lock the Connection Settings UI to keep config (warehouse host, dbt branch, schema, …) immutable for the duration of a review. The `disabled` prop that drives that lock was also being applied to the "Sign in with Databricks" / OAuth U2M sign-in button — meaning when a preview project's refresh token expired, the only path to re-authenticate was visibly present but un-clickable. Users had to tear down and recreate the preview, losing in-progress edits.

OAuth U2M re-auth writes to per-user `user_warehouse_credentials`, not the project's warehouse config, so it doesn't belong behind the project-update lock. This drops the form-level `disabled` from `DatabricksSSOInput`; the host-name guard stays.

The reason is non-obvious enough that I added a short inline comment so a future reviewer doesn't "fix" this back.

#### Why this is safe

- The OAuth callback (`databricksStrategy.ts`) writes only to `user_warehouse_credentials` keyed on `req.user.userUuid`, and `upsertProjectCredentialsPreference` re-checks `view` (not `update`) + asserts ownership.
- A read-only viewer can already self-authenticate from `Settings → My warehouse connections` today — this change just exposes the existing capability via the project form too.
- `UpdateProjectConnection` is unreachable from embed/JWT surfaces; service-account bearer tokens can't drive a browser-popup flow.

#### Pre-existing behavior worth noting

Re-authenticating from a preview project rotates the user's `project_user_warehouse_credentials_preference` row to point at the freshly-issued credentials for that preview's `projectUuid` (single PK on `user_uuid, project_uuid`). The same already happens today when re-auth is triggered from `My warehouse connections` — this PR doesn't change that, just makes the path discoverable from inside a preview.

### Test plan

- [x] Repro the bug in a local preview project with Databricks OAuth U2M:
  - Saved project with `warehouse_type = databricks`, `authenticationType = OAUTH_U2M`
  - Preview project created from it
  - Invalidate the user's refresh token in DB
  - Open the preview's Connection Settings → "Sign in with Databricks" button rendered but `disabled`
- [x] Apply the fix → button becomes `disabled: false`
- [x] Click → real OAuth popup against a Databricks trial workspace completes → callback 302 → fresh `user_warehouse_credentials` row + preference row pointing to the preview's `projectUuid`
- [x] Form re-renders to "You are connected to Databricks. Click here to reauthenticate" — that anchor was already clickable
- [x] `pnpm -F frontend typecheck` clean
- [x] `pnpm -F frontend lint` clean (one unrelated pre-existing warning in `ColorSelector.tsx`)
- [ ] CI to confirm

### Follow-ups (not in this PR)

- Snowflake (`SnowflakeForm.tsx`) and BigQuery (`BigQueryForm.tsx`) have the identical disabled-prop pattern on their respective SSO buttons. Worth a consistency pass — same blast-radius reasoning applies. No customer complaint yet, so leaving for a follow-up.
- `databricksSSOController.ts` returns HTTP 500 when stored `encrypted_credentials` fail to decrypt; should return 404 so the frontend conditional renders correctly. Out of scope for this fix (and only surfaces in artificially-corrupted-creds states; expired refresh tokens still parse fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)