### PR TITLE
feat(analytics): track SQL mode on AI agent streams

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1784,23 +1784,6 @@ export type AiAgentResponseStreamed = BaseTrack & {
     };
 };
 
-export type AiAgentStreamStartedEvent = BaseTrack & {
-    event: 'ai_agent.stream_started';
-    userId: string;
-    properties: {
-        organizationId: string;
-        projectId: string;
-        aiAgentId: string;
-        agentName: string;
-        threadId: string;
-        promptId: string;
-        model: string;
-        context: 'slack' | 'web_app';
-        sqlModeRequested: boolean;
-        canRunSql: boolean;
-    };
-};
-
 export type AiAgentEvalCreatedEvent = BaseTrack & {
     event: 'ai_agent_eval.created';
     userId: string;
@@ -2069,8 +2052,6 @@ type TypedEvent =
     | AiAgentEvalAppendedEvent
     | McpToolCallEvent
     | AiAgentToolCallEvent
-    | AiAgentStreamStartedEvent
-    | AiAgentResponseStreamed
     | AiAgentArtifactVersionVerifiedEvent
     | AiAgentArtifactsRetrievedEvent
     | ContentVerificationEvent

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1779,6 +1779,25 @@ export type AiAgentResponseStreamed = BaseTrack & {
         model: string;
         finishReason: string;
         stepCapReached: boolean;
+        sqlModeRequested: boolean;
+        canRunSql: boolean;
+    };
+};
+
+export type AiAgentStreamStartedEvent = BaseTrack & {
+    event: 'ai_agent.stream_started';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        aiAgentId: string;
+        agentName: string;
+        threadId: string;
+        promptId: string;
+        model: string;
+        context: 'slack' | 'web_app';
+        sqlModeRequested: boolean;
+        canRunSql: boolean;
     };
 };
 
@@ -2050,6 +2069,8 @@ type TypedEvent =
     | AiAgentEvalAppendedEvent
     | McpToolCallEvent
     | AiAgentToolCallEvent
+    | AiAgentStreamStartedEvent
+    | AiAgentResponseStreamed
     | AiAgentArtifactVersionVerifiedEvent
     | AiAgentArtifactsRetrievedEvent
     | ContentVerificationEvent

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3634,6 +3634,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             telemetryEnabled: this.lightdashConfig.ai.copilot.telemetryEnabled,
             enableDataAccess: agentSettings.enableDataAccess,
             enableSelfImprovement: agentSettings.enableSelfImprovement,
+            sqlModeRequested: enableSqlMode,
             canRunSql,
             warehouseType,
             warehouseSchema,
@@ -3716,6 +3717,26 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 },
             },
         };
+
+        this.analytics.track({
+            event: 'ai_agent.stream_started',
+            userId: user.userUuid,
+            properties: {
+                organizationId: user.organizationUuid,
+                projectId: agentSettings.projectUuid,
+                aiAgentId: agentSettings.uuid,
+                agentName: agentSettings.name,
+                threadId: prompt.threadUuid,
+                promptId: prompt.promptUuid,
+                model:
+                    typeof args.model === 'string'
+                        ? args.model
+                        : args.model.modelId,
+                context: isSlackPrompt(prompt) ? 'slack' : 'web_app',
+                sqlModeRequested: enableSqlMode,
+                canRunSql,
+            },
+        });
 
         return stream
             ? streamAgentResponse({ args, dependencies })

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3718,26 +3718,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             },
         };
 
-        this.analytics.track({
-            event: 'ai_agent.stream_started',
-            userId: user.userUuid,
-            properties: {
-                organizationId: user.organizationUuid,
-                projectId: agentSettings.projectUuid,
-                aiAgentId: agentSettings.uuid,
-                agentName: agentSettings.name,
-                threadId: prompt.threadUuid,
-                promptId: prompt.promptUuid,
-                model:
-                    typeof args.model === 'string'
-                        ? args.model
-                        : args.model.modelId,
-                context: isSlackPrompt(prompt) ? 'slack' : 'web_app',
-                sqlModeRequested: enableSqlMode,
-                canRunSql,
-            },
-        });
-
         return stream
             ? streamAgentResponse({ args, dependencies })
             : generateAgentResponse({ args, dependencies });

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -646,6 +646,8 @@ export const streamAgentResponse = async ({
                                 : args.model.modelId,
                         finishReason,
                         stepCapReached,
+                        sqlModeRequested: args.sqlModeRequested,
+                        canRunSql: args.canRunSql,
                     },
                 });
                 logger(

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -44,6 +44,7 @@ export type AiAgentArgs = AnyAiModel & {
     telemetryEnabled: boolean;
     enableDataAccess: boolean;
     enableSelfImprovement: boolean;
+    sqlModeRequested: boolean;
     canRunSql: boolean;
     warehouseType: WarehouseTypes | null;
     warehouseSchema: string | null;


### PR DESCRIPTION
## Summary

Adds analytics tracking for SQL mode on AI agent streams. One existing event, two new properties.

`ai_agent.response_streamed` now includes:
- `sqlModeRequested: boolean` — whether the user toggled SQL mode on for this stream.
- `canRunSql: boolean` — whether the SQL tools were actually registered after the `AiAgentRunSql` feature flag + Slack-OAuth requirement + CASL `SqlRunner` check.

The two booleans together let analytics segment three cohorts on top of the existing event properties (`usageTokensCount`, `stepsCount`, `model`, `finishReason`, `stepCapReached`):

- **Adoption** — `% of responses where sqlModeRequested = true`.
- **Friction** — `% where sqlModeRequested = true AND canRunSql = false` — users who opted in but were blocked by the flag, Slack-OAuth requirement, or CASL.
- **Effective usage** — `% where canRunSql = true` — the only cohort where `runSql` tool calls can actually happen.

All segmentable by agent, project, org, model, finish reason since those are already on the event.

## Why not `ai_agent_prompt.created`?

Considered, but `enableSqlMode` lives on the **stream** request body (`ApiAiAgentStreamRequest`), not the prompt-create body — so at the moment `prompt.created` fires we literally don't know yet whether SQL mode is on. Tracking on `response_streamed` keeps the API surface unchanged.

Trade-off: we don't capture aborted/failed streams. Considered acceptable since the abort cohort is small and a dedicated `stream_started` event was deemed not worth the new event surface.

## Regression analysis

Purely additive:
- No existing event property removed or renamed.
- No tool gating logic changed — `canRunSql` is read from the same place it was already computed (`AiAgentService.ts` line ~3562) and `enableSqlMode` is also unchanged. The new `sqlModeRequested` field on `AiAgentArgs` is read-only by the analytics emitter; tool registration in `agentV2.ts` still gates on `args.canRunSql`.
- No new permission / auth surface. Service accounts, custom roles, cross-project flows behave identically.

## Test plan

- [ ] Backend typecheck passes (`pnpm -F backend typecheck` — verified locally).
- [ ] Trigger a streaming AI agent prompt with SQL mode off → event fires with `sqlModeRequested: false`, `canRunSql: false`.
- [ ] Trigger one with SQL mode on (and the `AiAgentRunSql` flag enabled for the user) → event fires with `sqlModeRequested: true`, `canRunSql: true`.
- [ ] Trigger one with SQL mode on but flag off → `sqlModeRequested: true`, `canRunSql: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)