### PR TITLE
feat(backend): per-metric anchor CTE in PivotQueryBuilder

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -28,7 +28,15 @@ const mockWarehouseSqlBuilder = {
     getStartOfWeek: () => WeekDay.MONDAY,
     getNullSafeEqualSql: defaultNullSafeEqualSql,
     getStringQuoteChar: () => "'",
-    escapeString: (v: string) => v.replaceAll("'", "''"),
+    // Mirrors WarehouseBaseSqlBuilder.escapeString: double quotes, strip SQL
+    // comments, escape backslashes, drop null bytes.
+    escapeString: (v: string) =>
+        v
+            .replaceAll("'", "''")
+            .replace(/--.*$/gm, '')
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replaceAll('\\', '\\\\')
+            .replaceAll('\0', ''),
 } as unknown as WarehouseSqlBuilder;
 
 const replaceWhitespace = (str: string) => str.replace(/\s+/g, ' ').trim();
@@ -787,8 +795,8 @@ describe('PivotQueryBuilder', () => {
             );
             const result = builder.toSql();
 
-            // Single quote doubled → injection payload becomes a string literal.
-            expect(result).toContain("'completed''); DROP TABLE x;--'");
+            // Quote doubled and trailing -- comment stripped: payload is now an inert string literal.
+            expect(result).toContain("'completed''); DROP TABLE x;'");
             expect(result).not.toContain("'completed'); DROP TABLE x;--");
         });
 
@@ -839,6 +847,46 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('cr."status" = \'shipped\'');
             expect(result).toContain('CROSS JOIN "revenue_anchor_column" ac');
             expect(result).toContain('CROSS JOIN "orders_anchor_column" ac');
