### PR TITLE
feat(frontend): pivot table sort menu, indicator, and click target

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
+++ b/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
@@ -30,3 +30,15 @@
 .stickyColumnLast {
     box-shadow: 4px 0 4px -2px rgba(0, 0, 0, 0.1);
 }
+
+.clickableHeader {
+    cursor: pointer;
+    user-select: none;
+}
+
+.clickableHeader:hover {
+    background-color: light-dark(
+        var(--mantine-color-gray-1),
+        var(--mantine-color-ldGray-1)
+    );
+}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -1,5 +1,6 @@
 import {
     ConditionalFormattingColorApplyTo,
+    FieldType,
     formatItemValue,
     getConditionalFormattingColor,
     getConditionalFormattingConfig,
@@ -19,10 +20,13 @@ import {
     type PivotData,
     type ResultRow,
     type ResultValue,
+    type SortField,
 } from '@lightdash/common';
 import {
+    Box,
     Button,
     Group,
+    Menu,
     Text,
     useMantineColorScheme,
     type BoxProps,
@@ -60,6 +64,7 @@ import {
     getColorFromRange,
     transformColorsForDarkMode,
 } from '../../../utils/colorUtils';
+import { getSortIcon } from '../../../utils/sortUtils';
 import { getConditionalRuleLabelFromItem } from '../Filters/FilterInputs/utils';
 import Table from '../LightTable';
 import { CELL_HEIGHT } from '../LightTable/constants';
@@ -158,7 +163,21 @@ type PivotTableProps = BoxProps & // TODO: remove this
         isDashboard?: boolean;
         onColumnWidthChange?: (fieldId: string, width: number) => void;
         parameters?: ParametersValuesMap;
+        sortBy?: SortField[];
+        // Header click handler. Consumer renders Menu.Item children inside
+        // the Mantine Menu. Absent → headers are non-interactive.
+        renderSortMenu?: (target: PivotSortMenuTarget) => React.ReactNode;
     };
+
+export type PivotSortMenuTarget =
+    | {
+          kind: 'pivotColumn';
+          dataColIndex: number;
+          metricReference: string;
+          pivotValues: Array<{ reference: string; value: unknown }>;
+      }
+    | { kind: 'indexDim'; reference: string }
+    | { kind: 'groupByDim'; reference: string };
 
 const PivotTable: FC<PivotTableProps> = ({
     data,
@@ -174,6 +193,8 @@ const PivotTable: FC<PivotTableProps> = ({
     isDashboard = false,
     onColumnWidthChange,
     parameters,
+    sortBy,
+    renderSortMenu,
     ...tableProps
 }) => {
     const { colorScheme } = useMantineColorScheme();
@@ -241,6 +262,128 @@ const PivotTable: FC<PivotTableProps> = ({
             ).length,
         [data],
     );
+
+    // -1 when metricsAsRows is true. Clicks and sort indicators belong on
+    // this row; dim rows above are ambiguous with more than one value column.
+    const metricLabelHeaderRowIndex = useMemo(() => {
+        for (let i = data.headerValueTypes.length - 1; i >= 0; i -= 1) {
+            if (data.headerValueTypes[i].type === FieldType.METRIC) {
+                return i;
+            }
+        }
+        return -1;
+    }, [data.headerValueTypes]);
+
+    const metricRefByDataColIndex = useMemo(() => {
+        const dataColumnCount = data.dataColumnCount ?? 0;
+        const result: (string | undefined)[] = Array.from(
+            { length: dataColumnCount },
+            () => undefined,
+        );
+        if (metricLabelHeaderRowIndex < 0) return result;
+        const labelRow = data.headerValues[metricLabelHeaderRowIndex];
+        if (!labelRow) return result;
+        const limit = Math.min(labelRow.length, dataColumnCount);
+        for (let colIdx = 0; colIdx < limit; colIdx += 1) {
+            const cell = labelRow[colIdx];
+            if (cell.type === 'label') {
+                result[colIdx] = cell.fieldId;
+            }
+        }
+        return result;
+    }, [data.headerValues, data.dataColumnCount, metricLabelHeaderRowIndex]);
+
+    // Each header-row cell maps 1:1 with a data column (merged cells carry
+    // the owner's payload with colSpan=0) — index directly, never by colSpan
+    // cursor or merged slots get double-counted.
+    const pivotValuesByDataColIndex = useMemo(() => {
+        const dataColumnCount = data.dataColumnCount ?? 0;
+        const cumulative: Array<Record<string, unknown>> = Array.from(
+            { length: dataColumnCount },
+            () => ({}),
+        );
+        for (const headerRow of data.headerValues) {
+            const limit = Math.min(headerRow.length, dataColumnCount);
+            for (let colIdx = 0; colIdx < limit; colIdx += 1) {
+                const cell = headerRow[colIdx];
+                if (cell.type === 'value') {
+                    cumulative[colIdx][cell.fieldId] = cell.value?.raw;
+                }
+            }
+        }
+        return cumulative;
+    }, [data.headerValues, data.dataColumnCount]);
+
+    // Data-column index → matching sort entry. Built once so header render is O(1).
+    const sortMatchByDataColIndex = useMemo(() => {
+        const result = new Map<number, SortField>();
+        if (!sortBy?.length) return result;
+
+        for (const sort of sortBy) {
+            const pivots = sort.pivotValues ?? [];
+
+            if (pivots.length > 0) {
+                // Pinned: pivot values must match, plus metric (when known)
+                // — distinguishes per-metric sorts under the same pin.
+                for (
+                    let colIdx = 0;
+                    colIdx < pivotValuesByDataColIndex.length;
+                    colIdx += 1
+                ) {
+                    const info = pivotValuesByDataColIndex[colIdx];
+                    const allMatch = pivots.every(
+                        (pv) =>
+                            pv.reference in info &&
+                            info[pv.reference] === pv.value,
+                    );
+                    if (!allMatch) continue;
+                    const colMetric = metricRefByDataColIndex[colIdx];
+                    const metricMatches =
+                        colMetric === undefined || colMetric === sort.fieldId;
+                    if (metricMatches && !result.has(colIdx)) {
+                        result.set(colIdx, sort);
+                        break;
+                    }
+                }
+                continue;
+            }
+
+            // Unpinned: surface on leftmost matching column, or col 0 when
+            // there's no metric-label row (metricsAsRows: true).
+            const item = getField?.(sort.fieldId);
+            const isValueColumnSort =
+                item && isField(item) && item.fieldType === FieldType.METRIC;
+            if (!isValueColumnSort) continue;
+
+            if (metricLabelHeaderRowIndex < 0) {
+                if (pivotValuesByDataColIndex.length > 0 && !result.has(0)) {
+                    result.set(0, sort);
+                }
+                continue;
+            }
+
+            for (
+                let colIdx = 0;
+                colIdx < metricRefByDataColIndex.length;
+                colIdx += 1
+            ) {
+                if (
+                    metricRefByDataColIndex[colIdx] === sort.fieldId &&
+                    !result.has(colIdx)
+                ) {
+                    result.set(colIdx, sort);
+                    break;
+                }
+            }
+        }
+        return result;
+    }, [
+        getField,
+        sortBy,
+        pivotValuesByDataColIndex,
+        metricRefByDataColIndex,
+        metricLabelHeaderRowIndex,
+    ]);
 
     const hasColumnTotals = data.pivotConfig.columnTotals;
 
@@ -901,9 +1044,52 @@ const PivotTable: FC<PivotTableProps> = ({
                                 const isHeaderTitle =
                                     titleField?.direction === 'header';
 
+                                const isIndexTitle =
+                                    titleField?.direction === 'index';
+
+                                const isGroupByTitle =
+                                    titleField?.direction === 'header';
+
                                 const isLastHeaderRow =
                                     headerRowIndex ===
                                     data.headerValues.length - 1;
+
+                                const titleMenuTarget:
+                                    | PivotSortMenuTarget
+                                    | undefined =
+                                    isIndexTitle && titleField?.fieldId
+                                        ? {
+                                              kind: 'indexDim',
+                                              reference: titleField.fieldId,
+                                          }
+                                        : isGroupByTitle && titleField?.fieldId
+                                          ? {
+                                                kind: 'groupByDim',
+                                                reference: titleField.fieldId,
+                                            }
+                                          : undefined;
+                                const titleIsClickable =
+                                    !!titleMenuTarget && !!renderSortMenu;
+                                const titleSortMatch =
+                                    (isIndexTitle || isGroupByTitle) &&
+                                    titleField?.fieldId
+                                        ? sortBy?.find(
+                                              (s) =>
+                                                  s.fieldId ===
+                                                      titleField.fieldId &&
+                                                  !s.pivotValues?.length,
+                                          )
+                                        : undefined;
+                                const titleSortField = titleSortMatch
+                                    ? getField(titleSortMatch.fieldId)
+                                    : undefined;
+                                const titleSortIcon =
+                                    titleSortMatch && titleSortField
+                                        ? getSortIcon(
+                                              titleSortField,
+                                              titleSortMatch.descending,
+                                          )
+                                        : undefined;
 
                                 const titleWidthKey = titleField?.fieldId;
                                 const titleWidth = titleWidthKey
@@ -940,7 +1126,16 @@ const PivotTable: FC<PivotTableProps> = ({
                                 ) : (
                                     <Table.CellHead
                                         key={`title-${headerRowIndex}-${titleFieldIndex}`}
-                                        className={titleStickyProps.className}
+                                        className={
+                                            [
+                                                titleStickyProps.className,
+                                                titleIsClickable
+                                                    ? pivotStyles.clickableHeader
+                                                    : undefined,
+                                            ]
+                                                .filter(Boolean)
+                                                .join(' ') || undefined
+                                        }
                                         style={titleStickyProps.style}
                                         withAlignRight={isHeaderTitle}
                                         isMinimal={isMinimal}
@@ -970,9 +1165,54 @@ const PivotTable: FC<PivotTableProps> = ({
                                                 : undefined
                                         }
                                     >
-                                        {titleField?.fieldId
-                                            ? getFieldLabel(titleField?.fieldId)
-                                            : undefined}
+                                        {titleIsClickable &&
+                                        titleField &&
+                                        titleMenuTarget &&
+                                        renderSortMenu ? (
+                                            <Menu
+                                                shadow="md"
+                                                position="bottom-start"
+                                                withinPortal
+                                            >
+                                                <Menu.Target>
+                                                    <Box
+                                                        component="span"
+                                                        role="button"
+                                                        tabIndex={0}
+                                                    >
+                                                        {titleSortIcon ? (
+                                                            <Group
+                                                                display="inline-flex"
+                                                                spacing={4}
+                                                                noWrap
+                                                                align="center"
+                                                            >
+                                                                {getFieldLabel(
+                                                                    titleField.fieldId,
+                                                                )}
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        titleSortIcon
+                                                                    }
+                                                                    size={14}
+                                                                />
+                                                            </Group>
+                                                        ) : (
+                                                            getFieldLabel(
+                                                                titleField.fieldId,
+                                                            )
+                                                        )}
+                                                    </Box>
+                                                </Menu.Target>
+                                                <Menu.Dropdown>
+                                                    {renderSortMenu(
+                                                        titleMenuTarget,
+                                                    )}
+                                                </Menu.Dropdown>
+                                            </Menu>
+                                        ) : titleField?.fieldId ? (
+                                            getFieldLabel(titleField?.fieldId)
+                                        ) : undefined}
                                         {canResizeTitle && (
                                             <div
                                                 className={
@@ -1036,10 +1276,81 @@ const PivotTable: FC<PivotTableProps> = ({
                                   )
                                 : {};
 
+                            const isMetricLabelRow =
+                                metricLabelHeaderRowIndex >= 0 &&
+                                headerRowIndex === metricLabelHeaderRowIndex;
+                            const columnMetricRef =
+                                metricRefByDataColIndex[headerColIndex];
+                            const isClickableHeader =
+                                isMetricLabelRow &&
+                                isLabel &&
+                                !!renderSortMenu &&
+                                !!columnMetricRef;
+                            const sortMatch =
+                                isMetricLabelRow && isLabel
+                                    ? sortMatchByDataColIndex.get(
+                                          headerColIndex,
+                                      )
+                                    : undefined;
+                            const sortMatchItem = sortMatch
+                                ? getField(sortMatch.fieldId)
+                                : undefined;
+                            const sortIcon =
+                                sortMatch && sortMatchItem
+                                    ? getSortIcon(
+                                          sortMatchItem,
+                                          sortMatch.descending,
+                                      )
+                                    : undefined;
+
+                            const cellClassName = [
+                                headerValueStickyProps.className,
+                                isClickableHeader
+                                    ? pivotStyles.clickableHeader
+                                    : undefined,
+                            ]
+                                .filter(Boolean)
+                                .join(' ');
+
+                            const headerInnerContent = sortIcon ? (
+                                <Group
+                                    display="inline-flex"
+                                    spacing={4}
+                                    noWrap
+                                    align="center"
+                                >
+                                    {isLabel
+                                        ? getFieldLabel(headerValue.fieldId)
+                                        : formatCellContent(headerValue)}
+                                    <MantineIcon icon={sortIcon} size={14} />
+                                </Group>
+                            ) : isLabel ? (
+                                getFieldLabel(headerValue.fieldId)
+                            ) : (
+                                formatCellContent(headerValue)
+                            );
+
+                            const pivotMenuTarget: PivotSortMenuTarget | null =
+                                columnMetricRef
+                                    ? {
+                                          kind: 'pivotColumn',
+                                          dataColIndex: headerColIndex,
+                                          metricReference: columnMetricRef,
+                                          pivotValues: Object.entries(
+                                              pivotValuesByDataColIndex[
+                                                  headerColIndex
+                                              ] ?? {},
+                                          ).map(([reference, value]) => ({
+                                              reference,
+                                              value,
+                                          })),
+                                      }
+                                    : null;
+
                             return isLabel || headerValue.colSpan > 0 ? (
                                 <Table.CellHead
                                     key={`header-${headerRowIndex}-${headerColIndex}`}
-                                    className={headerValueStickyProps.className}
+                                    className={cellClassName || undefined}
                                     style={headerValueStickyProps.style}
                                     isMinimal={isMinimal}
                                     withBoldFont={isLabel}
@@ -1053,9 +1364,31 @@ const PivotTable: FC<PivotTableProps> = ({
                                     miw={effectiveWidth}
                                     maw={effectiveWidth}
                                 >
-                                    {isLabel
-                                        ? getFieldLabel(headerValue.fieldId)
-                                        : formatCellContent(headerValue)}
+                                    {isClickableHeader && pivotMenuTarget ? (
+                                        // BaseCell drops onClick — bind via Menu.Target instead.
+                                        <Menu
+                                            shadow="md"
+                                            position="bottom-start"
+                                            withinPortal
+                                        >
+                                            <Menu.Target>
+                                                <Box
+                                                    component="span"
+                                                    role="button"
+                                                    tabIndex={0}
+                                                >
+                                                    {headerInnerContent}
+                                                </Box>
+                                            </Menu.Target>
+                                            <Menu.Dropdown>
+                                                {renderSortMenu?.(
+                                                    pivotMenuTarget,
+                                                )}
+                                            </Menu.Dropdown>
+                                        </Menu>
+                                    ) : (
+                                        headerInnerContent
+                                    )}
                                     {canResize && (
                                         <div
                                             className={resizeHandleClassName}


### PR DESCRIPTION
PivotTable wiring for pivot sort:

- Sort direction indicator on header cells
- Click target on the metric-label row opens a sort menu via `renderSortMenu`
- Extracts shared `getPivotColumnIdentities` / `getMetricLabelHeaderRowIndex` helpers and `pivotSortIdentity` utilities

Relates to [PROD-6986](https://linear.app/lightdash/issue/PROD-6986/allow-sorting-by-pivot-column-values-in-table-charts).