### PR TITLE
fix(ai-agent): persist SQL auto-approve per thread via sessionStorage

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -340,10 +340,6 @@ const AssistantBubbleContent: FC<{
                                                     limit?: number;
                                                 }
                                             }
-                                            autoApprove={
-                                                streamingState?.sqlAutoApprove ??
-                                                false
-                                            }
                                         />
                                     ) : (
                                         <InlineToolCallCard

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/SqlApprovalCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/SqlApprovalCard.tsx
@@ -7,12 +7,10 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
+import { useSessionStorage } from 'react-use';
 import { lightdashApi } from '../../../../../../api';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
-import {
-    enableSqlAutoApprove,
-    markToolCallDecided,
-} from '../../../store/aiAgentThreadStreamSlice';
+import { markToolCallDecided } from '../../../store/aiAgentThreadStreamSlice';
 import { useAiAgentStoreDispatch } from '../../../store/hooks';
 
 type SqlApprovalCardProps = {
@@ -21,7 +19,6 @@ type SqlApprovalCardProps = {
     threadUuid: string;
     toolCallId: string;
     toolArgs: { sql: string; limit?: number };
-    autoApprove: boolean;
 };
 
 type SubmitState = 'idle' | 'approved' | 'rejected' | 'autoApproved';
@@ -32,9 +29,12 @@ export const SqlApprovalCard: FC<SqlApprovalCardProps> = ({
     threadUuid,
     toolCallId,
     toolArgs,
-    autoApprove,
 }) => {
     const dispatch = useAiAgentStoreDispatch();
+    const [autoApprove, setAutoApprove] = useSessionStorage<boolean>(
+        `sql-auto-approve:${threadUuid}`,
+        false,
+    );
     const [submitting, setSubmitting] = useState<SubmitState>('idle');
     const [error, setError] = useState<string | null>(null);
 
@@ -58,17 +58,16 @@ export const SqlApprovalCard: FC<SqlApprovalCardProps> = ({
         [projectUuid, agentUuid, threadUuid, toolCallId, dispatch],
     );
 
+    const autoApprovedFired = useRef(false);
+
     const onApprove = () => submitDecision('approved', 'approved');
     const onReject = () => submitDecision('rejected', 'rejected');
     const onApproveAlways = () => {
-        dispatch(enableSqlAutoApprove({ threadUuid }));
+        autoApprovedFired.current = true;
+        setAutoApprove(true);
         void submitDecision('approved', 'autoApproved');
     };
 
-    // Auto-approve on mount when the user previously opted in for this thread.
-    // Ref guard fires the request exactly once per mount even if submitDecision
-    // re-memoises mid-stream — avoids the eslint-disable on the deps array.
-    const autoApprovedFired = useRef(false);
     useEffect(() => {
         if (autoApprove && !autoApprovedFired.current) {
             autoApprovedFired.current = true;
@@ -76,7 +75,6 @@ export const SqlApprovalCard: FC<SqlApprovalCardProps> = ({
         }
     }, [autoApprove, submitDecision]);
 
-    // When auto-approving, render nothing — the agent's flow continues silently.
     if (autoApprove) {
         return null;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
@@ -30,7 +30,6 @@ export interface AiAgentThreadStreamingState {
     toolCalls: ToolCall[];
     reasoning: Reasoning[];
     decidedToolCallIds: string[];
-    sqlAutoApprove: boolean;
     error?: string;
     improveContextNotification?: {
         toolCallId: string;
@@ -51,7 +50,6 @@ const initialThread: Omit<
     toolCalls: [],
     reasoning: [],
     decidedToolCallIds: [],
-    sqlAutoApprove: false,
 };
 
 export const aiAgentThreadStreamSlice = createSlice({
@@ -115,16 +113,6 @@ export const aiAgentThreadStreamSlice = createSlice({
                 !streamingThread.decidedToolCallIds.includes(toolCallId)
             ) {
                 streamingThread.decidedToolCallIds.push(toolCallId);
-            }
-        },
-        enableSqlAutoApprove: (
-            state,
-            action: PayloadAction<{ threadUuid: string }>,
-        ) => {
-            const { threadUuid } = action.payload;
-            const streamingThread = state[threadUuid];
-            if (streamingThread) {
-                streamingThread.sqlAutoApprove = true;
             }
         },
         stopStreaming: (
@@ -251,7 +239,6 @@ export const {
     setMessage,
     setParts,
     markToolCallDecided,
-    enableSqlAutoApprove,
     stopStreaming,
     setError,
     addToolCall,


### PR DESCRIPTION
### Description

The "Approve & don't ask again this thread" button on the SQL approval card only persisted the decision inside the streaming Redux slice. That slice is reset on every new prompt — so the user opted in once, then was asked again on the very next SQL tool call. Reload the page and same thing.

This moves the flag to `sessionStorage`, keyed by `threadUuid`, via `react-use`'s `useSessionStorage` hook:

- Survives reloads and new prompts in the same tab.
- Clears when the tab closes — matches the "ephemeral" intent without a backend migration.
- Per-device only. Acceptable: the actual SQL approval is still recorded server-side per `toolCallId`, this flag is only a UX shortcut for "skip the manual click".

### Why not the original Slack-only fix?

The first version of this PR just renamed the Slack button to "...this session" so the misleading label matched the in-memory behaviour. That left the underlying problem in place on the web (which has the same bug, in a different form). This rewrites the PR to fix the web side properly. Slack auto-approve still uses the in-memory `Set` for now — separate problem, separate PR.

### Backend security guards

Unchanged. Tampering with `sessionStorage` only auto-fires an approve click on a card the same authenticated user could click manually anyway. No privilege escalation:

- Endpoint requires authenticated session and runs the same project / agent / thread access checks.
- Each decision is recorded in `ai_sql_approval` per `toolCallId`.

### Changes

- Replace the per-stream Redux `sqlAutoApprove` flag with `useSessionStorage<boolean>` keyed by `sql-auto-approve:{threadUuid}` inside `SqlApprovalCard`.
- Drop the `sqlAutoApprove` field, `enableSqlAutoApprove` reducer/export from `aiAgentThreadStreamSlice`.
- Drop the `autoApprove` prop pass-through from `AgentChatAssistantBubble`.
- Revert the original Slack button-text change.

### Regression analysis

- Affected: web users who clicked "Approve & don't ask again this thread" and were then re-prompted on the next SQL call. They now stay auto-approved for the rest of that tab session.
- Not affected: Slack approval flow (still in-memory `Set`), reject flow (unchanged), one-off approve flow (unchanged), backend persisted-decision path in `ai_sql_approval` (unchanged).

### Test plan

- [ ] Approve a SQL tool call with "don't ask again this thread" — next SQL call in the same thread runs without prompting.
- [ ] Send a new prompt in the same thread — still no SQL prompt.
- [ ] Reload the tab — still no SQL prompt.
- [ ] Close and reopen the tab — SQL prompt re-appears (sessionStorage cleared).
- [ ] Open the same thread in a different browser — SQL prompt appears (sessionStorage is per-device).