### PR TITLE
fix(mcp): mcp chart-app leaking node code

### DIFF
--- a/packages/backend/src/ee/services/McpService/mcp-chart-app/src/chart-app.ts
+++ b/packages/backend/src/ee/services/McpService/mcp-chart-app/src/chart-app.ts
@@ -1,10 +1,12 @@
+// Deep import bypasses @lightdash/common's barrel, which transitively pulls
+// in pegjs/postcss and breaks the browser bundle (path.isAbsolute externalized).
 import {
     formatCartesianTooltipRow,
     formatColorIndicator,
     formatTooltipHeader,
     formatTooltipRow,
     formatTooltipValue,
-} from '@lightdash/common';
+} from '@lightdash/common/src/visualizations/helpers/styles/tooltipStyles';
 import { App } from '@modelcontextprotocol/ext-apps';
 import * as echarts from 'echarts';
 import { lightdashTheme } from './lightdash-theme';

--- a/packages/backend/src/ee/services/McpService/mcp-chart-app/vite.config.ts
+++ b/packages/backend/src/ee/services/McpService/mcp-chart-app/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
         alias: {
             '@lightdash/common': path.resolve(
                 __dirname,
-                '../../../../../../common/src',
+                '../../../../../../common',
             ),
         },
     },


### PR DESCRIPTION
Closes: ZAP-402

## Summary

The MCP chart-app's prebuilt bundle was leaking Node-only code (`postcss`, `pegjs`) into the browser via `@lightdash/common`'s barrel export. At runtime this surfaced as:

> Module "" has been externalized for browser compatibility. Cannot access ".isAbsolute" in client code.

Root cause: `chart-app.ts` imported tooltip formatters from `@lightdash/common` (barrel). The barrel re-exports the formula module → pulls in `pegjs` (with direct `eval()`) and `postcss` source-map handling (calls `path.isAbsolute`). Vite externalizes `path` for the browser, so accessing `.isAbsolute` throws.

Fix: deep-import from `@lightdash/common/src/visualizations/helpers/styles/tooltipStyles` (a leaf that only imports color constants). Vite alias adjusted to `common/` so the `/src/` segment resolves correctly.

## Bundle size

| | Before | After | Saved |
|---|---|---|---|
| Raw | 4.46 MB | 1.42 MB | **−3.04 MB (−68%)** |
| Gzipped | 945 KB | 435 KB | **−510 KB (−54%)** |

Build is also faster (no more pegjs `eval` warnings).
