### PR TITLE
fix(dashboards): preserve filter overrides when duplicating a chart tile

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -32,7 +32,11 @@ import AddChartTilesModal from './TileForms/AddChartTilesModal';
 import { TileAddModal } from './TileForms/TileAddModal';
 
 type Props = {
-    onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
+    onAddTiles: (
+        tiles: Dashboard['tiles'][number][],
+        // Map of new tile UUID → source tile UUID, so dashboard filter `tileTargets` are copied from the source.
+        tileUuidMapping?: Record<string, string>,
+    ) => void;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
     activeTabUuid?: string;
     dashboardTabs?: Dashboard['tabs'];

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -544,7 +544,11 @@ interface DashboardChartTileMainProps extends Pick<
     tile: IDashboardChartTile;
     dashboardChartReadyQuery: DashboardChartReadyQuery;
     resultsData: InfiniteQueryResults;
-    onAddTiles?: (tiles: Dashboard['tiles'][number][]) => void;
+    onAddTiles?: (
+        tiles: Dashboard['tiles'][number][],
+        // Map of new tile UUID → source tile UUID, so dashboard filter `tileTargets` are copied from the source.
+        tileUuidMapping?: Record<string, string>,
+    ) => void;
     canExportCsv?: boolean;
     canExportImages?: boolean;
     canExportPagePdf?: boolean;
@@ -783,22 +787,25 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
 
         useEffect(() => {
             if (duplicatedChart && props.onAddTiles) {
-                // We duplicated a chart, we add it to the dashboard
-                props.onAddTiles([
-                    {
-                        uuid: uuid4(),
-                        properties: {
-                            savedChartUuid: duplicatedChart.uuid,
-                            chartName: duplicatedChart.name ?? '',
+                const newTileUuid = uuid4();
+                props.onAddTiles(
+                    [
+                        {
+                            uuid: newTileUuid,
+                            properties: {
+                                savedChartUuid: duplicatedChart.uuid,
+                                chartName: duplicatedChart.name ?? '',
+                            },
+                            type: DashboardTileTypes.SAVED_CHART,
+                            x: 0,
+                            y: 0,
+                            h: props.tile.h,
+                            w: props.tile.w,
+                            tabUuid: props.tile.tabUuid,
                         },
-                        type: DashboardTileTypes.SAVED_CHART,
-                        x: 0,
-                        y: 0,
-                        h: props.tile.h,
-                        w: props.tile.w,
-                        tabUuid: props.tile.tabUuid,
-                    },
-                ]);
+                    ],
+                    { [newTileUuid]: props.tile.uuid },
+                );
                 resetDuplicatedChart(); // Reset duplicated chart to avoid adding it multiple times
             }
         }, [props, duplicatedChart, resetDuplicatedChart]);

--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -19,7 +19,11 @@ import SuboptimalState from '../../common/SuboptimalState/SuboptimalState';
 import AddTileButton from '../AddTileButton';
 
 interface SavedChartsAvailableProps {
-    onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
+    onAddTiles: (
+        tiles: Dashboard['tiles'][number][],
+        // Map of new tile UUID → source tile UUID, so dashboard filter `tileTargets` are copied from the source.
+        tileUuidMapping?: Record<string, string>,
+    ) => void;
     emptyContainerType?: 'dashboard' | 'tab';
     isEditMode: boolean;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -35,7 +35,11 @@ import MantineModal from '../../common/MantineModal';
 import { ChartIcon } from '../../common/ResourceIcon';
 
 type Props = {
-    onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
+    onAddTiles: (
+        tiles: Dashboard['tiles'][number][],
+        // Map of new tile UUID → source tile UUID, so dashboard filter `tileTargets` are copied from the source.
+        tileUuidMapping?: Record<string, string>,
+    ) => void;
     onClose: () => void;
 };
 

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -105,7 +105,11 @@ type DashboardHeaderProps = {
     dashboardTiles?: Dashboard['tiles'];
     isMovingDashboardToSpace: boolean;
     onSwitchTab?: (tab: Dashboard['tabs'][number] | undefined) => void;
-    onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
+    onAddTiles: (
+        tiles: Dashboard['tiles'][number][],
+        // Map of new tile UUID → source tile UUID, so dashboard filter `tileTargets` are copied from the source.
+        tileUuidMapping?: Record<string, string>,
+    ) => void;
     onCancel: () => void;
     onSaveDashboard: () => void;
     onDelete: () => void;

--- a/packages/frontend/src/features/dashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/features/dashboardTabs/GridTile.tsx
@@ -21,7 +21,11 @@ type GridTileProps = Pick<
 > & {
     index: number;
     tabs?: DashboardTab[];
-    onAddTiles: (tiles: IDashboard['tiles'][number][]) => Promise<void>;
+    onAddTiles: (
+        tiles: IDashboard['tiles'][number][],
+        // Map of new tile UUID → source tile UUID, so dashboard filter `tileTargets` are copied from the source.
+        tileUuidMapping?: Record<string, string>,
+    ) => Promise<void>;
     locked: boolean;
 };
 

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -83,7 +83,11 @@ type TabGridPanelProps = {
     onWidthChange: (width: number) => void;
     onDeleteTile: (tile: IDashboard['tiles'][number]) => Promise<void>;
     onEditTile: (tile: IDashboard['tiles'][number]) => void;
-    onAddTiles: (tiles: IDashboard['tiles'][number][]) => Promise<void>;
+    onAddTiles: (
+        tiles: IDashboard['tiles'][number][],
+        // Map of new tile UUID → source tile UUID, so dashboard filter `tileTargets` are copied from the source.
+        tileUuidMapping?: Record<string, string>,
+    ) => Promise<void>;
 };
 
 /**

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -430,7 +430,11 @@ const Dashboard: FC = () => {
     );
 
     const handleAddTiles = useCallback(
-        async (tiles: IDashboard['tiles'][number][]) => {
+        async (
+            tiles: IDashboard['tiles'][number][],
+            // Map of new tile UUID → source tile UUID, so dashboard filter `tileTargets` are copied from the source.
+            tileUuidMapping?: Record<string, string>,
+        ) => {
             let newTiles = tiles;
             if (tabsEnabled) {
                 newTiles = tiles.map((tile: DashboardTile) => ({
@@ -444,6 +448,36 @@ const Dashboard: FC = () => {
             );
 
             setHaveTilesChanged(true);
+
+            // For each duplicated tile, copy the source tile's per-filter
+            // override (enabled/disabled + field mapping) onto the new tile's
+            // UUID. Without this, the new UUID is absent from `tileTargets`
+            // and `getDashboardFilterRulesForTile` falls back to auto-applying
+            // every matching filter — ignoring whatever was configured on the
+            // original.
+            if (tileUuidMapping && Object.keys(tileUuidMapping).length > 0) {
+                setDashboardFilters((prev) => {
+                    const updatedDimensions = prev.dimensions.map((filter) => {
+                        if (!filter.tileTargets) return filter;
+                        const nextTileTargets = { ...filter.tileTargets };
+                        let changed = false;
+                        for (const [newUuid, oldUuid] of Object.entries(
+                            tileUuidMapping,
+                        )) {
+                            if (oldUuid in nextTileTargets) {
+                                nextTileTargets[newUuid] =
+                                    nextTileTargets[oldUuid];
+                                changed = true;
+                            }
+                        }
+                        return changed
+                            ? { ...filter, tileTargets: nextTileTargets }
+                            : filter;
+                    });
+                    return { ...prev, dimensions: updatedDimensions };
+                });
+                setHaveFiltersChanged(true);
+            }
         },
         [
             activeTab,
@@ -452,6 +486,8 @@ const Dashboard: FC = () => {
             setDashboardTiles,
             setHaveTilesChanged,
             setHaveTabsChanged,
+            setDashboardFilters,
+            setHaveFiltersChanged,
         ],
     );
 


### PR DESCRIPTION
Closes: PROD-7487

## Summary

Duplicating a chart tile on a dashboard silently reset that tile's per-filter configuration. Filters the user had disabled on the source tile re-enabled themselves on the duplicate, and any custom field-mapping override was dropped.

Only the "Duplicate chart" action on a dashboard tile is affected. Adding a new chart, editing a chart, and duplicating an entire dashboard are unchanged.

## Root cause

Per-tile filter overrides live in `DashboardFilterRule.tileTargets`, keyed by tile UUID. When a chart is duplicated, a fresh tile UUID is minted via `uuid4()` and the tile is appended through `onAddTiles`, but `tileTargets` is never touched — so the new UUID is absent from the map.

```ts
// getDashboardFilterRulesForTile — packages/common/src/utils/filters.ts
const tileConfig = filter.tileTargets?.[tileUuid];
if (tileConfig === undefined) {
    // ...falls through to auto-apply the filter with default targeting
    return filter;
}
```

A missing entry is treated as "apply this filter to the tile with default targeting," so every matching filter snaps back on and any custom mapping is discarded. The source tile's entry is still in `tileTargets` — it just isn't being carried over to the new UUID.

```
source tile A  (uuid = a)
filter F.tileTargets = { a: { fieldId: "orders.status", isEnabled: false } }

Duplicate A -> new tile B (uuid = b)

Before:
  filter F.tileTargets = { a: { ... } }
  b not in tileTargets  ->  default auto-apply  ->  override lost

After:
  filter F.tileTargets = { a: { ... }, b: { ... } }   (b copied from a)
                          ->  duplicate inherits source's override
```

## Fix

`onAddTiles` now accepts an optional `tileUuidMapping: Record<newUuid, sourceUuid>`. When `Dashboard.tsx` receives a non-empty mapping, it walks every dimension filter and copies the source tile's `tileTargets` entry onto the new tile's UUID, then flags filters as changed. The chart-duplicate flow is the only caller that passes the mapping today; every other caller forwards `undefined` and behaves identically.

- `packages/frontend/src/pages/Dashboard.tsx` — `handleAddTiles` rewrites `dashboardFilters.dimensions[*].tileTargets` for the mapped UUIDs and sets `haveFiltersChanged`.
- `packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx` — duplicate-chart effect mints the new tile UUID up front and passes `{ [newUuid]: props.tile.uuid }`.
- `AddTileButton`, `AddChartTilesModal`, `DashboardHeader`, `EmptyStateNoTiles`, `GridTile`, `dashboardTabs/index` — widened `onAddTiles` signature to forward the optional mapping; no behaviour change.
- Out of scope: `metrics` and `tableCalculations` filter arrays. The dashboard model only writes `tileTargets` on `dimensions`, which matches the existing reducer surface.

## Test plan

- [x] `pnpm -F frontend typecheck && pnpm -F frontend lint`
- [ ] Manual: on a dashboard with a filter disabled for chart A, duplicate A and confirm the duplicate also has the filter disabled
- [ ] Manual: on a dashboard with a filter whose field is remapped for chart A, duplicate A and confirm the duplicate inherits the same remap
- [ ] Manual: add a brand-new chart tile (not a duplicate) and confirm filters still auto-apply as before