### PR TITLE
chore: increase managed agent session timeout default to 10 minutes

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2283,9 +2283,9 @@ export const parseConfig = (): LightdashConfig => {
                 .filter(Boolean),
             schedule: process.env.MANAGED_AGENT_SCHEDULE || '0 0 * * *',
             sessionTimeoutMs: parseInt(
-                process.env.MANAGED_AGENT_SESSION_TIMEOUT_MS || '300000',
+                process.env.MANAGED_AGENT_SESSION_TIMEOUT_MS || '600000',
                 10,
-            ), // 5 minutes default
+            ), // 10 minutes default
         },
         initialSetup: getInitialSetupConfig(),
         updateSetup: getUpdateSetupConfig(),


### PR DESCRIPTION
Closes:

### Description:
Increases the default managed agent session timeout from 5 minutes to 10 minutes (`300000ms` → `600000ms`). This can still be overridden via the `MANAGED_AGENT_SESSION_TIMEOUT_MS` environment variable.