### PR TITLE
fix(ai-agent): render emoji shortcodes in AI agent bubbles

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -124,6 +124,8 @@
         "rehype-external-links": "3.0.0",
         "rehype-raw": "7.0.0",
         "rehype-sanitize": "6.0.0",
+        "remark-emoji": "5.0.2",
+        "remark-gfm": "4.0.1",
         "reselect": "5.1.1",
         "rudder-sdk-js": "2.9.1",
         "scheduler": "0.23.2",

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -33,6 +33,8 @@ import {
     IconThumbUpFilled,
 } from '@tabler/icons-react';
 import { memo, useCallback, useState, type FC } from 'react';
+import remarkEmoji from 'remark-emoji';
+import remarkGfm from 'remark-gfm';
 // streamdown is a streaming-aware drop-in for react-markdown — used for the
 // final answer + intermediate text chunks in the AI bubble.
 import { Streamdown } from 'streamdown';
@@ -330,6 +332,7 @@ const AssistantBubbleContent: FC<{
                                 controls={false}
                                 animated
                                 mode={isStreaming ? 'streaming' : 'static'}
+                                remarkPlugins={[remarkGfm, remarkEmoji]}
                                 rehypePlugins={[rehypeAiAgentContentLinks]}
                                 components={{
                                     a: ({ node, children, ...props }) => {
@@ -463,6 +466,7 @@ const AssistantBubbleContent: FC<{
                                     controls={false}
                                     animated
                                     mode="static"
+                                    remarkPlugins={[remarkGfm, remarkEmoji]}
                                     rehypePlugins={[rehypeAiAgentContentLinks]}
                                     components={{
                                         a: ({ node, children, ...props }) => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -14,6 +14,8 @@ import {
 } from '@mantine-8/core';
 import { IconChevronRight } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
+import remarkEmoji from 'remark-emoji';
+import remarkGfm from 'remark-gfm';
 import { Streamdown } from 'streamdown';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import bubbleStyles from '../AgentChatAssistantBubble.module.css';
@@ -143,6 +145,7 @@ const ReasoningHistoryRow: FC<{ texts: string[]; isLive: boolean }> = ({
                         parseIncompleteMarkdown
                         controls={false}
                         mode="static"
+                        remarkPlugins={[remarkGfm, remarkEmoji]}
                     >
                         {combined}
                     </Streamdown>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1223,6 +1223,12 @@ importers:
       rehype-sanitize:
         specifier: 6.0.0
         version: 6.0.0
+      remark-emoji:
+        specifier: 5.0.2
+        version: 5.0.2
+      remark-gfm:
+        specifier: 4.0.1
+        version: 4.0.1
       reselect:
         specifier: 5.1.1
         version: 5.1.1
@@ -5680,6 +5686,10 @@ packages:
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
     engines: {node: '>=18'}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@sinonjs/commons@3.0.0':
     resolution: {integrity: sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==}
 
@@ -9433,6 +9443,12 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
+  emoticon@4.1.0:
+    resolution: {integrity: sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ==}
+
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -12614,6 +12630,10 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
+
   node-execution-context@3.1.0:
     resolution: {integrity: sha512-5h7Ofw6Q8HcNtzUNnL1Sx3UVmV8krL3R9NCYFjzMoyOd5aCHAc86lFF0Uqb7EqVJnL+mdTnLCowUyx8OIC6k0g==}
     engines: {node: '>=8.6.0'}
@@ -14274,11 +14294,12 @@ packages:
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
 
+  remark-emoji@5.0.2:
+    resolution: {integrity: sha512-IyIqGELcyK5AVdLFafoiNww+Eaw/F+rGrNSXoKucjo95uL267zrddgxGM83GN1wFIb68pyDuAsY3m5t2Cav1pQ==}
+    engines: {node: '>=18'}
+
   remark-gfm@1.0.0:
     resolution: {integrity: sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==}
-
-  remark-gfm@4.0.0:
-    resolution: {integrity: sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -14761,6 +14782,10 @@ packages:
 
   size-sensor@1.0.1:
     resolution: {integrity: sha512-QTy7MnuugCFXIedXRpUSk9gUnyNiaxIdxGfUjr8xxXOqIB3QvBUYP9+b51oCg2C4dnhaeNk/h57TxjbvoJrJUA==}
+
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
 
   slackify-markdown@4.4.0:
     resolution: {integrity: sha512-a2b0Rh4aPi3PYt23N0vxPn7emkQtShewhLX8uIiXOMlPBAXRki+/9kEXJztZr1Oo9rDb1YxScGuZ0D2ubLPhvQ==}
@@ -15700,6 +15725,10 @@ packages:
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
+    engines: {node: '>=4'}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -21774,6 +21803,8 @@ snapshots:
 
   '@sindresorhus/base62@1.0.0': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@sinonjs/commons@3.0.0':
     dependencies:
       type-detect: 4.0.8
@@ -23807,7 +23838,7 @@ snapshots:
       rehype-raw: 7.0.0
       rehype-rewrite: 4.0.2
       rehype-slug: 6.0.0
-      remark-gfm: 4.0.0
+      remark-gfm: 4.0.1
       remark-github-blockquote-alert: 1.3.0
       unist-util-visit: 5.0.0
     transitivePeerDependencies:
@@ -26338,6 +26369,10 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  emojilib@2.4.0: {}
+
+  emoticon@4.1.0: {}
 
   empathic@2.0.0: {}
 
@@ -30538,6 +30573,13 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
+
   node-execution-context@3.1.0: {}
 
   node-fetch@2.7.0(encoding@0.1.13):
@@ -32440,21 +32482,18 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
+  remark-emoji@5.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      emoticon: 4.1.0
+      mdast-util-find-and-replace: 3.0.2
+      node-emoji: 2.2.0
+      unified: 11.0.5
+
   remark-gfm@1.0.0:
     dependencies:
       mdast-util-gfm: 0.1.2
       micromark-extension-gfm: 0.3.3
-    transitivePeerDependencies:
-      - supports-color
-
-  remark-gfm@4.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.0.0
-      micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
-      remark-stringify: 11.0.0
-      unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -33111,6 +33150,10 @@ snapshots:
   sisteransi@1.0.5: {}
 
   size-sensor@1.0.1: {}
+
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
 
   slackify-markdown@4.4.0:
     dependencies:
@@ -34171,6 +34214,8 @@ snapshots:
   undici@6.24.1: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   unicode-match-property-ecmascript@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Renders Slack-style emoji shortcodes (`:warning:`, `:moneybag:`, etc.) as actual emoji in the AI agent bubble. Claude Sonnet sometimes emits shortcodes instead of the Unicode character; Streamdown's default plugin set (`remark-gfm` only) doesn't resolve them, so they were rendering as literal text.

Adds `remark-emoji` to the `remarkPlugins` prop on all three Streamdown call sites — final answer (streaming + persisted) and the reasoning body. Passes `remark-gfm` explicitly alongside to keep tables / strikethrough / autolinks intact (Streamdown's `remarkPlugins` prop replaces defaults, not appends).

## Regression analysis

Purely additive:
- Unicode emojis the model already emits flow through untouched — `remark-emoji` only acts on `:shortcode:` syntax.
- `remark-gfm` is still applied (now explicitly), so table / strikethrough / autolink behaviour is identical.
- Other Streamdown options (`parseIncompleteMarkdown`, `controls`, `animated`, `mode`, `rehypePlugins`) untouched.
- No backend, no API, no auth surface.

## Test plan

- [ ] Prompt the agent in a way that elicits shortcode emojis (Sonnet-emitted summaries with `:warning:` / `:moneybag:` style) → renders as emoji glyphs.
- [ ] Prompt the agent in a way that elicits Unicode emojis (e.g. "use lots of emojis in headings") → still renders correctly.
- [ ] Existing markdown tables in agent responses still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)