### PR TITLE
fix(ai-agent): reasoning row hover background respects padding

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.module.css
@@ -292,7 +292,6 @@
 
 .reasoningRow {
     border-radius: 6px;
-    padding: 0 8px;
     margin: 0 -8px;
 }
 
@@ -301,7 +300,7 @@
     text-align: left;
     border-radius: 6px;
     min-height: 22px;
-    padding: 1px 0;
+    padding: 2px 8px;
     transition: background-color 160ms ease;
 }
 
@@ -351,7 +350,7 @@
 }
 
 .reasoningBody {
-    padding: 6px 0 4px;
+    padding: 6px 8px 4px;
 }
 
 @keyframes cardSlideIn {


### PR DESCRIPTION
## Summary

`.reasoningRow` carried 8px horizontal padding alongside its `margin: 0 -8px` breakout trick — those cancel out, so the inner `.reasoningHeader` (the element that actually receives the hover background) ended up with `padding: 1px 0` and the gray fill ran straight through the "Reasoning" text with no breathing room.

Moved the horizontal padding onto `.reasoningHeader` itself (`padding: 2px 8px`) so the hover bg has internal padding. Mirrored the 8px horizontal pad on `.reasoningBody` so the expanded body's first character stays aligned under the header text.

## Regression analysis

CSS-only, scoped to one selector group:
- `.reasoningRow` outer geometry unchanged (still `margin: 0 -8px`, still `border-radius: 6px`); just relocated the inner padding from row → header.
- No JS, no other components, no API.

## Test plan

- [ ] Hover the "Reasoning" row in the activity card → gray background sits inset from the row edges with the "R" comfortably inside.
- [ ] Expand the reasoning body → body text first character aligns under the header text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)