### PR TITLE
feat: validate MCP server connection on creation and add MCP server UI to agent form

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -1,5 +1,10 @@
 import { SEED_PROJECT } from '@lightdash/common';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
     getModels,
     getServices,
@@ -9,25 +14,110 @@ import {
 
 describe('AiAgentService MCP support', () => {
     let context: IntegrationTestContext;
+    let mcpServerUrl: string;
+    let httpServer: Server;
 
-    beforeAll(() => {
+    beforeAll(async () => {
         context = getTestContext();
+
+        const expectedBearerToken = 'secret-token-for-test-server';
+        const app = createMcpExpressApp();
+
+        app.post('/mcp', async (req, res) => {
+            if (req.headers.authorization !== `Bearer ${expectedBearerToken}`) {
+                res.status(401).json({
+                    jsonrpc: '2.0',
+                    error: {
+                        code: -32001,
+                        message: 'Unauthorized',
+                    },
+                    id: null,
+                });
+                return;
+            }
+
+            const server = new McpServer({
+                name: 'test-mcp-server',
+                version: '1.0.0',
+            });
+
+            const transport = new StreamableHTTPServerTransport({
+                sessionIdGenerator: undefined,
+            });
+
+            try {
+                await server.connect(transport);
+                await transport.handleRequest(req, res, req.body);
+            } finally {
+                res.on('close', () => {
+                    void transport.close();
+                    void server.close();
+                });
+            }
+        });
+
+        app.get('/mcp', async (_req, res) => {
+            res.writeHead(405).end(
+                JSON.stringify({
+                    jsonrpc: '2.0',
+                    error: {
+                        code: -32000,
+                        message: 'Method not allowed.',
+                    },
+                    id: null,
+                }),
+            );
+        });
+
+        app.delete('/mcp', async (_req, res) => {
+            res.writeHead(405).end(
+                JSON.stringify({
+                    jsonrpc: '2.0',
+                    error: {
+                        code: -32000,
+                        message: 'Method not allowed.',
+                    },
+                    id: null,
+                }),
+            );
+        });
+
+        httpServer = await new Promise((resolve, reject) => {
+            const server = app.listen(0, () => resolve(server));
+            server.on('error', reject);
+        });
+
+        const { port } = httpServer.address() as AddressInfo;
+        mcpServerUrl = `http://127.0.0.1:${port}/mcp`;
+    });
+
+    afterAll(async () => {
+        await new Promise<void>((resolve, reject) => {
+            httpServer.close((error) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+                resolve();
+            });
+        });
     });
 
     it('stores encrypted MCP credentials and attaches servers to agents', async () => {
         const services = getServices(context.app);
         const models = getModels(context.app);
         const suffix = crypto.randomUUID().slice(0, 8);
+        const expectedBearerToken = 'secret-token-for-test-server';
 
         const mcpServer = await services.aiAgentService.createMcpServer(
             context.testUser,
             SEED_PROJECT.project_uuid,
             {
                 name: `Docs MCP ${suffix}`,
-                url: 'https://example.com/mcp',
+                url: mcpServerUrl,
                 authType: 'bearer',
                 credentials: {
-                    bearerToken: `secret-token-${suffix}`,
+                    bearerToken: expectedBearerToken,
                 },
             },
         );
@@ -88,7 +178,7 @@ describe('AiAgentService MCP support', () => {
 
         expect(sensitiveMcpServers).toHaveLength(1);
         expect(sensitiveMcpServers[0]?.credentials).toEqual({
-            bearerToken: `secret-token-${suffix}`,
+            bearerToken: expectedBearerToken,
         });
 
         await services.aiAgentService.updateAgent(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -179,6 +179,7 @@ import {
     getThinkingBlocks,
 } from '../ai/utils/getSlackBlocks';
 import { llmAsAJudge } from '../ai/utils/llmAsAJudge';
+import { testMcpConnection } from '../ai/utils/mcpClient';
 import { populateCustomMetricsSQL } from '../ai/utils/populateCustomMetricsSQL';
 import { validateSelectedFieldsExistence } from '../ai/utils/validators';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
@@ -489,7 +490,10 @@ export class AiAgentService extends BaseService {
 
                 const userAttributes =
                     await this.userAttributesModel.getAttributeValuesForOrgMember(
-                        { organizationUuid, userUuid: user.userUuid },
+                        {
+                            organizationUuid,
+                            userUuid: user.userUuid,
+                        },
                     );
 
                 const allExplores = Object.values(
@@ -1384,17 +1388,42 @@ export class AiAgentService extends BaseService {
                 );
         }
 
+        const credentials =
+            body.authType === 'bearer'
+                ? {
+                      bearerToken: body.credentials!.bearerToken.trim(),
+                  }
+                : null;
+
+        try {
+            await testMcpConnection(
+                {
+                    name,
+                    url: normalizedUrl,
+                    authType: body.authType,
+                    credentials,
+                },
+                (error) => {
+                    Logger.error(
+                        `[AiAgent][MCP][${name}] Uncaught MCP client error while validating connection`,
+                        error,
+                    );
+                },
+            );
+        } catch (error) {
+            throw new ParameterError(
+                `Could not connect to MCP server: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+
         return this.aiAgentModel.createMcpServer({
             projectUuid,
             name,
             url: normalizedUrl,
             authType: body.authType,
-            credentials:
-                body.authType === 'bearer'
-                    ? {
-                          bearerToken: body.credentials!.bearerToken.trim(),
-                      }
-                    : null,
+            credentials,
         });
     }
 
@@ -3276,9 +3305,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
                         if (queryResults.status === QueryHistoryStatus.ERROR) {
                             throw new WarehouseQueryError(
-                                `SQL query failed: ${
-                                    queryResults.error ?? 'Unknown error'
-                                }`,
+                                `SQL query failed: ${queryResults.error ?? 'Unknown error'}`,
                             );
                         }
 
@@ -6903,9 +6930,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             }
             if (artifact.dashboardConfig) {
                 contextParts.push(
-                    `Dashboard config: ${JSON.stringify(
-                        artifact.dashboardConfig,
-                    )}`,
+                    `Dashboard config: ${JSON.stringify(artifact.dashboardConfig)}`,
                 );
             }
         }

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1,4 +1,4 @@
-import { createMCPClient, type MCPClient } from '@ai-sdk/mcp';
+import type { MCPClient } from '@ai-sdk/mcp';
 import { AgentToolOutput, assertUnreachable, Explore } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
@@ -35,6 +35,7 @@ import {
     AiAgentStepCapReachedError,
     getUserFacingErrorMessage,
 } from '../utils/errorMessages';
+import { createHttpMcpClient } from '../utils/mcpClient';
 
 const createAiAgentLogger =
     (debugLoggingEnabled: boolean) => (context: string, message: string) => {
@@ -216,52 +217,16 @@ const getAgentTools = async (
 
     try {
         for await (const mcpServer of args.mcpServers) {
-            if (
-                mcpServer.authType === 'bearer' &&
-                (!mcpServer.credentials ||
-                    !('bearerToken' in mcpServer.credentials) ||
-                    !mcpServer.credentials.bearerToken)
-            ) {
-                throw new Error(
-                    `MCP server "${mcpServer.name}" is missing bearer credentials`,
-                );
-            }
-
-            const bearerToken =
-                mcpServer.authType === 'bearer' &&
-                mcpServer.credentials &&
-                'bearerToken' in mcpServer.credentials
-                    ? mcpServer.credentials.bearerToken
-                    : undefined;
-
-            if (mcpServer.authType === 'oauth') {
-                throw new Error(
-                    `OAuth MCP server "${mcpServer.name}" is not implemented yet`,
-                );
-            }
-
             logger(
                 'Agent Tools',
                 `Connecting to MCP server: ${mcpServer.name} (${mcpServer.url})`,
             );
 
-            const mcpClient = await createMCPClient({
-                transport: {
-                    type: 'http',
-                    url: mcpServer.url,
-                    headers: bearerToken
-                        ? {
-                              Authorization: `Bearer ${bearerToken}`,
-                          }
-                        : undefined,
-                    redirect: 'error',
-                },
-                onUncaughtError: (error) => {
-                    Logger.error(
-                        `[AiAgent][MCP][${mcpServer.name}] Uncaught MCP client error`,
-                        error,
-                    );
-                },
+            const mcpClient = await createHttpMcpClient(mcpServer, (error) => {
+                Logger.error(
+                    `[AiAgent][MCP][${mcpServer.name}] Uncaught MCP client error`,
+                    error,
+                );
             });
             mcpClients.push(mcpClient);
 
@@ -416,9 +381,7 @@ export const generateAgentResponse = async ({
                                         args.promptUuid
                                     }: ${toolCall.toolName} (ID: ${
                                         toolCall.toolCallId
-                                    }) (ARGS: ${JSON.stringify(
-                                        toolCall.input,
-                                    )})`,
+                                    }) (ARGS: ${JSON.stringify(toolCall.input)})`,
                                 );
 
                                 dependencies.trackEvent({
@@ -468,9 +431,7 @@ export const generateAgentResponse = async ({
                                         args.promptUuid
                                     }: ${toolResult.toolName} (ID: ${
                                         toolResult.toolCallId
-                                    }) (RESULT: ${JSON.stringify(
-                                        toolResult.output,
-                                    )})`,
+                                    }) (RESULT: ${JSON.stringify(toolResult.output)})`,
                                 );
                                 const output =
                                     toolResult.output as AgentToolOutput;

--- a/packages/backend/src/ee/services/ai/utils/mcpClient.ts
+++ b/packages/backend/src/ee/services/ai/utils/mcpClient.ts
@@ -1,0 +1,76 @@
+import { createMCPClient, type MCPClient } from '@ai-sdk/mcp';
+import { assertUnreachable, type AiMcpServerAuthType } from '@lightdash/common';
+import type { AiAgentMcpServer } from '../types/aiAgent';
+
+type McpServerConnectionArgs = {
+    name: string;
+    url: string;
+    authType: AiMcpServerAuthType;
+    credentials: AiAgentMcpServer['credentials'];
+};
+
+const getBearerToken = (mcpServer: McpServerConnectionArgs) => {
+    if (
+        mcpServer.authType === 'bearer' &&
+        (!mcpServer.credentials ||
+            !('bearerToken' in mcpServer.credentials) ||
+            !mcpServer.credentials.bearerToken)
+    ) {
+        throw new Error(
+            `MCP server "${mcpServer.name}" is missing bearer credentials`,
+        );
+    }
+
+    switch (mcpServer.authType) {
+        case 'none':
+            return undefined;
+        case 'bearer':
+            return mcpServer.credentials &&
+                'bearerToken' in mcpServer.credentials
+                ? mcpServer.credentials.bearerToken
+                : undefined;
+        case 'oauth':
+            throw new Error(
+                `OAuth MCP server "${mcpServer.name}" is not implemented yet`,
+            );
+        default:
+            return assertUnreachable(
+                mcpServer.authType,
+                `Unknown MCP auth type: ${mcpServer.authType}`,
+            );
+    }
+};
+
+export const createHttpMcpClient = async (
+    mcpServer: McpServerConnectionArgs,
+    onUncaughtError?: (error: unknown) => void,
+): Promise<MCPClient> => {
+    const bearerToken = getBearerToken(mcpServer);
+
+    return createMCPClient({
+        transport: {
+            type: 'http',
+            url: mcpServer.url,
+            headers: bearerToken
+                ? {
+                      Authorization: `Bearer ${bearerToken}`,
+                  }
+                : undefined,
+            redirect: 'error',
+        },
+        onUncaughtError,
+    });
+};
+
+export const testMcpConnection = async (
+    mcpServer: McpServerConnectionArgs,
+    onUncaughtError?: (error: unknown) => void,
+): Promise<void> => {
+    const client = await createHttpMcpClient(mcpServer, onUncaughtError);
+
+    try {
+        await client.tools();
+    } finally {
+        await client.close();
+    }
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -12,6 +12,7 @@ import {
     LoadingOverlay,
     MultiSelect,
     Paper,
+    SegmentedControl,
     Stack,
     Switch,
     TagsInput,
@@ -21,12 +22,13 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
-import type { useForm } from '@mantine/form';
+import { useForm, zodResolver } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAdjustmentsAlt,
     IconAlertTriangle,
     IconBook2,
+    IconBrandSpeedtest,
     IconInfoCircle,
     IconLock,
     IconPlug,
@@ -46,13 +48,19 @@ import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeature
 import useApp from '../../../../providers/App/useApp';
 import { UserAccessMultiSelect } from '../../../components/UserAccessMultiSelect';
 import AiExploreAccessTree from '../../../pages/AiAgents/AiExploreAccessTree';
-import { useDeleteAiAgentMutation } from '../hooks/useProjectAiAgents';
+import {
+    useDeleteAiAgentMutation,
+    useProjectAiMcpServers,
+    useProjectCreateAiMcpServerMutation,
+} from '../hooks/useProjectAiAgents';
 import { useGetAgentExploreAccessSummary } from '../hooks/useUserAgentPreferences';
 import {
     InstructionsGuidelines,
     InstructionsTemplates,
 } from './InstructionsSupport';
 import { SpaceAccessSelect } from './SpaceAccessSelect';
+
+const CREATE_MCP_SERVER_OPTION_VALUE = '__create_new_mcp_server__';
 
 const formSchema = z.object({
     name: z.string().min(1),
@@ -69,10 +77,138 @@ const formSchema = z.object({
     groupAccess: z.array(z.string()),
     userAccess: z.array(z.string()),
     spaceAccess: z.array(z.string()),
+    mcpServerUuids: z.array(z.string()),
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
     version: z.number(),
 });
+
+const createMcpServerFormSchema = z
+    .object({
+        name: z.string().trim().min(1, 'Name is required'),
+        url: z.string().trim().url('Enter a valid URL'),
+        authType: z.enum(['none', 'bearer']),
+        bearerToken: z.string(),
+    })
+    .superRefine((values, ctx) => {
+        if (
+            values.authType === 'bearer' &&
+            values.bearerToken.trim().length === 0
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'Bearer token is required',
+                path: ['bearerToken'],
+            });
+        }
+    });
+
+const CreateMcpServerModal = ({
+    opened,
+    isLoading,
+    onClose,
+    onSubmit,
+}: {
+    opened: boolean;
+    isLoading: boolean;
+    onClose: () => void;
+    onSubmit: (
+        values: z.infer<typeof createMcpServerFormSchema>,
+    ) => Promise<void> | void;
+}) => {
+    const form = useForm<z.infer<typeof createMcpServerFormSchema>>({
+        initialValues: {
+            name: '',
+            url: '',
+            authType: 'none',
+            bearerToken: '',
+        },
+        validate: zodResolver(createMcpServerFormSchema),
+    });
+
+    const handleClose = useCallback(() => {
+        form.reset();
+        onClose();
+    }, [form, onClose]);
+
+    const handleSubmit = form.onSubmit(async (values) => {
+        await onSubmit(values);
+        form.reset();
+    });
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleClose}
+            title="Create MCP server"
+            icon={IconBrandSpeedtest}
+            cancelDisabled={isLoading}
+            actions={
+                <Button
+                    type="submit"
+                    form="create-mcp-server-form"
+                    loading={isLoading}
+                >
+                    Create MCP
+                </Button>
+            }
+        >
+            <form id="create-mcp-server-form" onSubmit={handleSubmit}>
+                <Stack gap="md">
+                    <TextInput
+                        variant="subtle"
+                        label="Name"
+                        placeholder="Docs MCP"
+                        disabled={isLoading}
+                        {...form.getInputProps('name')}
+                    />
+                    <TextInput
+                        variant="subtle"
+                        label="URL"
+                        placeholder="https://example.com/mcp"
+                        disabled={isLoading}
+                        {...form.getInputProps('url')}
+                    />
+                    <Box>
+                        <Text size="sm" fw={500} mb="xs">
+                            Auth type
+                        </Text>
+                        <SegmentedControl
+                            fullWidth
+                            data={[
+                                { label: 'No auth', value: 'none' },
+                                { label: 'Bearer token', value: 'bearer' },
+                            ]}
+                            disabled={isLoading}
+                            value={form.values.authType}
+                            onChange={(value) =>
+                                form.setFieldValue(
+                                    'authType',
+                                    value as 'none' | 'bearer',
+                                )
+                            }
+                        />
+                    </Box>
+                    {form.values.authType === 'bearer' && (
+                        <Box>
+                            <TextInput
+                                variant="subtle"
+                                placeholder="API key or personal access token"
+                                disabled={isLoading}
+                                {...form.getInputProps('bearerToken')}
+                            />
+                            <Text size="xs" c="dimmed" mt="xs">
+                                The token will be encrypted and stored securely.
+                                This credential will be shared across all users
+                                of the agent.
+                            </Text>
+                        </Box>
+                    )}
+                </Stack>
+            </form>
+        </MantineModal>
+    );
+};
 
 export const AiAgentFormSetup = ({
     mode,
@@ -151,6 +287,67 @@ export const AiAgentFormSetup = ({
                 label: group.name,
             })) ?? [],
         [groups],
+    );
+
+    const [isCreateMcpServerModalOpen, createMcpServerModalHandlers] =
+        useDisclosure(false);
+    const { data: mcpServers, isLoading: isLoadingMcpServers } =
+        useProjectAiMcpServers(projectUuid);
+    const { mutateAsync: createMcpServer, isLoading: isCreatingMcpServer } =
+        useProjectCreateAiMcpServerMutation(projectUuid);
+
+    const mcpServerOptions = useMemo(
+        () => [
+            ...(mcpServers?.map((mcpServer) => ({
+                value: mcpServer.uuid,
+                label: `${mcpServer.name} (${mcpServer.authType === 'bearer' ? 'Bearer' : 'No auth'})`,
+            })) ?? []),
+            {
+                value: CREATE_MCP_SERVER_OPTION_VALUE,
+                label: '+ Create new MCP',
+            },
+        ],
+        [mcpServers],
+    );
+
+    const handleMcpServerChange = useCallback(
+        (value: string[]) => {
+            const selectedMcpServerUuids = value.filter(
+                (item) => item !== CREATE_MCP_SERVER_OPTION_VALUE,
+            );
+
+            form.setFieldValue('mcpServerUuids', selectedMcpServerUuids);
+
+            if (value.includes(CREATE_MCP_SERVER_OPTION_VALUE)) {
+                createMcpServerModalHandlers.open();
+            }
+        },
+        [createMcpServerModalHandlers, form],
+    );
+
+    const handleCreateMcpServer = useCallback(
+        async (values: z.infer<typeof createMcpServerFormSchema>) => {
+            const mcpServer = await createMcpServer({
+                name: values.name.trim(),
+                url: values.url.trim(),
+                authType: values.authType,
+                credentials:
+                    values.authType === 'bearer'
+                        ? {
+                              bearerToken: values.bearerToken.trim(),
+                          }
+                        : null,
+            });
+
+            form.setFieldValue(
+                'mcpServerUuids',
+                Array.from(
+                    new Set([...form.values.mcpServerUuids, mcpServer.uuid]),
+                ),
+            );
+            createMcpServerModalHandlers.close();
+        },
+        [createMcpServer, createMcpServerModalHandlers, form],
     );
 
     return (
@@ -399,6 +596,47 @@ export const AiAgentFormSetup = ({
                                     },
                                 )}
                             />
+                        </Stack>
+                    </Paper>
+
+                    <Paper p="xl">
+                        <Group align="center" gap="xs" mb="md">
+                            <Paper p="xxs" withBorder radius="sm">
+                                <MantineIcon
+                                    icon={IconBrandSpeedtest}
+                                    size="md"
+                                />
+                            </Paper>
+                            <Title order={5} c="ldGray.9" fw={700}>
+                                MCP servers
+                            </Title>
+                        </Group>
+                        <Stack gap="sm">
+                            <MultiSelect
+                                variant="subtle"
+                                placeholder={
+                                    isLoadingMcpServers
+                                        ? 'Loading MCP servers...'
+                                        : mcpServers?.length
+                                          ? 'Select MCP servers'
+                                          : 'Create an MCP server first'
+                                }
+                                data={mcpServerOptions}
+                                searchable
+                                clearable
+                                disabled={isLoadingMcpServers}
+                                value={form.values.mcpServerUuids}
+                                onChange={handleMcpServerChange}
+                            />
+                            {form.values.mcpServerUuids.length > 0 && (
+                                <Text size="xs" c="dimmed">
+                                    {form.values.mcpServerUuids.length} MCP
+                                    {form.values.mcpServerUuids.length === 1
+                                        ? ''
+                                        : 's'}{' '}
+                                    attached.
+                                </Text>
+                            )}
                         </Stack>
                     </Paper>
 
@@ -756,6 +994,12 @@ export const AiAgentFormSetup = ({
                 resourceType="agent"
                 description="This action cannot be undone."
                 onConfirm={handleDelete}
+            />
+            <CreateMcpServerModal
+                opened={isCreateMcpServerModalOpen}
+                onClose={createMcpServerModalHandlers.close}
+                onSubmit={handleCreateMcpServer}
+                isLoading={isCreatingMcpServer}
             />
         </>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -1,5 +1,7 @@
 import type {
     AiAgent,
+    ApiAiMcpServerListResponse,
+    ApiAiMcpServerResponse,
     AiPromptContext,
     AiPromptContextItem,
     AiPromptContextItemInput,
@@ -18,6 +20,7 @@ import type {
     ApiAppendInstructionResponse,
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
+    ApiCreateAiMcpServer,
     ApiError,
     ApiRevertChangeRequest,
     ApiRevertChangeResponse,
@@ -44,6 +47,8 @@ import { USER_AGENT_PREFERENCES } from './useUserAgentPreferences';
 
 const PROJECT_AI_AGENTS_KEY = 'projectAiAgents';
 const AI_AGENTS_KEY = 'aiAgents';
+const PROJECT_AI_MCP_SERVERS_KEY = 'projectAiMcpServers';
+const AGENT_AI_MCP_SERVERS_KEY = 'agentAiMcpServers';
 
 const listProjectAgents = (projectUuid: string) =>
     lightdashApi<ApiAiAgentSummaryResponse['results']>({
@@ -62,6 +67,38 @@ const getProjectAgent = async (
         url: `/projects/${projectUuid}/aiAgents/${agentUuid}`,
         method: 'GET',
         body: undefined,
+    });
+
+const listProjectAiMcpServers = async (
+    projectUuid: string,
+): Promise<ApiAiMcpServerListResponse['results']> =>
+    lightdashApi<ApiAiMcpServerListResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const listAgentAiMcpServers = async (
+    projectUuid: string,
+    agentUuid: string,
+): Promise<ApiAiMcpServerListResponse['results']> =>
+    lightdashApi<ApiAiMcpServerListResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/mcpServers`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const createProjectAiMcpServer = async (
+    projectUuid: string,
+    data: ApiCreateAiMcpServer,
+): Promise<ApiAiMcpServerResponse['results']> =>
+    lightdashApi<ApiAiMcpServerResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers`,
+        method: 'POST',
+        body: JSON.stringify(data),
     });
 
 type UseProjectAiAgentsProps = {
@@ -127,6 +164,49 @@ export const useProjectAiAgent = (
                 return false;
             }
             return failureCount < 3;
+        },
+    });
+};
+
+export const useProjectAiMcpServers = (
+    projectUuid: string | undefined,
+    options?: UseQueryOptions<ApiAiMcpServerListResponse['results'], ApiError>,
+) => {
+    const { showToastApiError } = useToaster();
+
+    return useQuery<ApiAiMcpServerListResponse['results'], ApiError>({
+        queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+        queryFn: () => listProjectAiMcpServers(projectUuid!),
+        enabled: !!projectUuid && options?.enabled !== false,
+        ...options,
+        onError: (error) => {
+            showToastApiError({
+                title: 'Failed to fetch MCP servers',
+                apiError: error.error,
+            });
+            options?.onError?.(error);
+        },
+    });
+};
+
+export const useAgentAiMcpServers = (
+    projectUuid: string | undefined,
+    agentUuid: string | undefined,
+    options?: UseQueryOptions<ApiAiMcpServerListResponse['results'], ApiError>,
+) => {
+    const { showToastApiError } = useToaster();
+
+    return useQuery<ApiAiMcpServerListResponse['results'], ApiError>({
+        queryKey: [AGENT_AI_MCP_SERVERS_KEY, projectUuid, agentUuid],
+        queryFn: () => listAgentAiMcpServers(projectUuid!, agentUuid!),
+        enabled: !!projectUuid && !!agentUuid && options?.enabled !== false,
+        ...options,
+        onError: (error) => {
+            showToastApiError({
+                title: 'Failed to fetch agent MCP servers',
+                apiError: error.error,
+            });
+            options?.onError?.(error);
         },
     });
 };
@@ -200,6 +280,33 @@ export const useProjectUpdateAiAgentMutation = (projectUuid: string) => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to update AI agent',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useProjectCreateAiMcpServerMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+
+    return useMutation<
+        ApiAiMcpServerResponse['results'],
+        ApiError,
+        ApiCreateAiMcpServer
+    >({
+        mutationFn: (data) => createProjectAiMcpServer(projectUuid, data),
+        onSuccess: async () => {
+            showToastSuccess({
+                title: 'MCP server created successfully',
+            });
+            await queryClient.invalidateQueries({
+                queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to create MCP server',
                 apiError: error,
             });
         },

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -37,6 +37,7 @@ import { EvalRunDetails } from '../../features/aiCopilot/components/Evals/EvalRu
 import { EvalSectionLayout } from '../../features/aiCopilot/components/Evals/EvalSectionLayout';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import {
+    useAgentAiMcpServers,
     useProjectAiAgent,
     useProjectCreateAiAgentMutation,
     useProjectUpdateAiAgentMutation,
@@ -58,6 +59,7 @@ const formSchema = z.object({
     groupAccess: z.array(z.string()),
     userAccess: z.array(z.string()),
     spaceAccess: z.array(z.string()),
+    mcpServerUuids: z.array(z.string()),
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
     version: z.number(),
@@ -95,6 +97,8 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
         projectUuid,
         actualAgentUuid,
     );
+    const { data: agentMcpServers, isFetched: isAgentMcpServersFetched } =
+        useAgentAiMcpServers(projectUuid, actualAgentUuid);
 
     const form = useForm<z.infer<typeof formSchema>>({
         initialValues: {
@@ -107,6 +111,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             groupAccess: [],
             userAccess: [],
             spaceAccess: [],
+            mcpServerUuids: [],
             enableDataAccess: false,
             enableSelfImprovement: false,
             version: 2, // INFO: Default to v2 for now
@@ -115,7 +120,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
     });
 
     useEffect(() => {
-        if (isCreateMode || !agent) {
+        if (isCreateMode || !agent || !isAgentMcpServersFetched) {
             return;
         }
 
@@ -130,6 +135,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 groupAccess: agent.groupAccess ?? [],
                 userAccess: agent.userAccess ?? [],
                 spaceAccess: agent.spaceAccess ?? [],
+                mcpServerUuids: agentMcpServers?.map((mcp) => mcp.uuid) ?? [],
                 enableDataAccess: agent.enableDataAccess ?? false,
                 enableSelfImprovement: agent.enableSelfImprovement ?? false,
                 version: agent.version ?? 2, // INFO: Default to v2 for now
@@ -138,7 +144,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             form.resetDirty(values);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [agent, isCreateMode]);
+    }, [agent, agentMcpServers, isAgentMcpServersFetched, isCreateMode]);
 
     // Derive activeTab from current pathname
     const activeTab = location.pathname.includes('/evals')


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Adds MCP server connection validation when creating an MCP server, and introduces a UI for managing MCP server attachments directly within the AI agent setup form.

**Connection validation on creation:**
When a new MCP server is created, the backend now attempts to connect to it and fetch its tools list before saving. If the connection fails, a `ParameterError` is returned to the user with a descriptive message. The MCP client logic (creating an HTTP MCP client, extracting bearer tokens, handling auth types) has been extracted into a shared `mcpClient.ts` utility used by both the agent runtime and the validation step.

**MCP server management in the agent form:**
- A new "MCP servers" section is added to the agent setup form, allowing users to select which MCP servers are attached to an agent via a searchable multi-select.
- A "Create new MCP" inline option opens a modal where users can define a new MCP server with a name, URL, and auth type (none or bearer token). Bearer tokens are noted as encrypted and shared across agent users.
- The agent edit page now fetches the agent's currently attached MCP servers and pre-populates the form field accordingly.

**Integration test improvements:**
The MCP integration test now spins up a real local MCP HTTP server (using `@modelcontextprotocol/sdk`) with bearer token authentication, replacing the previously mocked `https://example.com/mcp` URL. This ensures the test validates actual connection and credential handling end-to-end.