### PR TITLE
fix(table): align rich text cell to full cell width

### DIFF
--- a/packages/frontend/src/components/common/Table/RichTextCell.module.css
+++ b/packages/frontend/src/components/common/Table/RichTextCell.module.css
@@ -1,5 +1,5 @@
 .richTextCell {
-    display: inline-block;
+    display: block;
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Closes: PROD-7513

## Summary

In results tables, rich-text cells using template-level `text-align: right` (or `center`) appeared left-aligned. The alignment style applied, but only against a shrink-wrapped box the width of the rendered text — visually the content stayed flush left inside the `<td>`.

## Root cause

`RichTextCell` wraps `MarkdownPreview` in a `<div className={styles.richTextCell}>`. That wrapper used `display: inline-block`, which sizes the box to its content rather than the parent `<td>`. Any `text-align` set inside the rich-text template aligned text within that narrow box, not within the cell.

```css
.richTextCell {
    display: inline-block; /* shrink-wraps to content width */
    max-width: 100%;
    ...
}
```

```
Before (inline-block)              After (block)
+-------------------------+        +-------------------------+
| <td>                    |        | <td>                    |
|  +------+               |        |  +-------------------+  |
|  | text |   <- aligns   |        |  |              text |  |
|  +------+      here     |        |  +-------------------+  |
+-------------------------+        +-------------------------+
       ^ wrapper hugs text                 ^ wrapper fills td,
         so text-align: right                text-align: right
         is a no-op visually                 reaches the edge
```

## Fix

Switch the wrapper to `display: block` so it fills the cell. Template-level `text-align` now resolves against the full `<td>` width.

- `packages/frontend/src/components/common/Table/RichTextCell.module.css` — `display: inline-block` -> `display: block`.

## Test plan

- [ ] Manual: render a results table with a rich-text cell using a template containing `<div style="text-align: right">...</div>` and confirm the content sits flush right inside the cell.
- [ ] Manual: repeat with `text-align: center` and default (left) alignment to confirm no regression.
- [ ] Manual: verify overflow + ellipsis behaviour on long single-line content is unchanged.