+        });
+
+        test('Pinned sort: partial pin (covers only some groupBy columns) falls back to col_idx = 1', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'status' },
+                    { reference: 'channel' },
+                ],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        pivotValues: [
+                            { reference: 'status', value: 'completed' },
+                        ],
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // Pin doesn't cover 'channel', so the WHERE falls back rather than
+            // matching only on 'status' (which could pick multiple anchor rows).
+            expect(result).toContain('"revenue_anchor_column" AS (');
+            expect(replaceWhitespace(result)).toContain(
+                'FROM column_ranking cr WHERE "col_idx" = 1',
+            );
+            expect(result).not.toContain('cr."status" = \'completed\'');
         });
 
         test('Pinned sort: pivotValues with unknown groupBy reference falls back to col_idx = 1', () => {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -27,6 +27,8 @@ const mockWarehouseSqlBuilder = {
     getAdapterType: () => SupportedDbtAdapter.POSTGRES,
     getStartOfWeek: () => WeekDay.MONDAY,
     getNullSafeEqualSql: defaultNullSafeEqualSql,
+    getStringQuoteChar: () => "'",
+    escapeString: (v: string) => v.replaceAll("'", "''"),
 } as unknown as WarehouseSqlBuilder;
 
 const replaceWhitespace = (str: string) => str.replace(/\s+/g, ' ').trim();
@@ -675,6 +677,241 @@ describe('PivotQueryBuilder', () => {
             // Downstream CTEs should reference pivot_query directly
             expect(result).toContain('FROM pivot_query WHERE "row_index"');
             expect(result).toContain('FROM pivot_query p CROSS JOIN');
+        });
+
+        test('Pinned sort: pivotValues swaps WHERE col_idx = 1 for a null-safe value match on the pinned column', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'status' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        pivotValues: [
+                            { reference: 'status', value: 'completed' },
+                        ],
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            expect(result).toContain('"revenue_anchor_column" AS (');
+            expect(result).not.toContain('anchor_column AS (');
+            expect(replaceWhitespace(result)).toContain(
+                '(cr."status" = \'completed\' OR (cr."status" IS NULL AND \'completed\' IS NULL))',
+            );
+            expect(result).toContain('CROSS JOIN "revenue_anchor_column" ac');
+        });
+
+        test('Pinned sort: numeric and null pivot values are literal-encoded correctly', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [
+                    { reference: 'segment_id' },
+                    { reference: 'channel' },
+                ],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        pivotValues: [
+                            { reference: 'segment_id', value: 42 },
+                            { reference: 'channel', value: null },
+                        ],
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // Numbers bare, null as keyword.
+            expect(replaceWhitespace(result)).toContain(
+                '(cr."segment_id" = 42 OR (cr."segment_id" IS NULL AND 42 IS NULL))',
+            );
+            expect(replaceWhitespace(result)).toContain(
+                '(cr."channel" = NULL OR (cr."channel" IS NULL AND NULL IS NULL))',
+            );
+        });
+
+        test('Pinned sort: string values with single quotes are escaped (no SQL injection via pivotValues)', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'status' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        pivotValues: [
+                            {
+                                reference: 'status',
+                                value: "completed'); DROP TABLE x;--",
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // Single quote doubled → injection payload becomes a string literal.
+            expect(result).toContain("'completed''); DROP TABLE x;--'");
+            expect(result).not.toContain("'completed'); DROP TABLE x;--");
+        });
+
+        test('Pinned sort: multiple metrics each get their own per-metric anchor_column', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                    {
+                        reference: 'orders',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupByColumns: [{ reference: 'status' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        pivotValues: [
+                            { reference: 'status', value: 'completed' },
+                        ],
+                    },
+                    {
+                        reference: 'orders',
+                        direction: SortByDirection.ASC,
+                        pivotValues: [
+                            { reference: 'status', value: 'shipped' },
+                        ],
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            expect(result).toContain('"revenue_anchor_column" AS (');
+            expect(result).toContain('"orders_anchor_column" AS (');
+            expect(result).not.toContain('anchor_column AS (');
+
+            expect(result).toContain('cr."status" = \'completed\'');
+            expect(result).toContain('cr."status" = \'shipped\'');
+            expect(result).toContain('CROSS JOIN "revenue_anchor_column" ac');
+            expect(result).toContain('CROSS JOIN "orders_anchor_column" ac');
+        });
+
+        test('Pinned sort: pivotValues with unknown groupBy reference falls back to col_idx = 1', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'status' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        pivotValues: [
+                            {
+                                reference: 'not_a_groupby_column',
+                                value: 'whatever',
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // Per-metric anchor CTE still created, but with leftmost-column WHERE
+            // since the pinned reference isn't a valid groupBy.
+            expect(result).toContain('"revenue_anchor_column" AS (');
+            expect(replaceWhitespace(result)).toContain(
+                'FROM column_ranking cr WHERE "col_idx" = 1',
+            );
+            expect(result).not.toContain('cr."not_a_groupby_column"');
+        });
+
+        test('Unpinned metric sort: still uses shared anchor_column CTE (backwards compatible)', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'status' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            expect(result).toContain('anchor_column AS (');
+            expect(result).not.toContain('"revenue_anchor_column" AS (');
+            expect(replaceWhitespace(result)).toContain(
+                'FROM column_ranking cr WHERE "col_idx" = 1',
+            );
+            expect(result).toContain('CROSS JOIN anchor_column ac');
         });
     });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -687,7 +687,7 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('FROM pivot_query p CROSS JOIN');
         });
 
