### PR TITLE
fix: clear stale field values on filter autocomplete force-refresh

### DIFF
--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -348,10 +348,12 @@ export const useFieldValues = (
         [search],
     );
 
-    // reset state when field changes
+    // reset state when field changes or force-refresh is triggered
     useEffect(() => {
         if (!!fieldName && field.name !== fieldName) {
             setFieldName(field.name);
+        }
+        if ((!!fieldName && field.name !== fieldName) || forceRefresh) {
             setSearches(new Set<string>());
             setResults(new Set(initialData));
             setResultCounts(new Map());


### PR DESCRIPTION
## Bug description

When a user clicks the refresh button on the filter autocomplete dropdown, the backend correctly bypasses the S3 cache and returns fresh values from the warehouse. However, the frontend `useFieldValues` hook accumulated results in a Set that was never cleared on force-refresh -- stale values persisted alongside fresh ones.

## Root cause

The `useEffect` that resets `searches` / `results` / `resultCounts` already had `forceRefresh` in its dependency array, but only checked for field name changes. This meant clicking refresh fetched fresh data but merged it into the existing accumulated Set instead of replacing it.

## Fix

Added `forceRefresh` to the reset condition so the accumulated state is cleared when force-refresh is triggered.

## How I verified

1. Traced the flow in `FilterStringAutoComplete.tsx` -> `useFieldValues.ts`
2. Confirmed `forceRefresh` goes `true` -> `refetch()` -> `setForceRefresh(false)` before `onSuccess` fires
3. The existing `useEffect` with `forceRefresh` in deps fires on the prop change, clearing state BEFORE `handleUpdateResults` merges new results

Fixes #23039