### PR TITLE
fix(sql-runner): default time x-axis to readable date when format is None

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -797,6 +797,13 @@ export class CartesianChartDataModel {
             getFirstIndexColumns(transformedData.indexColumn)?.type ||
             DEFAULT_X_AXIS_TYPE;
 
+        // Under "None" on a time-typed X-axis, default to a readable Day
+        // format so the axis label formatter and tooltip header render the
+        // same clean date — fixes PROD-5672/PROD-2659.
+        const effectiveDateFormat: string | undefined =
+            display?.xAxis?.dateFormat ??
+            (xAxisType === VizIndexType.TIME ? 'MMM D, YYYY' : undefined);
+
         // Determine tooltip configuration
         let tooltipConfig = {};
         if (shouldStack100 && xAxisReference && originalValues) {
@@ -832,7 +839,7 @@ export class CartesianChartDataModel {
                     },
                     xAxisReference,
                     undefined,
-                    display?.xAxis?.dateFormat,
+                    effectiveDateFormat,
                 ),
             };
         } else if (xAxisType === VizIndexType.TIME && xAxisReference) {
@@ -849,13 +856,10 @@ export class CartesianChartDataModel {
                         }) => {
                             const rawValue =
                                 params.seriesData[0]?.value[xAxisReference];
-                            if (
-                                display?.xAxis?.dateFormat &&
-                                rawValue != null
-                            ) {
+                            if (effectiveDateFormat && rawValue != null) {
                                 return formatDateWithPattern(
                                     rawValue as string | number,
-                                    display.xAxis.dateFormat,
+                                    effectiveDateFormat,
                                 );
                             }
                             return rawValue;
@@ -892,7 +896,7 @@ export class CartesianChartDataModel {
                     flipAxes: false,
                     xFieldId: xAxisReference,
                     originalValues,
-                    xAxisDateFormat: display?.xAxis?.dateFormat,
+                    xAxisDateFormat: effectiveDateFormat,
                 }),
                 extraCssText: `overflow-y: auto; max-height:280px; ${
                     getTooltipStyle().extraCssText
@@ -921,13 +925,12 @@ export class CartesianChartDataModel {
                 nameTextStyle: getAxisTitleStyle(),
                 axisLabel: {
                     ...getAxisLabelStyle(),
-                    ...(xAxisType === VizIndexType.TIME &&
-                    display?.xAxis?.dateFormat
+                    ...(xAxisType === VizIndexType.TIME && effectiveDateFormat
                         ? {
                               formatter: (value: string | number) =>
                                   formatDateWithPattern(
                                       value,
-                                      display.xAxis!.dateFormat!,
+                                      effectiveDateFormat,
                                   ),
                           }
                         : {}),


### PR DESCRIPTION
Closes: PROD-5672 / PROD-2659

## Summary

In SQL Runner cartesian charts, when the X-axis is time-typed and the date-format picker is left on `None`, the axis labels and the tooltip header rendered raw, unformatted values (e.g. millisecond timestamps or ISO strings with timezones) instead of a human-readable date.

## Root cause

The chart spec only applied a date formatter when `display.xAxis.dateFormat` was explicitly set. With the picker on `None`, that field is `undefined`, so the four downstream consumers (stack-100 tooltip, time-axis axisPointer label, main tooltip formatter, and the xAxis `axisLabel.formatter`) all fell through to ECharts' default rendering of the raw value.

```ts
// Before — formatter only wired up when user picked a format
xAxisDateFormat: display?.xAxis?.dateFormat,
// ...
...(xAxisType === VizIndexType.TIME && display?.xAxis?.dateFormat
    ? { formatter: (v) => formatDateWithPattern(v, display.xAxis!.dateFormat!) }
    : {}),
```

The picker default has always been `None`, so any time-typed X-axis chart shipped with this raw rendering unless the user manually selected a format.

## Fix

Compute a single `effectiveDateFormat` once: use the user's pick if set, otherwise fall back to `MMM D, YYYY` when the X-axis type is `TIME`. Thread it through all four call sites so axis labels and tooltip header stay in lockstep.

- `packages/common/src/visualizations/CartesianChartDataModel.ts` — introduce `effectiveDateFormat`, replace all four references to `display?.xAxis?.dateFormat` inside the chart spec.

Explicit picker selections still win; the default only applies on `None` + time-typed axis.

## Resolution flow

```
display.xAxis.dateFormat ──set?──► use it
         │
         └─ undefined ──► xAxisType == TIME ? ──► "MMM D, YYYY"
                                    │
                                    └─ no ──► undefined (no formatter)
```

Consumers that read `effectiveDateFormat`:

- **stack-100 tooltip** — `createStack100TooltipFormatter(..., effectiveDateFormat)`
- **time-axis axisPointer label** — tooltip header date
- **main tooltip formatter** — `buildSqlRunnerCartesianTooltipFormatter({ xAxisDateFormat })`
- **xAxis axisLabel.formatter** — tick labels under the chart

## Test plan

- [ ] `pnpm -F common typecheck && pnpm -F common lint`
- [ ] Manual: SQL Runner bar/line chart over a time column with date-format picker on `None` — axis ticks and tooltip header both show `MMM D, YYYY`
- [ ] Manual: set the picker to a custom format (e.g. `YYYY-MM`) — both surfaces honour the explicit choice
- [ ] Manual: non-time X-axis (category / numeric) — no formatter applied, values render as before