### PR TITLE
feat(observability): wide-event logs for dashboard loads and project compiles

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1227,6 +1227,13 @@ export class ProjectModel {
         );
     }
 
+    async getCachedExploreNames(projectUuid: string): Promise<string[]> {
+        const rows = await this.database(CachedExploreTableName)
+            .select<{ name: string }[]>('name')
+            .where('project_uuid', projectUuid);
+        return rows.map((row) => row.name);
+    }
+
     async findVirtualViewsFromCache(
         projectUuid: string,
     ): Promise<Record<string, Explore | ExploreError>> {

--- a/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
@@ -95,9 +95,13 @@ describe('DashboardService - Content Verification', () => {
         pinnedListModel: {} as unknown as PinnedListModel,
         schedulerModel: {} as unknown as SchedulerModel,
         schedulerService: {} as unknown as SchedulerService,
-        savedChartModel: {} as unknown as SavedChartModel,
+        savedChartModel: {
+            getInfoForAvailableFilters: jest.fn(async () => []),
+        } as unknown as SavedChartModel,
         savedChartService: {} as unknown as SavedChartService,
-        projectModel: {} as unknown as ProjectModel,
+        projectModel: {
+            getCachedExploreNames: jest.fn(async () => []),
+        } as unknown as ProjectModel,
         slackClient: {} as unknown as SlackClient,
         schedulerClient: {} as unknown as SchedulerClient,
         catalogModel: {} as unknown as CatalogModel,

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -78,6 +78,11 @@ const savedChartModel = {
         uuid: 'chart_uuid',
         projectUuid: 'project_uuid',
     })),
+    getInfoForAvailableFilters: jest.fn(async () => []),
+};
+
+const projectModel = {
+    getCachedExploreNames: jest.fn(async () => []),
 };
 
 const contentVerificationModel = {
@@ -138,7 +143,7 @@ describe('DashboardService', () => {
         schedulerService: {} as SchedulerService,
         savedChartModel: savedChartModel as unknown as SavedChartModel,
         savedChartService: {} as SavedChartService, // Mock for test
-        projectModel: {} as ProjectModel,
+        projectModel: projectModel as unknown as ProjectModel,
         slackClient: {} as SlackClient,
         schedulerClient: {} as SchedulerClient,
         catalogModel: {} as CatalogModel,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -519,7 +519,142 @@ export class DashboardService
             },
         });
 
+        // Wide observability event for diagnosing stale dashboard filter references
+        // (e.g. PROD-5931). Best-effort — never block the request on logging errors.
+        try {
+            await this.logDashboardLoadedEvent(dashboard);
+        } catch (err) {
+            this.logger.warn('dashboard.loaded log failed', {
+                dashboardUuid: dashboard.uuid,
+                err: err instanceof Error ? err.message : String(err),
+            });
+        }
+
         return dashboard;
