### PR TITLE
fix(ai-agent): defer artifact auto-open until thread streaming completes

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
@@ -5,6 +5,7 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../store/hooks';
+import { useAiAgentThreadStreaming } from '../streaming/useAiAgentThreadStreamQuery';
 
 interface UseAiAgentThreadArtifactOptions {
     projectUuid: string | undefined;
@@ -23,6 +24,7 @@ export const useAiAgentThreadArtifact = ({
     const artifact = useAiAgentStoreSelector(
         (state) => state.aiArtifact.artifact,
     );
+    const isStreaming = useAiAgentThreadStreaming(threadUuid ?? '');
 
     const lastHandledMessageUuidRef = useRef<string | null>(null);
     const prevArtifactRef = useRef<typeof artifact>(null);
@@ -60,7 +62,13 @@ export const useAiAgentThreadArtifact = ({
         prevArtifactRef.current = artifact;
     }, [artifact, latestAssistantMessage]);
 
-    // Auto-select latest artifact if not already handled
+    // Auto-select latest artifact if not already handled. Defer while the
+    // thread is still streaming — the artifact gets appended to
+    // `message.artifacts` the moment its `runQuery`/`generateDashboard` tool
+    // call resolves, which is well before the assistant finishes producing
+    // its closing text. Opening the panel mid-stream yanks focus away from
+    // the message the user is reading. When `isStreaming` flips to false the
+    // hook re-runs and opens normally.
     useEffect(() => {
         if (
             !projectUuid ||
@@ -69,6 +77,7 @@ export const useAiAgentThreadArtifact = ({
             !latestAssistantMessage
         )
             return;
+        if (isStreaming) return;
         if (lastHandledMessageUuidRef.current === latestAssistantMessage.uuid)
             return;
         if (artifact?.messageUuid === latestAssistantMessage.uuid) return;
@@ -89,6 +98,7 @@ export const useAiAgentThreadArtifact = ({
         lastHandledMessageUuidRef.current = latestAssistantMessage.uuid;
     }, [
         artifact,
+        isStreaming,
         latestAssistantMessage,
         projectUuid,
         agentUuid,


### PR DESCRIPTION
## Summary

The thread-level "open the latest artifact" effect in `useAiAgentThreadArtifact` was firing the moment a new artifact got appended to `message.artifacts` — which happens as soon as the `runQuery` / `generateDashboard` tool result lands, **before** the assistant has finished producing its closing text after the tool call. The artifact panel popped open mid-stream and yanked focus away from the text the user was reading.

**Repro:** thread `607d6f8d-def6-46b5-b828-7578226d1ebc` — the prompt ran tool calls, generated a visualization artifact, and the panel auto-opened before the final response text finished streaming.

## Fix

Gate the dispatch on `!isStreaming` for the thread. The hook now subscribes to `useAiAgentThreadStreaming(threadUuid)` and adds it to the effect's deps, so when streaming flips to false the effect re-runs and opens the artifact normally.

## Regression analysis

Unchanged behaviour for:
- **Page reload on an existing thread** — `isStreaming` is false, the latest artifact opens as before.
- **User explicitly opening an artifact mid-stream via a content link** — the existing `artifact?.messageUuid === latestAssistantMessage.uuid` early-return short-circuits before the new streaming guard.
- **"User manually closed" tracking** — the separate effect that captures `lastHandledMessageUuidRef.current` when the user clears the panel still fires on artifact-cleared transitions regardless of streaming state.

## Test plan

- [x] `pnpm -F frontend typecheck`
- [x] `pnpm -F frontend lint` (2 pre-existing warnings in unrelated files)
- [ ] Manual: send a prompt that triggers `runQuery` → verify the artifact panel **does not** open until the assistant's final markdown finishes streaming (reviewer)
- [ ] Manual: reload a thread that has a visualization → verify the latest artifact opens automatically as before (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)