### PR TITLE
chore(nix): add sfw devtool to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,12 @@
               ];
             };
           };
+
+          # Socket Firewall Free — blocks malicious npm packages before they hit
+          # disk. Not in nixpkgs, so wrap `npx -y sfw` and expose it on PATH.
+          sfw = pkgs.writeShellScriptBin "sfw" ''
+            exec ${pkgs.nodejs}/bin/npx -y sfw "$@"
+          '';
         in
         {
           default = pkgs.mkShell {
@@ -46,7 +52,7 @@
               lz4
             ];
 
-            buildInputs = with pkgs; [
+            buildInputs = (with pkgs; [
               nodejs
               pnpm
 
@@ -72,7 +78,7 @@
               zlib
               util-linux # libuuid
               xz # liblzma
-            ];
+            ]) ++ [ sfw ];
 
             env.LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
               pkgs.expat


### PR DESCRIPTION
## Summary

Adds [Socket Firewall Free (`sfw`)](https://github.com/SocketDev/sfw-free) to the nix devshell. CLAUDE.md mandates `sfw pnpm install` for all installs in this repo to block confirmed-malicious packages before they hit disk — but `sfw` wasn't available out of the box, forcing a manual `npm i -g sfw` per developer.

`sfw` isn't in nixpkgs, so this wraps `npx -y sfw` in a `writeShellScriptBin`. First invocation downloads the binary into npm's npx cache; subsequent calls are instant.

Stacked on top of #23058.