### PR TITLE
fix: fetch all pages in query sdk queries

### DIFF
--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -268,7 +268,11 @@ export function useAppSdkBridge(
                                 limit: 0,
                                 queryUuid: result.queryUuid,
                                 status: 'ready',
-                                rowCount: result.rows?.length ?? null,
+                                // Use totalResults (full row count across all
+                                // pages), not rows.length (just this page).
+                                // The SDK paginates internally — the app sees
+                                // every row, so the inspector should too.
+                                rowCount: result.totalResults ?? null,
                                 durationMs:
                                     result.metadata?.performance
                                         ?.initialQueryExecutionMs ?? null,

--- a/packages/query-sdk/src/apiTransport.ts
+++ b/packages/query-sdk/src/apiTransport.ts
@@ -20,8 +20,13 @@ import type {
     Transport,
 } from './types';
 
-const POLL_INTERVAL_MS = 500;
-const MAX_POLL_ATTEMPTS = 120; // 60 seconds max
+// Mirrors the explorer's `useInfiniteQueryResults` polling rhythm so the
+// SDK behaves like a normal Lightdash chart: 500-row pages, exponential
+// backoff starting at 250ms, capped at 1000ms.
+const PAGE_SIZE = 500;
+const INITIAL_BACKOFF_MS = 250;
+const MAX_BACKOFF_MS = 1000;
+const MAX_POLL_DURATION_MS = 5 * 60 * 1000; // 5 minutes
 
 type ApiResponse<T> = {
     status: 'ok';
@@ -57,6 +62,12 @@ type PollResponse =
           queryUuid: string;
           columns: Record<string, { reference: string; type: string }>;
           rows: ResultRow[];
+          // Pagination — backend tells us the next page number, or undefined
+          // when this is the last page. totalResults lets us short-circuit
+          // when the warehouse returned fewer rows than the last fetched
+          // page could hold.
+          nextPage?: number;
+          totalResults: number;
       }
     | {
           status: 'pending' | 'queued' | 'executing' | 'cancelled';
@@ -195,7 +206,7 @@ export function createApiTransport(
             const qualifiedDims = query.dimensions.map(qualify);
             const qualifiedMetrics = query.metrics.map(qualify);
 
-            // Step 1: Execute async query
+            // Kick off the async query — returns a queryUuid we then poll.
             const body = {
                 query: {
                     exploreName: table,
@@ -237,91 +248,33 @@ export function createApiTransport(
 
             const { queryUuid, fields } = execResult;
 
-            // Step 2: Poll for results
-            let attempts = 0;
-            while (attempts < MAX_POLL_ATTEMPTS) {
+            const pollUrl = (page: number) =>
+                `/api/v2/projects/${config.projectUuid}/query/${queryUuid}?page=${page}&pageSize=${PAGE_SIZE}`;
+
+            // The poll endpoint returns status PENDING/QUEUED/EXECUTING while
+            // the warehouse is still running, and READY (with the first page
+            // of rows) once results are available. Mirrors the explorer's
+            // `useInfiniteQueryResults`: backoff while waiting, then follow
+            // `nextPage` to drain remaining pages.
+            const deadline = Date.now() + MAX_POLL_DURATION_MS;
+            let backoffMs = INITIAL_BACKOFF_MS;
+            let firstReadyPage:
+                | Extract<PollResponse, { status: 'ready' }>
+                | null = null;
+            const apiRows: ResultRow[] = [];
+
+            // Wait for the first ready page.
+            while (Date.now() < deadline) {
                 const pollResult = await fetchFn<PollResponse>(
                     'GET',
-                    `/api/v2/projects/${config.projectUuid}/query/${queryUuid}`,
+                    pollUrl(1),
                 );
 
                 if (pollResult.status === 'ready') {
-                    // Build a mapping from qualified → short field names
-                    // so app code uses row.driver_name, not row.fct_race_results_driver_name
-                    const allShort = [...query.dimensions, ...query.metrics];
-                    const allQualified = [
-                        ...qualifiedDims,
-                        ...qualifiedMetrics,
-                    ];
-                    const qualifiedToShort = new Map<string, string>();
-                    for (let i = 0; i < allShort.length; i++) {
-                        qualifiedToShort.set(allQualified[i], allShort[i]);
-                    }
-
-                    // Map columns from field metadata
-                    const columns: Column[] = allQualified.map((qFieldId) => {
-                        const shortName =
-                            qualifiedToShort.get(qFieldId) ?? qFieldId;
-                        const fieldMeta = fields[qFieldId];
-                        const colMeta = pollResult.columns[qFieldId];
-                        return {
-                            name: shortName,
-                            label: fieldMeta?.label ?? shortName,
-                            type: mapColumnType(
-                                colMeta?.type ?? fieldMeta?.type ?? 'string',
-                            ),
-                        };
-                    });
-
-                    // Map rows: extract raw values, keep formatted for format()
-                    const formattedCache = new Map<
-                        string,
-                        Map<unknown, string>
-                    >();
-
-                    const rows: Row[] = pollResult.rows.map((apiRow) => {
-                        const row: Row = {};
-                        for (const qFieldId of allQualified) {
-                            const shortName =
-                                qualifiedToShort.get(qFieldId) ?? qFieldId;
-                            const cell = apiRow[qFieldId];
-                            if (!cell) {
-                                row[shortName] = null;
-                                continue;
-                            }
-                            const { raw, formatted } = cell.value;
-
-                            // Store formatted value for the format() function
-                            if (!formattedCache.has(shortName)) {
-                                formattedCache.set(shortName, new Map());
-                            }
-                            formattedCache.get(shortName)!.set(raw, formatted);
-
-                            // Convert raw to typed value
-                            if (raw === null || raw === undefined) {
-                                row[shortName] = null;
-                            } else if (typeof raw === 'number') {
-                                row[shortName] = raw;
-                            } else if (typeof raw === 'boolean') {
-                                row[shortName] = raw;
-                            } else {
-                                row[shortName] = String(raw);
-                            }
-                        }
-                        return row;
-                    });
-
-                    const format: FormatFunction = (row, fieldId) => {
-                        const rawVal = row[fieldId];
-                        const cache = formattedCache.get(fieldId);
-                        if (cache) {
-                            const formatted = cache.get(rawVal);
-                            if (formatted !== undefined) return formatted;
-                        }
-                        return String(rawVal ?? '');
-                    };
-
-                    return { rows, columns, format };
+                    firstReadyPage = pollResult;
+                    apiRows.push(...pollResult.rows);
+                    backoffMs = INITIAL_BACKOFF_MS;
+                    break;
                 }
 
                 if (
@@ -337,15 +290,112 @@ export function createApiTransport(
                     throw new Error('Query was cancelled');
                 }
 
-                // Still running — wait and retry
+                // Still running — wait with exponential backoff and retry.
+                const sleepMs = backoffMs;
                 // eslint-disable-next-line no-promise-executor-return
-                await new Promise((resolve) =>
-                    setTimeout(resolve, POLL_INTERVAL_MS),
-                );
-                attempts++;
+                await new Promise((resolve) => setTimeout(resolve, sleepMs));
+                backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
             }
 
-            throw new Error('Query timed out waiting for results');
+            if (!firstReadyPage) {
+                throw new Error('Query timed out waiting for results');
+            }
+
+            // Drain remaining pages. The backend already streamed results to
+            // S3 by the time the first page is ready, so subsequent pages
+            // resolve quickly (no warehouse round-trip per page).
+            let { nextPage } = firstReadyPage;
+            const { totalResults } = firstReadyPage;
+            while (
+                nextPage !== undefined &&
+                apiRows.length < totalResults
+            ) {
+                const pageResult = await fetchFn<PollResponse>(
+                    'GET',
+                    pollUrl(nextPage),
+                );
+
+                if (pageResult.status !== 'ready') {
+                    // Status shouldn't regress once we've seen ready; treat
+                    // anything else as a hard failure rather than retrying.
+                    throw new Error(
+                        `Unexpected status while paginating results: ${pageResult.status}`,
+                    );
+                }
+
+                apiRows.push(...pageResult.rows);
+                nextPage = pageResult.nextPage;
+            }
+
+            // Build a mapping from qualified → short field names
+            // so app code uses row.driver_name, not row.fct_race_results_driver_name
+            const allShort = [...query.dimensions, ...query.metrics];
+            const allQualified = [...qualifiedDims, ...qualifiedMetrics];
+            const qualifiedToShort = new Map<string, string>();
+            for (let i = 0; i < allShort.length; i++) {
+                qualifiedToShort.set(allQualified[i], allShort[i]);
+            }
+
+            // Map columns from field metadata
+            const columns: Column[] = allQualified.map((qFieldId) => {
+                const shortName = qualifiedToShort.get(qFieldId) ?? qFieldId;
+                const fieldMeta = fields[qFieldId];
+                const colMeta = firstReadyPage.columns[qFieldId];
+                return {
+                    name: shortName,
+                    label: fieldMeta?.label ?? shortName,
+                    type: mapColumnType(
+                        colMeta?.type ?? fieldMeta?.type ?? 'string',
+                    ),
+                };
+            });
+
+            // Map rows: extract raw values, keep formatted for format()
+            const formattedCache = new Map<string, Map<unknown, string>>();
+
+            const rows: Row[] = apiRows.map((apiRow) => {
+                const row: Row = {};
+                for (const qFieldId of allQualified) {
+                    const shortName =
+                        qualifiedToShort.get(qFieldId) ?? qFieldId;
+                    const cell = apiRow[qFieldId];
+                    if (!cell) {
+                        row[shortName] = null;
+                        continue;
+                    }
+                    const { raw, formatted } = cell.value;
+
+                    // Store formatted value for the format() function
+                    if (!formattedCache.has(shortName)) {
+                        formattedCache.set(shortName, new Map());
+                    }
+                    formattedCache.get(shortName)!.set(raw, formatted);
+
+                    // Convert raw to typed value
+                    if (raw === null || raw === undefined) {
+                        row[shortName] = null;
+                    } else if (typeof raw === 'number') {
+                        row[shortName] = raw;
+                    } else if (typeof raw === 'boolean') {
+                        row[shortName] = raw;
+                    } else {
+                        row[shortName] = String(raw);
+                    }
+                }
+                return row;
+            });
+
+            const format: FormatFunction = (row, fieldId) => {
+                const rawVal = row[fieldId];
+                const cache = formattedCache.get(fieldId);
+                if (cache) {
+                    const formatted = cache.get(rawVal);
+                    if (formatted !== undefined) return formatted;
+                }
+                return String(rawVal ?? '');
+            };
+
+            return { rows, columns, format };
         },
 
         async getUser(): Promise<LightdashUser> {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Description:

The query-sdk's poll loop only ever fetched page 1 of the async metric query results endpoint. Since that endpoint paginates at 500 rows by default, `.limit(1000)` (or anything above 500)
silently truncated — the warehouse ran the full query, but the SDK threw away pages 2+.

Mirror `useInfiniteQueryResults` (the explorer's pattern):

- pass `?page=N&pageSize=500` on every poll
- after status flips to `ready`, follow `nextPage` and accumulate rows until `apiRows.length >= totalResults`
- exponential backoff (250 → 500 → 1000ms, reset on `ready`) replaces the fixed 500ms interval
- 5-minute wall-clock deadline replaces the 60s attempt budget

Also fix the data-app query inspector, which was showing the last page's row count (often 500, or the tail page's partial count) instead of the total. Use `result.totalResults` from the page
response.

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->