### PR TITLE
fix(sort-popover): keep dragged sort row inside popover

### DIFF
--- a/packages/frontend/src/components/SortButton/Sorting.tsx
+++ b/packages/frontend/src/components/SortButton/Sorting.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../features/explorer/store';
 import { useColumns } from '../../hooks/useColumns';
 import MantineIcon from '../common/MantineIcon';
+import { DraggablePortalHandler } from '../VisualizationConfigs/TreemapConfig/DraggablePortalHandler';
 import SortItem from './SortItem';
 
 const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
@@ -128,36 +129,45 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
                                         },
                                         snapshot,
                                     ) => (
-                                        <SortItem
-                                            isEditMode={isEditMode}
-                                            ref={innerRef}
-                                            isFirstItem={index === 0}
-                                            isOnlyItem={sorts.length === 1}
-                                            isDragging={snapshot.isDragging}
-                                            draggableProps={draggableProps}
-                                            dragHandleProps={dragHandleProps}
-                                            sort={sort}
-                                            column={columns.find(
-                                                (c) => c.id === sort.fieldId,
-                                            )}
-                                            onAddSortField={(options) => {
-                                                addSortField(
-                                                    sort.fieldId,
-                                                    options,
-                                                );
-                                            }}
-                                            onRemoveSortField={() => {
-                                                removeSortField(sort.fieldId);
-                                            }}
-                                            onSetSortFieldNullsFirst={(
-                                                payload,
-                                            ) => {
-                                                setSortFieldNullsFirst(
-                                                    sort.fieldId,
+                                        <DraggablePortalHandler
+                                            snapshot={snapshot}
+                                        >
+                                            <SortItem
+                                                isEditMode={isEditMode}
+                                                ref={innerRef}
+                                                isFirstItem={index === 0}
+                                                isOnlyItem={sorts.length === 1}
+                                                isDragging={snapshot.isDragging}
+                                                draggableProps={draggableProps}
+                                                dragHandleProps={
+                                                    dragHandleProps
+                                                }
+                                                sort={sort}
+                                                column={columns.find(
+                                                    (c) =>
+                                                        c.id === sort.fieldId,
+                                                )}
+                                                onAddSortField={(options) => {
+                                                    addSortField(
+                                                        sort.fieldId,
+                                                        options,
+                                                    );
+                                                }}
+                                                onRemoveSortField={() => {
+                                                    removeSortField(
+                                                        sort.fieldId,
+                                                    );
+                                                }}
+                                                onSetSortFieldNullsFirst={(
                                                     payload,
-                                                );
-                                            }}
-                                        />
+                                                ) => {
+                                                    setSortFieldNullsFirst(
+                                                        sort.fieldId,
+                                                        payload,
+                                                    );
+                                                }}
+                                            />
+                                        </DraggablePortalHandler>
                                     )}
                                 </Draggable>
                             ))}


### PR DESCRIPTION
## Summary

Dragging to reorder a sort row in the results-table sort popover used to send the row flying outside the dropdown, making reorder unusable.

## Root cause

`@hello-pangea/dnd` positions the dragging clone with `position: fixed`. After the Mantine v6 → v8 migration of `SortButton` in #20020, `Popover.Dropdown` renders inside a CSS `transform` context (Floating UI), which reparents `position: fixed` descendants to the popover instead of the viewport — so the drag clone's coordinates land outside the dropdown.

## Fix

Wrap the draggable in `DraggablePortalHandler`, which portals the dragging element to `document.body` while `snapshot.isDragging` is true. Same workaround already in use in `TableConfigPanel/DroppableItemsList`, `ChartConfigPanel/Series`, `GroupedSeriesConfiguration`, and `TreemapConfig`.

**Before**

https://github.com/user-attachments/assets/d0d06f42-c090-4d30-b67d-d97a26461b5a

**After**

https://github.com/user-attachments/assets/8d1e2d5e-18a1-4f02-acf2-d4f535c6ac3d



Closes: https://linear.app/lightdash/issue/PROD-7751/dragged-sort-row-escapes-the-sort-popover-in-results-table