### PR TITLE
feat(prod-7523): show dbt model metadata in the Explore UI

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6034,6 +6034,9 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                sqlPath: { dataType: 'string' },
+                ymlPath: { dataType: 'string' },
+                dbtPackageName: { dataType: 'string' },
                 warnings: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'InlineError' },
@@ -9577,11 +9580,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10059,11 +10062,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10078,11 +10081,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10097,11 +10100,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10116,11 +10119,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10135,11 +10138,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -19444,6 +19447,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                unfurlsEnabled: { dataType: 'boolean' },
                 aiMultiAgentProjectUuids: {
                     dataType: 'union',
                     subSchemas: [
@@ -19487,6 +19491,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                unfurlsEnabled: { dataType: 'boolean' },
                 aiMultiAgentProjectUuids: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7081,6 +7081,15 @@
             },
             "TableBase": {
                 "properties": {
+                    "sqlPath": {
+                        "type": "string"
+                    },
+                    "ymlPath": {
+                        "type": "string"
+                    },
+                    "dbtPackageName": {
+                        "type": "string"
+                    },
                     "warnings": {
                         "items": {
                             "$ref": "#/components/schemas/InlineError"
@@ -11023,6 +11032,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -20564,6 +20586,9 @@
             },
             "SlackAppCustomSettings": {
                 "properties": {
+                    "unfurlsEnabled": {
+                        "type": "boolean"
+                    },
                     "aiMultiAgentProjectUuids": {
                         "items": {
                             "type": "string"
@@ -20600,6 +20625,9 @@
             },
             "SlackSettings": {
                 "properties": {
+                    "unfurlsEnabled": {
+                        "type": "boolean"
+                    },
                     "aiMultiAgentProjectUuids": {
                         "items": {
                             "type": "string"
@@ -32517,7 +32545,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2929.0",
+        "version": "0.2931.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -968,6 +968,62 @@ describe('convert tables from dbt models', () => {
     });
 });
 
+describe('dbt source paths', () => {
+    it('omits dbtPackageName, ymlPath, and sqlPath when the model has no source paths', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.BIGQUERY,
+            MODEL_WITH_NO_METRICS,
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.dbtPackageName).toBeUndefined();
+        expect(result.ymlPath).toBeUndefined();
+        expect(result.sqlPath).toBeUndefined();
+    });
+
+    it('populates dbtPackageName, ymlPath, and sqlPath from manifest fields', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.BIGQUERY,
+            {
+                ...MODEL_WITH_NO_METRICS,
+                package_name: 'jaffle_shop',
+                patch_path: 'jaffle_shop://models/orders.yml',
+                path: 'orders.sql',
+            },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.dbtPackageName).toBe('jaffle_shop');
+        expect(result.ymlPath).toBe('models/orders.yml');
+        expect(result.sqlPath).toBe('orders.sql');
+    });
+
+    it('populates each source field independently when others are missing', () => {
+        const ymlOnly = convertTable(
+            SupportedDbtAdapter.BIGQUERY,
+            {
+                ...MODEL_WITH_NO_METRICS,
+                patch_path: 'pkg://schema.yml',
+            },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(ymlOnly.ymlPath).toBe('schema.yml');
+        expect(ymlOnly.dbtPackageName).toBeUndefined();
+        expect(ymlOnly.sqlPath).toBeUndefined();
+
+        const sqlOnly = convertTable(
+            SupportedDbtAdapter.BIGQUERY,
+            { ...MODEL_WITH_NO_METRICS, path: 'foo.sql' },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(sqlOnly.sqlPath).toBe('foo.sql');
+        expect(sqlOnly.ymlPath).toBeUndefined();
+        expect(sqlOnly.dbtPackageName).toBeUndefined();
+    });
+});
+
 describe('spotlight config', () => {
     it('should convert dbt model with metrics when no categories are defined', () => {
         expect(

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1031,6 +1031,11 @@ export const convertTable = (
         ...(meta.parameters ? { parameters: meta.parameters } : {}),
         ...(meta.sets ? { sets: meta.sets } : {}),
         ...(tableWarnings.length > 0 ? { warnings: tableWarnings } : {}),
+        ...(model.package_name ? { dbtPackageName: model.package_name } : {}),
+        ...(model.patch_path
+            ? { ymlPath: patchPathParts(model.patch_path).path }
+            : {}),
+        ...(model.path ? { sqlPath: model.path } : {}),
     };
 };
 

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -41,4 +41,7 @@ export type TableBase = {
     defaultShowUnderlyingValues?: string[];
     aiHint?: string | string[];
     warnings?: InlineError[];
+    dbtPackageName?: string;
+    ymlPath?: string;
+    sqlPath?: string;
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.module.css
@@ -1,0 +1,16 @@
+/* Override @uiw/react-markdown-preview defaults so tables fit their
+ * container and long cell content wraps. Compound element+class
+ * selectors beat the library's `.wmde-markdown table` (0,1,1) and
+ * `.wmde-markdown table td` (0,1,2) specificity. */
+table.markdownTable {
+    display: table;
+    width: 100%;
+    table-layout: fixed;
+}
+
+table.markdownTable th.markdownCell,
+table.markdownTable td.markdownCell {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -30,6 +30,7 @@ import {
 import { rehypeRemoveHeaderLinks } from '../../../../utils/markdownUtils';
 import { filterOperatorLabel } from '../../../common/Filters/FilterInputs/constants';
 import MantineIcon from '../../../common/MantineIcon';
+import classes from './ItemDetailPreview.module.css';
 
 /**
  * Renders markdown for an item's description, with additional constraints
@@ -45,6 +46,15 @@ export const ItemDetailMarkdown: FC<{ source: string }> = ({ source }) => {
                 h1: ({ children }) => <Title order={2}>{children}</Title>,
                 h2: ({ children }) => <Title order={3}>{children}</Title>,
                 h3: ({ children }) => <Title order={4}>{children}</Title>,
+                table: ({ children }) => (
+                    <table className={classes.markdownTable}>{children}</table>
+                ),
+                th: ({ children }) => (
+                    <th className={classes.markdownCell}>{children}</th>
+                ),
+                td: ({ children }) => (
+                    <td className={classes.markdownCell}>{children}</td>
+                ),
             }}
             rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }]]}
             rehypeRewrite={rehypeRemoveHeaderLinks}
@@ -261,6 +271,7 @@ export const TableItemDetailPreview = ({
     description,
     /** Position offset for the preview popover */
     offset = 20,
+    tableMetadata,
     children,
 }: PropsWithChildren<{
     showPreview: boolean;
@@ -268,6 +279,12 @@ export const TableItemDetailPreview = ({
     description?: string;
     label: string;
     offset?: number;
+    tableMetadata?: {
+        name: string;
+        dbtPackageName?: string;
+        ymlPath?: string;
+        sqlPath?: string;
+    };
 }>) => {
     const dispatch = useExplorerDispatch();
 
@@ -278,6 +295,7 @@ export const TableItemDetailPreview = ({
                 itemType: 'table',
                 label,
                 description,
+                tableMetadata,
             }),
         );
     };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailProvider.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailProvider.tsx
@@ -1,5 +1,16 @@
-import { Group, Modal, Text } from '@mantine-8/core';
-import { IconTable } from '@tabler/icons-react';
+import {
+    ActionIcon,
+    CopyButton,
+    Group,
+    Input,
+    Paper,
+    SimpleGrid,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconCheck, IconCopy, IconTable } from '@tabler/icons-react';
 import { useCallback, type FC, type PropsWithChildren } from 'react';
 import {
     explorerActions,
@@ -10,7 +21,42 @@ import {
 import { getFieldColor } from '../../../../utils/fieldColors';
 import FieldIcon from '../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../common/MantineIcon';
+import MantineModal from '../../../common/MantineModal';
 import { ItemDetailMarkdown } from './ItemDetailPreview';
+
+const CopyableInput: FC<{ label: string; value: string }> = ({
+    label,
+    value,
+}) => (
+    <TextInput
+        label={label}
+        value={value}
+        readOnly
+        size="xs"
+        onFocus={(e) => e.currentTarget.select()}
+        rightSection={
+            <CopyButton value={value} timeout={1500}>
+                {({ copied, copy }) => (
+                    <Tooltip
+                        label={copied ? 'Copied' : 'Copy'}
+                        withArrow
+                        position="left"
+                    >
+                        <ActionIcon
+                            variant="subtle"
+                            size="xs"
+                            color={copied ? 'teal' : 'gray'}
+                            onClick={copy}
+                            aria-label={`Copy ${label}`}
+                        >
+                            <MantineIcon icon={copied ? IconCheck : IconCopy} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+            </CopyButton>
+        }
+    />
+);
 
 /**
  * Provider for a shared modal to display details about tree items
@@ -63,24 +109,85 @@ export const ItemDetailProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
     }, [itemDetail.itemType, itemDetail.label, itemDetail.fieldItem]);
 
     const renderDetail = useCallback(() => {
+        const metadata = itemDetail.tableMetadata;
+        if (itemDetail.itemType === 'table' && metadata) {
+            return (
+                <Stack gap="xs">
+                    <SimpleGrid cols={2} spacing="xs">
+                        <CopyableInput
+                            label="Model name"
+                            value={metadata.name}
+                        />
+                        {metadata.dbtPackageName && (
+                            <CopyableInput
+                                label="dbt package"
+                                value={metadata.dbtPackageName}
+                            />
+                        )}
+                    </SimpleGrid>
+                    {(metadata.ymlPath || metadata.sqlPath) && (
+                        <SimpleGrid cols={2} spacing="xs">
+                            {metadata.ymlPath && (
+                                <CopyableInput
+                                    label="YAML file"
+                                    value={metadata.ymlPath}
+                                />
+                            )}
+                            {metadata.sqlPath && (
+                                <CopyableInput
+                                    label="SQL file"
+                                    value={metadata.sqlPath}
+                                />
+                            )}
+                        </SimpleGrid>
+                    )}
+                    {itemDetail.description && (
+                        <Input.Wrapper
+                            label="Description"
+                            size="xs"
+                            w="100%"
+                            miw={0}
+                        >
+                            <Paper
+                                p="md"
+                                radius="md"
+                                bg="white"
+                                bd="1px solid ldGray.2"
+                                w="100%"
+                                miw={0}
+                            >
+                                <ItemDetailMarkdown
+                                    source={itemDetail.description}
+                                />
+                            </Paper>
+                        </Input.Wrapper>
+                    )}
+                </Stack>
+            );
+        }
         if (itemDetail.description) {
             return <ItemDetailMarkdown source={itemDetail.description} />;
         }
         return <Text c="gray">No description available.</Text>;
-    }, [itemDetail.description]);
+    }, [itemDetail.description, itemDetail.itemType, itemDetail.tableMetadata]);
 
     return (
         <>
             {itemDetail.isOpen && (
-                <Modal
-                    p="xl"
-                    size="lg"
+                <MantineModal
                     opened={itemDetail.isOpen}
                     onClose={close}
                     title={renderHeader()}
+                    size={
+                        itemDetail.itemType === 'table' &&
+                        itemDetail.tableMetadata
+                            ? 'xl'
+                            : 'lg'
+                    }
+                    cancelLabel={false}
                 >
                     {renderDetail()}
-                </Modal>
+                </MantineModal>
             )}
 
             {children}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
@@ -1,7 +1,12 @@
+import { ActionIcon, Group, Tooltip } from '@mantine-8/core';
 import { NavLink, Text, useMantineTheme } from '@mantine/core';
-import { IconTable } from '@tabler/icons-react';
+import { IconInfoCircle, IconTable } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useToggle } from 'react-use';
+import {
+    explorerActions,
+    useExplorerDispatch,
+} from '../../../../../features/explorer/store';
 import MantineIcon from '../../../../common/MantineIcon';
 import { TableItemDetailPreview } from '../ItemDetailPreview';
 import type { TableHeaderItem } from './types';
@@ -19,8 +24,22 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
     onToggle,
 }) => {
     const theme = useMantineTheme();
+    const dispatch = useExplorerDispatch();
     const { table, isExpanded } = item.data;
     const [isHover, toggleHover] = useToggle(false);
+    const showMetadataIcon = Boolean(
+        table.dbtPackageName || table.ymlPath || table.sqlPath,
+    );
+
+    const tableMetadata = useMemo(
+        () => ({
+            name: table.name,
+            dbtPackageName: table.dbtPackageName,
+            ymlPath: table.ymlPath,
+            sqlPath: table.sqlPath,
+        }),
+        [table.name, table.dbtPackageName, table.ymlPath, table.sqlPath],
+    );
 
     const handleMouseEnter = useCallback(
         () => toggleHover(true),
@@ -30,10 +49,18 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
         () => toggleHover(false),
         [toggleHover],
     );
-    const handleClosePreview = useCallback(
-        () => toggleHover(false),
-        [toggleHover],
-    );
+
+    const openMetadataModal = useCallback(() => {
+        toggleHover(false);
+        dispatch(
+            explorerActions.openItemDetail({
+                itemType: 'table',
+                label: table.label,
+                description: table.description,
+                tableMetadata,
+            }),
+        );
+    }, [toggleHover, dispatch, table.label, table.description, tableMetadata]);
 
     const stickyStyle = useMemo(
         () => ({
@@ -53,11 +80,30 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({
             label={table.label}
             description={table.description}
             showPreview={isHover}
-            closePreview={handleClosePreview}
+            closePreview={handleMouseLeave}
+            tableMetadata={tableMetadata}
         >
-            <Text truncate fw={600}>
-                {table.label}
-            </Text>
+            <Group gap="xs" wrap="nowrap">
+                <Text truncate fw={600}>
+                    {table.label}
+                </Text>
+                {showMetadataIcon && (
+                    <Tooltip label="View dbt model details" withinPortal>
+                        <ActionIcon
+                            variant="subtle"
+                            size="sm"
+                            color="gray"
+                            aria-label="View dbt model details"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                openMetadataModal();
+                            }}
+                        >
+                            <MantineIcon icon={IconInfoCircle} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+            </Group>
         </TableItemDetailPreview>
     );
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -181,7 +181,7 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
     const virtualizedTreeData = useMemo(() => {
         return flattenTreeForVirtualization({
             tables: tableTrees,
-            showMultipleTables: Object.keys(explore.tables).length > 1,
+            showMultipleTables: true,
             expandedTables,
             expandedGroups,
             searchQuery: debouncedSearch,
@@ -203,7 +203,6 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
         debouncedSearch,
         expandedGroups,
         expandedTables,
-        explore.tables,
         isSearching,
         missingCustomDimensions,
         missingCustomMetrics,

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -61,7 +61,7 @@ const getVariantDescription = (
 export type MantineModalProps = {
     opened: boolean;
     onClose: () => void;
-    title: string;
+    title: React.ReactNode;
     /**
      * Modal variant for common action patterns.
      * - `delete`: Adds IconTrash, red action buttons, and auto-generates description

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -424,6 +424,12 @@ const explorerSlice = createSlice({
                 label: string;
                 description?: string;
                 fieldItem?: Item | AdditionalMetric;
+                tableMetadata?: {
+                    name: string;
+                    dbtPackageName?: string;
+                    ymlPath?: string;
+                    sqlPath?: string;
+                };
             }>,
         ) => {
             state.modals.itemDetail = {
@@ -432,6 +438,7 @@ const explorerSlice = createSlice({
                 label: action.payload.label,
                 description: action.payload.description,
                 fieldItem: action.payload.fieldItem,
+                tableMetadata: action.payload.tableMetadata,
             };
         },
         closeItemDetail: (state) => {
@@ -441,6 +448,7 @@ const explorerSlice = createSlice({
                 label: undefined,
                 description: undefined,
                 fieldItem: undefined,
+                tableMetadata: undefined,
             };
         },
 

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -300,6 +300,12 @@ export interface ExplorerReduceState {
             label?: string;
             description?: string;
             fieldItem?: Item | AdditionalMetric;
+            tableMetadata?: {
+                name: string;
+                dbtPackageName?: string;
+                ymlPath?: string;
+                sqlPath?: string;
+            };
         };
         periodOverPeriodComparison: {
             isOpen: boolean;


### PR DESCRIPTION
Closes: #22902
Closes: PROD-7523

### Description:

Surfaces dbt manifest info on each table in an Explore. A new info icon next to the table name (base table + each joined table) opens a shared modal showing the model name, dbt package, YAML schema path, SQL path, and description — all read directly from the existing compile-time manifest.

The same modal is reached from the description hover popover's "Read full description" link, so the metadata view is consistent across entry points. Backend changes add `dbtPackageName`, `ymlPath`, and `sqlPath` to `TableBase` and populate them in `convertTable()` from `model.package_name`, `patch_path`, and `model.path`; OpenAPI spec is regenerated. Frontend additions extend the `itemDetail` Redux modal with `tableMetadata`, render copyable read-only inputs + a description card inside `ItemDetailProvider`, switch it to `MantineModal` per the style guide, and force `VirtualTableHeader` to render for single-table explores so the icon is reachable there too.

### Demo

<img width="2826" height="1608" alt="CleanShot 2026-05-13 at 17 07 15@2x" src="https://github.com/user-attachments/assets/58479d56-1673-47b7-b463-c2d92cb6f3fe" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)