-        test('Pinned sort: pivotValues swaps WHERE col_idx = 1 for a null-safe value match on the pinned column', () => {
+        test('Pinned sort: pivotValues swaps WHERE col_idx = 1 for a value match on the pinned column', () => {
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -718,12 +718,12 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('"revenue_anchor_column" AS (');
             expect(result).not.toContain('anchor_column AS (');
             expect(replaceWhitespace(result)).toContain(
-                '(cr."status" = \'completed\' OR (cr."status" IS NULL AND \'completed\' IS NULL))',
+                '(cr."status") IN (\'completed\')',
             );
             expect(result).toContain('CROSS JOIN "revenue_anchor_column" ac');
         });
 
-        test('Pinned sort: numeric and null pivot values are literal-encoded correctly', () => {
+        test('Pinned sort: numeric and null pivot values emit type-correct SQL', () => {
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -755,12 +755,149 @@ describe('PivotQueryBuilder', () => {
             );
             const result = builder.toSql();
 
-            // Numbers bare, null as keyword.
+            // Number → NUMBER filter (bare numeric literal, IN syntax).
             expect(replaceWhitespace(result)).toContain(
-                '(cr."segment_id" = 42 OR (cr."segment_id" IS NULL AND 42 IS NULL))',
+                '(cr."segment_id") IN (42)',
             );
+            // Null → IS NULL (strict equality with NULL never matches).
             expect(replaceWhitespace(result)).toContain(
-                '(cr."channel" = NULL OR (cr."channel" IS NULL AND NULL IS NULL))',
+                '(cr."channel") IS NULL',
+            );
+        });
+
+        test('Pinned sort: boolean pivot value emits native TRUE/FALSE (not a string literal)', () => {
+            const booleanDim = {
+                name: 'is_completed',
+                table: 'orders',
+                tableLabel: 'Orders',
+                label: 'Is completed',
+                fieldType: FieldType.DIMENSION,
+                type: DimensionType.BOOLEAN,
+                sql: '${TABLE}.is_completed',
+                hidden: false,
+            } as unknown as CompiledDimension;
+
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'is_completed' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        pivotValues: [
+                            { reference: 'is_completed', value: false },
+                        ],
+                    },
+                ],
+            };
+            const itemsMap: ItemsMap = { is_completed: booleanDim };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+                undefined,
+                itemsMap,
+            );
+            const result = builder.toSql();
+
+            // Native boolean literal — no quotes around `false`, which is what
+            // BigQuery / Snowflake require (string='false' is a type error there).
+            expect(replaceWhitespace(result)).toContain(
+                '(cr."is_completed") = false',
+            );
+            expect(result).not.toContain('(cr."is_completed") = \'false\'');
+        });
+
+        test('Pinned sort: boolean inferred from JS type when dimension is unknown (fallback)', () => {
+            // No itemsMap → falls back to inferDimensionTypeFromValue, which
+            // recognizes typeof === 'boolean' and emits native TRUE/FALSE.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'is_completed' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        pivotValues: [
+                            { reference: 'is_completed', value: true },
+                        ],
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            expect(replaceWhitespace(result)).toContain(
+                '(cr."is_completed") = true',
+            );
+        });
+
+        test('Pinned sort: DATE pivot value emits date filter SQL when itemsMap exposes the type', () => {
+            const dateDim = {
+                name: 'order_date',
+                table: 'orders',
+                tableLabel: 'Orders',
+                label: 'Order date',
+                fieldType: FieldType.DIMENSION,
+                type: DimensionType.DATE,
+                sql: '${TABLE}.order_date',
+                hidden: false,
+            } as unknown as CompiledDimension;
+
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'order_date' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                        pivotValues: [
+                            { reference: 'order_date', value: '2024-01-01' },
+                        ],
+                    },
+                ],
+            };
+            const itemsMap: ItemsMap = { order_date: dateDim };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+                undefined,
+                itemsMap,
+            );
+            const result = builder.toSql();
+
+            // Date filter emits parenthesized literal — typed by the warehouse
+            // dialect, not a bare string comparison. Exact format depends on
+            // adapter, but the date value should appear and the column-side
+            // expression should not be wrapped in a cast in the default path.
+            expect(replaceWhitespace(result)).toContain(
+                '(cr."order_date") = (\'2024-01-01\')',
             );
         });
 
@@ -843,8 +980,8 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('"orders_anchor_column" AS (');
             expect(result).not.toContain('anchor_column AS (');
 
