### PR TITLE
feat(apps): UI for scheduling data app deliveries

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -4,9 +4,11 @@ import {
     ParameterError,
     type ApiAppImageUploadResponse,
     type ApiAppImageUrlResponse,
+    type ApiAppSchedulersResponse,
     type ApiCancelAppVersionResponse,
     type ApiClarifyAppRequest,
     type ApiClarifyAppResponse,
+    type ApiCreateAppSchedulerResponse,
     type ApiDeleteAppResponse,
     type ApiGenerateAppResponse,
     type ApiGetAppResponse,
@@ -39,6 +41,7 @@ import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
+    unauthorisedInDemo,
 } from '../../controllers/authentication';
 import { BaseController } from '../../controllers/baseController';
 import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
@@ -401,6 +404,60 @@ export class AppGenerateController extends BaseController {
         return {
             status: 'ok',
             results: result,
+        };
+    }
+
+    /**
+     * List schedulers for a data app
+     * @summary List app schedulers
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{appUuid}/schedulers')
+    @OperationId('getAppSchedulers')
+    async getAppSchedulers(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+    ): Promise<ApiAppSchedulersResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getSchedulerService()
+                .getAppSchedulers(toSessionUser(req.account), appUuid),
+        };
+    }
+
+    /**
+     * Create a scheduler for a data app
+     * @summary Create app scheduler
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/{appUuid}/schedulers')
+    @OperationId('createAppScheduler')
+    async createAppScheduler(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+    ): Promise<ApiCreateAppSchedulerResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getSchedulerService()
+                .createAppScheduler(
+                    toSessionUser(req.account),
+                    appUuid,
+                    req.body,
+                ),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7997,6 +7997,603 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess__imageUrl-string__', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerFormat: {
+        dataType: 'refEnum',
+        enums: ['csv', 'xlsx', 'image', 'gsheets', 'pdf'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerCsvOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                exportPivotedData: { dataType: 'boolean' },
+                asAttachment: { dataType: 'boolean' },
+                limit: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['table'] },
+                        { dataType: 'enum', enums: ['all'] },
+                        { dataType: 'double' },
+                    ],
+                    required: true,
+                },
+                formatted: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerImageOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { withPdf: { dataType: 'boolean' } },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerGsheetsOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                tabName: { dataType: 'string' },
+                url: { dataType: 'string', required: true },
+                gdriveOrganizationName: { dataType: 'string', required: true },
+                gdriveName: { dataType: 'string', required: true },
+                gdriveId: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.never_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerPdfOptions: {
+        dataType: 'refAlias',
+        type: { ref: 'Record_string.never_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'SchedulerCsvOptions' },
+                { ref: 'SchedulerImageOptions' },
+                { ref: 'SchedulerGsheetsOptions' },
+                { ref: 'SchedulerPdfOptions' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ThresholdOperator: {
+        dataType: 'refEnum',
+        enums: ['greaterThan', 'lessThan', 'increasedBy', 'decreasedBy'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ThresholdOptions: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                value: { dataType: 'double', required: true },
+                fieldId: { dataType: 'string', required: true },
+                operator: { ref: 'ThresholdOperator', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    NotificationFrequency: {
+        dataType: 'refEnum',
+        enums: ['always', 'once'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerBase: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                projectUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                includeLinks: { dataType: 'boolean', required: true },
+                notificationFrequency: { ref: 'NotificationFrequency' },
+                enabled: { dataType: 'boolean', required: true },
+                thresholds: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ThresholdOptions' },
+                },
+                options: { ref: 'SchedulerOptions', required: true },
+                appName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                appUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                savedSqlName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                savedSqlUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                dashboardName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                dashboardUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                savedChartName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                savedChartUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                projectSchedulerTimezone: { dataType: 'string' },
+                timezone: { dataType: 'string' },
+                cron: { dataType: 'string', required: true },
+                format: { ref: 'SchedulerFormat', required: true },
+                createdByName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdBy: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                message: { dataType: 'string' },
+                name: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ChartScheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SchedulerBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        appUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        savedSqlUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        dashboardUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        savedChartUuid: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardScheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SchedulerBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        selectedTabs: {
+                            dataType: 'union',
+                            subSchemas: [
+                                {
+                                    dataType: 'array',
+                                    array: { dataType: 'string' },
+                                },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        customViewportWidth: { dataType: 'double' },
+                        parameters: { ref: 'ParametersValuesMap' },
+                        filters: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'DashboardFilterRule',
+                            },
+                        },
+                        appUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        savedSqlUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        dashboardUuid: { dataType: 'string', required: true },
+                        savedChartUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SqlChartScheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SchedulerBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        appUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        savedSqlUuid: { dataType: 'string', required: true },
+                        dashboardUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        savedChartUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AppScheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'SchedulerBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        appUuid: { dataType: 'string', required: true },
+                        savedSqlUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        dashboardUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                        savedChartUuid: {
+                            dataType: 'enum',
+                            enums: [null],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Scheduler: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'ChartScheduler' },
+                { ref: 'DashboardScheduler' },
+                { ref: 'SqlChartScheduler' },
+                { ref: 'AppScheduler' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerSlackTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                channel: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                schedulerSlackTargetUuid: {
+                    dataType: 'string',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerEmailTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                recipient: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                schedulerEmailTargetUuid: {
+                    dataType: 'string',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerMsTeamsTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                webhook: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                schedulerMsTeamsTargetUuid: {
+                    dataType: 'string',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerGoogleChatTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                googleChatWebhook: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                schedulerGoogleChatTargetUuid: {
+                    dataType: 'string',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerJobStatus: {
+        dataType: 'refEnum',
+        enums: ['scheduled', 'started', 'completed', 'error'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerRunStatus: {
+        dataType: 'refEnum',
+        enums: [
+            'completed',
+            'partial_failure',
+            'failed',
+            'running',
+            'scheduled',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.AnyType_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: { dataType: 'any' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    LogCounts: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                error: { dataType: 'double', required: true },
+                completed: { dataType: 'double', required: true },
+                started: { dataType: 'double', required: true },
+                scheduled: { dataType: 'double', required: true },
+                total: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerResourceType: {
+        dataType: 'refEnum',
+        enums: ['chart', 'dashboard', 'sqlChart', 'app'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerRun: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                format: { ref: 'SchedulerFormat', required: true },
+                createdByUserName: { dataType: 'string', required: true },
+                createdByUserUuid: { dataType: 'string', required: true },
+                resourceName: { dataType: 'string', required: true },
+                resourceUuid: { dataType: 'string', required: true },
+                resourceType: { ref: 'SchedulerResourceType', required: true },
+                logCounts: { ref: 'LogCounts', required: true },
+                details: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'Record_string.AnyType_' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdAt: { dataType: 'datetime', required: true },
+                runStatus: { ref: 'SchedulerRunStatus', required: true },
+                status: { ref: 'SchedulerJobStatus', required: true },
+                scheduledTime: { dataType: 'datetime', required: true },
+                schedulerName: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+                runId: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerAndTargets: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Scheduler' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        latestRun: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'SchedulerRun' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
+                        targets: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { ref: 'SchedulerSlackTarget' },
+                                    { ref: 'SchedulerEmailTarget' },
+                                    { ref: 'SchedulerMsTeamsTarget' },
+                                    { ref: 'SchedulerGoogleChatTarget' },
+                                ],
+                            },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAppSchedulersResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SchedulerAndTargets' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSchedulerAndTargetsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'SchedulerAndTargets', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCreateAppSchedulerResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSchedulerAndTargetsResponse', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAppSummary: {
         dataType: 'refAlias',
         type: {
@@ -18448,570 +19045,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerFormat: {
-        dataType: 'refEnum',
-        enums: ['csv', 'xlsx', 'image', 'gsheets', 'pdf'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerCsvOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                exportPivotedData: { dataType: 'boolean' },
-                asAttachment: { dataType: 'boolean' },
-                limit: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['table'] },
-                        { dataType: 'enum', enums: ['all'] },
-                        { dataType: 'double' },
-                    ],
-                    required: true,
-                },
-                formatted: { dataType: 'boolean', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerImageOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { withPdf: { dataType: 'boolean' } },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerGsheetsOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                tabName: { dataType: 'string' },
-                url: { dataType: 'string', required: true },
-                gdriveOrganizationName: { dataType: 'string', required: true },
-                gdriveName: { dataType: 'string', required: true },
-                gdriveId: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.never_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerPdfOptions: {
-        dataType: 'refAlias',
-        type: { ref: 'Record_string.never_', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'SchedulerCsvOptions' },
-                { ref: 'SchedulerImageOptions' },
-                { ref: 'SchedulerGsheetsOptions' },
-                { ref: 'SchedulerPdfOptions' },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ThresholdOperator: {
-        dataType: 'refEnum',
-        enums: ['greaterThan', 'lessThan', 'increasedBy', 'decreasedBy'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ThresholdOptions: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                value: { dataType: 'double', required: true },
-                fieldId: { dataType: 'string', required: true },
-                operator: { ref: 'ThresholdOperator', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    NotificationFrequency: {
-        dataType: 'refEnum',
-        enums: ['always', 'once'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerBase: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                projectName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                },
-                projectUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                },
-                includeLinks: { dataType: 'boolean', required: true },
-                notificationFrequency: { ref: 'NotificationFrequency' },
-                enabled: { dataType: 'boolean', required: true },
-                thresholds: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'ThresholdOptions' },
-                },
-                options: { ref: 'SchedulerOptions', required: true },
-                appName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                appUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                savedSqlName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                savedSqlUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                dashboardName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                dashboardUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                savedChartName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                savedChartUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                projectSchedulerTimezone: { dataType: 'string' },
-                timezone: { dataType: 'string' },
-                cron: { dataType: 'string', required: true },
-                format: { ref: 'SchedulerFormat', required: true },
-                createdByName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                createdBy: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                message: { dataType: 'string' },
-                name: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ChartScheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'SchedulerBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        appUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        savedSqlUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        dashboardUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        savedChartUuid: { dataType: 'string', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DashboardScheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'SchedulerBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        selectedTabs: {
-                            dataType: 'union',
-                            subSchemas: [
-                                {
-                                    dataType: 'array',
-                                    array: { dataType: 'string' },
-                                },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        customViewportWidth: { dataType: 'double' },
-                        parameters: { ref: 'ParametersValuesMap' },
-                        filters: {
-                            dataType: 'array',
-                            array: {
-                                dataType: 'refAlias',
-                                ref: 'DashboardFilterRule',
-                            },
-                        },
-                        appUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        savedSqlUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        dashboardUuid: { dataType: 'string', required: true },
-                        savedChartUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SqlChartScheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'SchedulerBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        appUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        savedSqlUuid: { dataType: 'string', required: true },
-                        dashboardUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        savedChartUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AppScheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'SchedulerBase' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        appUuid: { dataType: 'string', required: true },
-                        savedSqlUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        dashboardUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                        savedChartUuid: {
-                            dataType: 'enum',
-                            enums: [null],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Scheduler: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'ChartScheduler' },
-                { ref: 'DashboardScheduler' },
-                { ref: 'SqlChartScheduler' },
-                { ref: 'AppScheduler' },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerSlackTarget: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                channel: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                schedulerSlackTargetUuid: {
-                    dataType: 'string',
-                    required: true,
-                },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerEmailTarget: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                recipient: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                schedulerEmailTargetUuid: {
-                    dataType: 'string',
-                    required: true,
-                },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerMsTeamsTarget: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                webhook: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                schedulerMsTeamsTargetUuid: {
-                    dataType: 'string',
-                    required: true,
-                },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerGoogleChatTarget: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                googleChatWebhook: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-                updatedAt: { dataType: 'datetime', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                schedulerGoogleChatTargetUuid: {
-                    dataType: 'string',
-                    required: true,
-                },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerJobStatus: {
-        dataType: 'refEnum',
-        enums: ['scheduled', 'started', 'completed', 'error'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerRunStatus: {
-        dataType: 'refEnum',
-        enums: [
-            'completed',
-            'partial_failure',
-            'failed',
-            'running',
-            'scheduled',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.AnyType_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
-            additionalProperties: { dataType: 'any' },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    LogCounts: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                error: { dataType: 'double', required: true },
-                completed: { dataType: 'double', required: true },
-                started: { dataType: 'double', required: true },
-                scheduled: { dataType: 'double', required: true },
-                total: { dataType: 'double', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerResourceType: {
-        dataType: 'refEnum',
-        enums: ['chart', 'dashboard', 'sqlChart', 'app'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerRun: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                format: { ref: 'SchedulerFormat', required: true },
-                createdByUserName: { dataType: 'string', required: true },
-                createdByUserUuid: { dataType: 'string', required: true },
-                resourceName: { dataType: 'string', required: true },
-                resourceUuid: { dataType: 'string', required: true },
-                resourceType: { ref: 'SchedulerResourceType', required: true },
-                logCounts: { ref: 'LogCounts', required: true },
-                details: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'Record_string.AnyType_' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                createdAt: { dataType: 'datetime', required: true },
-                runStatus: { ref: 'SchedulerRunStatus', required: true },
-                status: { ref: 'SchedulerJobStatus', required: true },
-                scheduledTime: { dataType: 'datetime', required: true },
-                schedulerName: { dataType: 'string', required: true },
-                schedulerUuid: { dataType: 'string', required: true },
-                runId: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerAndTargets: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'Scheduler' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        latestRun: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'SchedulerRun' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                        },
-                        targets: {
-                            dataType: 'array',
-                            array: {
-                                dataType: 'union',
-                                subSchemas: [
-                                    { ref: 'SchedulerSlackTarget' },
-                                    { ref: 'SchedulerEmailTarget' },
-                                    { ref: 'SchedulerMsTeamsTarget' },
-                                    { ref: 'SchedulerGoogleChatTarget' },
-                                ],
-                            },
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_SchedulerSlackTarget.channel_': {
         dataType: 'refAlias',
         type: {
@@ -20644,18 +20677,6 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             ref: 'ApiSuccess_KnexPaginatedData_SchedulerAndTargets-Array__',
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSchedulerAndTargetsResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'SchedulerAndTargets', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
             validators: {},
         },
     },
@@ -36055,6 +36076,140 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getAppImageUrl',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_getAppSchedulers: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/schedulers',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.getAppSchedulers,
+        ),
+
+        async function AppGenerateController_getAppSchedulers(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_getAppSchedulers,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAppSchedulers',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_createAppScheduler: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/schedulers',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.createAppScheduler,
+        ),
+
+        async function AppGenerateController_createAppScheduler(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_createAppScheduler,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createAppScheduler',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -9387,6 +9387,745 @@
             "ApiAppImageUrlResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__imageUrl-string__"
             },
+            "SchedulerFormat": {
+                "enum": ["csv", "xlsx", "image", "gsheets", "pdf"],
+                "type": "string"
+            },
+            "SchedulerCsvOptions": {
+                "properties": {
+                    "exportPivotedData": {
+                        "type": "boolean"
+                    },
+                    "asAttachment": {
+                        "type": "boolean"
+                    },
+                    "limit": {
+                        "anyOf": [
+                            {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            {
+                                "type": "string",
+                                "enum": ["table", "all"]
+                            }
+                        ]
+                    },
+                    "formatted": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["limit", "formatted"],
+                "type": "object"
+            },
+            "SchedulerImageOptions": {
+                "properties": {
+                    "withPdf": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "SchedulerGsheetsOptions": {
+                "properties": {
+                    "tabName": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "gdriveOrganizationName": {
+                        "type": "string"
+                    },
+                    "gdriveName": {
+                        "type": "string"
+                    },
+                    "gdriveId": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "url",
+                    "gdriveOrganizationName",
+                    "gdriveName",
+                    "gdriveId"
+                ],
+                "type": "object"
+            },
+            "Record_string.never_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "SchedulerPdfOptions": {
+                "$ref": "#/components/schemas/Record_string.never_"
+            },
+            "SchedulerOptions": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerCsvOptions"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SchedulerImageOptions"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SchedulerGsheetsOptions"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SchedulerPdfOptions"
+                    }
+                ]
+            },
+            "ThresholdOperator": {
+                "enum": [
+                    "greaterThan",
+                    "lessThan",
+                    "increasedBy",
+                    "decreasedBy"
+                ],
+                "type": "string"
+            },
+            "ThresholdOptions": {
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "fieldId": {
+                        "type": "string"
+                    },
+                    "operator": {
+                        "$ref": "#/components/schemas/ThresholdOperator"
+                    }
+                },
+                "required": ["value", "fieldId", "operator"],
+                "type": "object"
+            },
+            "NotificationFrequency": {
+                "enum": ["always", "once"],
+                "type": "string"
+            },
+            "SchedulerBase": {
+                "properties": {
+                    "projectName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "projectUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "includeLinks": {
+                        "type": "boolean"
+                    },
+                    "notificationFrequency": {
+                        "$ref": "#/components/schemas/NotificationFrequency"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "thresholds": {
+                        "items": {
+                            "$ref": "#/components/schemas/ThresholdOptions"
+                        },
+                        "type": "array"
+                    },
+                    "options": {
+                        "$ref": "#/components/schemas/SchedulerOptions"
+                    },
+                    "appName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "appUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "savedSqlName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "savedSqlUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "dashboardName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "dashboardUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "savedChartName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "savedChartUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "projectSchedulerTimezone": {
+                        "type": "string"
+                    },
+                    "timezone": {
+                        "type": "string"
+                    },
+                    "cron": {
+                        "type": "string"
+                    },
+                    "format": {
+                        "$ref": "#/components/schemas/SchedulerFormat"
+                    },
+                    "createdByName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "createdBy": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "includeLinks",
+                    "enabled",
+                    "options",
+                    "appName",
+                    "appUuid",
+                    "savedSqlName",
+                    "savedSqlUuid",
+                    "dashboardName",
+                    "dashboardUuid",
+                    "savedChartName",
+                    "savedChartUuid",
+                    "cron",
+                    "format",
+                    "createdByName",
+                    "createdBy",
+                    "updatedAt",
+                    "createdAt",
+                    "name",
+                    "schedulerUuid"
+                ],
+                "type": "object"
+            },
+            "ChartScheduler": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerBase"
+                    },
+                    {
+                        "properties": {
+                            "appUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "savedSqlUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "dashboardUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "savedChartUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "appUuid",
+                            "savedSqlUuid",
+                            "dashboardUuid",
+                            "savedChartUuid"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "DashboardScheduler": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerBase"
+                    },
+                    {
+                        "properties": {
+                            "selectedTabs": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array",
+                                "nullable": true
+                            },
+                            "customViewportWidth": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "parameters": {
+                                "$ref": "#/components/schemas/ParametersValuesMap"
+                            },
+                            "filters": {
+                                "items": {
+                                    "$ref": "#/components/schemas/DashboardFilterRule"
+                                },
+                                "type": "array"
+                            },
+                            "appUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "savedSqlUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "dashboardUuid": {
+                                "type": "string"
+                            },
+                            "savedChartUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            }
+                        },
+                        "required": [
+                            "selectedTabs",
+                            "appUuid",
+                            "savedSqlUuid",
+                            "dashboardUuid",
+                            "savedChartUuid"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "SqlChartScheduler": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerBase"
+                    },
+                    {
+                        "properties": {
+                            "appUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "savedSqlUuid": {
+                                "type": "string"
+                            },
+                            "dashboardUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "savedChartUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            }
+                        },
+                        "required": [
+                            "appUuid",
+                            "savedSqlUuid",
+                            "dashboardUuid",
+                            "savedChartUuid"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AppScheduler": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SchedulerBase"
+                    },
+                    {
+                        "properties": {
+                            "appUuid": {
+                                "type": "string"
+                            },
+                            "savedSqlUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "dashboardUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            },
+                            "savedChartUuid": {
+                                "type": "number",
+                                "enum": [null],
+                                "nullable": true
+                            }
+                        },
+                        "required": [
+                            "appUuid",
+                            "savedSqlUuid",
+                            "dashboardUuid",
+                            "savedChartUuid"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "Scheduler": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ChartScheduler"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DashboardScheduler"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SqlChartScheduler"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AppScheduler"
+                    }
+                ]
+            },
+            "SchedulerSlackTarget": {
+                "properties": {
+                    "channel": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schedulerSlackTargetUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "channel",
+                    "schedulerUuid",
+                    "updatedAt",
+                    "createdAt",
+                    "schedulerSlackTargetUuid"
+                ],
+                "type": "object"
+            },
+            "SchedulerEmailTarget": {
+                "properties": {
+                    "recipient": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schedulerEmailTargetUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "recipient",
+                    "schedulerUuid",
+                    "updatedAt",
+                    "createdAt",
+                    "schedulerEmailTargetUuid"
+                ],
+                "type": "object"
+            },
+            "SchedulerMsTeamsTarget": {
+                "properties": {
+                    "webhook": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schedulerMsTeamsTargetUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "webhook",
+                    "schedulerUuid",
+                    "updatedAt",
+                    "createdAt",
+                    "schedulerMsTeamsTargetUuid"
+                ],
+                "type": "object"
+            },
+            "SchedulerGoogleChatTarget": {
+                "properties": {
+                    "googleChatWebhook": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schedulerGoogleChatTargetUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "googleChatWebhook",
+                    "schedulerUuid",
+                    "updatedAt",
+                    "createdAt",
+                    "schedulerGoogleChatTargetUuid"
+                ],
+                "type": "object"
+            },
+            "SchedulerJobStatus": {
+                "enum": ["scheduled", "started", "completed", "error"],
+                "type": "string"
+            },
+            "SchedulerRunStatus": {
+                "enum": [
+                    "completed",
+                    "partial_failure",
+                    "failed",
+                    "running",
+                    "scheduled"
+                ],
+                "type": "string"
+            },
+            "Record_string.AnyType_": {
+                "properties": {},
+                "additionalProperties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "LogCounts": {
+                "properties": {
+                    "error": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "completed": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "started": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "scheduled": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "total": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": [
+                    "error",
+                    "completed",
+                    "started",
+                    "scheduled",
+                    "total"
+                ],
+                "type": "object"
+            },
+            "SchedulerResourceType": {
+                "enum": ["chart", "dashboard", "sqlChart", "app"],
+                "type": "string"
+            },
+            "SchedulerRun": {
+                "properties": {
+                    "format": {
+                        "$ref": "#/components/schemas/SchedulerFormat"
+                    },
+                    "createdByUserName": {
+                        "type": "string"
+                    },
+                    "createdByUserUuid": {
+                        "type": "string"
+                    },
+                    "resourceName": {
+                        "type": "string"
+                    },
+                    "resourceUuid": {
+                        "type": "string"
+                    },
+                    "resourceType": {
+                        "$ref": "#/components/schemas/SchedulerResourceType"
+                    },
+                    "logCounts": {
+                        "$ref": "#/components/schemas/LogCounts"
+                    },
+                    "details": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Record_string.AnyType_"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "runStatus": {
+                        "$ref": "#/components/schemas/SchedulerRunStatus"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/SchedulerJobStatus"
+                    },
+                    "scheduledTime": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "schedulerName": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    },
+                    "runId": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "format",
+                    "createdByUserName",
+                    "createdByUserUuid",
+                    "resourceName",
+                    "resourceUuid",
+                    "resourceType",
+                    "logCounts",
+                    "details",
+                    "createdAt",
+                    "runStatus",
+                    "status",
+                    "scheduledTime",
+                    "schedulerName",
+                    "schedulerUuid",
+                    "runId"
+                ],
+                "type": "object"
+            },
+            "SchedulerAndTargets": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Scheduler"
+                    },
+                    {
+                        "properties": {
+                            "latestRun": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/SchedulerRun"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "targets": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/SchedulerSlackTarget"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/SchedulerEmailTarget"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/SchedulerMsTeamsTarget"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/SchedulerGoogleChatTarget"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["targets"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiAppSchedulersResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/SchedulerAndTargets"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiSchedulerAndTargetsResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/SchedulerAndTargets"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiCreateAppSchedulerResponse": {
+                "$ref": "#/components/schemas/ApiSchedulerAndTargetsResponse"
+            },
             "ApiAppSummary": {
                 "properties": {
                     "lastVersionStatus": {
@@ -19422,711 +20161,6 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "SchedulerFormat": {
-                "enum": ["csv", "xlsx", "image", "gsheets", "pdf"],
-                "type": "string"
-            },
-            "SchedulerCsvOptions": {
-                "properties": {
-                    "exportPivotedData": {
-                        "type": "boolean"
-                    },
-                    "asAttachment": {
-                        "type": "boolean"
-                    },
-                    "limit": {
-                        "anyOf": [
-                            {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            {
-                                "type": "string",
-                                "enum": ["table", "all"]
-                            }
-                        ]
-                    },
-                    "formatted": {
-                        "type": "boolean"
-                    }
-                },
-                "required": ["limit", "formatted"],
-                "type": "object"
-            },
-            "SchedulerImageOptions": {
-                "properties": {
-                    "withPdf": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "SchedulerGsheetsOptions": {
-                "properties": {
-                    "tabName": {
-                        "type": "string"
-                    },
-                    "url": {
-                        "type": "string"
-                    },
-                    "gdriveOrganizationName": {
-                        "type": "string"
-                    },
-                    "gdriveName": {
-                        "type": "string"
-                    },
-                    "gdriveId": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "url",
-                    "gdriveOrganizationName",
-                    "gdriveName",
-                    "gdriveId"
-                ],
-                "type": "object"
-            },
-            "Record_string.never_": {
-                "properties": {},
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
-            },
-            "SchedulerPdfOptions": {
-                "$ref": "#/components/schemas/Record_string.never_"
-            },
-            "SchedulerOptions": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerCsvOptions"
-                    },
-                    {
-                        "$ref": "#/components/schemas/SchedulerImageOptions"
-                    },
-                    {
-                        "$ref": "#/components/schemas/SchedulerGsheetsOptions"
-                    },
-                    {
-                        "$ref": "#/components/schemas/SchedulerPdfOptions"
-                    }
-                ]
-            },
-            "ThresholdOperator": {
-                "enum": [
-                    "greaterThan",
-                    "lessThan",
-                    "increasedBy",
-                    "decreasedBy"
-                ],
-                "type": "string"
-            },
-            "ThresholdOptions": {
-                "properties": {
-                    "value": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "fieldId": {
-                        "type": "string"
-                    },
-                    "operator": {
-                        "$ref": "#/components/schemas/ThresholdOperator"
-                    }
-                },
-                "required": ["value", "fieldId", "operator"],
-                "type": "object"
-            },
-            "NotificationFrequency": {
-                "enum": ["always", "once"],
-                "type": "string"
-            },
-            "SchedulerBase": {
-                "properties": {
-                    "projectName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "projectUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "includeLinks": {
-                        "type": "boolean"
-                    },
-                    "notificationFrequency": {
-                        "$ref": "#/components/schemas/NotificationFrequency"
-                    },
-                    "enabled": {
-                        "type": "boolean"
-                    },
-                    "thresholds": {
-                        "items": {
-                            "$ref": "#/components/schemas/ThresholdOptions"
-                        },
-                        "type": "array"
-                    },
-                    "options": {
-                        "$ref": "#/components/schemas/SchedulerOptions"
-                    },
-                    "appName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "appUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "savedSqlName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "savedSqlUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "dashboardName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "dashboardUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "savedChartName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "savedChartUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "projectSchedulerTimezone": {
-                        "type": "string"
-                    },
-                    "timezone": {
-                        "type": "string"
-                    },
-                    "cron": {
-                        "type": "string"
-                    },
-                    "format": {
-                        "$ref": "#/components/schemas/SchedulerFormat"
-                    },
-                    "createdByName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "createdBy": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "includeLinks",
-                    "enabled",
-                    "options",
-                    "appName",
-                    "appUuid",
-                    "savedSqlName",
-                    "savedSqlUuid",
-                    "dashboardName",
-                    "dashboardUuid",
-                    "savedChartName",
-                    "savedChartUuid",
-                    "cron",
-                    "format",
-                    "createdByName",
-                    "createdBy",
-                    "updatedAt",
-                    "createdAt",
-                    "name",
-                    "schedulerUuid"
-                ],
-                "type": "object"
-            },
-            "ChartScheduler": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerBase"
-                    },
-                    {
-                        "properties": {
-                            "appUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "savedSqlUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "dashboardUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "savedChartUuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "appUuid",
-                            "savedSqlUuid",
-                            "dashboardUuid",
-                            "savedChartUuid"
-                        ],
-                        "type": "object"
-                    }
-                ]
-            },
-            "DashboardScheduler": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerBase"
-                    },
-                    {
-                        "properties": {
-                            "selectedTabs": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array",
-                                "nullable": true
-                            },
-                            "customViewportWidth": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "parameters": {
-                                "$ref": "#/components/schemas/ParametersValuesMap"
-                            },
-                            "filters": {
-                                "items": {
-                                    "$ref": "#/components/schemas/DashboardFilterRule"
-                                },
-                                "type": "array"
-                            },
-                            "appUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "savedSqlUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "dashboardUuid": {
-                                "type": "string"
-                            },
-                            "savedChartUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            }
-                        },
-                        "required": [
-                            "selectedTabs",
-                            "appUuid",
-                            "savedSqlUuid",
-                            "dashboardUuid",
-                            "savedChartUuid"
-                        ],
-                        "type": "object"
-                    }
-                ]
-            },
-            "SqlChartScheduler": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerBase"
-                    },
-                    {
-                        "properties": {
-                            "appUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "savedSqlUuid": {
-                                "type": "string"
-                            },
-                            "dashboardUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "savedChartUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            }
-                        },
-                        "required": [
-                            "appUuid",
-                            "savedSqlUuid",
-                            "dashboardUuid",
-                            "savedChartUuid"
-                        ],
-                        "type": "object"
-                    }
-                ]
-            },
-            "AppScheduler": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/SchedulerBase"
-                    },
-                    {
-                        "properties": {
-                            "appUuid": {
-                                "type": "string"
-                            },
-                            "savedSqlUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "dashboardUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            },
-                            "savedChartUuid": {
-                                "type": "number",
-                                "enum": [null],
-                                "nullable": true
-                            }
-                        },
-                        "required": [
-                            "appUuid",
-                            "savedSqlUuid",
-                            "dashboardUuid",
-                            "savedChartUuid"
-                        ],
-                        "type": "object"
-                    }
-                ]
-            },
-            "Scheduler": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/ChartScheduler"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DashboardScheduler"
-                    },
-                    {
-                        "$ref": "#/components/schemas/SqlChartScheduler"
-                    },
-                    {
-                        "$ref": "#/components/schemas/AppScheduler"
-                    }
-                ]
-            },
-            "SchedulerSlackTarget": {
-                "properties": {
-                    "channel": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "schedulerSlackTargetUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "channel",
-                    "schedulerUuid",
-                    "updatedAt",
-                    "createdAt",
-                    "schedulerSlackTargetUuid"
-                ],
-                "type": "object"
-            },
-            "SchedulerEmailTarget": {
-                "properties": {
-                    "recipient": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "schedulerEmailTargetUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "recipient",
-                    "schedulerUuid",
-                    "updatedAt",
-                    "createdAt",
-                    "schedulerEmailTargetUuid"
-                ],
-                "type": "object"
-            },
-            "SchedulerMsTeamsTarget": {
-                "properties": {
-                    "webhook": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "schedulerMsTeamsTargetUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "webhook",
-                    "schedulerUuid",
-                    "updatedAt",
-                    "createdAt",
-                    "schedulerMsTeamsTargetUuid"
-                ],
-                "type": "object"
-            },
-            "SchedulerGoogleChatTarget": {
-                "properties": {
-                    "googleChatWebhook": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "schedulerGoogleChatTargetUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "googleChatWebhook",
-                    "schedulerUuid",
-                    "updatedAt",
-                    "createdAt",
-                    "schedulerGoogleChatTargetUuid"
-                ],
-                "type": "object"
-            },
-            "SchedulerJobStatus": {
-                "enum": ["scheduled", "started", "completed", "error"],
-                "type": "string"
-            },
-            "SchedulerRunStatus": {
-                "enum": [
-                    "completed",
-                    "partial_failure",
-                    "failed",
-                    "running",
-                    "scheduled"
-                ],
-                "type": "string"
-            },
-            "Record_string.AnyType_": {
-                "properties": {},
-                "additionalProperties": {},
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
-            },
-            "LogCounts": {
-                "properties": {
-                    "error": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "completed": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "started": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "scheduled": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "total": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": [
-                    "error",
-                    "completed",
-                    "started",
-                    "scheduled",
-                    "total"
-                ],
-                "type": "object"
-            },
-            "SchedulerResourceType": {
-                "enum": ["chart", "dashboard", "sqlChart", "app"],
-                "type": "string"
-            },
-            "SchedulerRun": {
-                "properties": {
-                    "format": {
-                        "$ref": "#/components/schemas/SchedulerFormat"
-                    },
-                    "createdByUserName": {
-                        "type": "string"
-                    },
-                    "createdByUserUuid": {
-                        "type": "string"
-                    },
-                    "resourceName": {
-                        "type": "string"
-                    },
-                    "resourceUuid": {
-                        "type": "string"
-                    },
-                    "resourceType": {
-                        "$ref": "#/components/schemas/SchedulerResourceType"
-                    },
-                    "logCounts": {
-                        "$ref": "#/components/schemas/LogCounts"
-                    },
-                    "details": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Record_string.AnyType_"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "runStatus": {
-                        "$ref": "#/components/schemas/SchedulerRunStatus"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/SchedulerJobStatus"
-                    },
-                    "scheduledTime": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "schedulerName": {
-                        "type": "string"
-                    },
-                    "schedulerUuid": {
-                        "type": "string"
-                    },
-                    "runId": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "format",
-                    "createdByUserName",
-                    "createdByUserUuid",
-                    "resourceName",
-                    "resourceUuid",
-                    "resourceType",
-                    "logCounts",
-                    "details",
-                    "createdAt",
-                    "runStatus",
-                    "status",
-                    "scheduledTime",
-                    "schedulerName",
-                    "schedulerUuid",
-                    "runId"
-                ],
-                "type": "object"
-            },
-            "SchedulerAndTargets": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Scheduler"
-                    },
-                    {
-                        "properties": {
-                            "latestRun": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/SchedulerRun"
-                                    }
-                                ],
-                                "nullable": true
-                            },
-                            "targets": {
-                                "items": {
-                                    "anyOf": [
-                                        {
-                                            "$ref": "#/components/schemas/SchedulerSlackTarget"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/SchedulerEmailTarget"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/SchedulerMsTeamsTarget"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/SchedulerGoogleChatTarget"
-                                        }
-                                    ]
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["targets"],
-                        "type": "object"
-                    }
-                ]
-            },
             "Pick_SchedulerSlackTarget.channel_": {
                 "properties": {
                     "channel": {
@@ -21827,20 +21861,6 @@
             },
             "ApiSchedulersResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData_SchedulerAndTargets-Array__"
-            },
-            "ApiSchedulerAndTargetsResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/SchedulerAndTargets"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
             },
             "ApiSuccess_SchedulerAndTargets-Array_": {
                 "properties": {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -495,6 +495,93 @@ export class SchedulerService extends BaseService {
         return this.schedulerModel.attachLatestRunToSchedulers(schedulers);
     }
 
+    private async checkAppScheduledDeliveryAccess(
+        user: SessionUser,
+        appUuid: string,
+    ): Promise<void> {
+        const app = await this.appModel.findAppByUuid(appUuid);
+        if (!app) {
+            throw new NotFoundError(`App not found: ${appUuid}`);
+        }
+        const auditedAbility = this.createAuditedAbility(user);
+        const spaceContext = app.space_uuid
+            ? await this.spacePermissionService.getSpaceAccessContext(
+                  user.userUuid,
+                  app.space_uuid,
+              )
+            : {};
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('DataApp', {
+                    organizationUuid: app.organization_uuid,
+                    projectUuid: app.project_uuid,
+                    createdByUserUuid: app.created_by_user_uuid,
+                    ...spaceContext,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        if (
+            auditedAbility.cannot(
+                'create',
+                subject('ScheduledDeliveries', {
+                    organizationUuid: app.organization_uuid,
+                    projectUuid: app.project_uuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    async getAppSchedulers(
+        user: SessionUser,
+        appUuid: string,
+    ): Promise<SchedulerAndTargets[]> {
+        await this.checkAppScheduledDeliveryAccess(user, appUuid);
+        return this.schedulerModel.getAppSchedulers(appUuid);
+    }
+
+    async createAppScheduler(
+        user: SessionUser,
+        appUuid: string,
+        newScheduler: Omit<
+            CreateSchedulerAndTargets,
+            | 'createdBy'
+            | 'savedChartUuid'
+            | 'dashboardUuid'
+            | 'savedSqlUuid'
+            | 'appUuid'
+        >,
+    ): Promise<SchedulerAndTargets> {
+        await this.checkAppScheduledDeliveryAccess(user, appUuid);
+
+        if (newScheduler.format !== SchedulerFormat.IMAGE) {
+            throw new ParameterError(
+                'Data app schedulers only support image deliveries',
+            );
+        }
+        if (!isValidFrequency(newScheduler.cron)) {
+            throw new ParameterError(
+                'Frequency not allowed, custom input is limited to hourly',
+            );
+        }
+        if (!isValidTimezone(newScheduler.timezone)) {
+            throw new ParameterError('Timezone string is not valid');
+        }
+
+        return this.schedulerModel.createScheduler({
+            ...newScheduler,
+            createdBy: user.userUuid,
+            savedChartUuid: null,
+            dashboardUuid: null,
+            savedSqlUuid: null,
+            appUuid,
+        });
+    }
+
     async getScheduler(
         user: SessionUser,
         schedulerUuid: string,

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -474,6 +474,13 @@ export type ApiSchedulerAndTargetsResponse = {
     results: SchedulerAndTargets;
 };
 
+export type ApiAppSchedulersResponse = {
+    status: 'ok';
+    results: SchedulerAndTargets[];
+};
+
+export type ApiCreateAppSchedulerResponse = ApiSchedulerAndTargetsResponse;
+
 export type ApiSchedulersResponse = ApiSuccess<
     KnexPaginatedData<SchedulerAndTargets[]>
 >;

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormSetupTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormSetupTab.tsx
@@ -15,6 +15,7 @@ import {
 } from '@lightdash/common';
 import {
     Anchor,
+    Badge,
     Box,
     Button,
     Checkbox,
@@ -78,6 +79,7 @@ type Props = {
         TableCalculation | Metric | Field | CustomDimension
     >;
     isDashboardTabsAvailable: boolean;
+    isApp?: boolean;
 };
 
 export const SchedulerFormSetupTab: FC<Props> = ({
@@ -86,6 +88,7 @@ export const SchedulerFormSetupTab: FC<Props> = ({
     isThresholdAlertWithNoFields,
     numericMetrics,
     isDashboardTabsAvailable,
+    isApp,
 }) => {
     const form = useSchedulerFormContext();
     const { activeProjectUuid } = useActiveProjectUuid();
@@ -297,37 +300,48 @@ export const SchedulerFormSetupTab: FC<Props> = ({
                 <Stack gap={0}>
                     <Input.Label> Format </Input.Label>
                     <Group gap="xs" wrap="nowrap">
-                        <SegmentedControl
-                            radius="md"
-                            data={[
-                                {
-                                    label: '.csv',
-                                    value: SchedulerFormat.CSV,
-                                },
-                                {
-                                    label: '.xlsx',
-                                    value: SchedulerFormat.XLSX,
-                                },
-                                {
-                                    label: 'Image',
-                                    value: SchedulerFormat.IMAGE,
-                                    disabled: isImageDisabled,
-                                },
-                                {
-                                    label: 'PDF',
-                                    value: SchedulerFormat.PDF,
-                                    disabled:
-                                        isImageDisabled ||
-                                        (form.values.msTeamsTargets?.length ??
-                                            0) > 0 ||
-                                        (form.values.googleChatTargets
-                                            ?.length ?? 0) > 0,
-                                },
-                            ]}
-                            w="50%"
-                            {...form.getInputProps('format')}
-                        />
-                        {isImageDisabled && (
+                        {isApp ? (
+                            <Badge
+                                variant="light"
+                                radius="sm"
+                                size="lg"
+                                px="sm"
+                            >
+                                Image
+                            </Badge>
+                        ) : (
+                            <SegmentedControl
+                                radius="md"
+                                data={[
+                                    {
+                                        label: '.csv',
+                                        value: SchedulerFormat.CSV,
+                                    },
+                                    {
+                                        label: '.xlsx',
+                                        value: SchedulerFormat.XLSX,
+                                    },
+                                    {
+                                        label: 'Image',
+                                        value: SchedulerFormat.IMAGE,
+                                        disabled: isImageDisabled,
+                                    },
+                                    {
+                                        label: 'PDF',
+                                        value: SchedulerFormat.PDF,
+                                        disabled:
+                                            isImageDisabled ||
+                                            (form.values.msTeamsTargets
+                                                ?.length ?? 0) > 0 ||
+                                            (form.values.googleChatTargets
+                                                ?.length ?? 0) > 0,
+                                    },
+                                ]}
+                                w="50%"
+                                {...form.getInputProps('format')}
+                            />
+                        )}
+                        {isImageDisabled && !isApp && (
                             <Text
                                 size="xs"
                                 c="ldGray.6"

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/index.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/index.tsx
@@ -20,7 +20,7 @@ type Props = {
     savedSchedulerData?: SchedulerAndTargets;
     resource?: {
         uuid: string;
-        type: 'chart' | 'dashboard';
+        type: 'chart' | 'dashboard' | 'app';
     };
     onSubmit: (data: any) => void;
     onSendNow: (data: CreateSchedulerAndTargetsWithoutIds) => void;
@@ -49,7 +49,9 @@ const SchedulerForm: FC<Props> = ({
     numericMetrics,
     isDashboardTabsAvailable,
     onSubmit,
+    resource,
 }) => {
+    const isApp = resource?.type === 'app';
     const form = useSchedulerFormContext();
 
     const isDashboard = dashboard !== undefined;
@@ -128,6 +130,7 @@ const SchedulerForm: FC<Props> = ({
                         }
                         numericMetrics={numericMetrics}
                         isDashboardTabsAvailable={isDashboardTabsAvailable}
+                        isApp={isApp}
                     />
                 </Tabs.Panel>
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -185,7 +185,7 @@ export const getFormValuesFromScheduler = (
 
 export const transformFormValues = (
     values: SchedulerFormValues,
-    resourceType: 'chart' | 'dashboard' | undefined,
+    resourceType: 'chart' | 'dashboard' | 'app' | undefined,
 ): CreateSchedulerAndTargetsWithoutIds => {
     let options = {};
     if ([SchedulerFormat.CSV, SchedulerFormat.XLSX].includes(values.format)) {

--- a/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
@@ -44,6 +44,7 @@ const SchedulersModal: FC<
         | 'resourceUuid'
         | 'createMutation'
         | 'isChart'
+        | 'isApp'
         | 'currentParameterValues'
         | 'availableParameters'
     > & {
@@ -66,7 +67,8 @@ const SchedulersModal: FC<
     schedulersQuery,
     createMutation,
     isOpen = false,
-    isChart,
+    isChart = false,
+    isApp = false,
     isThresholdAlert,
     itemsMap,
     currentParameterValues,
@@ -269,6 +271,7 @@ const SchedulersModal: FC<
                 onClose={onClose}
                 onBack={() => setModalState(States.LIST)}
                 isChart={isChart}
+                isApp={isApp}
                 isThresholdAlert={isThresholdAlert}
                 itemsMap={itemsMap}
                 currentParameterValues={currentParameterValues}

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -2,6 +2,7 @@ import {
     getMetricsFromItemsMap,
     getTableCalculationsFromItemsMap,
     isNumericItem,
+    SchedulerFormat,
     type ApiError,
     type CreateSchedulerAndTargets,
     type CreateSchedulerAndTargetsWithoutIds,
@@ -49,7 +50,8 @@ import { Limit } from './types';
 interface UseSchedulerFormModalProps {
     schedulerUuid: string | undefined; // undefined = create, string = edit
     resourceUuid: string;
-    isChart: boolean;
+    isChart?: boolean;
+    isApp?: boolean;
     isThresholdAlert?: boolean;
     createMutation: UseMutationResult<
         SchedulerAndTargets,
@@ -65,6 +67,7 @@ const useSchedulerFormModal = ({
     schedulerUuid,
     resourceUuid,
     isChart,
+    isApp,
     isThresholdAlert,
     createMutation,
     onBack,
@@ -88,28 +91,37 @@ const useSchedulerFormModal = ({
         useSendNowScheduler();
 
     // Resource prop for form
-    const formResource = useMemo(
-        () =>
-            isEditMode
-                ? scheduler.data?.dashboardUuid ||
-                  scheduler.data?.savedChartUuid
-                    ? {
-                          type: (scheduler.data.dashboardUuid
-                              ? 'dashboard'
-                              : 'chart') as 'dashboard' | 'chart',
-                          uuid:
-                              scheduler.data.dashboardUuid ??
-                              scheduler.data.savedChartUuid,
-                      }
-                    : undefined
-                : {
-                      type: (isChart ? 'chart' : 'dashboard') as
-                          | 'dashboard'
-                          | 'chart',
-                      uuid: resourceUuid,
-                  },
-        [isEditMode, scheduler.data, isChart, resourceUuid],
-    );
+    const formResource = useMemo(() => {
+        if (isEditMode) {
+            if (scheduler.data?.appUuid) {
+                return {
+                    type: 'app' as const,
+                    uuid: scheduler.data.appUuid,
+                };
+            }
+            if (
+                scheduler.data?.dashboardUuid ||
+                scheduler.data?.savedChartUuid
+            ) {
+                return {
+                    type: scheduler.data.dashboardUuid
+                        ? ('dashboard' as const)
+                        : ('chart' as const),
+                    uuid:
+                        scheduler.data.dashboardUuid ??
+                        scheduler.data.savedChartUuid,
+                };
+            }
+            return undefined;
+        }
+        if (isApp) {
+            return { type: 'app' as const, uuid: resourceUuid };
+        }
+        return {
+            type: (isChart ? 'chart' : 'dashboard') as 'dashboard' | 'chart',
+            uuid: resourceUuid,
+        };
+    }, [isEditMode, scheduler.data, isApp, isChart, resourceUuid]);
 
     const projectUuid = useProjectUuid();
     const isDashboard = formResource?.type === 'dashboard';
@@ -142,6 +154,10 @@ const useSchedulerFormModal = ({
                   ? DEFAULT_VALUES_ALERT
                   : {
                         ...DEFAULT_VALUES,
+                        // Apps only support image deliveries
+                        format: isApp
+                            ? SchedulerFormat.IMAGE
+                            : DEFAULT_VALUES.format,
                         selectedTabs: isDashboardTabsAvailable
                             ? dashboard?.tabs.map((tab) => tab.uuid)
                             : null,
@@ -278,23 +294,41 @@ const useSchedulerFormModal = ({
             formResource?.type,
         );
 
-        const resource = isEditMode
-            ? {
-                  savedChartUuid: scheduler.data?.savedChartUuid ?? null,
-                  dashboardUuid: scheduler.data?.dashboardUuid ?? null,
-                  savedSqlUuid: scheduler.data?.savedSqlUuid ?? null,
-              }
-            : isChart
-              ? {
-                    savedChartUuid: resourceUuid,
-                    dashboardUuid: null,
-                    savedSqlUuid: null,
-                }
-              : {
-                    dashboardUuid: resourceUuid,
-                    savedChartUuid: null,
-                    savedSqlUuid: null,
-                };
+        let resource: {
+            savedChartUuid: string | null;
+            dashboardUuid: string | null;
+            savedSqlUuid: string | null;
+            appUuid: string | null;
+        };
+        if (isEditMode) {
+            resource = {
+                savedChartUuid: scheduler.data?.savedChartUuid ?? null,
+                dashboardUuid: scheduler.data?.dashboardUuid ?? null,
+                savedSqlUuid: scheduler.data?.savedSqlUuid ?? null,
+                appUuid: scheduler.data?.appUuid ?? null,
+            };
+        } else if (isApp) {
+            resource = {
+                appUuid: resourceUuid,
+                savedChartUuid: null,
+                dashboardUuid: null,
+                savedSqlUuid: null,
+            };
+        } else if (isChart) {
+            resource = {
+                savedChartUuid: resourceUuid,
+                dashboardUuid: null,
+                savedSqlUuid: null,
+                appUuid: null,
+            };
+        } else {
+            resource = {
+                dashboardUuid: resourceUuid,
+                savedChartUuid: null,
+                savedSqlUuid: null,
+                appUuid: null,
+            };
+        }
 
         const unsavedScheduler: CreateSchedulerAndTargets = {
             ...schedulerData,
@@ -309,6 +343,7 @@ const useSchedulerFormModal = ({
         isEditMode,
         scheduler.data,
         isChart,
+        isApp,
         resourceUuid,
         user,
         track,
@@ -356,7 +391,8 @@ interface Props {
     >;
     onClose: () => void;
     onBack: () => void;
-    isChart: boolean;
+    isChart?: boolean;
+    isApp?: boolean;
     isThresholdAlert?: boolean;
     itemsMap?: ItemsMap;
     currentParameterValues?: ParametersValuesMap;
@@ -369,7 +405,8 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
     resourceUuid,
     createMutation,
     schedulerUuidToEdit,
-    isChart,
+    isChart = false,
+    isApp,
     isThresholdAlert,
     itemsMap,
     currentParameterValues,
@@ -400,6 +437,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
         schedulerUuid,
         resourceUuid,
         isChart,
+        isApp,
         isThresholdAlert,
         createMutation,
         onBack,

--- a/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
@@ -8,6 +8,10 @@ import {
 } from '../../../features/explorer/store';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import {
+    useAppSchedulerCreateMutation,
+    useAppSchedulers,
+} from '../hooks/useAppSchedulers';
+import {
     useChartSchedulerCreateMutation,
     useChartSchedulers,
 } from '../hooks/useChartSchedulers';
@@ -82,6 +86,37 @@ const DELIVERY_FORMATS = [
     SchedulerFormat.IMAGE,
     SchedulerFormat.PDF,
 ];
+
+interface AppSchedulersProps {
+    projectUuid: string;
+    appUuid: string;
+    name: string;
+    isOpen: boolean;
+    onClose: () => void;
+    /** If provided, opens directly in edit mode for this scheduler */
+    initialSchedulerUuid?: string;
+}
+
+export const AppSchedulersModal: FC<AppSchedulersProps> = ({
+    projectUuid,
+    appUuid,
+    name,
+    ...modalProps
+}) => {
+    const schedulersQuery = useAppSchedulers({ projectUuid, appUuid });
+    const createMutation = useAppSchedulerCreateMutation(projectUuid);
+
+    return (
+        <SchedulerModal
+            resourceUuid={appUuid}
+            name={name}
+            schedulersQuery={schedulersQuery}
+            createMutation={createMutation}
+            isApp
+            {...modalProps}
+        />
+    );
+};
 
 export const ChartSchedulersModal: FC<ChartSchedulersProps> = ({
     chartUuid,

--- a/packages/frontend/src/features/scheduler/hooks/useAppSchedulers.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useAppSchedulers.ts
@@ -1,0 +1,101 @@
+import {
+    type ApiAppSchedulersResponse,
+    type ApiCreateAppSchedulerResponse,
+    type ApiError,
+    type CreateSchedulerAndTargetsWithoutIds,
+    type KnexPaginatedData,
+    type SchedulerAndTargets,
+} from '@lightdash/common';
+import {
+    useInfiniteQuery,
+    useMutation,
+    useQueryClient,
+} from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+// Apps use a flat (non-paginated) list endpoint — schedule counts per app
+// are expected to be small. We wrap the response in the same paginated
+// shape the chart/dashboard hooks return so SchedulerModal can consume it
+// uniformly via useInfiniteQuery.
+type AppSchedulersPage = KnexPaginatedData<SchedulerAndTargets[]>;
+
+const getAppSchedulers = async (
+    projectUuid: string,
+    appUuid: string,
+): Promise<AppSchedulersPage> => {
+    const results = await lightdashApi<ApiAppSchedulersResponse['results']>({
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/schedulers`,
+        method: 'GET',
+        body: undefined,
+    });
+    return {
+        data: results,
+        pagination: {
+            page: 1,
+            pageSize: results.length || 1,
+            totalPageCount: 1,
+            totalResults: results.length,
+        },
+    };
+};
+
+export type UseAppSchedulersParams = {
+    projectUuid: string;
+    appUuid: string;
+};
+
+export const useAppSchedulers = ({
+    projectUuid,
+    appUuid,
+}: UseAppSchedulersParams) =>
+    useInfiniteQuery<AppSchedulersPage, ApiError>({
+        queryKey: ['app_schedulers', appUuid],
+        queryFn: () => getAppSchedulers(projectUuid, appUuid),
+        getNextPageParam: () => undefined, // single-page wrapper
+        keepPreviousData: true,
+        refetchOnWindowFocus: false,
+        enabled: !!appUuid && !!projectUuid,
+    });
+
+const createAppScheduler = (
+    projectUuid: string,
+    appUuid: string,
+    data: CreateSchedulerAndTargetsWithoutIds,
+) =>
+    lightdashApi<ApiCreateAppSchedulerResponse['results']>({
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/schedulers`,
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+
+export const useAppSchedulerCreateMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<
+        SchedulerAndTargets,
+        ApiError,
+        { resourceUuid: string; data: CreateSchedulerAndTargetsWithoutIds }
+    >(
+        ({ resourceUuid, data }) =>
+            createAppScheduler(projectUuid, resourceUuid, data),
+        {
+            mutationKey: ['create_app_scheduler'],
+            onSuccess: async (_, variables) => {
+                await queryClient.invalidateQueries([
+                    'app_schedulers',
+                    variables.resourceUuid,
+                ]);
+                showToastSuccess({
+                    title: 'Success! Scheduled delivery was created.',
+                });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to create scheduled delivery',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,7 +1,12 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags } from '@lightdash/common';
 import { ActionIcon, Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
-import { IconAppsOff, IconDots, IconPencil } from '@tabler/icons-react';
+import {
+    IconAppsOff,
+    IconDots,
+    IconPencil,
+    IconSend,
+} from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
@@ -10,6 +15,7 @@ import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
+import { AppSchedulersModal } from '../features/scheduler/components/SchedulerModals';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
@@ -68,6 +74,7 @@ export default function AppPreviewTest() {
     } = useAppPreviewToken(projectUuid, appUuid, version);
 
     const [menuOpened, setMenuOpened] = useState(false);
+    const [schedulerModalOpen, setSchedulerModalOpen] = useState(false);
 
     // Close menu when the iframe receives focus (i.e. user clicked on it)
     const handleBlur = useCallback(() => {
@@ -193,6 +200,12 @@ export default function AppPreviewTest() {
                             >
                                 Continue building
                             </Menu.Item>
+                            <Menu.Item
+                                leftSection={<IconSend size={14} />}
+                                onClick={() => setSchedulerModalOpen(true)}
+                            >
+                                Schedule delivery
+                            </Menu.Item>
                         </Menu.Dropdown>
                     </Menu>
                 </Box>
@@ -202,6 +215,15 @@ export default function AppPreviewTest() {
                 expectedPreviewOrigin={previewOrigin}
                 identityKey={`${appUuid}:${version}`}
             />
+            {schedulerModalOpen && (
+                <AppSchedulersModal
+                    projectUuid={projectUuid}
+                    appUuid={appUuid}
+                    name={appQuery.data?.pages[0]?.name ?? 'Data app'}
+                    isOpen
+                    onClose={() => setSchedulerModalOpen(false)}
+                />
+            )}
         </Box>
     );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #22932

### Description:

 Adds a "Schedule delivery" menu entry on the app preview page. Reuses the existing SchedulerModal so users get Send Now, Slack/MSTeams/email targets, and the
  existing-schedulers list — same UX as charts and dashboards.

  Design notes:
  - New POST / GET /api/v1/ee/projects/{projectUuid}/apps/{appUuid}/schedulers endpoints delegating to SchedulerService.createAppScheduler / getAppSchedulers. Service
  enforces space-access CASL checks and restricts format to IMAGE only. POST is guarded with unauthorisedInDemo to match chart/dashboard scheduler endpoints.
  - SchedulerModal extended with an isApp boolean alongside existing isChart — minimal blast radius. Format selector renders as a static Image badge for apps (the
  underlying value is locked), and filter/parameter/tabs UI naturally hides because none of those are applicable to apps.
  - useAppSchedulers hook wraps the flat list endpoint in the same paginated shape SchedulerModal consumes from chart/dashboard hooks, so the modal's plumbing stays
  uniform across all three resource types.
  - Per-app inline