### PR TITLE
fix(mcp): allow icons to be embedded cross-origin

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -486,6 +486,13 @@ export default class App {
 
         expressApp.use(helmet(helmetConfig));
 
+        // Allow MCP-related icons to be embedded cross-origin so MCP hosts
+        // (e.g. claude.ai) can display them in connector listings.
+        expressApp.use(
+            ['/logo-icon.svg', '/favicon-32x32.png', '/apple-touch-icon.png'],
+            helmet.crossOriginResourcePolicy({ policy: 'cross-origin' }),
+        );
+
         const helmetConfigForEmbeds = produce(helmetConfig, (draft) => {
             // eslint-disable-next-line no-param-reassign
             draft.contentSecurityPolicy.directives['frame-ancestors'] = [


### PR DESCRIPTION
Closes: ZAP-400

## Summary

- Helmet's default `Cross-Origin-Resource-Policy: same-origin` blocked the icons the MCP server advertises (`/logo-icon.svg`, `/favicon-32x32.png`, `/apple-touch-icon.png`) from being rendered in MCP host UIs (claude.ai, Claude Desktop).
- Override CORP to `cross-origin` on just those three paths.
