### PR TITLE
feat(frontend): pivot-aware sort UX

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -6,6 +6,7 @@ import {
     getHiddenTableFields,
     getPivotConfig,
     NotFoundError,
+    FeatureFlags,
     type ApiErrorDetail,
     type ChartConfig,
     type ChartType,
@@ -34,6 +35,7 @@ import {
     selectIsVisualizationConfigOpen,
     selectIsVisualizationExpanded,
     selectSavedChart,
+    selectSorts,
     selectTableCalculationsMetadata,
     selectUnsavedChartVersion,
     selectUnsavedColorPaletteUuid,
@@ -46,6 +48,7 @@ import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
@@ -56,6 +59,7 @@ import MantineIcon from '../../common/MantineIcon';
 import LightdashVisualization from '../../LightdashVisualization';
 import VisualizationProvider from '../../LightdashVisualization/VisualizationProvider';
 import { type EchartsSeriesClickEvent } from '../../SimpleChart';
+import SortButton from '../../SortButton';
 import { VisualizationConfigPortalId } from '../ExplorePanel/constants';
 import { DevCopyChartDebugData } from '../ExplorerHeader/DevCopyChartDebugData';
 import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
@@ -88,6 +92,13 @@ const VisualizationCard: FC<Props> = memo((props) => {
 
     // Get savedChart from Redux
     const savedChart = useExplorerSelector(selectSavedChart);
+
+    const sorts = useExplorerSelector(selectSorts);
+
+    const { data: pivotColumnSortFlag } = useServerFeatureFlag(
+        FeatureFlags.PivotColumnSort,
+    );
+    const isPivotColumnSortEnabled = pivotColumnSortFlag?.enabled ?? false;
 
     const projectUuid = savedChart?.projectUuid || fallBackUUid;
     const stagedColorPaletteUuid = useExplorerSelector(
@@ -350,17 +361,28 @@ const VisualizationCard: FC<Props> = memo((props) => {
                     onToggle={toggleSection}
                     headerElement={
                         isOpen && (
-                            <VisualizationWarning
-                                dirtyPivotConfiguration={
-                                    dirtyPivotConfiguration
-                                }
-                                chartConfig={unsavedChartVersion.chartConfig}
-                                resultsData={resultsData}
-                                isLoading={isLoadingQueryResults}
-                                maxColumnLimit={
-                                    health.data?.pivotTable?.maxColumnLimit
-                                }
-                            />
+                            <>
+                                {isPivotColumnSortEnabled &&
+                                    sorts.length > 0 && (
+                                        <SortButton
+                                            sorts={sorts}
+                                            isEditMode={isEditMode}
+                                        />
+                                    )}
+                                <VisualizationWarning
+                                    dirtyPivotConfiguration={
+                                        dirtyPivotConfiguration
+                                    }
+                                    chartConfig={
+                                        unsavedChartVersion.chartConfig
+                                    }
+                                    resultsData={resultsData}
+                                    isLoading={isLoadingQueryResults}
+                                    maxColumnLimit={
+                                        health.data?.pivotTable?.maxColumnLimit
+                                    }
+                                />
+                            </>
                         )
                     }
                     rightHeaderElement={

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -143,10 +143,17 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
 
         const defaultSort = useDefaultSortField(chartVersionForSort as any);
 
+        // Seed the default sort once per explore; without this guard, clearing
+        // all sorts would re-seed and override the user's intent.
+        const lastSeededTableRef = useRef<string | null>(null);
         useEffect(() => {
-            if (tableName && !sorts.length && defaultSort) {
+            if (!tableName) return;
+            if (lastSeededTableRef.current === tableName) return;
+            if (sorts.length === 0 && !defaultSort) return;
+            if (sorts.length === 0 && defaultSort) {
                 dispatch(explorerActions.setSortFields([defaultSort]));
             }
+            lastSeededTableRef.current = tableName;
         }, [tableName, sorts.length, defaultSort, dispatch]);
 
         useEffect(() => {

--- a/packages/frontend/src/components/SimpleTable/ExplorerPivotTable.tsx
+++ b/packages/frontend/src/components/SimpleTable/ExplorerPivotTable.tsx
@@ -1,0 +1,181 @@
+import { FieldType, type SortField } from '@lightdash/common';
+import { Menu } from '@mantine-8/core';
+import { useCallback, useMemo, type ComponentProps, type FC } from 'react';
+import {
+    explorerActions,
+    selectIsEditMode,
+    selectMetrics,
+    selectSorts,
+    useExplorerDispatch,
+    useExplorerSelector,
+} from '../../features/explorer/store';
+import {
+    matchesIdentity,
+    normalizePivotValues,
+    pivotValuesEqual,
+} from '../../utils/pivotSortIdentity';
+import { SortDirection } from '../../utils/sortUtils';
+import PivotTable, { type PivotSortMenuTarget } from '../common/PivotTable';
+import ColumnHeaderSortMenuOptions from '../Explorer/ResultsCard/ColumnHeaderSortMenuOptions';
+
+type ExplorerPivotTableProps = Omit<
+    ComponentProps<typeof PivotTable>,
+    'sortBy' | 'renderSortMenu'
+>;
+
+type SortTarget = {
+    kind: 'valueColumn' | 'indexDim' | 'groupBy';
+    fieldId: string;
+    pivotValues?: NonNullable<SortField['pivotValues']>;
+};
+
+const ExplorerPivotTable: FC<ExplorerPivotTableProps> = ({
+    getFieldLabel,
+    getField,
+    data,
+    ...rest
+}) => {
+    const dispatch = useExplorerDispatch();
+    const sorts = useExplorerSelector(selectSorts);
+    const isEditMode = useExplorerSelector(selectIsEditMode);
+    const metrics = useExplorerSelector(selectMetrics);
+
+    // Sort axes:
+    //   valueColumn — metric or pinned: drives row order
+    //   groupBy     — pivot dimension: drives column order (independent)
+    //   indexDim    — row dimension / table calc: composes with other indexDims
+    const metricSet = useMemo(() => new Set(metrics), [metrics]);
+    const groupByRefs = useMemo(() => {
+        const refs = new Set<string>();
+        for (const t of data.headerValueTypes) {
+            if (t.type === FieldType.DIMENSION) refs.add(t.fieldId);
+        }
+        return refs;
+    }, [data.headerValueTypes]);
+
+    const classifySort = useCallback(
+        (s: SortField): 'valueColumn' | 'groupBy' | 'indexDim' => {
+            if (metricSet.has(s.fieldId) || (s.pivotValues?.length ?? 0) > 0) {
+                return 'valueColumn';
+            }
+            if (groupByRefs.has(s.fieldId)) return 'groupBy';
+            return 'indexDim';
+        },
+        [groupByRefs, metricSet],
+    );
+
+    const targetFromMenuTarget = useCallback(
+        (target: PivotSortMenuTarget): SortTarget => {
+            if (target.kind === 'pivotColumn') {
+                return {
+                    kind: 'valueColumn',
+                    fieldId: target.metricReference,
+                    pivotValues: normalizePivotValues(target.pivotValues),
+                };
+            }
+            if (target.kind === 'indexDim') {
+                return { kind: 'indexDim', fieldId: target.reference };
+            }
+            return { kind: 'groupBy', fieldId: target.reference };
+        },
+        [],
+    );
+
+    const applySort = useCallback(
+        (target: SortTarget, direction: SortDirection) => {
+            const next: SortField = {
+                fieldId: target.fieldId,
+                descending: direction === SortDirection.DESC,
+                pivotValues: target.pivotValues?.length
+                    ? target.pivotValues
+                    : undefined,
+            };
+
+            const existing = sorts.find((s) => matchesIdentity(s, target));
+            if (existing) {
+                dispatch(
+                    explorerActions.setSortFields(
+                        sorts.map((s) =>
+                            matchesIdentity(s, target) ? next : s,
+                        ),
+                    ),
+                );
+                return;
+            }
+
+            const filtered = sorts.filter((s) => {
+                const kind = classifySort(s);
+                if (target.kind === 'valueColumn') {
+                    // Same pivot group composes; different group replaces.
+                    if (kind === 'valueColumn') {
+                        return pivotValuesEqual(
+                            s.pivotValues,
+                            target.pivotValues,
+                        );
+                    }
+                    return kind === 'groupBy';
+                }
+                if (target.kind === 'indexDim') {
+                    return (
+                        kind === 'groupBy' ||
+                        (kind === 'indexDim' && !matchesIdentity(s, target))
+                    );
+                }
+                return kind !== 'groupBy' || !matchesIdentity(s, target);
+            });
+
+            dispatch(explorerActions.setSortFields([...filtered, next]));
+        },
+        [classifySort, dispatch, sorts],
+    );
+
+    const removeSort = useCallback(
+        (target: SortTarget) => {
+            dispatch(
+                explorerActions.setSortFields(
+                    sorts.filter((s) => !matchesIdentity(s, target)),
+                ),
+            );
+        },
+        [dispatch, sorts],
+    );
+
+    const renderSortMenu = useCallback(
+        (menuTarget: PivotSortMenuTarget) => {
+            const target = targetFromMenuTarget(menuTarget);
+            const item = getField?.(target.fieldId);
+            if (!item) {
+                return <Menu.Label>Sort target is not in the chart</Menu.Label>;
+            }
+            const existing = sorts.find((s) => matchesIdentity(s, target));
+            const selectedDirection = existing
+                ? existing.descending
+                    ? SortDirection.DESC
+                    : SortDirection.ASC
+                : undefined;
+
+            return (
+                <ColumnHeaderSortMenuOptions
+                    item={item}
+                    selectedDirection={selectedDirection}
+                    onSelect={(direction) => applySort(target, direction)}
+                    onRemove={() => removeSort(target)}
+                />
+            );
+        },
+        [applySort, getField, removeSort, sorts, targetFromMenuTarget],
+    );
+
+    return (
+        <PivotTable
+            {...rest}
+            data={data}
+            getFieldLabel={getFieldLabel}
+            getField={getField}
+            sortBy={sorts}
+            renderSortMenu={isEditMode ? renderSortMenu : undefined}
+        />
+    );
+};
+
+export default ExplorerPivotTable;

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags } from '@lightdash/common';
 import { Box, Button, Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
@@ -6,6 +7,7 @@ import {
     isChunkLoadError,
     triggerChunkErrorReload,
 } from '../../features/chunkErrorHandler';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { computeLimitedRowCount, sliceRows } from '../../utils/sliceRows';
 import LoadingChart from '../common/LoadingChart';
 import PivotTable from '../common/PivotTable';
@@ -21,6 +23,7 @@ import { useVisualizationContext } from '../LightdashVisualization/useVisualizat
 import CellContextMenu from './CellContextMenu';
 import DashboardCellContextMenu from './DashboardCellContextMenu';
 import DashboardHeaderContextMenu from './DashboardHeaderContextMenu';
+import ExplorerPivotTable from './ExplorerPivotTable';
 import MinimalCellContextMenu from './MinimalCellContextMenu';
 
 type SimpleTableProps = {
@@ -52,6 +55,11 @@ const SimpleTable: FC<SimpleTableProps> = ({
         isEditMode,
         parameters,
     } = useVisualizationContext();
+
+    const { data: pivotColumnSortFlag } = useServerFeatureFlag(
+        FeatureFlags.PivotColumnSort,
+    );
+    const isPivotColumnSortEnabled = pivotColumnSortFlag?.enabled ?? false;
 
     const hasSignaledScreenshotReady = useRef(false);
 
@@ -282,24 +290,51 @@ const SimpleTable: FC<SimpleTableProps> = ({
             >
                 {pivotTableData.data && resultsData?.hasFetchedAllRows ? (
                     <>
-                        <PivotTable
-                            className={className}
-                            data={pivotTableData.data}
-                            isMinimal={minimal}
-                            isDashboard={isDashboard}
-                            conditionalFormattings={conditionalFormattings}
-                            minMaxMap={minMaxMap}
-                            getFieldLabel={getFieldLabel}
-                            getField={getField}
-                            hideRowNumbers={hideRowNumbers}
-                            showSubtotals={showSubtotals}
-                            columnProperties={
-                                visualizationConfig.chartConfig.columnProperties
-                            }
-                            onColumnWidthChange={onColumnWidthChange}
-                            parameters={parameters}
-                            {...rest}
-                        />
+                        {/* Dashboard mode has no explorer store — use plain
+                         * table. Gated behind PivotColumnSort flag so we can
+                         * validate the new sort UX with design partners before
+                         * GA. */}
+                        {isDashboard || !isPivotColumnSortEnabled ? (
+                            <PivotTable
+                                className={className}
+                                data={pivotTableData.data}
+                                isMinimal={minimal}
+                                isDashboard={isDashboard}
+                                conditionalFormattings={conditionalFormattings}
+                                minMaxMap={minMaxMap}
+                                getFieldLabel={getFieldLabel}
+                                getField={getField}
+                                hideRowNumbers={hideRowNumbers}
+                                showSubtotals={showSubtotals}
+                                columnProperties={
+                                    visualizationConfig.chartConfig
+                                        .columnProperties
+                                }
+                                onColumnWidthChange={onColumnWidthChange}
+                                parameters={parameters}
+                                {...rest}
+                            />
+                        ) : (
+                            <ExplorerPivotTable
+                                className={className}
+                                data={pivotTableData.data}
+                                isMinimal={minimal}
+                                isDashboard={isDashboard}
+                                conditionalFormattings={conditionalFormattings}
+                                minMaxMap={minMaxMap}
+                                getFieldLabel={getFieldLabel}
+                                getField={getField}
+                                hideRowNumbers={hideRowNumbers}
+                                showSubtotals={showSubtotals}
+                                columnProperties={
+                                    visualizationConfig.chartConfig
+                                        .columnProperties
+                                }
+                                onColumnWidthChange={onColumnWidthChange}
+                                parameters={parameters}
+                                {...rest}
+                            />
+                        )}
                         {showResultsTotal && (
                             <Flex justify="flex-end" pt="xxs" align="center">
                                 <ResultCount

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -257,6 +257,19 @@ const explorerSlice = createSlice({
             action: PayloadAction<{ columns: string[] } | undefined>,
         ) => {
             state.unsavedChartVersion.pivotConfig = action.payload;
+            if (!action.payload?.columns.length) {
+                const seen = new Set<string>();
+                state.unsavedChartVersion.metricQuery.sorts =
+                    state.unsavedChartVersion.metricQuery.sorts.reduce<
+                        SortField[]
+                    >((acc, sort) => {
+                        if (seen.has(sort.fieldId)) return acc;
+                        seen.add(sort.fieldId);
+                        const { pivotValues: _pivotValues, ...rest } = sort;
+                        acc.push(rest);
+                        return acc;
+                    }, []);
+            }
         },
 
         setParameter: (


### PR DESCRIPTION
Pivot-aware sort UX:

- Click a pivot column header → sort menu (reuses `ColumnHeaderSortMenuOptions`, now presentational)
- Same pivot group composes; switching to a different pivot group replaces prior pinned sorts
- Pinned sorts are stripped from state when the pivot config clears
- Drops the "Clear all" item from the sort popover (per-item remove covers it)

Closes [PROD-6986](https://linear.app/lightdash/issue/PROD-6986/allow-sorting-by-pivot-column-values-in-table-charts).