### PR TITLE
feat: add toggle to disable Slack link unfurls

### DIFF
--- a/packages/backend/src/database/entities/slackAuthentication.ts
+++ b/packages/backend/src/database/entities/slackAuthentication.ts
@@ -16,6 +16,7 @@ export type DbSlackAuthTokens = {
     ai_require_oauth: boolean;
     ai_multi_agent_channel_id: string | null;
     ai_multi_agent_project_uuids: string[] | null;
+    unfurls_enabled: boolean;
     // Channel sync status
     channels_last_sync_at: Date | null;
     channels_sync_started_at: Date | null;
@@ -38,6 +39,7 @@ export type UpdateDbSlackAuthTokens = Partial<
         | 'ai_require_oauth'
         | 'ai_multi_agent_channel_id'
         | 'ai_multi_agent_project_uuids'
+        | 'unfurls_enabled'
         | 'channels_last_sync_at'
         | 'channels_sync_started_at'
         | 'channels_sync_status'

--- a/packages/backend/src/database/migrations/20260513134959_slack_setting_unfurls_enabled.ts
+++ b/packages/backend/src/database/migrations/20260513134959_slack_setting_unfurls_enabled.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.table('slack_auth_tokens', (table) => {
+        table.boolean('unfurls_enabled').defaultTo(true);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.table('slack_auth_tokens', (table) => {
+        table.dropColumn('unfurls_enabled');
+    });
+}

--- a/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
+++ b/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
@@ -52,6 +52,7 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
             aiRequireOAuth: row.ai_require_oauth,
             aiMultiAgentChannelId: row.ai_multi_agent_channel_id ?? undefined,
             aiMultiAgentProjectUuids: row.ai_multi_agent_project_uuids ?? null,
+            unfurlsEnabled: row.unfurls_enabled ?? true,
         };
 
         const slackChannelProjectMappingRows = await this.database(
@@ -109,6 +110,7 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
             aiRequireOAuth,
             aiMultiAgentChannelId,
             aiMultiAgentProjectUuids,
+            unfurlsEnabled,
         }: SlackAppCustomSettings,
     ) {
         const organizationId = await this.getOrganizationId(organizationUuid);
@@ -128,6 +130,7 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
                     ai_require_oauth: aiRequireOAuth ?? false,
                     ai_multi_agent_channel_id: aiMultiAgentChannelId ?? null,
                     ai_multi_agent_project_uuids: projectUuidsToSave,
+                    unfurls_enabled: unfurlsEnabled,
                 })
                 .where('organization_id', organizationId);
 

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -131,6 +131,7 @@ export class SlackAuthenticationModel {
             scopes: row.installation?.bot?.scopes || [],
             notificationChannel: row.notification_channel ?? undefined,
             appProfilePhotoUrl: row.app_profile_photo_url ?? undefined,
+            unfurlsEnabled: row.unfurls_enabled ?? true,
         };
     }
 
