### PR TITLE
feat(mcp): pre-select project via X-Lightdash-Project header

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -157,6 +157,8 @@ export type ExtraContext = {
     account: OauthAccount | ApiKeyAccount | ServiceAcctAccount;
     /** User attribute overrides passed via X-Lightdash-User-Attributes header */
     headerUserAttributes?: UserAttributeValueMap;
+    /** Project UUID passed via X-Lightdash-Project header; overrides stored context */
+    headerProjectUuid?: string;
 };
 type McpProtocolContext = {
     authInfo?: AuthInfo & {
@@ -332,7 +334,9 @@ export class McpService extends BaseService {
         return this.mcpCompatLayer.processZodType(schema).shape;
     }
 
-    setupHandlers(): void {
+    setupHandlers(
+        options: { projectPinned: boolean } = { projectPinned: false },
+    ): void {
         this.mcpServer.registerTool(
             McpToolName.GET_LIGHTDASH_VERSION,
             {
@@ -625,158 +629,171 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
-            McpToolName.LIST_PROJECTS,
-            {
-                description:
-                    'List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations.',
-                inputSchema: {},
-                annotations: {
-                    readOnlyHint: true,
-                    destructiveHint: false,
-                    idempotentHint: true,
+        // When the project is pinned via header, hide the project-selection
+        // tools so clients can't change context for a request-scoped pin.
+        if (!options.projectPinned) {
+            this.mcpServer.registerTool(
+                McpToolName.LIST_PROJECTS,
+                {
+                    description:
+                        'List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations.',
+                    inputSchema: {},
+                    annotations: {
+                        readOnlyHint: true,
+                        destructiveHint: false,
+                        idempotentHint: true,
+                    },
                 },
-            },
-            async (
-                _args: Record<string, never>,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
-                const { user, organizationUuid } = this.getAccount(
-                    extra as McpProtocolContext,
-                );
+                async (
+                    _args: Record<string, never>,
+                    extra: RequestHandlerExtra<
+                        ServerRequest,
+                        ServerNotification
+                    >,
+                ) => {
+                    const { user, organizationUuid } = this.getAccount(
+                        extra as McpProtocolContext,
+                    );
 
-                this.trackToolCall(
-                    extra as McpProtocolContext,
-                    McpToolName.LIST_PROJECTS,
-                );
+                    this.trackToolCall(
+                        extra as McpProtocolContext,
+                        McpToolName.LIST_PROJECTS,
+                    );
 
-                const allProjects = await wrapSentryTransaction(
-                    'McpService.listProjects.getAllByOrganizationUuid',
-                    { organizationUuid },
-                    async () =>
-                        this.projectModel.getAllByOrganizationUuid(
-                            organizationUuid,
-                        ),
-                );
+                    const allProjects = await wrapSentryTransaction(
+                        'McpService.listProjects.getAllByOrganizationUuid',
+                        { organizationUuid },
+                        async () =>
+                            this.projectModel.getAllByOrganizationUuid(
+                                organizationUuid,
+                            ),
+                    );
 
-                const auditedAbility = this.createAuditedAbility(user);
-                const projectList = allProjects
-                    .filter((project) =>
-                        auditedAbility.can(
+                    const auditedAbility = this.createAuditedAbility(user);
+                    const projectList = allProjects
+                        .filter((project) =>
+                            auditedAbility.can(
+                                'view',
+                                subject('Project', {
+                                    organizationUuid,
+                                    projectUuid: project.projectUuid,
+                                }),
+                            ),
+                        )
+                        .map((project) => ({
+                            name: project.name,
+                            projectUuid: project.projectUuid,
+                        }));
+
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: JSON.stringify(projectList, null, 2),
+                            },
+                        ],
+                    };
+                },
+            );
+
+            this.mcpServer.registerTool(
+                McpToolName.SET_PROJECT,
+                {
+                    description:
+                        'Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, use list_agents to discover available AI agents and optionally set_agent to activate one.',
+                    inputSchema: {
+                        projectUuid: z.string(),
+                        tags: z.array(z.string()).optional(),
+                    },
+                    annotations: {
+                        readOnlyHint: true,
+                        destructiveHint: false,
+                        idempotentHint: true,
+                    },
+                },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                async (
+                    _args: AnyType,
+                    extra: RequestHandlerExtra<
+                        ServerRequest,
+                        ServerNotification
+                    >,
+                ) => {
+                    const args = _args as {
+                        projectUuid: string;
+                        tags?: string[];
+                    };
+                    const { user, organizationUuid, account } = this.getAccount(
+                        extra as McpProtocolContext,
+                    );
+
+                    this.trackToolCall(
+                        extra as McpProtocolContext,
+                        McpToolName.SET_PROJECT,
+                        args.projectUuid,
+                    );
+
+                    if (!args.projectUuid) {
+                        throw new ParameterError('Project UUID is required');
+                    }
+
+                    // Validate project access
+                    const project = await this.projectService.getProject(
+                        args.projectUuid,
+                        account,
+                    );
+
+                    const auditedAbility = this.createAuditedAbility(user);
+                    if (
+                        auditedAbility.cannot(
                             'view',
                             subject('Project', {
-                                organizationUuid,
-                                projectUuid: project.projectUuid,
+                                projectUuid: args.projectUuid,
+                                organizationUuid: project.organizationUuid,
                             }),
-                        ),
-                    )
-                    .map((project) => ({
-                        name: project.name,
-                        projectUuid: project.projectUuid,
-                    }));
+                        )
+                    ) {
+                        throw new ForbiddenError(
+                            'You do not have access to this project',
+                        );
+                    }
 
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: JSON.stringify(projectList, null, 2),
-                        },
-                    ],
-                };
-            },
-        );
+                    // Determine tags: use provided tags, or preserve existing, or set to null
+                    let tagsToSet: string[] | null = null;
+                    if (args.tags !== undefined) {
+                        tagsToSet = args.tags.length > 0 ? args.tags : null;
+                    }
 
-        this.mcpServer.registerTool(
-            McpToolName.SET_PROJECT,
-            {
-                description:
-                    'Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, use list_agents to discover available AI agents and optionally set_agent to activate one.',
-                inputSchema: {
-                    projectUuid: z.string(),
-                    tags: z.array(z.string()).optional(),
-                },
-                annotations: {
-                    readOnlyHint: true,
-                    destructiveHint: false,
-                    idempotentHint: true,
-                },
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
-                const args = _args as { projectUuid: string; tags?: string[] };
-                const { user, organizationUuid, account } = this.getAccount(
-                    extra as McpProtocolContext,
-                );
-
-                this.trackToolCall(
-                    extra as McpProtocolContext,
-                    McpToolName.SET_PROJECT,
-                    args.projectUuid,
-                );
-
-                if (!args.projectUuid) {
-                    throw new ParameterError('Project UUID is required');
-                }
-
-                // Validate project access
-                const project = await this.projectService.getProject(
-                    args.projectUuid,
-                    account,
-                );
-
-                const auditedAbility = this.createAuditedAbility(user);
-                if (
-                    auditedAbility.cannot(
-                        'view',
-                        subject('Project', {
+                    // Agent is cleared because agents are scoped to a project
+                    await this.mcpContextModel.setContext({
+                        userUuid: user.userUuid,
+                        organizationUuid,
+                        context: {
                             projectUuid: args.projectUuid,
-                            organizationUuid: project.organizationUuid,
-                        }),
-                    )
-                ) {
-                    throw new ForbiddenError(
-                        'You do not have access to this project',
-                    );
-                }
+                            projectName: project.name,
+                            tags: tagsToSet,
+                            agentUuid: null,
+                            agentName: null,
+                        },
+                    });
 
-                // Determine tags: use provided tags, or preserve existing, or set to null
-                let tagsToSet: string[] | null = null;
-                if (args.tags !== undefined) {
-                    tagsToSet = args.tags.length > 0 ? args.tags : null;
-                }
-
-                // Agent is cleared because agents are scoped to a project
-                await this.mcpContextModel.setContext({
-                    userUuid: user.userUuid,
-                    organizationUuid,
-                    context: {
+                    const result = {
                         projectUuid: args.projectUuid,
                         projectName: project.name,
-                        tags: tagsToSet,
-                        agentUuid: null,
-                        agentName: null,
-                    },
-                });
+                        selectedTags: tagsToSet,
+                    };
 
-                const result = {
-                    projectUuid: args.projectUuid,
-                    projectName: project.name,
-                    selectedTags: tagsToSet,
-                };
-
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: JSON.stringify(result, null, 2),
-                        },
-                    ],
-                };
-            },
-        );
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: JSON.stringify(result, null, 2),
+                            },
+                        ],
+                    };
+                },
+            );
+        }
 
         this.mcpServer.registerTool(
             McpToolName.GET_CURRENT_PROJECT,
@@ -1704,11 +1721,15 @@ export class McpService extends BaseService {
     async getProjectUuidFromContext(
         context: McpProtocolContext,
     ): Promise<string | undefined> {
-        const { user } = context.authInfo!.extra;
+        const { user, headerProjectUuid } = context.authInfo!.extra;
         const { organizationUuid } = user;
 
         if (!user || !organizationUuid) {
             return undefined;
+        }
+
+        if (headerProjectUuid) {
+            return headerProjectUuid;
         }
 
         const contextRow = await this.mcpContextModel.getContext(
@@ -1865,12 +1886,36 @@ export class McpService extends BaseService {
     }
 
     async resolveProjectUuid(context: McpProtocolContext): Promise<string> {
-        // Use projectUuid from args or get from context
+        const { user, account, headerProjectUuid } = context.authInfo!.extra;
         const projectUuid = await this.getProjectUuidFromContext(context);
         if (!projectUuid) {
             throw new ForbiddenError(
                 'No project context set. Use set_project or provide projectUuid parameter.',
             );
+        }
+        // UUIDs from mcp_context were view-checked at set_project write time.
+        // The X-Lightdash-Project header skips that path, so gate it here —
+        // otherwise any tool that doesn't re-check (e.g. list_explores) would
+        // leak project metadata cross-tenant.
+        if (headerProjectUuid && headerProjectUuid === projectUuid) {
+            const project = await this.projectService.getProject(
+                projectUuid,
+                account,
+            );
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'view',
+                    subject('Project', {
+                        projectUuid,
+                        organizationUuid: project.organizationUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    'You do not have access to this project',
+                );
+            }
         }
         return projectUuid;
     }
@@ -2344,7 +2389,7 @@ export class McpService extends BaseService {
      * Required for SDK 1.26.0+ stateful mode where each session needs its own server.
      * See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
      */
-    public createServer(): McpServer {
+    public createServer(options?: { projectPinned?: boolean }): McpServer {
         const newServer = Sentry.wrapMcpServerWithSentry(
             new McpServer({
                 name: 'Lightdash MCP Server',
@@ -2372,7 +2417,7 @@ export class McpService extends BaseService {
         // Temporarily swap the server to register handlers on the new instance
         const originalServer = this.mcpServer;
         this.mcpServer = newServer;
-        this.setupHandlers();
+        this.setupHandlers({ projectPinned: options?.projectPinned ?? false });
         this.mcpServer = originalServer;
 
         return newServer;

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -14,6 +14,7 @@ import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import express, { type Router } from 'express';
 import { IncomingMessage } from 'http';
+import { validate as isValidUuid } from 'uuid';
 import { allowApiKeyAuthentication } from '../controllers/authentication';
 import { ExtraContext, McpService } from '../ee/services/McpService/McpService';
 import Logger from '../logging/logger';
@@ -30,6 +31,27 @@ function getMcpService(req: express.Request): McpService {
 }
 
 const MCP_USER_ATTRIBUTE_HEADER = 'X-Lightdash-User-Attributes';
+const MCP_PROJECT_HEADER = 'X-Lightdash-Project';
+
+/**
+ * Extracts a project UUID override from the X-Lightdash-Project header.
+ * Project-level permissions are enforced downstream by the services invoked
+ * by each MCP tool (e.g. ProjectService.getProject), so we only validate the
+ * UUID shape here.
+ */
+function extractProjectUuidFromHeader(
+    req: express.Request,
+): string | undefined {
+    const headerValue = req.headers[MCP_PROJECT_HEADER.toLowerCase()];
+    if (!headerValue || typeof headerValue !== 'string') {
+        return undefined;
+    }
+    if (!isValidUuid(headerValue)) {
+        Logger.warn(`Invalid ${MCP_PROJECT_HEADER} header: not a UUID`);
+        return undefined;
+    }
+    return headerValue;
+}
 
 /**
  * Extracts user attribute overrides from the X-Lightdash-User-Attributes header.
@@ -147,7 +169,10 @@ mcpRouter.all(
                 // SDK 1.26.0 requires a new server+transport per request in stateless mode
                 // to prevent cross-client response data leaks (CVE-2026-25536)
                 // See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
-                const mcpServer = mcpService.createServer();
+                const headerProjectUuid = extractProjectUuidFromHeader(req);
+                const mcpServer = mcpService.createServer({
+                    projectPinned: headerProjectUuid !== undefined,
+                });
                 const transport = new StreamableHTTPServerTransport({
                     enableJsonResponse: true,
                     sessionIdGenerator: undefined,
@@ -170,6 +195,7 @@ mcpRouter.all(
                         user: req.user,
                         account: oauthAuth,
                         headerUserAttributes,
+                        headerProjectUuid,
                     };
                     authReq.auth = {
                         token: oauthAuth.authentication.token,
@@ -185,6 +211,7 @@ mcpRouter.all(
                         user: req.user,
                         account: apiKeyAuth,
                         headerUserAttributes,
+                        headerProjectUuid,
                     };
                     authReq.auth = {
                         token: apiKeyAuth.authentication.source,
@@ -201,6 +228,7 @@ mcpRouter.all(
                         user: req.user,
                         account: serviceAccountAuth,
                         headerUserAttributes,
+                        headerProjectUuid,
                     };
                     authReq.auth = {
                         token: serviceAccountAuth.authentication.source,


### PR DESCRIPTION
## Summary
Adds `X-Lightdash-Project` header so MCP clients can pin a project per-integration without an interactive `set_project` call. The header overrides any stored `mcp_context` for the request.

When set, `list_projects` / `set_project` are omitted from `tools/list`. `resolveProjectUuid` runs a CASL `view Project` check on header-supplied UUIDs (same check `set_project` does for the stored-context path), so every tool that reads the resolved UUID is gated by construction.