### PR TITLE
chore(mcp): pass --ignore-scripts when installing chart-app deps

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,7 +9,7 @@
         "generate-api-dev": "chokidar './src/**/controllers/**/*.ts' -c 'pnpm run generate-api'",
         "dev": "LIGHTDASH_MODE=development HEADLESS=true tsx watch --clear-screen=false --inspect=0.0.0.0:9229 src/index.ts",
         "build": "tsc --build tsconfig.json",
-        "build:mcp-app": "cd src/ee/services/McpService/mcp-chart-app && npm install && npm run build",
+        "build:mcp-app": "cd src/ee/services/McpService/mcp-chart-app && npm install --ignore-scripts && npm run build",
         "build-sourcemaps": "tsc --build tsconfig.sentry.json",
         "typecheck": "tsc --project tsconfig.json --noEmit",
         "postbuild": "copyfiles --error --up 1 'src/**/*.html' 'src/**/*.png' dist",


### PR DESCRIPTION
## Summary

Adds `--ignore-scripts` to the `build:mcp-app` install step in `packages/backend/package.json` to mirror how it's already done in the Dockerfile ([line 241](https://github.com/lightdash/lightdash/blob/main/Dockerfile#L241)):

```dockerfile
RUN cd packages/backend/src/ee/services/McpService/mcp-chart-app \\
    && npm install --ignore-scripts \\
    && npm run build \\
    && rm -rf node_modules
```

Disabling lifecycle scripts on the nested install reduces supply-chain attack surface and brings the local build path to parity with the production image build.