### PR TITLE
fix(filters): clear stale autocomplete results on force-refresh (PROD-7747)

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -179,6 +179,7 @@ const FilterStringAutoComplete: FC<Props> = ({
         results: resultsSet,
         refreshedAt,
         refetch,
+        reset,
         error,
         isError,
     } = useFieldValues(
@@ -340,12 +341,20 @@ const FilterStringAutoComplete: FC<Props> = ({
                 {healthData?.hasCacheAutocompleResults ? (
                     <RefreshIndicator
                         refreshedAtRef={refreshedAtRef}
-                        onRefresh={() => setForceRefresh(true)}
+                        onRefresh={() => {
+                            reset();
+                            setForceRefresh(true);
+                        }}
                     />
                 ) : null}
             </Stack>
         ),
-        [searchedMaxResults, search, healthData?.hasCacheAutocompleResults],
+        [
+            searchedMaxResults,
+            search,
+            healthData?.hasCacheAutocompleResults,
+            reset,
+        ],
     );
 
     return (

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -358,6 +358,12 @@ export const useFieldValues = (
         }
     }, [initialData, fieldName, field.name, forceRefresh]);
 
+    const reset = useCallback(() => {
+        setSearches(new Set<string>());
+        setResults(new Set(initialData));
+        setResultCounts(new Map());
+    }, [initialData]);
+
     return {
         ...query,
         debouncedSearch,
@@ -365,6 +371,7 @@ export const useFieldValues = (
         results,
         resultCounts,
         refreshedAt,
+        reset,
     };
 };
 
@@ -433,6 +440,7 @@ export const useFieldValuesSafely = (
             results: undefined,
             resultCounts: undefined,
             refreshedAt: undefined,
+            reset: undefined,
         };
     }
 


### PR DESCRIPTION
## Summary

- The autocomplete dropdown's refresh icon (\"Results loaded at … ↻\") updated the timestamp and the backend correctly bypassed its cache, but the frontend kept accumulating values into a Set that was only reset on field or filter changes. Stale values (e.g. a renamed dimension value) persisted in the dropdown until a full page reload.
- Fixes [PROD-7747](https://linear.app/lightdash/issue/PROD-7747) / #23039.

## Change

\`useFieldValues\` now exposes a \`reset()\` callback that restores the results Set to \`initialData\` and clears the searches/resultCounts maps. \`FilterStringAutoComplete\` calls it from the refresh handler before \`setForceRefresh(true)\`, so the accumulator is wiped before the fresh response merges in.

## Test plan

- [x] Manual A/B reproduction (post-page-load marker `ZzzPostLoad` / `ZzzBugTest` inserted in warehouse, typed in autocomplete to populate the Set, then dropdown refresh icon clicked):
  - **Without fix**: count `51 → 52 → 52`, marker survives refresh ❌
  - **With fix**: count `81 → 82 → 81`, marker cleared after refresh ✅
- [ ] Add a unit test in `FilterStringAutoComplete.test.tsx` that mocks two sequential `useFieldValues` responses, simulates a refresh icon click, and asserts first-batch-only values are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)