### PR TITLE
feat: add OAuth support and improved UI for MCP server management

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -12,7 +12,6 @@ import {
     LoadingOverlay,
     MultiSelect,
     Paper,
-    SegmentedControl,
     Stack,
     Switch,
     TagsInput,
@@ -22,13 +21,12 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
-import { useForm, zodResolver } from '@mantine/form';
+import { type useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAdjustmentsAlt,
     IconAlertTriangle,
     IconBook2,
-    IconBrandSpeedtest,
     IconInfoCircle,
     IconLock,
     IconPlug,
@@ -48,19 +46,14 @@ import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeature
 import useApp from '../../../../providers/App/useApp';
 import { UserAccessMultiSelect } from '../../../components/UserAccessMultiSelect';
 import AiExploreAccessTree from '../../../pages/AiAgents/AiExploreAccessTree';
-import {
-    useDeleteAiAgentMutation,
-    useProjectAiMcpServers,
-    useProjectCreateAiMcpServerMutation,
-} from '../hooks/useProjectAiAgents';
+import { useDeleteAiAgentMutation } from '../hooks/useProjectAiAgents';
 import { useGetAgentExploreAccessSummary } from '../hooks/useUserAgentPreferences';
+import { AiAgentMcpServersInput } from './AiAgentMcpServersInput';
 import {
     InstructionsGuidelines,
     InstructionsTemplates,
 } from './InstructionsSupport';
 import { SpaceAccessSelect } from './SpaceAccessSelect';
-
-const CREATE_MCP_SERVER_OPTION_VALUE = '__create_new_mcp_server__';
 
 const formSchema = z.object({
     name: z.string().min(1),
@@ -82,133 +75,6 @@ const formSchema = z.object({
     enableSelfImprovement: z.boolean(),
     version: z.number(),
 });
-
-const createMcpServerFormSchema = z
-    .object({
-        name: z.string().trim().min(1, 'Name is required'),
-        url: z.string().trim().url('Enter a valid URL'),
-        authType: z.enum(['none', 'bearer']),
-        bearerToken: z.string(),
-    })
-    .superRefine((values, ctx) => {
-        if (
-            values.authType === 'bearer' &&
-            values.bearerToken.trim().length === 0
-        ) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: 'Bearer token is required',
-                path: ['bearerToken'],
-            });
-        }
-    });
-
-const CreateMcpServerModal = ({
-    opened,
-    isLoading,
-    onClose,
-    onSubmit,
-}: {
-    opened: boolean;
-    isLoading: boolean;
-    onClose: () => void;
-    onSubmit: (
-        values: z.infer<typeof createMcpServerFormSchema>,
-    ) => Promise<void> | void;
-}) => {
-    const form = useForm<z.infer<typeof createMcpServerFormSchema>>({
-        initialValues: {
-            name: '',
-            url: '',
-            authType: 'none',
-            bearerToken: '',
-        },
-        validate: zodResolver(createMcpServerFormSchema),
-    });
-
-    const handleClose = useCallback(() => {
-        form.reset();
-        onClose();
-    }, [form, onClose]);
-
-    const handleSubmit = form.onSubmit(async (values) => {
-        await onSubmit(values);
-        form.reset();
-    });
-
-    return (
-        <MantineModal
-            opened={opened}
-            onClose={handleClose}
-            title="Create MCP server"
-            icon={IconBrandSpeedtest}
-            cancelDisabled={isLoading}
-            actions={
-                <Button
-                    type="submit"
-                    form="create-mcp-server-form"
-                    loading={isLoading}
-                >
-                    Create MCP
-                </Button>
-            }
-        >
-            <form id="create-mcp-server-form" onSubmit={handleSubmit}>
-                <Stack gap="md">
-                    <TextInput
-                        variant="subtle"
-                        label="Name"
-                        placeholder="Docs MCP"
-                        disabled={isLoading}
-                        {...form.getInputProps('name')}
-                    />
-                    <TextInput
-                        variant="subtle"
-                        label="URL"
-                        placeholder="https://example.com/mcp"
-                        disabled={isLoading}
-                        {...form.getInputProps('url')}
-                    />
-                    <Box>
-                        <Text size="sm" fw={500} mb="xs">
-                            Auth type
-                        </Text>
-                        <SegmentedControl
-                            fullWidth
-                            data={[
-                                { label: 'No auth', value: 'none' },
-                                { label: 'Bearer token', value: 'bearer' },
-                            ]}
-                            disabled={isLoading}
-                            value={form.values.authType}
-                            onChange={(value) =>
-                                form.setFieldValue(
-                                    'authType',
-                                    value as 'none' | 'bearer',
-                                )
-                            }
-                        />
-                    </Box>
-                    {form.values.authType === 'bearer' && (
-                        <Box>
-                            <TextInput
-                                variant="subtle"
-                                placeholder="API key or personal access token"
-                                disabled={isLoading}
-                                {...form.getInputProps('bearerToken')}
-                            />
-                            <Text size="xs" c="dimmed" mt="xs">
-                                The token will be encrypted and stored securely.
-                                This credential will be shared across all users
-                                of the agent.
-                            </Text>
-                        </Box>
-                    )}
-                </Stack>
-            </form>
-        </MantineModal>
-    );
-};
 
 export const AiAgentFormSetup = ({
     mode,
@@ -287,67 +153,6 @@ export const AiAgentFormSetup = ({
                 label: group.name,
             })) ?? [],
         [groups],
-    );
-
-    const [isCreateMcpServerModalOpen, createMcpServerModalHandlers] =
-        useDisclosure(false);
-    const { data: mcpServers, isLoading: isLoadingMcpServers } =
-        useProjectAiMcpServers(projectUuid);
-    const { mutateAsync: createMcpServer, isLoading: isCreatingMcpServer } =
-        useProjectCreateAiMcpServerMutation(projectUuid);
-
-    const mcpServerOptions = useMemo(
-        () => [
-            ...(mcpServers?.map((mcpServer) => ({
-                value: mcpServer.uuid,
-                label: `${mcpServer.name} (${mcpServer.authType === 'bearer' ? 'Bearer' : 'No auth'})`,
-            })) ?? []),
-            {
-                value: CREATE_MCP_SERVER_OPTION_VALUE,
-                label: '+ Create new MCP',
-            },
-        ],
-        [mcpServers],
-    );
-
-    const handleMcpServerChange = useCallback(
-        (value: string[]) => {
-            const selectedMcpServerUuids = value.filter(
-                (item) => item !== CREATE_MCP_SERVER_OPTION_VALUE,
-            );
-
-            form.setFieldValue('mcpServerUuids', selectedMcpServerUuids);
-
-            if (value.includes(CREATE_MCP_SERVER_OPTION_VALUE)) {
-                createMcpServerModalHandlers.open();
-            }
-        },
-        [createMcpServerModalHandlers, form],
-    );
-
-    const handleCreateMcpServer = useCallback(
-        async (values: z.infer<typeof createMcpServerFormSchema>) => {
-            const mcpServer = await createMcpServer({
-                name: values.name.trim(),
-                url: values.url.trim(),
-                authType: values.authType,
-                credentials:
-                    values.authType === 'bearer'
-                        ? {
-                              bearerToken: values.bearerToken.trim(),
-                          }
-                        : null,
-            });
-
-            form.setFieldValue(
-                'mcpServerUuids',
-                Array.from(
-                    new Set([...form.values.mcpServerUuids, mcpServer.uuid]),
-                ),
-            );
-            createMcpServerModalHandlers.close();
-        },
-        [createMcpServer, createMcpServerModalHandlers, form],
     );
 
     return (
@@ -599,46 +404,13 @@ export const AiAgentFormSetup = ({
                         </Stack>
                     </Paper>
 
-                    <Paper p="xl">
-                        <Group align="center" gap="xs" mb="md">
-                            <Paper p="xxs" withBorder radius="sm">
-                                <MantineIcon
-                                    icon={IconBrandSpeedtest}
-                                    size="md"
-                                />
-                            </Paper>
-                            <Title order={5} c="ldGray.9" fw={700}>
-                                MCP servers
-                            </Title>
-                        </Group>
-                        <Stack gap="sm">
-                            <MultiSelect
-                                variant="subtle"
-                                placeholder={
-                                    isLoadingMcpServers
-                                        ? 'Loading MCP servers...'
-                                        : mcpServers?.length
-                                          ? 'Select MCP servers'
-                                          : 'Create an MCP server first'
-                                }
-                                data={mcpServerOptions}
-                                searchable
-                                clearable
-                                disabled={isLoadingMcpServers}
-                                value={form.values.mcpServerUuids}
-                                onChange={handleMcpServerChange}
-                            />
-                            {form.values.mcpServerUuids.length > 0 && (
-                                <Text size="xs" c="dimmed">
-                                    {form.values.mcpServerUuids.length} MCP
-                                    {form.values.mcpServerUuids.length === 1
-                                        ? ''
-                                        : 's'}{' '}
-                                    attached.
-                                </Text>
-                            )}
-                        </Stack>
-                    </Paper>
+                    <AiAgentMcpServersInput
+                        projectUuid={projectUuid}
+                        value={form.values.mcpServerUuids}
+                        onChange={(value) => {
+                            form.setFieldValue('mcpServerUuids', value);
+                        }}
+                    />
 
                     <Paper p="xl">
                         <Group align="center" gap="xs" mb="md">
@@ -994,12 +766,6 @@ export const AiAgentFormSetup = ({
                 resourceType="agent"
                 description="This action cannot be undone."
                 onConfirm={handleDelete}
-            />
-            <CreateMcpServerModal
-                opened={isCreateMcpServerModalOpen}
-                onClose={createMcpServerModalHandlers.close}
-                onSubmit={handleCreateMcpServer}
-                isLoading={isCreatingMcpServer}
             />
         </>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -1,0 +1,706 @@
+import {
+    type AiMcpServer,
+    type AiMcpServerAuthType,
+    type AiMcpServerConnectionStatus,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Alert,
+    Badge,
+    Box,
+    Button,
+    Center,
+    Checkbox,
+    Group,
+    Menu,
+    MultiSelect,
+    Paper,
+    SegmentedControl,
+    Stack,
+    Table,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine-8/core';
+import { useForm, zodResolver } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
+import {
+    IconAlertTriangle,
+    IconDots,
+    IconPlug,
+    IconPlugConnected,
+    IconTrash,
+} from '@tabler/icons-react';
+import { useCallback, useMemo, useState } from 'react';
+import { z } from 'zod';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+import {
+    useProjectAiMcpServers,
+    useProjectCreateAiMcpServerMutation,
+    useStartMcpOAuthConnectionMutation,
+} from '../hooks/useProjectAiMcpServers';
+
+const CREATE_NEW_MCP_OPTION_VALUE = '__create_new_mcp__';
+
+const createMcpServerFormSchema = z
+    .object({
+        name: z.string().trim().min(1, 'Name is required'),
+        url: z.string().trim().url('Enter a valid URL'),
+        authType: z.enum(['none', 'bearer', 'oauth']),
+        bearerToken: z.string(),
+    })
+    .superRefine((values, ctx) => {
+        if (
+            values.authType === 'bearer' &&
+            values.bearerToken.trim().length === 0
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'Bearer token is required',
+                path: ['bearerToken'],
+            });
+        }
+    });
+
+const getMcpAuthTypeLabel = (authType: AiMcpServerAuthType) => {
+    switch (authType) {
+        case 'oauth':
+            return 'OAuth';
+        case 'bearer':
+            return 'Bearer';
+        default:
+            return 'No auth';
+    }
+};
+
+const getMcpConnectionStatusLabel = (
+    connectionStatus: AiMcpServerConnectionStatus | null,
+) => {
+    switch (connectionStatus) {
+        case 'connected':
+            return 'Connected';
+        case 'connecting':
+            return 'Connecting';
+        case 'error':
+            return 'Reconnect required';
+        case 'not_connected':
+        default:
+            return 'Not connected';
+    }
+};
+
+const getMcpConnectionStatusColor = (
+    connectionStatus: AiMcpServerConnectionStatus | null,
+) => {
+    switch (connectionStatus) {
+        case 'connected':
+            return 'green';
+        case 'connecting':
+            return 'blue';
+        case 'error':
+            return 'red';
+        case 'not_connected':
+        default:
+            return 'gray';
+    }
+};
+
+const CreateMcpServerModal = ({
+    opened,
+    isLoading,
+    onClose,
+    onSubmit,
+}: {
+    opened: boolean;
+    isLoading: boolean;
+    onClose: () => void;
+    onSubmit: (
+        values: z.infer<typeof createMcpServerFormSchema>,
+    ) => Promise<void> | void;
+}) => {
+    const [isSharedOauthAcknowledged, setIsSharedOauthAcknowledged] =
+        useState(false);
+    const form = useForm<z.infer<typeof createMcpServerFormSchema>>({
+        initialValues: {
+            name: '',
+            url: '',
+            authType: 'none',
+            bearerToken: '',
+        },
+        validate: zodResolver(createMcpServerFormSchema),
+    });
+
+    const handleClose = useCallback(() => {
+        form.reset();
+        setIsSharedOauthAcknowledged(false);
+        onClose();
+    }, [form, onClose]);
+
+    const handleSubmit = form.onSubmit(async (values) => {
+        await onSubmit(values);
+        form.reset();
+        setIsSharedOauthAcknowledged(false);
+    });
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleClose}
+            title="Create MCP server"
+            icon={IconPlug}
+            cancelDisabled={isLoading}
+            actions={
+                <Button
+                    type="submit"
+                    form="create-mcp-server-form"
+                    loading={isLoading}
+                    disabled={
+                        form.values.authType === 'oauth' &&
+                        !isSharedOauthAcknowledged
+                    }
+                >
+                    {form.values.authType === 'oauth'
+                        ? 'Create and connect'
+                        : 'Create MCP'}
+                </Button>
+            }
+        >
+            <form id="create-mcp-server-form" onSubmit={handleSubmit}>
+                <Stack gap="md">
+                    <TextInput
+                        variant="subtle"
+                        label="Name"
+                        placeholder="Docs MCP"
+                        disabled={isLoading}
+                        {...form.getInputProps('name')}
+                    />
+                    <TextInput
+                        variant="subtle"
+                        label="URL"
+                        placeholder="https://example.com/mcp"
+                        disabled={isLoading}
+                        {...form.getInputProps('url')}
+                    />
+                    <Box>
+                        <Text size="sm" fw={500} mb="xs">
+                            Auth type
+                        </Text>
+                        <SegmentedControl
+                            fullWidth
+                            data={[
+                                { label: 'No auth', value: 'none' },
+                                { label: 'Bearer token', value: 'bearer' },
+                                { label: 'OAuth', value: 'oauth' },
+                            ]}
+                            disabled={isLoading}
+                            value={form.values.authType}
+                            onChange={(value) =>
+                                form.setFieldValue(
+                                    'authType',
+                                    value as 'none' | 'bearer' | 'oauth',
+                                )
+                            }
+                        />
+                    </Box>
+                    {form.values.authType === 'oauth' && (
+                        <Alert
+                            color="orange"
+                            variant="light"
+                            icon={<MantineIcon icon={IconAlertTriangle} />}
+                            title="Shared OAuth connection"
+                        >
+                            <Stack gap={4}>
+                                <Text size="sm">
+                                    This connection is shared across this
+                                    project.
+                                </Text>
+                                <Text size="sm">
+                                    Anyone who can run an agent attached to this
+                                    MCP can use the connected account.
+                                </Text>
+                                <Text size="sm">
+                                    Actions on the remote system may appear as
+                                    the connected account.
+                                </Text>
+                            </Stack>
+                        </Alert>
+                    )}
+                    {form.values.authType === 'oauth' && (
+                        <Checkbox
+                            checked={isSharedOauthAcknowledged}
+                            onChange={(event) =>
+                                setIsSharedOauthAcknowledged(
+                                    event.currentTarget.checked,
+                                )
+                            }
+                            label="I understand everyone using agents attached to this MCP will act as the connected account."
+                        />
+                    )}
+                    {form.values.authType === 'bearer' && (
+                        <Box>
+                            <TextInput
+                                variant="subtle"
+                                placeholder="API key or personal access token"
+                                disabled={isLoading}
+                                {...form.getInputProps('bearerToken')}
+                            />
+                            <Text size="xs" c="dimmed" mt="xs">
+                                The token will be encrypted and stored securely.
+                                This credential will be shared across all users
+                                of the agent.
+                            </Text>
+                        </Box>
+                    )}
+                </Stack>
+            </form>
+        </MantineModal>
+    );
+};
+
+const AttachMcpServersModal = ({
+    opened,
+    isLoading,
+    options,
+    value,
+    onChange,
+    onClose,
+    onSubmit,
+}: {
+    opened: boolean;
+    isLoading: boolean;
+    options: { value: string; label: string }[];
+    value: string[];
+    onChange: (value: string[]) => void;
+    onClose: () => void;
+    onSubmit: () => void;
+}) => {
+    const hasAttachableOptions = options.some(
+        (option) => option.value !== CREATE_NEW_MCP_OPTION_VALUE,
+    );
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Add MCP"
+            icon={IconPlug}
+            cancelLabel={false}
+            actions={
+                <Button
+                    onClick={onSubmit}
+                    disabled={isLoading || value.length === 0}
+                >
+                    Add selected
+                </Button>
+            }
+        >
+            <Stack gap="md">
+                <MultiSelect
+                    variant="subtle"
+                    placeholder={
+                        hasAttachableOptions
+                            ? 'Select existing MCP servers'
+                            : 'Create a new MCP server'
+                    }
+                    data={options}
+                    searchable
+                    disabled={isLoading}
+                    value={value}
+                    onChange={onChange}
+                    filter={({ options: filterOptions, search }) => {
+                        const normalizedSearch = search.toLowerCase().trim();
+                        const createOption = filterOptions.find(
+                            (option) =>
+                                'value' in option &&
+                                option.value === CREATE_NEW_MCP_OPTION_VALUE,
+                        );
+                        const filteredOptions = filterOptions.filter(
+                            (option) =>
+                                'value' in option &&
+                                option.value !== CREATE_NEW_MCP_OPTION_VALUE &&
+                                option.label
+                                    .toLowerCase()
+                                    .includes(normalizedSearch),
+                        );
+
+                        return createOption
+                            ? [createOption, ...filteredOptions]
+                            : filteredOptions;
+                    }}
+                />
+                {!hasAttachableOptions && (
+                    <Text size="sm" c="dimmed">
+                        No existing MCP servers available yet.
+                    </Text>
+                )}
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export const AiAgentMcpServersInput = ({
+    projectUuid,
+    value,
+    onChange,
+}: {
+    projectUuid: string;
+    value: string[];
+    onChange: (value: string[]) => void;
+}) => {
+    const [isCreateMcpServerModalOpen, createMcpServerModalHandlers] =
+        useDisclosure(false);
+    const [isAttachMcpServersModalOpen, attachMcpServersModalHandlers] =
+        useDisclosure(false);
+    const [attachSelection, setAttachSelection] = useState<string[]>([]);
+    const { data: mcpServers, isLoading: isLoadingMcpServers } =
+        useProjectAiMcpServers(projectUuid);
+    const { mutateAsync: createMcpServer, isLoading: isCreatingMcpServer } =
+        useProjectCreateAiMcpServerMutation(projectUuid);
+    const {
+        mutateAsync: startMcpOAuthConnection,
+        isLoading: isStartingMcpOAuthConnection,
+        variables: startingMcpOAuthConnection,
+    } = useStartMcpOAuthConnectionMutation(projectUuid);
+
+    const selectedMcpServers = useMemo(
+        () =>
+            value
+                .map((uuid) =>
+                    mcpServers?.find((mcpServer) => mcpServer.uuid === uuid),
+                )
+                .filter((mcpServer): mcpServer is AiMcpServer => !!mcpServer),
+        [value, mcpServers],
+    );
+
+    const availableMcpServerOptions = useMemo(
+        () => [
+            {
+                value: CREATE_NEW_MCP_OPTION_VALUE,
+                label: '+ Create new MCP',
+            },
+            ...(mcpServers ?? [])
+                .filter((mcpServer) => !value.includes(mcpServer.uuid))
+                .map((mcpServer) => ({
+                    value: mcpServer.uuid,
+                    label:
+                        mcpServer.authType === 'oauth'
+                            ? `${mcpServer.name} (${getMcpAuthTypeLabel(mcpServer.authType)}, ${getMcpConnectionStatusLabel(mcpServer.connectionStatus)})`
+                            : `${mcpServer.name} (${getMcpAuthTypeLabel(mcpServer.authType)})`,
+                })),
+        ],
+        [mcpServers, value],
+    );
+
+    const openCreateMcpServerModal = useCallback(() => {
+        setAttachSelection([]);
+        attachMcpServersModalHandlers.close();
+        createMcpServerModalHandlers.open();
+    }, [attachMcpServersModalHandlers, createMcpServerModalHandlers]);
+
+    const openAttachMcpServersModal = useCallback(() => {
+        setAttachSelection([]);
+        attachMcpServersModalHandlers.open();
+    }, [attachMcpServersModalHandlers]);
+
+    const handleAttachSelectionChange = useCallback(
+        (nextValue: string[]) => {
+            if (nextValue.includes(CREATE_NEW_MCP_OPTION_VALUE)) {
+                setAttachSelection(
+                    nextValue.filter(
+                        (selectedValue) =>
+                            selectedValue !== CREATE_NEW_MCP_OPTION_VALUE,
+                    ),
+                );
+                openCreateMcpServerModal();
+                return;
+            }
+
+            setAttachSelection(nextValue);
+        },
+        [openCreateMcpServerModal],
+    );
+
+    const handleAttachMcpServers = useCallback(() => {
+        onChange(Array.from(new Set([...value, ...attachSelection])));
+        setAttachSelection([]);
+        attachMcpServersModalHandlers.close();
+    }, [attachMcpServersModalHandlers, attachSelection, onChange, value]);
+
+    const handleCloseAttachMcpServersModal = useCallback(() => {
+        setAttachSelection([]);
+        attachMcpServersModalHandlers.close();
+    }, [attachMcpServersModalHandlers]);
+
+    const handleCreateMcpServer = useCallback(
+        async (values: z.infer<typeof createMcpServerFormSchema>) => {
+            const popupWindow =
+                values.authType === 'oauth'
+                    ? window.open('', 'mcp-oauth-popup', 'width=600,height=700')
+                    : null;
+            try {
+                const mcpServer = await createMcpServer({
+                    name: values.name.trim(),
+                    url: values.url.trim(),
+                    authType: values.authType,
+                    credentials:
+                        values.authType === 'bearer'
+                            ? {
+                                  bearerToken: values.bearerToken.trim(),
+                              }
+                            : null,
+                });
+
+                onChange(Array.from(new Set([...value, mcpServer.uuid])));
+                createMcpServerModalHandlers.close();
+
+                if (mcpServer.authType === 'oauth') {
+                    await startMcpOAuthConnection({
+                        mcpServerUuid: mcpServer.uuid,
+                        popupWindow,
+                    });
+                }
+            } catch (error) {
+                popupWindow?.close();
+                throw error;
+            }
+        },
+        [
+            createMcpServer,
+            createMcpServerModalHandlers,
+            onChange,
+            startMcpOAuthConnection,
+            value,
+        ],
+    );
+
+    const handleStartMcpOAuthConnection = useCallback(
+        async (mcpServerUuid: string) => {
+            await startMcpOAuthConnection({ mcpServerUuid });
+        },
+        [startMcpOAuthConnection],
+    );
+
+    const handleRemoveMcpServer = useCallback(
+        (mcpServerUuid: string) => {
+            onChange(
+                value.filter((selectedUuid) => selectedUuid !== mcpServerUuid),
+            );
+        },
+        [onChange, value],
+    );
+
+    const renderMcpServerActionMenu = useCallback(
+        (
+            mcpServer: AiMcpServer,
+            connectionStatus: AiMcpServerConnectionStatus | null,
+            isConnecting: boolean,
+        ) => {
+            return (
+                <Menu
+                    position="bottom-end"
+                    withArrow
+                    withinPortal
+                    shadow="md"
+                    width={220}
+                >
+                    <Menu.Target>
+                        <ActionIcon variant="subtle" color="gray">
+                            <MantineIcon icon={IconDots} />
+                        </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        {mcpServer.authType === 'oauth' && (
+                            <Menu.Item
+                                leftSection={
+                                    <MantineIcon icon={IconPlugConnected} />
+                                }
+                                onClick={() => {
+                                    void handleStartMcpOAuthConnection(
+                                        mcpServer.uuid,
+                                    );
+                                }}
+                                disabled={isConnecting}
+                            >
+                                {isConnecting
+                                    ? 'Connecting...'
+                                    : connectionStatus === 'connected' ||
+                                        connectionStatus === 'error'
+                                      ? 'Reconnect'
+                                      : 'Connect account'}
+                            </Menu.Item>
+                        )}
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                            onClick={() =>
+                                handleRemoveMcpServer(mcpServer.uuid)
+                            }
+                            disabled={isConnecting}
+                            color="red"
+                        >
+                            Remove
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
+            );
+        },
+        [handleRemoveMcpServer, handleStartMcpOAuthConnection],
+    );
+
+    return (
+        <>
+            <Paper p="xl">
+                <Group align="center" gap="xs" mb="md">
+                    <Group align="center" gap="xs">
+                        <Paper p="xxs" withBorder radius="sm">
+                            <MantineIcon icon={IconPlug} size="md" />
+                        </Paper>
+                        <Title order={5} c="ldGray.9" fw={700}>
+                            MCP servers
+                        </Title>
+                    </Group>
+                    {selectedMcpServers.length > 0 && (
+                        <Button
+                            variant="default"
+                            size="compact-xs"
+                            onClick={openAttachMcpServersModal}
+                        >
+                            + Add
+                        </Button>
+                    )}
+                </Group>
+                <Stack gap="sm">
+                    {selectedMcpServers.length === 0 && (
+                        <Center
+                            py="xl"
+                            style={{
+                                border: '1px dashed var(--mantine-color-ldGray-4)',
+                                borderRadius: 'var(--mantine-radius-md)',
+                            }}
+                        >
+                            <Stack align="center" gap="xs">
+                                <Text size="sm" c="dimmed">
+                                    No MCP servers attached
+                                </Text>
+                                <Button
+                                    variant="default"
+                                    size="xs"
+                                    disabled={isLoadingMcpServers}
+                                    onClick={openAttachMcpServersModal}
+                                >
+                                    + Add
+                                </Button>
+                            </Stack>
+                        </Center>
+                    )}
+                    {selectedMcpServers.length > 0 && (
+                        <Table.ScrollContainer minWidth={560}>
+                            <Table
+                                highlightOnHover
+                                withTableBorder
+                                withColumnBorders={false}
+                                verticalSpacing="sm"
+                                style={{
+                                    borderRadius: 'var(--mantine-radius-md)',
+                                    overflow: 'hidden',
+                                }}
+                            >
+                                <Table.Thead>
+                                    <Table.Tr>
+                                        <Table.Th>Name</Table.Th>
+                                        <Table.Th w={140}>Type</Table.Th>
+                                        <Table.Th w={160}>Status</Table.Th>
+                                        <Table.Th w={56} />
+                                    </Table.Tr>
+                                </Table.Thead>
+                                <Table.Tbody>
+                                    {selectedMcpServers.map((mcpServer) => {
+                                        const isConnecting =
+                                            mcpServer.authType === 'oauth' &&
+                                            isStartingMcpOAuthConnection &&
+                                            startingMcpOAuthConnection?.mcpServerUuid ===
+                                                mcpServer.uuid;
+                                        const connectionStatus =
+                                            mcpServer.authType === 'none'
+                                                ? 'connected'
+                                                : isConnecting
+                                                  ? 'connecting'
+                                                  : mcpServer.connectionStatus;
+
+                                        return (
+                                            <Table.Tr key={mcpServer.uuid}>
+                                                <Table.Td>
+                                                    <Stack gap={2}>
+                                                        <Text fw={600}>
+                                                            {mcpServer.name}
+                                                        </Text>
+                                                        <Text
+                                                            size="xs"
+                                                            c="dimmed"
+                                                        >
+                                                            {mcpServer.url}
+                                                        </Text>
+                                                    </Stack>
+                                                </Table.Td>
+                                                <Table.Td>
+                                                    <Text
+                                                        fw={450}
+                                                        c="ldDark.9"
+                                                        size="sm"
+                                                    >
+                                                        {getMcpAuthTypeLabel(
+                                                            mcpServer.authType,
+                                                        )}
+                                                    </Text>
+                                                </Table.Td>
+                                                <Table.Td>
+                                                    <Badge
+                                                        variant="light"
+                                                        color={getMcpConnectionStatusColor(
+                                                            connectionStatus,
+                                                        )}
+                                                    >
+                                                        {getMcpConnectionStatusLabel(
+                                                            connectionStatus,
+                                                        )}
+                                                    </Badge>
+                                                </Table.Td>
+                                                <Table.Td>
+                                                    <Group
+                                                        justify="flex-end"
+                                                        wrap="nowrap"
+                                                    >
+                                                        {renderMcpServerActionMenu(
+                                                            mcpServer,
+                                                            connectionStatus,
+                                                            isConnecting,
+                                                        )}
+                                                    </Group>
+                                                </Table.Td>
+                                            </Table.Tr>
+                                        );
+                                    })}
+                                </Table.Tbody>
+                            </Table>
+                        </Table.ScrollContainer>
+                    )}
+                </Stack>
+            </Paper>
+            <CreateMcpServerModal
+                opened={isCreateMcpServerModalOpen}
+                onClose={createMcpServerModalHandlers.close}
+                onSubmit={handleCreateMcpServer}
+                isLoading={isCreatingMcpServer}
+            />
+            <AttachMcpServersModal
+                opened={isAttachMcpServersModalOpen}
+                onClose={handleCloseAttachMcpServersModal}
+                onSubmit={handleAttachMcpServers}
+                isLoading={isLoadingMcpServers}
+                options={availableMcpServerOptions}
+                value={attachSelection}
+                onChange={handleAttachSelectionChange}
+            />
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -191,8 +191,10 @@ const AssistantBubbleContent: FC<{
 
     const isPending = message.status === 'pending';
     const hasError = message.status === 'error';
-    const hasNoResponse = !isStreaming && !message.message && !isPending;
-    const shouldShowRetry = hasError || hasNoResponse;
+    const streamingError = streamingState?.error;
+    const hasNoResponse =
+        !isStreaming && !streamingError && !message.message && !isPending;
+    const shouldShowRetry = hasError || hasNoResponse || !!streamingError;
 
     const baseMessageContent =
         isStreaming && streamingState
@@ -257,7 +259,8 @@ const AssistantBubbleContent: FC<{
                                     Something went wrong
                                 </Text>
                                 <Text size="xs" c="dimmed">
-                                    {message.errorMessage ||
+                                    {streamingError ||
+                                        message.errorMessage ||
                                         'Failed to generate response. Please try again.'}
                                 </Text>
                             </Stack>
@@ -504,7 +507,7 @@ const AssistantBubbleContent: FC<{
              *  any tool call or text part. Reasoning alone doesn't count: it
              *  collapses by default and would otherwise leave the bubble silent.
              *  Once a part exists, the bento + rolling preview take over. */}
-            {(isStreaming || isPending) &&
+            {(isStreaming || (isPending && !streamingError)) &&
                 (streamingState?.parts?.length ?? 0) === 0 && <TypingDots />}
             {proposeChangeToolCall && (
                 <AiProposeChangeToolCall

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -1,10 +1,5 @@
 import type {
     AiAgent,
-    ApiAiMcpServerListResponse,
-    ApiAiMcpServerResponse,
-    AiPromptContext,
-    AiPromptContextItem,
-    AiPromptContextItemInput,
     ApiAiAgentResponse,
     ApiAiAgentSummaryResponse,
     ApiAiAgentThreadCreateRequest,
@@ -18,9 +13,11 @@ import type {
     ApiAiAgentVerifiedQuestionsResponse,
     ApiAppendInstructionRequest,
     ApiAppendInstructionResponse,
+    AiPromptContext,
+    AiPromptContextItem,
+    AiPromptContextItemInput,
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
-    ApiCreateAiMcpServer,
     ApiError,
     ApiRevertChangeRequest,
     ApiRevertChangeResponse,
@@ -47,8 +44,6 @@ import { USER_AGENT_PREFERENCES } from './useUserAgentPreferences';
 
 const PROJECT_AI_AGENTS_KEY = 'projectAiAgents';
 const AI_AGENTS_KEY = 'aiAgents';
-const PROJECT_AI_MCP_SERVERS_KEY = 'projectAiMcpServers';
-const AGENT_AI_MCP_SERVERS_KEY = 'agentAiMcpServers';
 
 const listProjectAgents = (projectUuid: string) =>
     lightdashApi<ApiAiAgentSummaryResponse['results']>({
@@ -67,38 +62,6 @@ const getProjectAgent = async (
         url: `/projects/${projectUuid}/aiAgents/${agentUuid}`,
         method: 'GET',
         body: undefined,
-    });
-
-const listProjectAiMcpServers = async (
-    projectUuid: string,
-): Promise<ApiAiMcpServerListResponse['results']> =>
-    lightdashApi<ApiAiMcpServerListResponse['results']>({
-        version: 'v1',
-        url: `/projects/${projectUuid}/aiAgents/mcpServers`,
-        method: 'GET',
-        body: undefined,
-    });
-
-const listAgentAiMcpServers = async (
-    projectUuid: string,
-    agentUuid: string,
-): Promise<ApiAiMcpServerListResponse['results']> =>
-    lightdashApi<ApiAiMcpServerListResponse['results']>({
-        version: 'v1',
-        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/mcpServers`,
-        method: 'GET',
-        body: undefined,
-    });
-
-const createProjectAiMcpServer = async (
-    projectUuid: string,
-    data: ApiCreateAiMcpServer,
-): Promise<ApiAiMcpServerResponse['results']> =>
-    lightdashApi<ApiAiMcpServerResponse['results']>({
-        version: 'v1',
-        url: `/projects/${projectUuid}/aiAgents/mcpServers`,
-        method: 'POST',
-        body: JSON.stringify(data),
     });
 
 type UseProjectAiAgentsProps = {
@@ -164,49 +127,6 @@ export const useProjectAiAgent = (
                 return false;
             }
             return failureCount < 3;
-        },
-    });
-};
-
-export const useProjectAiMcpServers = (
-    projectUuid: string | undefined,
-    options?: UseQueryOptions<ApiAiMcpServerListResponse['results'], ApiError>,
-) => {
-    const { showToastApiError } = useToaster();
-
-    return useQuery<ApiAiMcpServerListResponse['results'], ApiError>({
-        queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
-        queryFn: () => listProjectAiMcpServers(projectUuid!),
-        enabled: !!projectUuid && options?.enabled !== false,
-        ...options,
-        onError: (error) => {
-            showToastApiError({
-                title: 'Failed to fetch MCP servers',
-                apiError: error.error,
-            });
-            options?.onError?.(error);
-        },
-    });
-};
-
-export const useAgentAiMcpServers = (
-    projectUuid: string | undefined,
-    agentUuid: string | undefined,
-    options?: UseQueryOptions<ApiAiMcpServerListResponse['results'], ApiError>,
-) => {
-    const { showToastApiError } = useToaster();
-
-    return useQuery<ApiAiMcpServerListResponse['results'], ApiError>({
-        queryKey: [AGENT_AI_MCP_SERVERS_KEY, projectUuid, agentUuid],
-        queryFn: () => listAgentAiMcpServers(projectUuid!, agentUuid!),
-        enabled: !!projectUuid && !!agentUuid && options?.enabled !== false,
-        ...options,
-        onError: (error) => {
-            showToastApiError({
-                title: 'Failed to fetch agent MCP servers',
-                apiError: error.error,
-            });
-            options?.onError?.(error);
         },
     });
 };
@@ -280,33 +200,6 @@ export const useProjectUpdateAiAgentMutation = (projectUuid: string) => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to update AI agent',
-                apiError: error,
-            });
-        },
-    });
-};
-
-export const useProjectCreateAiMcpServerMutation = (projectUuid: string) => {
-    const queryClient = useQueryClient();
-    const { showToastApiError, showToastSuccess } = useToaster();
-
-    return useMutation<
-        ApiAiMcpServerResponse['results'],
-        ApiError,
-        ApiCreateAiMcpServer
-    >({
-        mutationFn: (data) => createProjectAiMcpServer(projectUuid, data),
-        onSuccess: async () => {
-            showToastSuccess({
-                title: 'MCP server created successfully',
-            });
-            await queryClient.invalidateQueries({
-                queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
-            });
-        },
-        onError: ({ error }) => {
-            showToastApiError({
-                title: 'Failed to create MCP server',
                 apiError: error,
             });
         },
@@ -544,6 +437,27 @@ const createOptimisticMessages = (
     ];
 };
 
+const markOptimisticAssistantMessageAsErrored = (
+    currentData: ApiAiAgentThreadResponse['results'] | undefined,
+    messageUuid: string,
+    errorMessage: string,
+) => {
+    if (!currentData) return currentData;
+
+    return {
+        ...currentData,
+        messages: currentData.messages.map((message) =>
+            message.uuid === messageUuid && message.role === 'assistant'
+                ? {
+                      ...message,
+                      status: 'error' as const,
+                      errorMessage,
+                  }
+                : message,
+        ),
+    };
+};
+
 const generateAgentThreadTitle = async (
     projectUuid: string,
     agentUuid: string,
@@ -698,6 +612,37 @@ export const useCreateAgentThreadMutation = (
                             thread.uuid,
                         ],
                     }),
+                onError: (errorMessage) => {
+                    queryClient.setQueryData(
+                        [
+                            AI_AGENTS_KEY,
+                            projectUuid,
+                            agentUuid,
+                            'threads',
+                            thread.uuid,
+                        ],
+                        (
+                            currentData:
+                                | ApiAiAgentThreadResponse['results']
+                                | undefined,
+                        ) =>
+                            markOptimisticAssistantMessageAsErrored(
+                                currentData,
+                                thread.firstMessage.uuid,
+                                errorMessage,
+                            ),
+                    );
+
+                    void queryClient.invalidateQueries({
+                        queryKey: [
+                            AI_AGENTS_KEY,
+                            projectUuid,
+                            agentUuid,
+                            'threads',
+                            thread.uuid,
+                        ],
+                    });
+                },
                 refetchThread: () =>
                     queryClient.invalidateQueries({
                         queryKey: [
@@ -855,6 +800,37 @@ export const useCreateAgentThreadMessageMutation = (
                         'threads',
                         threadUuid,
                     ]),
+                onError: (errorMessage) => {
+                    queryClient.setQueryData(
+                        [
+                            AI_AGENTS_KEY,
+                            projectUuid,
+                            agentUuid,
+                            'threads',
+                            threadUuid,
+                        ],
+                        (
+                            currentData:
+                                | ApiAiAgentThreadResponse['results']
+                                | undefined,
+                        ) =>
+                            markOptimisticAssistantMessageAsErrored(
+                                currentData,
+                                data.uuid,
+                                errorMessage,
+                            ),
+                    );
+
+                    void queryClient.invalidateQueries({
+                        queryKey: [
+                            AI_AGENTS_KEY,
+                            projectUuid,
+                            agentUuid,
+                            'threads',
+                            threadUuid,
+                        ],
+                    });
+                },
                 refetchThread: () =>
                     queryClient.invalidateQueries({
                         queryKey: [

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
@@ -1,0 +1,286 @@
+import type {
+    ApiAiMcpServerListResponse,
+    ApiAiMcpServerResponse,
+    ApiCreateAiMcpServer,
+    ApiError,
+} from '@lightdash/common';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    type UseQueryOptions,
+} from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
+
+const PROJECT_AI_MCP_SERVERS_KEY = 'projectAiMcpServers';
+const AGENT_AI_MCP_SERVERS_KEY = 'agentAiMcpServers';
+
+const listProjectAiMcpServers = async (
+    projectUuid: string,
+): Promise<ApiAiMcpServerListResponse['results']> =>
+    lightdashApi<ApiAiMcpServerListResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const listAgentAiMcpServers = async (
+    projectUuid: string,
+    agentUuid: string,
+): Promise<ApiAiMcpServerListResponse['results']> =>
+    lightdashApi<ApiAiMcpServerListResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/mcpServers`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const createProjectAiMcpServer = async (
+    projectUuid: string,
+    data: ApiCreateAiMcpServer,
+): Promise<ApiAiMcpServerResponse['results']> =>
+    lightdashApi<ApiAiMcpServerResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers`,
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+
+const startProjectAiMcpOAuthConnection = async (
+    projectUuid: string,
+    mcpServerUuid: string,
+): Promise<{ authorizationUrl: string }> =>
+    lightdashApi<any>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers/${mcpServerUuid}/oauth/start`,
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+
+const getProjectAiMcpServerConnectionStatus = async (
+    projectUuid: string,
+    mcpServerUuid: string,
+) => {
+    const mcpServers = await listProjectAiMcpServers(projectUuid);
+    return (
+        mcpServers.find((server) => server.uuid === mcpServerUuid)
+            ?.connectionStatus ?? null
+    );
+};
+
+const waitForProjectAiMcpServerConnection = async (
+    projectUuid: string,
+    mcpServerUuid: string,
+    options?: {
+        timeoutMs?: number;
+        pollIntervalMs?: number;
+    },
+) => {
+    const timeoutMs = options?.timeoutMs ?? 180_000;
+    const pollIntervalMs = options?.pollIntervalMs ?? 1_000;
+    return new Promise<'connected' | 'error' | 'timeout'>((resolve) => {
+        let settled = false;
+
+        const finish = (result: 'connected' | 'error' | 'timeout') => {
+            if (settled) return;
+            settled = true;
+            window.clearInterval(intervalId);
+            window.clearTimeout(timeoutId);
+            resolve(result);
+        };
+
+        const poll = async () => {
+            const connectionStatus =
+                await getProjectAiMcpServerConnectionStatus(
+                    projectUuid,
+                    mcpServerUuid,
+                );
+
+            if (connectionStatus === 'connected') {
+                finish('connected');
+                return;
+            }
+
+            if (connectionStatus === 'error') {
+                finish('error');
+            }
+        };
+
+        const intervalId = window.setInterval(() => {
+            void poll();
+        }, pollIntervalMs);
+        const timeoutId = window.setTimeout(() => {
+            finish('timeout');
+        }, timeoutMs);
+
+        void poll();
+    });
+};
+
+const openOAuthPopup = async ({
+    authorizationUrl,
+    projectUuid,
+    mcpServerUuid,
+    popupWindow,
+}: {
+    authorizationUrl: string;
+    projectUuid: string;
+    mcpServerUuid: string;
+    popupWindow?: Window | null;
+}) => {
+    const oauthPopupWindow =
+        popupWindow ??
+        window.open('', 'mcp-oauth-popup', 'width=600,height=700');
+
+    if (!oauthPopupWindow) {
+        throw new Error('Failed to open popup window');
+    }
+
+    oauthPopupWindow.location.href = authorizationUrl;
+
+    const result = await waitForProjectAiMcpServerConnection(
+        projectUuid,
+        mcpServerUuid,
+    );
+
+    if (result === 'connected') {
+        return;
+    }
+
+    if (result === 'error') {
+        throw new Error('Authentication failed');
+    }
+
+    throw new Error('Authentication timed out');
+};
+
+export const useProjectAiMcpServers = (
+    projectUuid: string | undefined,
+    options?: UseQueryOptions<ApiAiMcpServerListResponse['results'], ApiError>,
+) => {
+    const { showToastApiError } = useToaster();
+
+    return useQuery<ApiAiMcpServerListResponse['results'], ApiError>({
+        queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+        queryFn: () => listProjectAiMcpServers(projectUuid!),
+        enabled: !!projectUuid && options?.enabled !== false,
+        ...options,
+        onError: (error) => {
+            showToastApiError({
+                title: 'Failed to fetch MCP servers',
+                apiError: error.error,
+            });
+            options?.onError?.(error);
+        },
+    });
+};
+
+export const useAgentAiMcpServers = (
+    projectUuid: string | undefined,
+    agentUuid: string | undefined,
+    options?: UseQueryOptions<ApiAiMcpServerListResponse['results'], ApiError>,
+) => {
+    const { showToastApiError } = useToaster();
+
+    return useQuery<ApiAiMcpServerListResponse['results'], ApiError>({
+        queryKey: [AGENT_AI_MCP_SERVERS_KEY, projectUuid, agentUuid],
+        queryFn: () => listAgentAiMcpServers(projectUuid!, agentUuid!),
+        enabled: !!projectUuid && !!agentUuid && options?.enabled !== false,
+        ...options,
+        onError: (error) => {
+            showToastApiError({
+                title: 'Failed to fetch agent MCP servers',
+                apiError: error.error,
+            });
+            options?.onError?.(error);
+        },
+    });
+};
+
+export const useProjectCreateAiMcpServerMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+
+    return useMutation<
+        ApiAiMcpServerResponse['results'],
+        ApiError,
+        ApiCreateAiMcpServer
+    >({
+        mutationFn: (data) => createProjectAiMcpServer(projectUuid, data),
+        onSuccess: async (result) => {
+            showToastSuccess({
+                title: 'MCP server created successfully',
+            });
+            queryClient.setQueryData(
+                [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+                (
+                    currentData:
+                        | ApiAiMcpServerListResponse['results']
+                        | undefined,
+                ) => {
+                    if (!currentData) return currentData;
+                    if (
+                        currentData.some(
+                            (server) => server.uuid === result.uuid,
+                        )
+                    )
+                        return currentData;
+                    return [...currentData, result];
+                },
+            );
+            await queryClient.invalidateQueries({
+                queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to create MCP server',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useStartMcpOAuthConnectionMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastError, showToastSuccess } = useToaster();
+
+    return useMutation<
+        void,
+        Error,
+        { mcpServerUuid: string; popupWindow?: Window | null }
+    >({
+        mutationFn: async ({ mcpServerUuid, popupWindow }) => {
+            const { authorizationUrl } = await startProjectAiMcpOAuthConnection(
+                projectUuid,
+                mcpServerUuid,
+            );
+            await openOAuthPopup({
+                authorizationUrl,
+                projectUuid,
+                mcpServerUuid,
+                popupWindow,
+            });
+        },
+        onSuccess: async () => {
+            showToastSuccess({
+                title: 'MCP account connected successfully',
+            });
+            await queryClient.invalidateQueries({
+                queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+            });
+            await queryClient.refetchQueries({
+                queryKey: [PROJECT_AI_MCP_SERVERS_KEY, projectUuid],
+                exact: true,
+            });
+        },
+        onError: (error) => {
+            showToastError({
+                title: 'Authentication failed',
+                subtitle: error.message || 'Please try again',
+            });
+        },
+    });
+};

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -37,11 +37,11 @@ import { EvalRunDetails } from '../../features/aiCopilot/components/Evals/EvalRu
 import { EvalSectionLayout } from '../../features/aiCopilot/components/Evals/EvalSectionLayout';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import {
-    useAgentAiMcpServers,
     useProjectAiAgent,
     useProjectCreateAiAgentMutation,
     useProjectUpdateAiAgentMutation,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import { useAgentAiMcpServers } from '../../features/aiCopilot/hooks/useProjectAiMcpServers';
 import { EvalsSetup } from './EvalsSetup';
 
 const formSchema = z.object({


### PR DESCRIPTION
### Description:

Extracts the MCP server management logic from `AiAgentFormSetup` into a new self-contained `AiAgentMcpServersInput` component, and moves all MCP server-related hooks and API calls into a dedicated `useProjectAiMcpServers` hook file.

The new `AiAgentMcpServersInput` component introduces several UX improvements over the previous inline implementation:

- Replaces the single `MultiSelect` dropdown with a table view showing attached MCP servers, displaying their name, URL, auth type, and connection status as a colored badge.
- Splits the "select existing" and "create new" flows into two separate modals (`AttachMcpServersModal` and `CreateMcpServerModal`), with an "+ Add" button to open the attach modal.
- Adds OAuth as a supported auth type when creating an MCP server. Creating an OAuth MCP server opens a popup window to complete the OAuth flow and polls for connection status.
- Adds a `useStartMcpOAuthConnectionMutation` hook that handles opening the OAuth popup, redirecting to the authorization URL, and polling until the connection is confirmed or times out.
- Adds per-server action menus allowing users to reconnect (for OAuth servers) or remove an attached server.

Additionally, streaming errors from the AI chat are now surfaced in the assistant bubble UI. When a streaming error occurs, the error message is displayed and a retry option is shown, and the optimistic assistant message in the query cache is marked as errored so the state persists correctly after the stream ends.