### PR TITLE
feat: skip connection change notifications for preview projects

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2573,6 +2573,7 @@ export class ProjectService extends BaseService {
         await this.projectModel.update(projectUuid, updatedProject);
 
         if (
+            savedProject.type !== ProjectType.PREVIEW &&
             hasConnectionChanges(
                 {
                     warehouseConnection: savedProject.warehouseConnection,
@@ -2693,6 +2694,7 @@ export class ProjectService extends BaseService {
         await this.projectModel.update(projectUuid, updatedProject);
 
         if (
+            savedProject.type !== ProjectType.PREVIEW &&
             hasConnectionChanges(
                 { warehouseConnection: savedProject.warehouseConnection },
                 { warehouseConnection: updatedProject.warehouseConnection },


### PR DESCRIPTION
## Summary
- Admin email notifications for warehouse / dbt connection changes now skip preview projects — they were noisy and not useful for short-lived previews.
- Guards both update paths in `ProjectService`: `updateAndScheduleAsyncWork` (PATCH `/api/v1/projects/:uuid`) and `updateWarehouseCredentials` (PUT `/api/v1/projects/:uuid/warehouse-credentials`).
- Non-preview projects continue to send the notification as before.

## Test plan
- [x] PUT `/warehouse-credentials` on a `DEFAULT` project — notification logged + email received in Mailpit
- [x] PUT `/warehouse-credentials` on a `PREVIEW` project — no log, no email
- [x] PATCH `/` on a `DEFAULT` project — notification logged + email received
- [x] PATCH `/` on a `PREVIEW` project — no log, no email
- [x] `pnpm -F backend typecheck` passes
- [x] `pnpm -F backend lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)