### PR TITLE
feat: add `--project` flag to `deploy` command to override default project

### DIFF
--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -44,6 +44,7 @@ type DeployHandlerOptions = DbtCompileOptions & {
     profilesDir: string;
     target: string | undefined;
     profile: string | undefined;
+    project?: string;
     create?: boolean | string;
     verbose: boolean;
     ignoreErrors: boolean;
@@ -618,7 +619,7 @@ export const deployHandler = async (originalOptions: DeployHandlerOptions) => {
                 `No active Lightdash project. Run 'lightdash login --help'`,
             );
         }
-        const projectSelection = await selectProject(config);
+        const projectSelection = await selectProject(config, options.project);
         if (!projectSelection) {
             throw new AuthorizationError(
                 `No active Lightdash project. Run 'lightdash login --help'`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -805,6 +805,10 @@ program
     .command('deploy')
     .description('Compiles and deploys a Lightdash project')
     .option(
+        '--project <project uuid>',
+        'Project UUID to deploy to. Overrides the default project configured via `lightdash config set-project`',
+    )
+    .option(
         '--project-dir <path>',
         'The directory of the dbt project',
         defaultProjectDir,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-3703/i-want-to-be-able-to-set-a-project-flag-in-the-lightdash-deploy

eg:

> lightdash deploy  --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ~/.dbt --profile jaffle_shop -y --project 3675b69e-8324-4110-bdca-059031aa8da3

Project setting priority:

> CLI arg > ENV > config

### Description:
Adds a `--project <project uuid>` option to the `deploy` command, allowing users to specify a target project UUID directly via the CLI. This overrides the default project configured via `lightdash config set-project`, making it easier to deploy to a specific project without changing the global configuration.