+    }
+
+    private async logDashboardLoadedEvent(dashboard: Dashboard): Promise<void> {
+        const STALE_SAMPLE_CAP = 10;
+
+        const cachedExploreNames = new Set(
+            await this.projectModel.getCachedExploreNames(
+                dashboard.projectUuid,
+            ),
+        );
+
+        const chartTileUuids = dashboard.tiles
+            .filter(isDashboardChartTileType)
+            .map((tile) => tile.properties.savedChartUuid)
+            .filter((uuid): uuid is string => Boolean(uuid));
+
+        const chartInfos = chartTileUuids.length
+            ? await this.savedChartModel.getInfoForAvailableFilters(
+                  chartTileUuids,
+              )
+            : [];
+
+        const chartTables = new Set(
+            chartInfos.map((chart) => chart.tableName).filter(Boolean),
+        );
+        const chartTablesMissing = [...chartTables].filter(
+            (name) => !cachedExploreNames.has(name),
+        );
+
+        const staleFilterTargets: Array<{
+            path: string;
+            tableName: string;
+            fieldId: string;
+        }> = [];
+        const staleTileTargets: Array<{
+            path: string;
+            tableName: string;
+            fieldId: string;
+        }> = [];
+
+        const dimensions = dashboard.filters?.dimensions ?? [];
+        dimensions.forEach((dim, dimIndex) => {
+            const target = dim.target as
+                | {
+                      tableName?: string;
+                      fieldId?: string;
+                      isSqlColumn?: boolean;
+                  }
+                | undefined;
+            if (
+                target?.tableName &&
+                target.fieldId &&
+                !target.isSqlColumn &&
+                !cachedExploreNames.has(target.tableName)
+            ) {
+                staleFilterTargets.push({
+                    path: `dimensions[${dimIndex}].target`,
+                    tableName: target.tableName,
+                    fieldId: target.fieldId,
+                });
+            }
+
+            const { tileTargets } = dim as {
+                tileTargets?: Record<string, unknown>;
+            };
+            if (tileTargets) {
+                Object.entries(tileTargets).forEach(([tileUuid, raw]) => {
+                    if (!raw || typeof raw !== 'object') {
+                        return;
+                    }
+                    const tt = raw as {
+                        tableName?: string;
+                        fieldId?: string;
+                        isSqlColumn?: boolean;
+                    };
+                    if (
+                        tt.tableName &&
+                        tt.fieldId &&
+                        !tt.isSqlColumn &&
+                        !cachedExploreNames.has(tt.tableName)
+                    ) {
+                        staleTileTargets.push({
+                            path: `dimensions[${dimIndex}].tileTargets.${tileUuid}`,
+                            tableName: tt.tableName,
+                            fieldId: tt.fieldId,
+                        });
+                    }
+                });
+            }
+        });
+
+        const filterDimensionCount = dimensions.length;
+        const filterMetricCount = dashboard.filters?.metrics?.length ?? 0;
+        const tileTargetCount = dimensions.reduce(
+            (acc, dim) =>
+                acc +
+                Object.keys(
+                    (dim as { tileTargets?: Record<string, unknown> })
+                        .tileTargets ?? {},
+                ).length,
+            0,
+        );
+
+        this.logger.info('dashboard.loaded', {
+            projectUuid: dashboard.projectUuid,
+            organizationUuid: dashboard.organizationUuid,
+            dashboardUuid: dashboard.uuid,
+            dashboardVersionUuid: dashboard.versionUuid,
+
+            tileCount: dashboard.tiles.length,
+            chartTileCount: chartTileUuids.length,
+            filterDimensionCount,
+            filterMetricCount,
+            tileTargetCount,
+
+            cachedExploreCount: cachedExploreNames.size,
+            chartTablesMissingCount: chartTablesMissing.length,
+            staleFilterTargetCount: staleFilterTargets.length,
+            staleTileTargetCount: staleTileTargets.length,
+
+            chartTablesMissing: chartTablesMissing.slice(0, STALE_SAMPLE_CAP),
+            staleFilterTargets: staleFilterTargets.slice(0, STALE_SAMPLE_CAP),
+            staleTileTargets: staleTileTargets.slice(0, STALE_SAMPLE_CAP),
+        });
     }
 
     static findChartsThatBelongToDashboard(

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -155,6 +155,7 @@ const projectModel = {
     })),
     findExploreByTableName: jest.fn(async () => validExplore),
     getAllExploresFromCache: jest.fn(async () => ({})),
