### PR TITLE
fix(rename): include bare model name in chart rename gate

### DIFF
--- a/packages/backend/src/services/RenameService/rename.test.ts
+++ b/packages/backend/src/services/RenameService/rename.test.ts
@@ -1262,6 +1262,63 @@ describe('renameSavedChart', () => {
         expect(updatedChart.pivotConfig?.columns).toEqual(['invoice_type']);
     });
 
+    // Regression test for PROD-7548: model rename silently skipped charts
+    // whose fields were all sourced from a joined table.
+    test('should rename tableName/exploreName when all fields come from a joined table', () => {
+        const chart = {
+            name: 'Joined-only Chart',
+            tableName: 'model_a',
+            metricQuery: {
+                exploreName: 'model_a',
+                dimensions: ['joined_b_id'],
+                metrics: ['joined_b_amount'],
+                sorts: [
+                    {
+                        fieldId: 'joined_b_id',
+                        descending: true,
+                    },
+                ],
+                filters: {},
+                tableCalculations: [],
+                additionalMetrics: [],
+                customDimensions: [],
+            },
+            chartConfig: {
+                type: ChartType.CARTESIAN,
+                config: {
+                    layout: {
+                        xField: 'joined_b_id',
+                        yField: ['joined_b_amount'],
+                    },
+                },
+            },
+            tableConfig: {
+                columnOrder: ['joined_b_id', 'joined_b_amount'],
+            },
+        } as unknown as SavedChartDAO;
+
+        const { updatedChart, hasChanges } = renameSavedChart({
+            type: RenameType.MODEL,
+            chart,
+            nameChanges: {
+                from: 'model_a',
+                fromReference: 'model_a',
+                to: 'model_a_v2',
+                toReference: 'model_a_v2',
+                fromFieldName: undefined,
+                toFieldName: undefined,
+            },
+            validate: false,
+        });
+
+        expect(hasChanges).toBe(true);
+        expect(updatedChart.tableName).toBe('model_a_v2');
+        expect(updatedChart.metricQuery.exploreName).toBe('model_a_v2');
+        // Joined-table field references should remain untouched
+        expect(updatedChart.metricQuery.dimensions).toEqual(['joined_b_id']);
+        expect(updatedChart.metricQuery.metrics).toEqual(['joined_b_amount']);
+    });
+
     test('should return unchanged chart when no matches found', () => {
         const chart = {
             name: 'Payment Analysis',

--- a/packages/backend/src/services/RenameService/rename.ts
+++ b/packages/backend/src/services/RenameService/rename.ts
@@ -757,14 +757,17 @@ export const renameSavedChart = ({
 }): { updatedChart: SavedChartDAO; hasChanges: boolean } => {
     const isPrefix = type === RenameType.MODEL;
 
-    const searchTerms = [
-        addSuffixIfPrefix(nameChanges.from, isPrefix),
-        addSuffixIfPrefix(nameChanges.fromReference, isPrefix),
-        // fromFieldName is only available when rename type is FIELD
-        nameChanges.fromFieldName
-            ? addSuffixIfPrefix(nameChanges.fromFieldName, isPrefix)
-            : null,
-    ].filter((s) => s !== null);
+    const searchTerms = isPrefix
+        ? [
+              addSuffixIfPrefix(nameChanges.from, true), // "model_" for fieldId matches
+              nameChanges.from, // "model" for tableName/exploreName matches (e.g. charts that only use joined-table fields)
+          ]
+        : [
+              nameChanges.from,
+              nameChanges.fromReference,
+              // fromFieldName is only available when rename type is FIELD
+              nameChanges.fromFieldName ?? null,
+          ].filter((s) => s !== null);
 
     const containsModelName = buildModelNameChecker(searchTerms);
     if (!containsModelName(chart)) {


### PR DESCRIPTION
## Summary

`renameSavedChart` silently skipped charts whose fields all came from a joined table — the early-exit gate only matched the prefix form `"model_"` (with trailing underscore), so charts containing only `"tableName":"model"` and `"exploreName":"model"` (no `model_*` field IDs) bailed out before any rewriting happened. After `lightdash rename --type model` or the validator UI "Change explore" fix, those charts kept their stale `tableName`/`exploreName`.

Mirror what `renameDashboard` already does at `rename.ts:829-834`: for MODEL renames, include both `"model_"` (for field-id matches) and bare `"model"` (for `tableName`/`exploreName` matches). The inner rename methods are unchanged — they still use anchored / prefix patterns that won't false-match bare substrings.

Fixes [PROD-7548](https://linear.app/lightdash/issue/PROD-7548).

## Test plan

- [x] New regression test in `rename.test.ts` covering a chart whose fields all come from a joined table — fails before the change, passes after.
- [x] All 50 unit tests in `rename.test.ts` pass.
- [x] End-to-end repro against local API: created a chart on `orders` using only `customers_*` (joined) fields, called `POST /projects/{p}/rename/chart/{c}` with `type: model`, confirmed `explore_name` updates from `orders` → `orders_v2`. Control chart with mixed fields still renames correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)