@@ -167,7 +168,11 @@ export class SlackAuthenticationModel {
 
     async updateAppCustomSettings(
         organizationUuid: string,
-        { notificationChannel, appProfilePhotoUrl }: SlackAppCustomSettings,
+        {
+            notificationChannel,
+            appProfilePhotoUrl,
+            unfurlsEnabled,
+        }: SlackAppCustomSettings,
     ) {
         const organizationId = await this.getOrganizationId(organizationUuid);
 
@@ -175,7 +180,18 @@ export class SlackAuthenticationModel {
             .update({
                 notification_channel: notificationChannel,
                 app_profile_photo_url: appProfilePhotoUrl,
+                unfurls_enabled: unfurlsEnabled,
             })
             .where('organization_id', organizationId);
+    }
+
+    async getUnfurlsEnabled(teamId: string): Promise<boolean> {
+        const row = await this.database(SlackAuthTokensTableName)
+            .select<Pick<DbSlackAuthTokens, 'unfurls_enabled'>>(
+                'unfurls_enabled',
+            )
+            .where('slack_team_id', teamId)
+            .first();
+        return row?.unfurls_enabled ?? true;
     }
 }

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1838,11 +1838,27 @@ export class UnfurlService extends BaseService {
 
         Logger.debug(`Got link_shared slack event ${event.message_ts}`);
 
+        const { teamId } = context;
+        if (!teamId) {
+            Logger.warn(
+                `Slack unfurl skipped: no teamId on link_shared event ${event.message_ts}`,
+            );
+            return;
+        }
+
+        const unfurlsEnabled =
+            await this.slackAuthenticationModel.getUnfurlsEnabled(teamId);
+        if (!unfurlsEnabled) {
+            Logger.info(
+                `Slack unfurl skipped for team ${teamId}: link unfurls disabled in integration settings`,
+            );
+            return;
+        }
+
         void event.links.map(async (l) => {
             const eventUserId = context.botUserId;
 
             try {
-                const { teamId } = context;
                 const details = await this.unfurlDetails(l.url, null);
 
                 if (details) {
@@ -1870,9 +1886,7 @@ export class UnfurlService extends BaseService {
 
                     const imageId = `slack-image-${useNanoid()}`;
                     const authUserUuid =
-                        await this.slackAuthenticationModel.getUserUuid(
-                            teamId ?? '',
-                        );
+                        await this.slackAuthenticationModel.getUserUuid(teamId);
 
                     const installation =
                         await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(

--- a/packages/common/src/types/slack.ts
+++ b/packages/common/src/types/slack.ts
@@ -26,6 +26,7 @@ export type SlackAppCustomSettings = {
     aiRequireOAuth?: boolean;
     aiMultiAgentChannelId?: string;
     aiMultiAgentProjectUuids?: string[] | null;
+    unfurlsEnabled?: boolean;
 };
 
 export type ApiSlackGetInstallationResponse = ApiSuccess<

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -15,4 +15,5 @@ export type SlackSettings = {
     aiRequireOAuth?: boolean;
     aiMultiAgentChannelId?: string;
     aiMultiAgentProjectUuids?: string[] | null;
+    unfurlsEnabled?: boolean;
 };

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -70,6 +70,7 @@ const formSchema = z.object({
     aiRequireOAuth: z.boolean().optional(),
     aiMultiAgentChannelId: z.string().min(1).optional(),
     aiMultiAgentProjectUuids: z.array(z.string().uuid()).nullable().optional(),
+    unfurlsEnabled: z.boolean().optional(),
 });
 
 const SlackSettingsPanel: FC = () => {
@@ -102,6 +103,7 @@ const SlackSettingsPanel: FC = () => {
             aiRequireOAuth: false,
             aiMultiAgentChannelId: undefined,
             aiMultiAgentProjectUuids: null,
+            unfurlsEnabled: true,
         },
         validate: zodResolver(formSchema),
     });
@@ -123,6 +125,7 @@ const SlackSettingsPanel: FC = () => {
                 slackInstallation.aiMultiAgentChannelId ?? undefined,
             aiMultiAgentProjectUuids:
                 slackInstallation.aiMultiAgentProjectUuids ?? null,
+            unfurlsEnabled: slackInstallation.unfurlsEnabled ?? true,
         };
 
         if (form.initialized) {
@@ -253,6 +256,34 @@ const SlackSettingsPanel: FC = () => {
                                     }
                                 />
                             </Group>
+                            <Stack gap="sm">
+                                <Divider mt="sm" />
+                                <Title order={5} fw={600}>
+                                    Unfurling
+                                </Title>
+                                <Group gap="two">
+                                    <Title order={6} fw={500}>
+                                        Link previews
+                                    </Title>
+                                    <Tooltip
+                                        multiline
+                                        maw={280}
+                                        label="When enabled, Lightdash posts chart and dashboard previews when links are shared in Slack. Previews are rendered as the user who installed the Slack app, so any queries they trigger are attributed to that user. Disable to stop posting previews."
+                                    >
+                                        <MantineIcon icon={IconHelpCircle} />
+                                    </Tooltip>
+                                </Group>
+                                <Switch
+                                    label="Enable link unfurls"
+                                    checked={form.values.unfurlsEnabled ?? true}
+                                    onChange={(event) => {
+                                        setFieldValue(
+                                            'unfurlsEnabled',
+                                            event.currentTarget.checked,
+                                        );
+                                    }}
+                                />
+                            </Stack>
                             {isAiCopilotEnabledOrTrial && (
                                 <Stack gap="sm">
                                     <Divider mt="sm" />


### PR DESCRIPTION
Closes: PROD-7569

### Description:

Adds a new **Unfurling** section to the Slack integration settings with an **Enable link unfurls** switch. When disabled, `UnfurlService.unfurlSlackUrls` returns early without rendering previews — no headless-browser session is opened and no queries are attributed to the Slack installer, which is the kill switch for the query-attribution contamination reported in PROD-7569.

A new `unfurls_enabled` column is added to `slack_auth_tokens` (default `true`, so existing installs keep their current behavior) and threaded through the common types, OSS + EE models, and the existing `PUT /slack/custom-settings` endpoint. Setting the toggle to `undefined` from the API leaves the column unchanged, so callers can patch other fields without flipping it. The proper attribution fix (resolving the link sharer via `openid_identities`) will live as a sibling toggle in this same section in a follow-up.

### Demo

<img width="1856" height="1104" alt="CleanShot 2026-05-13 at 16 44 27@2x" src="https://github.com/user-attachments/assets/a589572b-4669-4729-9ff0-b1b7272c3455" />