+    getCachedExploreNames: jest.fn(async () => []),
     saveExploresToCache: jest.fn(async () => ({ cachedExploreUuids: [] })),
     updateDefaultUserSpaces: jest.fn(async () => undefined),
 };

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1841,6 +1841,11 @@ export class ProjectService extends BaseService {
         const prevMetricsTreeNodes =
             await this.catalogModel.getAllMetricsTreeNodes(projectUuid);
 
+        // Capture the explore names already in cache so we can emit an
+        // added/removed diff once the new explores are written (PROD-5931).
+        const previousExploreNames =
+            await this.projectModel.getCachedExploreNames(projectUuid);
+
         const { cachedExploreUuids } =
             await this.projectModel.saveExploresToCache(projectUuid, explores);
         const { organizationUuid } =
@@ -1849,6 +1854,40 @@ export class ProjectService extends BaseService {
         this.logger.info(
             `Saved ${cachedExploreUuids.length} explores to cache for project ${projectUuid}`,
         );
+
+        // Wide observability event for explore lifecycle. Pair with the
+        // `dashboard.loaded` event to correlate "table removed at T1" with
+        // "dashboard loaded with stale reference at T2".
+        try {
+            const NAME_SAMPLE_CAP = 50;
+            const previousNameSet = new Set(previousExploreNames);
+            const newNames = explores.map((explore) => explore.name);
+            const newNameSet = new Set(newNames);
+            const removed = previousExploreNames.filter(
+                (name) => !newNameSet.has(name),
+            );
+            const added = newNames.filter((name) => !previousNameSet.has(name));
+
+            this.logger.info('compile.completed', {
+                projectUuid,
+                organizationUuid,
+                jobUuid: jobUuid ?? null,
+                compilationSource,
+                requestMethod: requestMethod ?? null,
+                cliVersion: cliVersion ?? null,
+                previousExploreCount: previousExploreNames.length,
+                newExploreCount: newNames.length,
+                addedExploreCount: added.length,
+                removedExploreCount: removed.length,
+                addedExploreNames: added.slice(0, NAME_SAMPLE_CAP),
+                removedExploreNames: removed.slice(0, NAME_SAMPLE_CAP),
+            });
+        } catch (err) {
+            this.logger.warn('compile.completed log failed', {
+                projectUuid,
+                err: err instanceof Error ? err.message : String(err),
+            });
+        }
 
         const compilationReport = calculateCompilationReport({ explores });
         const project = await this.projectModel.get(projectUuid);

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1841,10 +1841,20 @@ export class ProjectService extends BaseService {
         const prevMetricsTreeNodes =
             await this.catalogModel.getAllMetricsTreeNodes(projectUuid);
 
-        // Capture the explore names already in cache so we can emit an
-        // added/removed diff once the new explores are written (PROD-5931).
-        const previousExploreNames =
-            await this.projectModel.getCachedExploreNames(projectUuid);
+        // Best-effort: capture the explore names already in cache so we can
+        // emit an added/removed diff after the new explores are written
+        // (PROD-5931). Wrapped because this fetch must never interrupt the
+        // compile flow if the DB has a transient error.
+        let previousExploreNames: string[] | null = null;
+        try {
+            previousExploreNames =
+                await this.projectModel.getCachedExploreNames(projectUuid);
+        } catch (err) {
+            this.logger.warn('compile.completed previous-names fetch failed', {
+                projectUuid,
+                err: err instanceof Error ? err.message : String(err),
+            });
+        }
 
         const { cachedExploreUuids } =
             await this.projectModel.saveExploresToCache(projectUuid, explores);
@@ -1860,10 +1870,10 @@ export class ProjectService extends BaseService {
         // "dashboard loaded with stale reference at T2".
         try {
             const NAME_SAMPLE_CAP = 50;
-            const previousNameSet = new Set(previousExploreNames);
             const newNames = explores.map((explore) => explore.name);
+            const previousNameSet = new Set(previousExploreNames ?? []);
             const newNameSet = new Set(newNames);
-            const removed = previousExploreNames.filter(
+            const removed = (previousExploreNames ?? []).filter(
                 (name) => !newNameSet.has(name),
             );
             const added = newNames.filter((name) => !previousNameSet.has(name));
@@ -1875,12 +1885,21 @@ export class ProjectService extends BaseService {
                 compilationSource,
                 requestMethod: requestMethod ?? null,
                 cliVersion: cliVersion ?? null,
-                previousExploreCount: previousExploreNames.length,
+                // null distinguishes "fetch failed" from "no previous explores"
+                previousExploreCount: previousExploreNames?.length ?? null,
                 newExploreCount: newNames.length,
-                addedExploreCount: added.length,
-                removedExploreCount: removed.length,
-                addedExploreNames: added.slice(0, NAME_SAMPLE_CAP),
-                removedExploreNames: removed.slice(0, NAME_SAMPLE_CAP),
+                addedExploreCount:
+                    previousExploreNames === null ? null : added.length,
+                removedExploreCount:
+                    previousExploreNames === null ? null : removed.length,
+                addedExploreNames:
+                    previousExploreNames === null
+                        ? null
+                        : added.slice(0, NAME_SAMPLE_CAP),
+                removedExploreNames:
+                    previousExploreNames === null
+                        ? null
+                        : removed.slice(0, NAME_SAMPLE_CAP),
             });
         } catch (err) {
             this.logger.warn('compile.completed log failed', {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -780,6 +780,79 @@ export class ValidationService extends BaseService {
                         return acc;
                     }, []);
 
+                    // Wide observability event for diagnosing validation
+                    // suppression (related to PROD-5931). Per-dashboard summary
+                    // of inputs vs outputs, with a capped sample of tile targets
+                    // that passed all checks without producing an error — these
+                    // are the suspicious ones to inspect when the bell icon is
+                    // silent but a stale filter exists.
+                    try {
+                        const SAMPLE_CAP = 5;
+                        const tileTargetSummaries = dashboardTileTargets.map(
+                            (tt) => {
+                                if (!tt) {
+                                    return { kind: 'falsy' as const };
+                                }
+                                if (!isDashboardFieldTarget(tt)) {
+                                    return { kind: 'notFieldTarget' as const };
+                                }
+                                if (tt.isSqlColumn) {
+                                    return { kind: 'sqlColumn' as const };
+                                }
+                                return {
+                                    kind: 'processed' as const,
+                                    fieldId: tt.fieldId,
+                                    tableName: tt.tableName,
+                                    fieldIdInExistingFields:
+                                        existingFieldIds.includes(tt.fieldId),
+                                };
+                            },
+                        );
+                        const counts = tileTargetSummaries.reduce(
+                            (acc, t) => {
+                                acc[t.kind] = (acc[t.kind] ?? 0) + 1;
+                                return acc;
+                            },
+                            {} as Record<string, number>,
+                        );
+                        const processedWithoutError =
+                            tileTargetSummaries.filter(
+                                (t) =>
+                                    t.kind === 'processed' &&
+                                    t.fieldIdInExistingFields,
+                            );
+
+                        this.logger.info('validation.dashboardScanned', {
+                            projectUuid,
+                            dashboardUuid: uuid,
+                            existingFieldIdCount: existingFieldIds.length,
+                            filterRuleCount: dashboardFilterRules.length,
+                            tileTargetCount: dashboardTileTargets.length,
+                            filterErrorCount: filterErrors.length,
+                            tileTargetErrorCount: tileTargetErrors.length,
+                            chartErrorCount: chartErrors.length,
+                            tileTargetSkippedFalsyCount: counts.falsy ?? 0,
+                            tileTargetSkippedNotFieldTargetCount:
+                                counts.notFieldTarget ?? 0,
+                            tileTargetSkippedSqlColumnCount:
+                                counts.sqlColumn ?? 0,
+                            tileTargetProcessedCount: counts.processed ?? 0,
+                            tileTargetProcessedWithoutErrorCount:
+                                processedWithoutError.length,
+                            tileTargetProcessedWithoutErrorSamples:
+                                processedWithoutError.slice(0, SAMPLE_CAP),
+                        });
+                    } catch (e) {
+                        this.logger.warn(
+                            'validation.dashboardScanned log failed',
+                            {
+                                projectUuid,
+                                dashboardUuid: uuid,
+                                err: e instanceof Error ? e.message : String(e),
+                            },
+                        );
+                    }
+
                     return [
                         ...filterErrors,
                         ...tileTargetErrors,


### PR DESCRIPTION
## Summary
Related to: PROD-5931 (https://github.com/lightdash/lightdash/issues/21130)

Adds three structured log events to help diagnose stale dashboard filter references in production without shipping a behavioural fix yet. We want to see the prevalence and shape of the problem before settling on the right fix.

- **`dashboard.loaded`** (`DashboardService.getByIdOrSlug`)
  Emitted on every dashboard render. Captures cache health and walks both top-level filter targets and per-tile `tileTargets`, surfacing any field/table reference that points at an explore no longer in `cached_explore`.
- **`compile.completed`** (`ProjectService.saveExploresToCacheAndIndexCatalog`)
  Emitted on every project compile. Reports the diff of explore names vs the previously cached set, so model renames and deletions are visible alongside the load events.
- **`validation.dashboardScanned`** (`ValidationService.validateDashboards`)
  Emitted once per dashboard validated. Breaks down the input vs output: counts of filter rules, tile targets, error categories, and the silent-suppression paths (`tileTargetSkippedFalsyCount`, `tileTargetSkippedNotFieldTargetCount`, `tileTargetSkippedSqlColumnCount`, `tileTargetProcessedWithoutErrorCount`). Includes a capped sample of processed-but-no-error tile targets — exactly the case where a stale reference doesn't produce an error.

All three events are emitted on the happy path too (counts are zero / arrays empty when healthy) so a single log filter gives both prevalence and detail. Stale samples are capped per event to keep payloads bounded. Each event is wrapped in try/catch so logging failures never affect the underlying request.

## How they answer the open questions

| Signal | Tells us |
|---|---|
| `dashboard.loaded.staleTileTargetCount > 0` AND `chartTablesMissingCount == 0` | Bug lives in stored filter JSONB, not cache drift |
| `compile.completed.removedExploreNames` × `dashboard.loaded.staleFilterTargets[].tableName` correlation | Whether model renames are the trigger |
| `validation.dashboardScanned.tileTargetCount > 0` AND `tileTargetErrorCount == 0` | Why the validation bell stays silent on a known-broken dashboard |
| Counts by suppression bucket | Which specific suppression path fired |

## Test plan
- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend lint` — clean
- [x] `npx jest DashboardService` — 22 tests pass
- [x] `npx jest ProjectService` — 59 tests pass
- [x] `npx jest ValidationService` — 21 tests pass
- [x] Manual (debug-local): loaded a dashboard whose filter targets a deleted explore — `dashboard.loaded` JSON showed `staleFilterTargetCount: 1` with the full `{ path, tableName, fieldId }` sample.
- [x] Manual (debug-local): triggered a project refresh — `compile.completed` JSON showed `previousExploreCount: 62`, `newExploreCount: 61`, `removedExploreNames: ["product_events"]`.
- [x] Manual (debug-local): triggered validation against a dashboard with an injected `tileTargets` reference to a deleted table — `validation.dashboardScanned` JSON showed `tileTargetCount: 1`, `tileTargetErrorCount: 1`, all suppression counts zero (validation working correctly locally; the production silence is what we want to observe).

## Example payloads

`dashboard.loaded` on a broken dashboard:
```json
{
  "message": "dashboard.loaded",
  "projectUuid": "...",
  "dashboardUuid": "...",
  "cachedExploreCount": 61,
  "chartTablesMissingCount": 1,
  "chartTablesMissing": ["product_events"],
  "staleFilterTargetCount": 1,
  "staleFilterTargets": [
    { "path": "dimensions[0].target", "tableName": "product_events", "fieldId": "product_events_browser" }
  ],
  "staleTileTargetCount": 0
}
```

`compile.completed` after a rename:
```json
{
  "message": "compile.completed",
  "projectUuid": "...",
  "compilationSource": "refresh_dbt",
  "previousExploreCount": 62,
  "newExploreCount": 61,
  "removedExploreCount": 1,
  "removedExploreNames": ["product_events"],
  "addedExploreCount": 0
}
```

`validation.dashboardScanned` on a dashboard with a broken tile target:
```json
{
  "message": "validation.dashboardScanned",
  "projectUuid": "...",
  "dashboardUuid": "...",
  "existingFieldIdCount": 3564,
  "filterRuleCount": 1,
  "tileTargetCount": 1,
  "filterErrorCount": 1,
  "tileTargetErrorCount": 1,
  "chartErrorCount": 1,
  "tileTargetSkippedFalsyCount": 0,
  "tileTargetSkippedNotFieldTargetCount": 0,
  "tileTargetSkippedSqlColumnCount": 0,
  "tileTargetProcessedCount": 1,
  "tileTargetProcessedWithoutErrorCount": 0,
  "tileTargetProcessedWithoutErrorSamples": []
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)