### PR TITLE
chore: handle nested workspace members in clean scripts

### DIFF
--- a/scripts/clean-build-cache.sh
+++ b/scripts/clean-build-cache.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 
-# Remove tsbuildinfo files
-rm -rf packages/*/tsconfig*.tsbuildinfo
+# Remove tsbuildinfo files (incl. nested workspace members)
+find packages -name "*.tsbuildinfo" -not -path "*/node_modules/*" -delete
 
-# Remove turbo cache
+# Remove turbo cache (root + per-package)
 rm -rf .turbo
+rm -rf packages/*/.turbo
 
-# Remove build/dist and next build cache
-rm -rf packages/*/build
-rm -rf packages/*/dist
-rm -rf packages/*/.next
+# Remove build/dist/.next under packages (incl. nested workspace members)
+find packages -type d \( -name node_modules -prune \) -o \
+    -type d \( -name dist -o -name build -o -name .next \) -prune -print0 | \
+    xargs -0 rm -rf
 
-# Remove sdk build cache
-rm -rf packages/frontend/sdk/dist
-
-echo "🧼 cleaned \"build\", \"dist\" and \"tsbuildinfo\" files"
+echo "🧼 cleaned \"build\", \"dist\", \".turbo\" and \"tsbuildinfo\" files"

--- a/scripts/clean-node-modules.sh
+++ b/scripts/clean-node-modules.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 rm -rf node_modules
-rm -rf packages/*/node_modules
+find packages -name node_modules -type d -prune -exec rm -rf {} +
 
 echo "🧼 cleaned \"node_modules\""


### PR DESCRIPTION
## Summary

The clean scripts used `packages/*/` globs, which only match top-level workspace packages. Nested members (e.g. `packages/frontend/sdk`, `packages/backend/src/ee/services/McpService/mcp-chart-app`) were silently skipped — leaving stale `node_modules`, `dist`, `build`, `.turbo`, and `.tsbuildinfo` behind.

Switched both scripts to `find` so they reach any nested workspace package.

## Changes

- `scripts/clean-build-cache.sh` — recursively find `dist/`, `build/`, `.next/`, `.turbo/`, `*.tsbuildinfo` under `packages/` (excluding anything under `node_modules`). Also drops the now-redundant `packages/frontend/sdk/dist` line.
- `scripts/clean-node-modules.sh` — recursively delete `node_modules` under `packages/` instead of just `packages/*/node_modules`.