-            expect(result).toContain('cr."status" = \'completed\'');
-            expect(result).toContain('cr."status" = \'shipped\'');
+            expect(result).toContain('(cr."status") IN (\'completed\')');
+            expect(result).toContain('(cr."status") IN (\'shipped\')');
             expect(result).toContain('CROSS JOIN "revenue_anchor_column" ac');
             expect(result).toContain('CROSS JOIN "orders_anchor_column" ac');
         });

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -1,4 +1,5 @@
 import {
+    convertItemTypeToDimensionType,
     DimensionType,
     FilterOperator,
     getAggregatedField,
@@ -773,8 +774,8 @@ export class PivotQueryBuilder {
         }
 
         const item = this.itemsMap[reference];
-        const fieldType = isDimension(item)
-            ? item.type
+        const fieldType = item
+            ? convertItemTypeToDimensionType(item)
             : PivotQueryBuilder.inferDimensionTypeFromValue(value);
 
         const filterRule: FilterRule<FilterOperator, unknown> = {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -495,6 +495,8 @@ export class PivotQueryBuilder {
             // Create values order parts
             const valuesOrderByParts = sortBy
                 .filter(isValueColumn)
+                // Pinned sorts reorder rows only; columns keep natural order.
+                .filter((sort) => !sort.pivotValues?.length)
                 .reduce<string[]>((acc, sort) => {
                     const sortDirection =
                         sort.direction === SortByDirection.DESC
@@ -503,14 +505,8 @@ export class PivotQueryBuilder {
                     const nullsClause = PivotQueryBuilder.getNullsFirstLast(
                         sort.nullsFirst,
                     );
-                    // Use column anchor value for value columns
                     const colAnchorCteName = `${sort.reference}_column_anchor`;
-
-                    // todo: current SQL does not work with value sorting and multiple group columns
-                    if (
-                        groupByColumns.length === 1 &&
-                        metricFirstValueQueries[colAnchorCteName]
-                    ) {
+                    if (metricFirstValueQueries[colAnchorCteName]) {
                         acc.push(
                             `${q}${colAnchorCteName}${q}.${q}${colAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
                         );
@@ -755,18 +751,66 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Generates the anchor_column CTE that identifies the groupBy value(s) with column_index = 1.
-     * This is the "first pivot column" - when users sort by a metric, rows are ordered by
-     * their metric value in this column (e.g., the latest month when columns are sorted DESC by date).
-     * Uses ORDER BY + LIMIT 1 for deterministic selection of a single anchor value.
+     * Encodes a JS literal value as a SQL literal for inclusion in a WHERE clause.
+     * Numbers pass through; strings are warehouse-escaped and string-quoted; null
+     * becomes the SQL keyword. Non-finite numbers fall back to NULL.
+     */
+    private encodeLiteralValue(value: string | number | null): string {
+        if (value === null) return 'NULL';
+        if (typeof value === 'number') {
+            return Number.isFinite(value) ? String(value) : 'NULL';
+        }
+        const sq = this.warehouseSqlBuilder.getStringQuoteChar();
+        return `${sq}${this.warehouseSqlBuilder.escapeString(value)}${sq}`;
+    }
+
+    /**
+     * Builds the WHERE clause that selects which row of `column_ranking` becomes
+     * the anchor. When pivotValues is provided and references valid groupBy columns,
+     * the WHERE matches those values null-safely. Otherwise falls back to the
+     * leftmost pivot column (col_idx = 1).
+     */
+    private buildAnchorWhereClause(
+        pivotValues: VizSortBy['pivotValues'] | undefined,
+        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
+    ): string {
+        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
+        if (!pivotValues?.length) {
+            return `${q}col_idx${q} = 1`;
+        }
+        const validRefs = new Set(groupByColumns.map((c) => c.reference));
+        const valid = pivotValues.filter((pv) => validRefs.has(pv.reference));
+        if (valid.length === 0) {
+            // Stale pin — fall back so the anchor is never empty.
+            return `${q}col_idx${q} = 1`;
+        }
+        return valid
+            .map((pv) =>
+                this.warehouseSqlBuilder.getNullSafeEqualSql(
+                    `cr.${q}${pv.reference}${q}`,
+                    this.encodeLiteralValue(pv.value),
+                ),
+            )
+            .join(' AND ');
+    }
+
+    /**
+     * Generates the anchor_column CTE that identifies the groupBy value(s) used as
+     * the row-sort anchor. By default this is the "first pivot column" (col_idx = 1):
+     * when users sort by a metric, rows are ordered by their metric value in this
+     * column (e.g. the latest month when columns are sorted DESC by date). When
+     * `pivotValues` is provided, the WHERE clause pins the anchor to a specific
+     * pivot column instead. Uses ORDER BY + LIMIT 1 for deterministic selection.
      *
      * @param groupByColumns - Group by columns
      * @param sortBy - Sort configuration to determine ORDER BY direction
+     * @param pivotValues - Optional pin identifying which pivot column is the anchor
      * @returns SQL for the anchor_column CTE
      */
     private getAnchorColumnSQL(
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         sortBy: PivotConfiguration['sortBy'],
+        pivotValues?: VizSortBy['pivotValues'],
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
@@ -786,8 +830,13 @@ export class PivotQueryBuilder {
             return `cr.${q}${col.reference}${q} ${direction}`;
         });
 
+        const whereClause = this.buildAnchorWhereClause(
+            pivotValues,
+            groupByColumns,
+        );
+
         // ORDER BY + LIMIT 1 ensures deterministic, scalar result
-        return `SELECT ${selectParts} FROM column_ranking cr WHERE ${q}col_idx${q} = 1 ORDER BY ${orderByParts.join(
+        return `SELECT ${selectParts} FROM column_ranking cr WHERE ${whereClause} ORDER BY ${orderByParts.join(
             ', ',
         )} LIMIT 1`;
     }
@@ -804,6 +853,9 @@ export class PivotQueryBuilder {
      * @param valuesColumns - Value columns configuration
      * @param groupByColumns - Group by columns
      * @param sortBy - Sort configuration
+     * @param perMetricAnchorCte - Optional map of metric reference → anchor_column CTE name.
+     *   When a metric has its own entry, the row anchor CROSS JOINs that CTE instead of
+     *   the shared `anchor_column`. Used when any sort entry has `pivotValues`.
      * @returns Record mapping CTE names to their SQL definitions
      */
     private getRowAnchorCTEs(
@@ -811,6 +863,7 @@ export class PivotQueryBuilder {
         valuesColumns: PivotConfiguration['valuesColumns'],
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         sortBy: PivotConfiguration['sortBy'],
+        perMetricAnchorCte?: Map<string, string>,
     ): Record<string, { cteName: string; sql: string }> {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const result: Record<string, { cteName: string; sql: string }> = {};
@@ -849,10 +902,16 @@ export class PivotQueryBuilder {
             );
 
             const rowAnchorCteName = `${valCol.reference}_row_anchor`;
+            const anchorCteName =
+                perMetricAnchorCte?.get(valCol.reference) ?? 'anchor_column';
+            const anchorCteRef =
+                anchorCteName === 'anchor_column'
+                    ? 'anchor_column'
+                    : `${q}${anchorCteName}${q}`;
 
             // Use CROSS JOIN with anchor_column and conditional aggregation
             // MAX is used because there should be at most one value per (indexCols, anchorCol)
-            const rowAnchorSql = `SELECT ${indexColumnRefs}, MAX(CASE WHEN ${anchorMatchConditions} THEN q.${q}${fieldName}${q} END) AS ${q}${rowAnchorCteName}_value${q} FROM group_by_query q CROSS JOIN anchor_column ac GROUP BY ${indexColumnGroupBy}`;
+            const rowAnchorSql = `SELECT ${indexColumnRefs}, MAX(CASE WHEN ${anchorMatchConditions} THEN q.${q}${fieldName}${q} END) AS ${q}${rowAnchorCteName}_value${q} FROM group_by_query q CROSS JOIN ${anchorCteRef} ac GROUP BY ${indexColumnGroupBy}`;
 
             result[rowAnchorCteName] = {
                 cteName: rowAnchorCteName,
@@ -881,7 +940,7 @@ export class PivotQueryBuilder {
     ): {
         columnAnchorCTEs: string[];
         columnRankingCTE: string | null;
-        anchorColumnCTE: string | null;
+        anchorColumnCTEs: string[];
         rowAnchorCTEs: string[];
         metricFirstValueQueries: Record<
             string,
@@ -910,7 +969,7 @@ export class PivotQueryBuilder {
         const needsRowAnchor = hasMetricSort && indexColumns.length > 0;
 
         let columnRankingCTE: string | null = null;
-        let anchorColumnCTE: string | null = null;
+        let anchorColumnCTEs: string[] = [];
         let rowAnchorCTEs: string[] = [];
         let rowAnchorQueries: Record<string, { cteName: string; sql: string }> =
             {};
@@ -925,19 +984,44 @@ export class PivotQueryBuilder {
             );
             columnRankingCTE = `column_ranking AS (${columnRankingSQL})`;
 
-            // Generate anchor_column CTE
-            const anchorColumnSQL = this.getAnchorColumnSQL(
-                groupByColumns,
-                sortBy,
-            );
-            anchorColumnCTE = `anchor_column AS (${anchorColumnSQL})`;
+            // Any pinned sort upgrades the shared anchor_column to per-metric
+            // anchors so two metrics can pin different columns independently.
+            const hasAnyPin =
+                sortBy?.some((s) => s.pivotValues?.length) ?? false;
 
-            // Generate row anchor CTEs using anchor_column
+            const perMetricAnchorCte = new Map<string, string>();
+
+            if (hasAnyPin && valuesColumns) {
+                valuesColumns.forEach((valCol) => {
+                    const sortConfig = sortBy?.find(
+                        (s) => s.reference === valCol.reference,
+                    );
+                    if (!sortConfig) return;
+                    const anchorCteName = `${valCol.reference}_anchor_column`;
+                    const anchorSQL = this.getAnchorColumnSQL(
+                        groupByColumns,
+                        sortBy,
+                        sortConfig.pivotValues,
+                    );
+                    anchorColumnCTEs.push(
+                        `${q}${anchorCteName}${q} AS (${anchorSQL})`,
+                    );
+                    perMetricAnchorCte.set(valCol.reference, anchorCteName);
+                });
+            } else {
+                const anchorColumnSQL = this.getAnchorColumnSQL(
+                    groupByColumns,
+                    sortBy,
+                );
+                anchorColumnCTEs = [`anchor_column AS (${anchorColumnSQL})`];
+            }
+
             rowAnchorQueries = this.getRowAnchorCTEs(
                 indexColumns,
                 valuesColumns,
                 groupByColumns,
                 sortBy,
+                hasAnyPin ? perMetricAnchorCte : undefined,
             );
             rowAnchorCTEs = Object.values(rowAnchorQueries).map(
                 ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
@@ -953,7 +1037,7 @@ export class PivotQueryBuilder {
         return {
             columnAnchorCTEs,
             columnRankingCTE,
-            anchorColumnCTE,
+            anchorColumnCTEs,
             rowAnchorCTEs,
             metricFirstValueQueries,
         };
@@ -1298,7 +1382,7 @@ export class PivotQueryBuilder {
         const {
             columnAnchorCTEs,
             columnRankingCTE,
-            anchorColumnCTE,
+            anchorColumnCTEs,
             rowAnchorCTEs,
             metricFirstValueQueries,
         } = this.getMetricAnchorCTEs(
@@ -1374,7 +1458,7 @@ export class PivotQueryBuilder {
             `group_by_query AS (${groupByQuery})`,
             ...columnAnchorCTEs,
             ...(columnRankingCTE ? [columnRankingCTE] : []),
-            ...(anchorColumnCTE ? [anchorColumnCTE] : []),
+            ...anchorColumnCTEs,
             ...rowAnchorCTEs,
             ...(rowRankingCTE ? [rowRankingCTE] : []),
             `pivot_query AS (${pivotQuery})`,

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -1,4 +1,6 @@
 import {
+    DimensionType,
+    FilterOperator,
     getAggregatedField,
     getItemId,
     getParsedReference,
@@ -11,14 +13,17 @@ import {
     normalizeIndexColumns,
     ParameterError,
     parseTableCalculationFunctions,
+    renderFilterRuleSql,
     SortByDirection,
     TableCalculationFunctionCompiler,
     TimeFrames,
     VizAggregationOptions,
     VizSortBy,
     WarehouseSqlBuilder,
+    type FilterRule,
     type ItemsMap,
     type PivotConfiguration,
+    type PivotSortAnchor,
     type TableCalculation,
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
@@ -751,17 +756,57 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Encodes a JS literal value as a SQL literal for inclusion in a WHERE clause.
-     * Numbers pass through; strings are warehouse-escaped and string-quoted; null
-     * becomes the SQL keyword. Non-finite numbers fall back to NULL.
+     * Renders a single anchor equality predicate by delegating to the filter
+     * compiler, so boolean/date/timestamp pins emit type-correct SQL on every
+     * warehouse. Null pins short-circuit to `IS NULL` since strict equality
+     * never matches NULL columns.
      */
-    private encodeLiteralValue(value: string | number | null): string {
-        if (value === null) return 'NULL';
-        if (typeof value === 'number') {
-            return Number.isFinite(value) ? String(value) : 'NULL';
+    private renderAnchorEqualitySql(
+        reference: string,
+        value: PivotSortAnchor['value'],
+    ): string {
+        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
+        const colSql = `cr.${q}${reference}${q}`;
+
+        if (value === null) {
+            return `(${colSql}) IS NULL`;
         }
-        const sq = this.warehouseSqlBuilder.getStringQuoteChar();
-        return `${sq}${this.warehouseSqlBuilder.escapeString(value)}${sq}`;
+
+        const item = this.itemsMap[reference];
+        const fieldType = isDimension(item)
+            ? item.type
+            : PivotQueryBuilder.inferDimensionTypeFromValue(value);
+
+        const filterRule: FilterRule<FilterOperator, unknown> = {
+            id: 'pivot-anchor',
+            target: { fieldId: reference },
+            operator: FilterOperator.EQUALS,
+            values: [value],
+        };
+
+        return renderFilterRuleSql(
+            filterRule,
+            fieldType,
+            colSql,
+            this.warehouseSqlBuilder.getStringQuoteChar(),
+            (s) => this.warehouseSqlBuilder.escapeString(s),
+            this.warehouseSqlBuilder.getStartOfWeek(),
+            this.warehouseSqlBuilder.getAdapterType(),
+        );
+    }
+
+    /**
+     * Fallback dimension type used when the pin's `reference` isn't a known
+     * dimension in `itemsMap` (mostly tests). Cannot recover DATE/TIMESTAMP
+     * from a string value here — callers in production paths always pass a
+     * populated itemsMap.
+     */
+    private static inferDimensionTypeFromValue(
+        value: string | number | boolean,
+    ): DimensionType {
+        if (typeof value === 'boolean') return DimensionType.BOOLEAN;
+        if (typeof value === 'number') return DimensionType.NUMBER;
+        return DimensionType.STRING;
     }
 
     /**
@@ -785,9 +830,9 @@ export class PivotQueryBuilder {
 
         return groupByColumns
             .map((c) =>
-                this.warehouseSqlBuilder.getNullSafeEqualSql(
-                    `cr.${q}${c.reference}${q}`,
-                    this.encodeLiteralValue(pinByRef.get(c.reference)!.value),
+                this.renderAnchorEqualitySql(
+                    c.reference,
+                    pinByRef.get(c.reference)!.value,
                 ),
             )
             .join(' AND ');

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -765,30 +765,29 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Builds the WHERE clause that selects which row of `column_ranking` becomes
-     * the anchor. When pivotValues is provided and references valid groupBy columns,
-     * the WHERE matches those values null-safely. Otherwise falls back to the
-     * leftmost pivot column (col_idx = 1).
+     * Builds the WHERE clause that picks the anchor row from `column_ranking`.
+     * Requires a full pin (one value per groupBy column) — partial or stale pins
+     * fall back to the leftmost pivot column so the anchor row stays predictable.
      */
     private buildAnchorWhereClause(
         pivotValues: VizSortBy['pivotValues'] | undefined,
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-        if (!pivotValues?.length) {
-            return `${q}col_idx${q} = 1`;
-        }
-        const validRefs = new Set(groupByColumns.map((c) => c.reference));
-        const valid = pivotValues.filter((pv) => validRefs.has(pv.reference));
-        if (valid.length === 0) {
-            // Stale pin — fall back so the anchor is never empty.
-            return `${q}col_idx${q} = 1`;
-        }
-        return valid
-            .map((pv) =>
+        const fallback = `${q}col_idx${q} = 1`;
+        if (!pivotValues?.length) return fallback;
+
+        const pinByRef = new Map(pivotValues.map((pv) => [pv.reference, pv]));
+        const fullyCovered = groupByColumns.every((c) =>
+            pinByRef.has(c.reference),
+        );
+        if (!fullyCovered) return fallback;
+
+        return groupByColumns
+            .map((c) =>
                 this.warehouseSqlBuilder.getNullSafeEqualSql(
-                    `cr.${q}${pv.reference}${q}`,
-                    this.encodeLiteralValue(pv.value),
+                    `cr.${q}${c.reference}${q}`,
+                    this.encodeLiteralValue(pinByRef.get(c.reference)!.value),
                 ),
             )
             .join(' AND ');
@@ -842,21 +841,13 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Generates row anchor CTEs for value columns that have sorts.
-     * When sorting by a metric, rows are ordered by their metric value in the first pivot column
-     * (anchor column), not by their MIN/MAX across all columns. This matches user expectations
-     * when they click to sort by a metric - they expect ordering by the leftmost visible column.
+     * Generates row anchor CTEs for sorted value columns. Each row anchor pulls
+     * the metric value at its anchor column via CROSS JOIN, so row ordering uses
+     * that single column rather than an aggregate across all columns.
      *
-     * Uses CROSS JOIN with anchor_column CTE instead of scalar subqueries for cleaner SQL.
-     *
-     * @param indexColumns - Normalized index columns
-     * @param valuesColumns - Value columns configuration
-     * @param groupByColumns - Group by columns
-     * @param sortBy - Sort configuration
-     * @param perMetricAnchorCte - Optional map of metric reference → anchor_column CTE name.
-     *   When a metric has its own entry, the row anchor CROSS JOINs that CTE instead of
-     *   the shared `anchor_column`. Used when any sort entry has `pivotValues`.
-     * @returns Record mapping CTE names to their SQL definitions
+     * @param perMetricAnchorCte - Optional map of metric → anchor CTE name. When
+     *   set, the row anchor CROSS JOINs that CTE instead of the shared
+     *   `anchor_column`. Used when any sort has `pivotValues`.
      */
     private getRowAnchorCTEs(
         indexColumns: ReturnType<typeof normalizeIndexColumns>,


### PR DESCRIPTION
Adds per-metric anchor CTE generation in `PivotQueryBuilder` so a row sort can be pinned to a specific pivot column slice. Stale pins fall back gracefully when the referenced column no longer exists.

Relates to [PROD-6986](https://linear.app/lightdash/issue/PROD-6986/allow-sorting-by-pivot-column-values-in-table-charts).