### PR TITLE
fix(timezone): skip date-trunc/extract wrap when target tz matches source

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -319,11 +319,14 @@ export class MetricQueryBuilder {
         CompiledDimension
     > = {};
 
-    /** Query timezone when timezone-aware DATE_TRUNC is active, undefined otherwise. */
+    /** Query timezone when timezone-aware DATE_TRUNC is active, undefined otherwise.
+     *  The target-vs-source equality short-circuit lives in `getSqlForTruncatedDate`
+     *  (and its EXTRACT siblings) so any call site that passes a timezone gets the
+     *  same no-op treatment — see `needsTimezoneWrap` in `timeFrames.ts`. */
     private get timezoneForDateTrunc(): string | undefined {
-        if (!this.args.useTimezoneAwareDateTrunc) return undefined;
-        if (this.columnTimezone === this.args.timezone) return undefined;
-        return this.args.timezone;
+        return this.args.useTimezoneAwareDateTrunc
+            ? this.args.timezone
+            : undefined;
     }
 
     private get columnTimezone(): string {

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -104,11 +104,72 @@ describe('TimeFrames', () => {
                     '${TABLE}.created',
                     DimensionType.TIMESTAMP,
                     undefined,
-                    'UTC',
+                    'America/New_York',
                 ),
             ).toEqual(
-                "TIMESTAMP_TRUNC(TIMESTAMP(${TABLE}.created), DAY, 'UTC')",
+                "TIMESTAMP_TRUNC(TIMESTAMP(${TABLE}.created), DAY, 'America/New_York')",
             );
+        });
+
+        test('UTC target with default (UTC) source short-circuits the wrap', () => {
+            // BigQuery: avoids TIMESTAMP() cast + 3-arg overload that defeats
+            // partition pruning when both sides are UTC.
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    undefined,
+                    'UTC',
+                ),
+            ).toEqual('TIMESTAMP_TRUNC(${TABLE}.created, DAY)');
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    undefined,
+                    'UTC',
+                ),
+            ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.SNOWFLAKE,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    undefined,
+                    'UTC',
+                ),
+            ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
+        });
+
+        test('Matching non-UTC target and source short-circuits the wrap', () => {
+            const tz = 'America/New_York';
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    undefined,
+                    tz,
+                    tz,
+                ),
+            ).toEqual('TIMESTAMP_TRUNC(${TABLE}.created, DAY)');
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.SNOWFLAKE,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    undefined,
+                    tz,
+                    tz,
+                ),
+            ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
         });
 
         test('BigQuery 2-arg TIMESTAMP_TRUNC keeps original expr unchanged (DATETIME overload still applies)', () => {
@@ -911,6 +972,42 @@ describe('TimeFrames', () => {
             ).toEqual(`EXTRACT(MONTH FROM ${col})`);
         });
 
+        test('target timezone matching source timezone short-circuits the wrap', () => {
+            // UTC default source — most common BQ case, partition-pruning sensitive.
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.MONTH_NUM,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    'UTC',
+                ),
+            ).toEqual(`EXTRACT(MONTH FROM ${col})`);
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.DAY_OF_WEEK_INDEX,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    'UTC',
+                ),
+            ).toEqual(`DATE_PART('DOW', ${col})`);
+            // Explicit matching non-UTC pair.
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.MONTH_NUM,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    'America/New_York',
+                    'America/New_York',
+                ),
+            ).toEqual(`EXTRACT(MONTH FROM ${col})`);
+        });
+
         test('DATE base dimension with timezone short-circuits (no wrap)', () => {
             expect(
                 getSqlForDatePart(
@@ -1087,6 +1184,30 @@ describe('TimeFrames', () => {
                     DimensionType.TIMESTAMP,
                 ),
             ).toEqual(`FORMAT_DATETIME('%B', ${col})`);
+        });
+
+        test('target timezone matching source timezone short-circuits the wrap', () => {
+            expect(
+                getSqlForDatePartName(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.MONTH_NAME,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    'UTC',
+                ),
+            ).toEqual(`FORMAT_DATETIME('%B', ${col})`);
+            expect(
+                getSqlForDatePartName(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.MONTH_NAME,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    'America/New_York',
+                    'America/New_York',
+                ),
+            ).toEqual(`TO_CHAR(${col}, 'FMMonth')`);
         });
 
         test.each([

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -679,6 +679,21 @@ const warehouseConfigs: Record<SupportedDbtAdapter, WarehouseConfig> = {
  * performed in the project TZ and the result is converted back to a proper
  * UTC instant so downstream consumers apply .tz(project_tz) uniformly.
  */
+// Returns the resolved (timezone, sourceTimezone) when the dim needs a tz
+// wrap, else null. Wrap conditions: TIMESTAMP-typed dim AND a target timezone
+// AND target != source (defaulting to UTC). Wrapping when target equals source
+// produces semantically-identical SQL that defeats partition pruning on
+// warehouses like BigQuery.
+const resolveTimezoneWrap = (
+    type: DimensionType,
+    timezone?: string,
+    sourceTimezone?: string,
+): { timezone: string; sourceTimezone?: string } | null => {
+    if (type !== DimensionType.TIMESTAMP || !timezone) return null;
+    if (timezone === (sourceTimezone ?? 'UTC')) return null;
+    return { timezone, sourceTimezone };
+};
+
 export const getSqlForTruncatedDate = (
     adapterType: SupportedDbtAdapter,
     timeFrame: TimeFrames,
@@ -688,7 +703,8 @@ export const getSqlForTruncatedDate = (
     timezone?: string,
     sourceTimezone?: string,
 ): string => {
-    if (!timezone || type !== DimensionType.TIMESTAMP) {
+    const wrap = resolveTimezoneWrap(type, timezone, sourceTimezone);
+    if (!wrap) {
         return warehouseConfigs[adapterType].getSqlForTruncatedDate(
             timeFrame,
             originalSql,
@@ -698,15 +714,15 @@ export const getSqlForTruncatedDate = (
     }
 
     const { toProjectTz, toUTC } = dateTruncTimezoneConversions[adapterType];
-    const input = toProjectTz(originalSql, timezone, sourceTimezone);
+    const input = toProjectTz(originalSql, wrap.timezone, wrap.sourceTimezone);
     const truncated = warehouseConfigs[adapterType].getSqlForTruncatedDate(
         timeFrame,
         input,
         type,
         startOfWeek,
-        timezone,
+        wrap.timezone,
     );
-    return toUTC(truncated, timezone);
+    return toUTC(truncated, wrap.timezone);
 };
 
 // DATE base dimensions short-circuit: no time component to shift.
@@ -719,14 +735,14 @@ export const getSqlForDatePart = (
     timezone?: string,
     sourceTimezone?: string,
 ): string => {
-    const wrappedSql =
-        timezone && type === DimensionType.TIMESTAMP
-            ? dateExtractsTimezoneConversions[adapterType].toExtractInputTz(
-                  originalSql,
-                  timezone,
-                  sourceTimezone,
-              )
-            : originalSql;
+    const wrap = resolveTimezoneWrap(type, timezone, sourceTimezone);
+    const wrappedSql = wrap
+        ? dateExtractsTimezoneConversions[adapterType].toExtractInputTz(
+              originalSql,
+              wrap.timezone,
+              wrap.sourceTimezone,
+          )
+        : originalSql;
     return warehouseConfigs[adapterType].getSqlForDatePart(
         timeFrame,
         wrappedSql,
@@ -747,7 +763,8 @@ export const getSqlForDatePartName = (
     timezone?: string,
     sourceTimezone?: string,
 ): string => {
-    if (!timezone || type !== DimensionType.TIMESTAMP) {
+    const wrap = resolveTimezoneWrap(type, timezone, sourceTimezone);
+    if (!wrap) {
         return warehouseConfigs[adapterType].getSqlForDatePartName(
             timeFrame,
             originalSql,
@@ -758,8 +775,8 @@ export const getSqlForDatePartName = (
         timeFrame,
         originalSql,
         type,
-        timezone,
-        sourceTimezone,
+        wrap.timezone,
+        wrap.sourceTimezone,
     );
 };
 


### PR DESCRIPTION
Closes GLITCH-444

## Summary

When the project query timezone matches the warehouse column timezone (the default UTC↔UTC case for vanilla BigQuery with `EnableTimezoneSupport` on), the timezone-aware DATE_TRUNC / EXTRACT paths still emit a tz round-trip that is semantically a no-op but **defeats partition pruning** on BigQuery — turning scoped queries into full-table scans and ballooning billed bytes.

This consolidates the no-op short-circuit at the boundary so every caller is gated by the same rule.

## SQL examples (local BigQuery `timezone_test` explore, default project tz)

### DATE_TRUNC — DAY dim, project tz `UTC`

Before:
```sql
SELECT TIMESTAMP_TRUNC(TIMESTAMP(`t`.event_timestamp), DAY, 'UTC') AS `day` ...
```
After:
```sql
SELECT TIMESTAMP_TRUNC(`t`.event_timestamp, DAY) AS `day` ...
```

### DATE_TRUNC — DAY dim, project tz `America/New_York` (preserved)

```sql
SELECT TIMESTAMP_TRUNC(TIMESTAMP(`t`.event_timestamp), DAY, 'America/New_York') AS `day` ...
```

### EXTRACT — HOUR_OF_DAY dim, project tz `UTC`

Before:
```sql
SELECT EXTRACT(HOUR FROM TIMESTAMP(`t`.event_timestamp) AT TIME ZONE 'UTC') AS `hour` ...
```
After:
```sql
SELECT EXTRACT(HOUR FROM `t`.event_timestamp) AS `hour` ...
```

### EXTRACT — HOUR_OF_DAY dim, project tz `America/New_York` (preserved)

```sql
SELECT EXTRACT(HOUR FROM TIMESTAMP(`t`.event_timestamp) AT TIME ZONE 'America/New_York') AS `hour` ...
```

### FORMAT — MONTH_NAME dim, project tz `UTC`

Before / After (now stable at the byte level):
```sql
SELECT FORMAT_DATETIME('%B', `t`.event_timestamp) AS `month_name` ...
```

## Root cause

The equality short-circuit (`columnTimezone === args.timezone → undefined`) lived only in `MetricQueryBuilder.timezoneForDateTrunc`, but two call sites destructured `args.timezone` directly and bypassed the getter — and `getSqlForTruncatedDate` / `getSqlForDatePart` / `getSqlForDatePartName` only bailed on `!timezone || type !== TIMESTAMP`, never on `target === source`. So the wrap fired even when source and target both defaulted to UTC.

## What changed

- **`packages/common/src/utils/timeFrames.ts`** — new `resolveTimezoneWrap(type, timezone, sourceTimezone)` helper that returns the resolved wrap pair or `null` (treating missing source as UTC). Applied at all three boundary functions: `getSqlForTruncatedDate`, `getSqlForDatePart`, `getSqlForDatePartName`.
- **`packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts`** — `timezoneForDateTrunc` getter simplified to its feature-flag gate; the equality check now lives at the boundary so call sites that bypass the getter are still covered.
- **`packages/common/src/utils/timeFrames.test.ts`** — updated the stale BQ wrap test (was asserting `'UTC'` which is now the no-op) to use a non-UTC tz. Added regression tests asserting UTC-on-UTC and matching non-UTC source/target short-circuit for all three paths.

## Test plan

- [x] Typecheck + lint clean (`common`, `backend`)
- [x] Unit tests pass: `timeFrames` (83/83), `MetricQueryBuilder` (179/179, 60 snapshots), all tz-adjacent backend suites (276/276)
- [x] Pre-existing common failures (`filtersCompiler`, `formatting`) verified identical on `main` — not introduced here
- [x] Live `/compileQuery` sanity across BigQuery, Postgres, ClickHouse, Databricks, Trino, Snowflake (default + `disableTimestampConversion` with non-UTC `dataTimezone`) — UTC tz drops the wrap, non-UTC preserves it, on both TRUNC and EXTRACT paths