### PR TITLE
chore(mcp): type-tighten McpService end-to-end

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -22,7 +22,6 @@ import {
     SchedulerJobStatus,
     ServiceAcctAccount,
     SessionUser,
-    sleep,
     ToolFindContentArgs,
     toolFindContentArgsSchema,
     toolFindExploresArgsSchemaV3,
@@ -1527,49 +1526,31 @@ export class McpService extends BaseService {
         account: Account,
         jobId: string,
     ): Promise<{ fileUrl: string; columns: Array<{ reference: string }> }> {
-        const maxWaitMs = 5 * 60 * 1000;
-        const startTime = Date.now();
-        let delayMs = 500;
+        const job = await this.schedulerService.pollJobToCompletion(
+            account,
+            jobId,
+        );
 
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-            if (Date.now() - startTime > maxWaitMs) {
-                throw new Error('SQL query timed out after 5 minutes');
-            }
-
-            // eslint-disable-next-line no-await-in-loop
-            const job = await this.schedulerService.getJobStatus(
-                account,
-                jobId,
-            );
-
-            if (job.status === SchedulerJobStatus.COMPLETED) {
-                const details = job.details as {
-                    fileUrl?: string;
-                    columns?: Array<{ reference: string }>;
-                } | null;
-                if (!details?.fileUrl) {
-                    throw new Error(
-                        'SQL query completed but no results file was produced',
-                    );
-                }
-                return {
-                    fileUrl: details.fileUrl,
-                    columns: details.columns ?? [],
-                };
-            }
-
-            if (job.status === SchedulerJobStatus.ERROR) {
-                const errorDetail =
-                    (job.details as { error?: string } | null)?.error ??
-                    'Unknown error';
-                throw new Error(`SQL query failed: ${errorDetail}`);
-            }
-
-            // eslint-disable-next-line no-await-in-loop
-            await sleep(delayMs);
-            delayMs = Math.min(delayMs * 2, 2000);
+        if (job.status === SchedulerJobStatus.ERROR) {
+            const errorDetail =
+                (job.details as { error?: string } | null)?.error ??
+                'Unknown error';
+            throw new Error(`SQL query failed: ${errorDetail}`);
         }
+
+        const details = job.details as {
+            fileUrl?: string;
+            columns?: Array<{ reference: string }>;
+        } | null;
+        if (!details?.fileUrl) {
+            throw new Error(
+                'SQL query completed but no results file was produced',
+            );
+        }
+        return {
+            fileUrl: details.fileUrl,
+            columns: details.columns ?? [],
+        };
     }
 
     private async downloadSqlResults(

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -190,7 +190,7 @@ const getMcpContext = (
 // we validate at the read boundary instead of casting.
 const sqlJobCompletedDetailsSchema = z.object({
     fileUrl: z.string(),
-    columns: z.array(z.object({ reference: z.string() })).optional(),
+    columns: z.array(z.object({ reference: z.string() })).nullish(),
 });
 
 const sqlJobErrorDetailsSchema = z.object({

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -13,6 +13,7 @@ import {
     getSlackAiEchartsConfig,
     getValidAiQueryLimit,
     isExploreError,
+    JobPollTimeoutError,
     mcpToolListExploresArgsSchema,
     MissingConfigError,
     NotFoundError,
@@ -1538,10 +1539,22 @@ export class McpService extends BaseService {
         account: Account,
         jobId: string,
     ): Promise<{ fileUrl: string; columns: Array<{ reference: string }> }> {
-        const job = await this.schedulerService.pollJobToCompletion(
-            account,
-            jobId,
-        );
+        let job;
+        try {
+            job = await this.schedulerService.pollJobToCompletion(
+                account,
+                jobId,
+            );
+        } catch (e) {
+            if (e instanceof JobPollTimeoutError) {
+                throw new Error(
+                    `SQL query timed out after ${Math.round(
+                        e.timeoutMs / 1000,
+                    )}s`,
+                );
+            }
+            throw e;
+        }
 
         if (job.status === SchedulerJobStatus.ERROR) {
             const errorDetail =

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -47,7 +47,6 @@ import * as Sentry from '@sentry/node';
 import { stringify } from 'csv-stringify/sync';
 import fs from 'fs/promises';
 import path from 'path';
-import { Readable } from 'stream';
 import { z, ZodRawShape } from 'zod';
 import {
     LightdashAnalytics,
@@ -298,9 +297,7 @@ export class McpService extends BaseService {
     private async buildScopedResponse(
         context: McpProtocolContext,
         toolResult: string,
-    ): Promise<{
-        content: Array<{ type: 'text'; text: string }>;
-    }> {
+    ) {
         const metadata = await this.getActiveContextMetadata(context);
 
         const scopeInfo = [
@@ -312,9 +309,7 @@ export class McpService extends BaseService {
             .filter(Boolean)
             .join('. ');
 
-        const content: Array<{ type: 'text'; text: string }> = [
-            { type: 'text', text: toolResult },
-        ];
+        const content = [{ type: 'text' as const, text: toolResult }];
 
         if (scopeInfo) {
             content.push({
@@ -328,7 +323,7 @@ export class McpService extends BaseService {
 
     static async streamToolResult<T extends { result: string }>(
         result: T | AsyncIterable<T>,
-    ): Promise<string> {
+    ) {
         if (Symbol.asyncIterator in result) {
             let out = '';
             for await (const chunk of result) {
@@ -339,7 +334,9 @@ export class McpService extends BaseService {
         return result.result;
     }
 
-    private getMcpCompatibleSchema(schema: z.ZodSchema<unknown>): ZodRawShape {
+    private getMcpCompatibleSchema<TShape extends ZodRawShape>(
+        schema: z.ZodObject<TShape>,
+    ): TShape {
         return this.mcpCompatLayer.processZodType(schema).shape;
     }
 
@@ -458,9 +455,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (_args, extra) => {
-                const args = _args as Omit<ToolFindExploresArgsV3, 'type'>;
-
+            async (args, extra) => {
                 const projectUuid = await this.resolveProjectUuid(
                     getMcpContext(extra),
                 );
@@ -530,9 +525,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (_args, extra) => {
-                const args = _args as Omit<ToolFindFieldsArgs, 'type'>;
-
+            async (args, extra) => {
                 const projectUuid = await this.resolveProjectUuid(
                     getMcpContext(extra),
                 );
@@ -581,9 +574,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (_args, extra) => {
-                const args = _args as Omit<ToolFindContentArgs, 'type'>;
-
+            async (args, extra) => {
                 const projectUuid = await this.resolveProjectUuid(
                     getMcpContext(extra),
                 );
@@ -905,8 +896,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (_args, extra) => {
-                const args = _args as { agentUuid: string };
+            async (args, extra) => {
                 const { user, organizationUuid } = this.getAccount(
                     getMcpContext(extra),
                 );
@@ -1332,7 +1322,7 @@ export class McpService extends BaseService {
                         .filter(Boolean)
                         .join('. ');
 
-                    const content: Array<{ type: 'text'; text: string }> = [
+                    const content = [
                         {
                             type: 'text' as const,
                             text: serializeData(csv, 'csv'),
@@ -1383,9 +1373,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (_args, extra) => {
-                const args = _args as Omit<ToolSearchFieldValuesArgs, 'type'>;
-
+            async (args, extra) => {
                 const projectUuid = await this.resolveProjectUuid(
                     getMcpContext(extra),
                 );
@@ -1432,8 +1420,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (_args, extra) => {
-                const args = _args as { sql: string; limit?: number };
+            async (args, extra) => {
                 const { user, account } = this.getAccount(getMcpContext(extra));
                 const projectUuid = await this.resolveProjectUuid(
                     getMcpContext(extra),
@@ -1644,13 +1631,13 @@ export class McpService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         fileUrl: string,
-    ): Promise<Record<string, unknown>[]> {
+    ) {
         const fileId = fileUrl.split('/').pop();
         if (!fileId) {
             throw new Error(`Could not extract file ID from URL: ${fileUrl}`);
         }
 
-        const readStream: Readable = await this.projectService.getFileStream(
+        const readStream = await this.projectService.getFileStream(
             user,
             projectUuid,
             fileId,
@@ -1664,9 +1651,7 @@ export class McpService extends BaseService {
         return results;
     }
 
-    async getProjectUuidFromContext(
-        context: McpProtocolContext,
-    ): Promise<string | undefined> {
+    async getProjectUuidFromContext(context: McpProtocolContext) {
         const { user, headerProjectUuid } = context.authInfo!.extra;
         const { organizationUuid } = user;
 
@@ -1686,9 +1671,7 @@ export class McpService extends BaseService {
         return contextRow?.context.projectUuid;
     }
 
-    async getTagsFromContext(
-        context: McpProtocolContext,
-    ): Promise<string[] | null> {
+    async getTagsFromContext(context: McpProtocolContext) {
         const { user } = context.authInfo!.extra;
         const { organizationUuid } = user;
 
@@ -1701,12 +1684,10 @@ export class McpService extends BaseService {
             organizationUuid,
         );
 
-        return contextRow?.context.tags || null;
+        return contextRow?.context.tags ?? null;
     }
 
-    async getAgentUuidFromContext(
-        context: McpProtocolContext,
-    ): Promise<string | null> {
+    async getAgentUuidFromContext(context: McpProtocolContext) {
         const { user } = context.authInfo!.extra;
         const { organizationUuid } = user;
 
@@ -1722,13 +1703,7 @@ export class McpService extends BaseService {
         return contextRow?.context.agentUuid ?? null;
     }
 
-    async getActiveContextMetadata(context: McpProtocolContext): Promise<{
-        projectUuid: string | null;
-        projectName: string | null;
-        agentUuid: string | null;
-        agentName: string | null;
-        tags: string[] | null;
-    }> {
+    async getActiveContextMetadata(context: McpProtocolContext) {
         const { user } = context.authInfo!.extra;
         const { organizationUuid } = user;
 
@@ -1761,11 +1736,11 @@ export class McpService extends BaseService {
             contextRow.context;
 
         return {
-            projectUuid: projectUuid || null,
-            projectName: projectName || null,
-            agentUuid: agentUuid ?? null,
-            agentName: agentName ?? null,
-            tags: tags || null,
+            projectUuid,
+            projectName,
+            agentUuid,
+            agentName,
+            tags,
         };
     }
 
@@ -1831,7 +1806,7 @@ export class McpService extends BaseService {
         return headerUserAttributes;
     }
 
-    async resolveProjectUuid(context: McpProtocolContext): Promise<string> {
+    async resolveProjectUuid(context: McpProtocolContext) {
         const { user, account, headerProjectUuid } = context.authInfo!.extra;
         const projectUuid = await this.getProjectUuidFromContext(context);
         if (!projectUuid) {
@@ -2415,7 +2390,7 @@ export class McpService extends BaseService {
     // MCP is enabled if MCP_ENABLED is true, AI Copilot is enabled, or user is on trial
     public async isEnabled(
         user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
-    ): Promise<boolean> {
+    ) {
         if (this.lightdashConfig.mcp.enabled) {
             return true;
         }
@@ -2444,7 +2419,7 @@ export class McpService extends BaseService {
         return VERSION;
     }
 
-    private async checkAiAgentsVisible(user: SessionUser): Promise<void> {
+    private async checkAiAgentsVisible(user: SessionUser) {
         if (!user.organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -185,6 +185,18 @@ const getMcpContext = (
     extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
 ): McpProtocolContext => mcpProtocolContextSchema.parse(extra);
 
+// Shape of `scheduler_log.details` written by the run-SQL scheduler task on
+// COMPLETED / ERROR. Loosely typed in the DB (Record<string, any> | null), so
+// we validate at the read boundary instead of casting.
+const sqlJobCompletedDetailsSchema = z.object({
+    fileUrl: z.string(),
+    columns: z.array(z.object({ reference: z.string() })).optional(),
+});
+
+const sqlJobErrorDetailsSchema = z.object({
+    error: z.string().optional(),
+});
+
 export class McpService extends BaseService {
     private lightdashConfig: LightdashConfig;
 
@@ -1533,23 +1545,20 @@ export class McpService extends BaseService {
 
         if (job.status === SchedulerJobStatus.ERROR) {
             const errorDetail =
-                (job.details as { error?: string } | null)?.error ??
+                sqlJobErrorDetailsSchema.safeParse(job.details).data?.error ??
                 'Unknown error';
             throw new Error(`SQL query failed: ${errorDetail}`);
         }
 
-        const details = job.details as {
-            fileUrl?: string;
-            columns?: Array<{ reference: string }>;
-        } | null;
-        if (!details?.fileUrl) {
+        const details = sqlJobCompletedDetailsSchema.safeParse(job.details);
+        if (!details.success) {
             throw new Error(
                 'SQL query completed but no results file was produced',
             );
         }
         return {
-            fileUrl: details.fileUrl,
-            columns: details.columns ?? [],
+            fileUrl: details.data.fileUrl,
+            columns: details.data.columns ?? [],
         };
     }
 

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -397,7 +397,7 @@ export class McpService extends BaseService {
                 try {
                     const ctx = getMcpContext(extra);
 
-                    const { user } = this.getAccount(ctx);
+                    const { user } = McpService.getAccount(ctx);
 
                     const projectUuid = await this.resolveProjectUuid(ctx);
 
@@ -470,7 +470,7 @@ export class McpService extends BaseService {
                 const findExplores: FindExploresFn =
                     await this.getFindExploresFunction(argsWithProject, ctx);
 
-                const { user } = this.getAccount(ctx);
+                const { user } = McpService.getAccount(ctx);
 
                 const tagsFromContext = await this.getTagsFromContext(ctx);
                 const userAttributeOverrides =
@@ -611,7 +611,8 @@ export class McpService extends BaseService {
                     >,
                 ) => {
                     const ctx = getMcpContext(extra);
-                    const { user, organizationUuid } = this.getAccount(ctx);
+                    const { user, organizationUuid } =
+                        McpService.getAccount(ctx);
 
                     this.trackToolCall(ctx, McpToolName.LIST_PROJECTS);
 
@@ -675,7 +676,7 @@ export class McpService extends BaseService {
                 ) => {
                     const ctx = getMcpContext(extra);
                     const { user, organizationUuid, account } =
-                        this.getAccount(ctx);
+                        McpService.getAccount(ctx);
 
                     this.trackToolCall(
                         ctx,
@@ -760,7 +761,7 @@ export class McpService extends BaseService {
             async (_args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const { user, organizationUuid } = this.getAccount(ctx);
+                const { user, organizationUuid } = McpService.getAccount(ctx);
 
                 this.trackToolCall(ctx, McpToolName.GET_CURRENT_PROJECT);
 
@@ -824,7 +825,7 @@ export class McpService extends BaseService {
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const { user } = this.getAccount(ctx);
+                const { user } = McpService.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
 
@@ -871,7 +872,7 @@ export class McpService extends BaseService {
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const { user, organizationUuid } = this.getAccount(ctx);
+                const { user, organizationUuid } = McpService.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
 
@@ -946,7 +947,7 @@ export class McpService extends BaseService {
             async (_args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const { user, organizationUuid } = this.getAccount(ctx);
+                const { user, organizationUuid } = McpService.getAccount(ctx);
 
                 this.trackToolCall(ctx, McpToolName.CLEAR_AGENT);
 
@@ -1000,7 +1001,7 @@ export class McpService extends BaseService {
             async (_args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const { user, organizationUuid } = this.getAccount(ctx);
+                const { user, organizationUuid } = McpService.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
 
@@ -1261,7 +1262,7 @@ export class McpService extends BaseService {
                         JSON.stringify(exploreConfigState),
                     )}&isExploreFromHere=true`;
 
-                    const { user } = this.getAccount(ctx);
+                    const { user } = McpService.getAccount(ctx);
 
                     const shareUrl = await this.shareService.createShareUrl(
                         user,
@@ -1383,7 +1384,7 @@ export class McpService extends BaseService {
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const { user, account } = this.getAccount(ctx);
+                const { user, account } = McpService.getAccount(ctx);
                 const projectUuid = await this.resolveProjectUuid(ctx);
 
                 this.trackToolCall(ctx, McpToolName.RUN_SQL, projectUuid);
@@ -1459,7 +1460,7 @@ export class McpService extends BaseService {
             async (_args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const { user } = this.getAccount(ctx);
+                const { user } = McpService.getAccount(ctx);
                 const projectUuid = await this.resolveProjectUuid(ctx);
 
                 this.trackToolCall(
@@ -1492,9 +1493,8 @@ export class McpService extends BaseService {
             async (_args, extra) => {
                 const ctx = getMcpContext(extra);
 
-                const context = ctx;
-                const metadata = await this.getActiveContextMetadata(context);
-                const { user } = this.getAccount(context);
+                const metadata = await this.getActiveContextMetadata(ctx);
+                const { user } = McpService.getAccount(ctx);
 
                 let promptText: string;
 
@@ -1754,7 +1754,7 @@ export class McpService extends BaseService {
         // otherwise any tool that doesn't re-check (e.g. list_explores) would
         // leak project metadata cross-tenant.
         if (headerProjectUuid && headerProjectUuid === projectUuid) {
-            const { user, account } = this.getAccount(context);
+            const { user, account } = McpService.getAccount(context);
 
             const project = await this.projectService.getProject(
                 projectUuid,
@@ -1868,7 +1868,7 @@ export class McpService extends BaseService {
         },
         context: McpProtocolContext,
     ): Promise<FindExploresFn> {
-        const { user, account } = this.getAccount(context);
+        const { user, account } = McpService.getAccount(context);
         const { projectUuid } = toolArgs;
 
         const project = await this.projectService.getProject(
@@ -1965,7 +1965,7 @@ export class McpService extends BaseService {
         toolArgs: Omit<ToolFindFieldsArgs, 'type'> & { projectUuid: string },
         context: McpProtocolContext,
     ): Promise<{ findFields: FindFieldFn; getExplore: GetExploreFn }> {
-        const { user, account } = this.getAccount(context);
+        const { user, account } = McpService.getAccount(context);
         const { projectUuid } = toolArgs;
 
         const project = await this.projectService.getProject(
@@ -2036,7 +2036,7 @@ export class McpService extends BaseService {
         toolArgs: Omit<ToolFindContentArgs, 'type'> & { projectUuid: string },
         context: McpProtocolContext,
     ): Promise<FindContentFn> {
-        const { user, account } = this.getAccount(context);
+        const { user, account } = McpService.getAccount(context);
         const { projectUuid } = toolArgs;
 
         const project = await this.projectService.getProject(
@@ -2100,7 +2100,7 @@ export class McpService extends BaseService {
         agentContext: AgentContext;
         runAsyncQuery: RunAsyncQueryFn;
     }> {
-        const { user, account } = this.getAccount(context);
+        const { user, account } = McpService.getAccount(context);
         const { projectUuid } = toolArgs;
 
         const project = await this.projectService.getProject(
@@ -2157,7 +2157,7 @@ export class McpService extends BaseService {
         },
         context: McpProtocolContext,
     ): Promise<SearchFieldValuesFn> {
-        const { user, account } = this.getAccount(context);
+        const { user, account } = McpService.getAccount(context);
         const { projectUuid } = toolArgs;
 
         const project = await this.projectService.getProject(
@@ -2257,8 +2257,7 @@ export class McpService extends BaseService {
         return newServer;
     }
 
-    // eslint-disable-next-line class-methods-use-this
-    public getAccount(context: McpProtocolContext) {
+    static getAccount(context: McpProtocolContext) {
         const user = context.authInfo?.extra.user;
         const account = context.authInfo?.extra.account;
 
@@ -2349,7 +2348,7 @@ export class McpService extends BaseService {
         projectUuid?: string,
     ): void {
         try {
-            const { user, organizationUuid } = this.getAccount(context);
+            const { user, organizationUuid } = McpService.getAccount(context);
             this.analytics.track<McpToolCallEvent>({
                 event: 'mcp_tool_call',
                 userId: user.userUuid,

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/extensions */
 import { subject } from '@casl/ability';
 import {
     Account,
@@ -38,13 +37,13 @@ import {
     toolSearchFieldValuesArgsSchema,
     UserAttributeValueMap,
 } from '@lightdash/common';
-import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import {
     ServerNotification,
     ServerRequest,
-} from '@modelcontextprotocol/sdk/types.js';
+} from '@modelcontextprotocol/sdk/types';
 import * as Sentry from '@sentry/node';
 import { stringify } from 'csv-stringify/sync';
 import fs from 'fs/promises';
@@ -160,11 +159,34 @@ export type ExtraContext = {
     /** Project UUID passed via X-Lightdash-Project header; overrides stored context */
     headerProjectUuid?: string;
 };
-type McpProtocolContext = {
-    authInfo?: AuthInfo & {
-        extra: ExtraContext;
-    };
-};
+
+// Narrows the SDK's loosely-typed `RequestHandlerExtra` into the shape the
+// McpService methods expect. The MCP router (mcpRouter.ts) populates
+// `authInfo.extra` with ExtraContext before the SDK invokes any tool
+// callback; this parses that out so call sites don't need type casts.
+// `z.custom<T>()` is used for types we don't want to mirror as Zod schemas —
+// it asserts the type without runtime validation of the inner shape.
+const extraContextSchema = z.object({
+    user: z.custom<SessionUser>(),
+    account: z.custom<OauthAccount | ApiKeyAccount | ServiceAcctAccount>(),
+    headerUserAttributes: z.custom<UserAttributeValueMap>().optional(),
+    headerProjectUuid: z.string().optional(),
+});
+
+const mcpProtocolContextSchema = z.object({
+    authInfo: z
+        .intersection(
+            z.custom<AuthInfo>(),
+            z.object({ extra: extraContextSchema }),
+        )
+        .optional(),
+});
+
+type McpProtocolContext = z.infer<typeof mcpProtocolContextSchema>;
+
+const getMcpContext = (
+    extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+): McpProtocolContext => mcpProtocolContextSchema.parse(extra);
 
 export class McpService extends BaseService {
     private lightdashConfig: LightdashConfig;
@@ -353,7 +375,7 @@ export class McpService extends BaseService {
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.GET_LIGHTDASH_VERSION,
                 );
                 return {
@@ -361,7 +383,7 @@ export class McpService extends BaseService {
                         {
                             type: 'text',
                             text: this.getLightdashVersion(
-                                extra as McpProtocolContext,
+                                getMcpContext(extra),
                             ),
                         },
                     ],
@@ -388,27 +410,25 @@ export class McpService extends BaseService {
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
                 try {
-                    const { user } = this.getAccount(
-                        extra as McpProtocolContext,
-                    );
+                    const { user } = this.getAccount(getMcpContext(extra));
 
                     const projectUuid = await this.resolveProjectUuid(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
 
                     this.trackToolCall(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                         McpToolName.LIST_EXPLORES,
                         projectUuid,
                     );
 
                     const tagsFromContext = await this.getTagsFromContext(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
 
                     const userAttributeOverrides =
                         await this.getUserAttributeOverridesFromContext(
-                            extra as McpProtocolContext,
+                            getMcpContext(extra),
                         );
 
                     const listExplores = async () =>
@@ -432,7 +452,7 @@ export class McpService extends BaseService {
                     );
 
                     return await this.buildScopedResponse(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                         await McpService.streamToolResult(result),
                     );
                 } catch (error) {
@@ -466,12 +486,12 @@ export class McpService extends BaseService {
                 const args = _args as Omit<ToolFindExploresArgsV3, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.FIND_EXPLORES,
                     projectUuid,
                 );
@@ -479,16 +499,16 @@ export class McpService extends BaseService {
                 const findExplores: FindExploresFn =
                     await this.getFindExploresFunction(
                         argsWithProject,
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
 
-                const { user } = (extra as McpProtocolContext).authInfo!.extra;
+                const { user } = getMcpContext(extra).authInfo!.extra;
                 const tagsFromContext = await this.getTagsFromContext(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
                 const userAttributeOverrides =
                     await this.getUserAttributeOverridesFromContext(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
                 const availableExplores = await this.getAvailableExplores(
                     user,
@@ -515,7 +535,7 @@ export class McpService extends BaseService {
                 );
 
                 return this.buildScopedResponse(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     await McpService.streamToolResult(result),
                 );
             },
@@ -542,12 +562,12 @@ export class McpService extends BaseService {
                 const args = _args as Omit<ToolFindFieldsArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.FIND_FIELDS,
                     projectUuid,
                 );
@@ -555,7 +575,7 @@ export class McpService extends BaseService {
                 const { findFields, getExplore } =
                     await this.getFindFieldsFunction(
                         argsWithProject,
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
 
                 const findFieldsTool = getFindFields({
@@ -570,7 +590,7 @@ export class McpService extends BaseService {
                 });
 
                 return this.buildScopedResponse(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     await McpService.streamToolResult(result),
                 );
             },
@@ -597,12 +617,12 @@ export class McpService extends BaseService {
                 const args = _args as Omit<ToolFindContentArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.FIND_CONTENT,
                     projectUuid,
                 );
@@ -610,7 +630,7 @@ export class McpService extends BaseService {
                 const findContent: FindContentFn =
                     await this.getFindContentFunction(
                         argsWithProject,
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
 
                 const findContentTool = getFindContent({
@@ -623,7 +643,7 @@ export class McpService extends BaseService {
                 });
 
                 return this.buildScopedResponse(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     await McpService.streamToolResult(result),
                 );
             },
@@ -652,11 +672,11 @@ export class McpService extends BaseService {
                     >,
                 ) => {
                     const { user, organizationUuid } = this.getAccount(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
 
                     this.trackToolCall(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                         McpToolName.LIST_PROJECTS,
                     );
 
@@ -724,11 +744,11 @@ export class McpService extends BaseService {
                         tags?: string[];
                     };
                     const { user, organizationUuid, account } = this.getAccount(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
 
                     this.trackToolCall(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                         McpToolName.SET_PROJECT,
                         args.projectUuid,
                     );
@@ -812,11 +832,11 @@ export class McpService extends BaseService {
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
                 const { user, organizationUuid } = this.getAccount(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.GET_CURRENT_PROJECT,
                 );
 
@@ -882,12 +902,12 @@ export class McpService extends BaseService {
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
                 const args = _args as { projectUuid?: string };
-                const { user } = this.getAccount(extra as McpProtocolContext);
+                const { user } = this.getAccount(getMcpContext(extra));
 
                 await this.checkAiAgentsVisible(user);
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.LIST_AGENTS,
                 );
 
@@ -935,13 +955,13 @@ export class McpService extends BaseService {
             ) => {
                 const args = _args as { agentUuid: string };
                 const { user, organizationUuid } = this.getAccount(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
 
                 await this.checkAiAgentsVisible(user);
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.SET_AGENT,
                     args.agentUuid,
                 );
@@ -1017,11 +1037,11 @@ export class McpService extends BaseService {
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
                 const { user, organizationUuid } = this.getAccount(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.CLEAR_AGENT,
                 );
 
@@ -1077,13 +1097,13 @@ export class McpService extends BaseService {
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
                 const { user, organizationUuid } = this.getAccount(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
 
                 await this.checkAiAgentsVisible(user);
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.GET_CURRENT_AGENT,
                 );
 
@@ -1189,12 +1209,12 @@ export class McpService extends BaseService {
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
                 const projectUuid = await this.resolveProjectUuid(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
                 const argsWithProject = { ..._args, projectUuid };
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.RUN_METRIC_QUERY,
                     projectUuid,
                 );
@@ -1203,7 +1223,7 @@ export class McpService extends BaseService {
                     const { agentContext, runAsyncQuery } =
                         await this.getRunMetricQueryDependencies(
                             { projectUuid },
-                            extra as McpProtocolContext,
+                            getMcpContext(extra),
                         );
 
                     const queryTool =
@@ -1346,8 +1366,8 @@ export class McpService extends BaseService {
                         JSON.stringify(exploreConfigState),
                     )}&isExploreFromHere=true`;
 
-                    const { user: mcpUser } = (extra as McpProtocolContext)
-                        .authInfo!.extra;
+                    const { user: mcpUser } =
+                        getMcpContext(extra).authInfo!.extra;
                     const shareUrl = await this.shareService.createShareUrl(
                         mcpUser,
                         explorePath,
@@ -1356,7 +1376,7 @@ export class McpService extends BaseService {
                     const exploreUrl = `${this.lightdashConfig.siteUrl}/share/${shareUrl.nanoid}`;
 
                     const metadata = await this.getActiveContextMetadata(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
                     const scopeInfo = [
                         metadata.agentName
@@ -1428,12 +1448,12 @@ export class McpService extends BaseService {
                 const args = _args as Omit<ToolSearchFieldValuesArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.SEARCH_FIELD_VALUES,
                     projectUuid,
                 );
@@ -1441,7 +1461,7 @@ export class McpService extends BaseService {
                 const searchFieldValues: SearchFieldValuesFn =
                     await this.getSearchFieldValuesFunction(
                         argsWithProject,
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                     );
 
                 const searchFieldValuesTool = getSearchFieldValues({
@@ -1456,7 +1476,7 @@ export class McpService extends BaseService {
                 );
 
                 return this.buildScopedResponse(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     await McpService.streamToolResult(result),
                 );
             },
@@ -1479,15 +1499,13 @@ export class McpService extends BaseService {
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
                 const args = _args as { sql: string; limit?: number };
-                const { user, account } = this.getAccount(
-                    extra as McpProtocolContext,
-                );
+                const { user, account } = this.getAccount(getMcpContext(extra));
                 const projectUuid = await this.resolveProjectUuid(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.RUN_SQL,
                     projectUuid,
                 );
@@ -1521,7 +1539,7 @@ export class McpService extends BaseService {
                                 ? `Columns: ${columns.join(', ')}`
                                 : '';
                         return await this.buildScopedResponse(
-                            extra as McpProtocolContext,
+                            getMcpContext(extra),
                             `Query returned 0 rows.${header ? ` ${header}` : ''}`,
                         );
                     }
@@ -1532,7 +1550,7 @@ export class McpService extends BaseService {
                     });
 
                     return await this.buildScopedResponse(
-                        extra as McpProtocolContext,
+                        getMcpContext(extra),
                         csv,
                     );
                 } catch (e) {
@@ -1567,13 +1585,13 @@ export class McpService extends BaseService {
                 _args: Record<string, never>,
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
-                const { user } = this.getAccount(extra as McpProtocolContext);
+                const { user } = this.getAccount(getMcpContext(extra));
                 const projectUuid = await this.resolveProjectUuid(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                 );
 
                 this.trackToolCall(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     McpToolName.LIST_VERIFIED_CONTENT,
                     projectUuid,
                 );
@@ -1585,7 +1603,7 @@ export class McpService extends BaseService {
                     );
 
                 return this.buildScopedResponse(
-                    extra as McpProtocolContext,
+                    getMcpContext(extra),
                     JSON.stringify(verifiedContent, null, 2),
                 );
             },
@@ -1604,7 +1622,7 @@ export class McpService extends BaseService {
                 _args: AnyType,
                 extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
             ) => {
-                const context = extra as McpProtocolContext;
+                const context = getMcpContext(extra);
                 const metadata = await this.getActiveContextMetadata(context);
 
                 let promptText: string;

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -326,29 +326,17 @@ export class McpService extends BaseService {
         return { content };
     }
 
-    static async streamToolResult(
-        result:
-            | { result: string }
-            | AsyncIterable<{
-                  result: string;
-              }>,
+    static async streamToolResult<T extends { result: string }>(
+        result: T | AsyncIterable<T>,
     ): Promise<string> {
-        if (
-            'result' in result &&
-            typeof result.result === 'string' &&
-            Symbol.asyncIterator in result === false
-        ) {
-            return result.result;
+        if (Symbol.asyncIterator in result) {
+            let out = '';
+            for await (const chunk of result) {
+                out += chunk.result;
+            }
+            return out;
         }
-
-        let out = '';
-        for await (const chunk of result as AsyncIterable<{
-            result: string;
-            metadata: { status: 'error' | 'success' };
-        }>) {
-            out += chunk.result;
-        }
-        return out;
+        return result.result;
     }
 
     private getMcpCompatibleSchema(schema: z.ZodSchema<unknown>): ZodRawShape {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -355,17 +355,14 @@ export class McpService extends BaseService {
                 },
             },
             async (_args, extra) => {
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.GET_LIGHTDASH_VERSION,
-                );
+                const ctx = getMcpContext(extra);
+
+                this.trackToolCall(ctx, McpToolName.GET_LIGHTDASH_VERSION);
                 return {
                     content: [
                         {
                             type: 'text',
-                            text: this.getLightdashVersion(
-                                getMcpContext(extra),
-                            ),
+                            text: this.getLightdashVersion(ctx),
                         },
                     ],
                 };
@@ -387,26 +384,22 @@ export class McpService extends BaseService {
             },
             async (_args, extra) => {
                 try {
-                    const { user } = this.getAccount(getMcpContext(extra));
+                    const ctx = getMcpContext(extra);
 
-                    const projectUuid = await this.resolveProjectUuid(
-                        getMcpContext(extra),
-                    );
+                    const { user } = this.getAccount(ctx);
+
+                    const projectUuid = await this.resolveProjectUuid(ctx);
 
                     this.trackToolCall(
-                        getMcpContext(extra),
+                        ctx,
                         McpToolName.LIST_EXPLORES,
                         projectUuid,
                     );
 
-                    const tagsFromContext = await this.getTagsFromContext(
-                        getMcpContext(extra),
-                    );
+                    const tagsFromContext = await this.getTagsFromContext(ctx);
 
                     const userAttributeOverrides =
-                        await this.getUserAttributeOverridesFromContext(
-                            getMcpContext(extra),
-                        );
+                        await this.getUserAttributeOverridesFromContext(ctx);
 
                     const listExplores = async () =>
                         this.getAvailableExplores(
@@ -429,7 +422,7 @@ export class McpService extends BaseService {
                     );
 
                     return await this.buildScopedResponse(
-                        getMcpContext(extra),
+                        ctx,
                         await McpService.streamToolResult(result),
                     );
                 } catch (error) {
@@ -456,32 +449,21 @@ export class McpService extends BaseService {
                 },
             },
             async (args, extra) => {
-                const projectUuid = await this.resolveProjectUuid(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
+
+                const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
 
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.FIND_EXPLORES,
-                    projectUuid,
-                );
+                this.trackToolCall(ctx, McpToolName.FIND_EXPLORES, projectUuid);
 
                 const findExplores: FindExploresFn =
-                    await this.getFindExploresFunction(
-                        argsWithProject,
-                        getMcpContext(extra),
-                    );
+                    await this.getFindExploresFunction(argsWithProject, ctx);
 
-                const { user } = this.getAccount(getMcpContext(extra));
+                const { user } = this.getAccount(ctx);
 
-                const tagsFromContext = await this.getTagsFromContext(
-                    getMcpContext(extra),
-                );
+                const tagsFromContext = await this.getTagsFromContext(ctx);
                 const userAttributeOverrides =
-                    await this.getUserAttributeOverridesFromContext(
-                        getMcpContext(extra),
-                    );
+                    await this.getUserAttributeOverridesFromContext(ctx);
                 const availableExplores = await this.getAvailableExplores(
                     user,
                     argsWithProject.projectUuid,
@@ -507,7 +489,7 @@ export class McpService extends BaseService {
                 );
 
                 return this.buildScopedResponse(
-                    getMcpContext(extra),
+                    ctx,
                     await McpService.streamToolResult(result),
                 );
             },
@@ -527,22 +509,15 @@ export class McpService extends BaseService {
                 },
             },
             async (args, extra) => {
-                const projectUuid = await this.resolveProjectUuid(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
+
+                const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
 
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.FIND_FIELDS,
-                    projectUuid,
-                );
+                this.trackToolCall(ctx, McpToolName.FIND_FIELDS, projectUuid);
 
                 const { findFields, getExplore } =
-                    await this.getFindFieldsFunction(
-                        argsWithProject,
-                        getMcpContext(extra),
-                    );
+                    await this.getFindFieldsFunction(argsWithProject, ctx);
 
                 const findFieldsTool = getFindFields({
                     getExplore,
@@ -556,7 +531,7 @@ export class McpService extends BaseService {
                 });
 
                 return this.buildScopedResponse(
-                    getMcpContext(extra),
+                    ctx,
                     await McpService.streamToolResult(result),
                 );
             },
@@ -576,22 +551,15 @@ export class McpService extends BaseService {
                 },
             },
             async (args, extra) => {
-                const projectUuid = await this.resolveProjectUuid(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
+
+                const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
 
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.FIND_CONTENT,
-                    projectUuid,
-                );
+                this.trackToolCall(ctx, McpToolName.FIND_CONTENT, projectUuid);
 
                 const findContent: FindContentFn =
-                    await this.getFindContentFunction(
-                        argsWithProject,
-                        getMcpContext(extra),
-                    );
+                    await this.getFindContentFunction(argsWithProject, ctx);
 
                 const findContentTool = getFindContent({
                     findContent,
@@ -603,7 +571,7 @@ export class McpService extends BaseService {
                 });
 
                 return this.buildScopedResponse(
-                    getMcpContext(extra),
+                    ctx,
                     await McpService.streamToolResult(result),
                 );
             },
@@ -631,14 +599,10 @@ export class McpService extends BaseService {
                         ServerNotification
                     >,
                 ) => {
-                    const { user, organizationUuid } = this.getAccount(
-                        getMcpContext(extra),
-                    );
+                    const ctx = getMcpContext(extra);
+                    const { user, organizationUuid } = this.getAccount(ctx);
 
-                    this.trackToolCall(
-                        getMcpContext(extra),
-                        McpToolName.LIST_PROJECTS,
-                    );
+                    this.trackToolCall(ctx, McpToolName.LIST_PROJECTS);
 
                     const allProjects = await wrapSentryTransaction(
                         'McpService.listProjects.getAllByOrganizationUuid',
@@ -698,12 +662,12 @@ export class McpService extends BaseService {
                         ServerNotification
                     >,
                 ) => {
-                    const { user, organizationUuid, account } = this.getAccount(
-                        getMcpContext(extra),
-                    );
+                    const ctx = getMcpContext(extra);
+                    const { user, organizationUuid, account } =
+                        this.getAccount(ctx);
 
                     this.trackToolCall(
-                        getMcpContext(extra),
+                        ctx,
                         McpToolName.SET_PROJECT,
                         args.projectUuid,
                     );
@@ -783,14 +747,11 @@ export class McpService extends BaseService {
                 },
             },
             async (_args, extra) => {
-                const { user, organizationUuid } = this.getAccount(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
 
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.GET_CURRENT_PROJECT,
-                );
+                const { user, organizationUuid } = this.getAccount(ctx);
+
+                this.trackToolCall(ctx, McpToolName.GET_CURRENT_PROJECT);
 
                 const contextRow = await this.mcpContextModel.getContext(
                     user.userUuid,
@@ -850,14 +811,13 @@ export class McpService extends BaseService {
                 },
             },
             async (args, extra) => {
-                const { user } = this.getAccount(getMcpContext(extra));
+                const ctx = getMcpContext(extra);
+
+                const { user } = this.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
 
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.LIST_AGENTS,
-                );
+                this.trackToolCall(ctx, McpToolName.LIST_AGENTS);
 
                 const agents = await this.aiAgentService.listAgents(
                     user,
@@ -898,17 +858,13 @@ export class McpService extends BaseService {
                 },
             },
             async (args, extra) => {
-                const { user, organizationUuid } = this.getAccount(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
+
+                const { user, organizationUuid } = this.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
 
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.SET_AGENT,
-                    args.agentUuid,
-                );
+                this.trackToolCall(ctx, McpToolName.SET_AGENT, args.agentUuid);
 
                 if (!args.agentUuid) {
                     throw new ParameterError('Agent UUID is required');
@@ -977,14 +933,11 @@ export class McpService extends BaseService {
                 },
             },
             async (_args, extra) => {
-                const { user, organizationUuid } = this.getAccount(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
 
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.CLEAR_AGENT,
-                );
+                const { user, organizationUuid } = this.getAccount(ctx);
+
+                this.trackToolCall(ctx, McpToolName.CLEAR_AGENT);
 
                 const existingContext = await this.mcpContextModel.getContext(
                     user.userUuid,
@@ -1034,16 +987,13 @@ export class McpService extends BaseService {
                 },
             },
             async (_args, extra) => {
-                const { user, organizationUuid } = this.getAccount(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
+
+                const { user, organizationUuid } = this.getAccount(ctx);
 
                 await this.checkAiAgentsVisible(user);
 
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.GET_CURRENT_AGENT,
-                );
+                this.trackToolCall(ctx, McpToolName.GET_CURRENT_AGENT);
 
                 const contextRow = await this.mcpContextModel.getContext(
                     user.userUuid,
@@ -1142,13 +1092,13 @@ export class McpService extends BaseService {
                 _meta: { ui: { resourceUri: chartResourceUri } },
             },
             async (_args, extra) => {
-                const projectUuid = await this.resolveProjectUuid(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
+
+                const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ..._args, projectUuid };
 
                 this.trackToolCall(
-                    getMcpContext(extra),
+                    ctx,
                     McpToolName.RUN_METRIC_QUERY,
                     projectUuid,
                 );
@@ -1157,7 +1107,7 @@ export class McpService extends BaseService {
                     const { agentContext, runAsyncQuery } =
                         await this.getRunMetricQueryDependencies(
                             { projectUuid },
-                            getMcpContext(extra),
+                            ctx,
                         );
 
                     const queryTool =
@@ -1300,7 +1250,7 @@ export class McpService extends BaseService {
                         JSON.stringify(exploreConfigState),
                     )}&isExploreFromHere=true`;
 
-                    const { user } = this.getAccount(getMcpContext(extra));
+                    const { user } = this.getAccount(ctx);
 
                     const shareUrl = await this.shareService.createShareUrl(
                         user,
@@ -1309,9 +1259,7 @@ export class McpService extends BaseService {
                     );
                     const exploreUrl = `${this.lightdashConfig.siteUrl}/share/${shareUrl.nanoid}`;
 
-                    const metadata = await this.getActiveContextMetadata(
-                        getMcpContext(extra),
-                    );
+                    const metadata = await this.getActiveContextMetadata(ctx);
                     const scopeInfo = [
                         metadata.agentName
                             ? `Active agent: ${metadata.agentName}`
@@ -1375,13 +1323,13 @@ export class McpService extends BaseService {
                 },
             },
             async (args, extra) => {
-                const projectUuid = await this.resolveProjectUuid(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
+
+                const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    getMcpContext(extra),
+                    ctx,
                     McpToolName.SEARCH_FIELD_VALUES,
                     projectUuid,
                 );
@@ -1389,7 +1337,7 @@ export class McpService extends BaseService {
                 const searchFieldValues: SearchFieldValuesFn =
                     await this.getSearchFieldValuesFunction(
                         argsWithProject,
-                        getMcpContext(extra),
+                        ctx,
                     );
 
                 const searchFieldValuesTool = getSearchFieldValues({
@@ -1404,7 +1352,7 @@ export class McpService extends BaseService {
                 );
 
                 return this.buildScopedResponse(
-                    getMcpContext(extra),
+                    ctx,
                     await McpService.streamToolResult(result),
                 );
             },
@@ -1422,16 +1370,12 @@ export class McpService extends BaseService {
                 },
             },
             async (args, extra) => {
-                const { user, account } = this.getAccount(getMcpContext(extra));
-                const projectUuid = await this.resolveProjectUuid(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
 
-                this.trackToolCall(
-                    getMcpContext(extra),
-                    McpToolName.RUN_SQL,
-                    projectUuid,
-                );
+                const { user, account } = this.getAccount(ctx);
+                const projectUuid = await this.resolveProjectUuid(ctx);
+
+                this.trackToolCall(ctx, McpToolName.RUN_SQL, projectUuid);
 
                 try {
                     const { jobId } =
@@ -1462,7 +1406,7 @@ export class McpService extends BaseService {
                                 ? `Columns: ${columns.join(', ')}`
                                 : '';
                         return await this.buildScopedResponse(
-                            getMcpContext(extra),
+                            ctx,
                             `Query returned 0 rows.${header ? ` ${header}` : ''}`,
                         );
                     }
@@ -1472,10 +1416,7 @@ export class McpService extends BaseService {
                         columns,
                     });
 
-                    return await this.buildScopedResponse(
-                        getMcpContext(extra),
-                        csv,
-                    );
+                    return await this.buildScopedResponse(ctx, csv);
                 } catch (e) {
                     const errorMessage =
                         e instanceof Error ? e.message : String(e);
@@ -1505,13 +1446,13 @@ export class McpService extends BaseService {
                 },
             },
             async (_args, extra) => {
-                const { user } = this.getAccount(getMcpContext(extra));
-                const projectUuid = await this.resolveProjectUuid(
-                    getMcpContext(extra),
-                );
+                const ctx = getMcpContext(extra);
+
+                const { user } = this.getAccount(ctx);
+                const projectUuid = await this.resolveProjectUuid(ctx);
 
                 this.trackToolCall(
-                    getMcpContext(extra),
+                    ctx,
                     McpToolName.LIST_VERIFIED_CONTENT,
                     projectUuid,
                 );
@@ -1523,7 +1464,7 @@ export class McpService extends BaseService {
                     );
 
                 return this.buildScopedResponse(
-                    getMcpContext(extra),
+                    ctx,
                     JSON.stringify(verifiedContent, null, 2),
                 );
             },
@@ -1538,7 +1479,9 @@ export class McpService extends BaseService {
                 argsSchema: {},
             },
             async (_args, extra) => {
-                const context = getMcpContext(extra);
+                const ctx = getMcpContext(extra);
+
+                const context = ctx;
                 const metadata = await this.getActiveContextMetadata(context);
                 const { user } = this.getAccount(context);
 

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -473,7 +473,8 @@ export class McpService extends BaseService {
                         getMcpContext(extra),
                     );
 
-                const { user } = getMcpContext(extra).authInfo!.extra;
+                const { user } = this.getAccount(getMcpContext(extra));
+
                 const tagsFromContext = await this.getTagsFromContext(
                     getMcpContext(extra),
                 );
@@ -932,7 +933,7 @@ export class McpService extends BaseService {
                     context: {
                         projectUuid: existingContext?.context.projectUuid ?? '',
                         projectName: existingContext?.context.projectName ?? '',
-                        tags: existingContext?.context.tags ?? null,
+                        tags: existingContext?.context.tags || null,
                         agentUuid: agent.uuid,
                         agentName: agent.name,
                     },
@@ -996,7 +997,7 @@ export class McpService extends BaseService {
                     context: {
                         projectUuid: existingContext?.context.projectUuid ?? '',
                         projectName: existingContext?.context.projectName ?? '',
-                        tags: existingContext?.context.tags ?? null,
+                        tags: existingContext?.context.tags || null,
                         agentUuid: null,
                         agentName: null,
                     },
@@ -1299,10 +1300,10 @@ export class McpService extends BaseService {
                         JSON.stringify(exploreConfigState),
                     )}&isExploreFromHere=true`;
 
-                    const { user: mcpUser } =
-                        getMcpContext(extra).authInfo!.extra;
+                    const { user } = this.getAccount(getMcpContext(extra));
+
                     const shareUrl = await this.shareService.createShareUrl(
-                        mcpUser,
+                        user,
                         explorePath,
                         exploreParams,
                     );
@@ -1539,13 +1540,14 @@ export class McpService extends BaseService {
             async (_args, extra) => {
                 const context = getMcpContext(extra);
                 const metadata = await this.getActiveContextMetadata(context);
+                const { user } = this.getAccount(context);
 
                 let promptText: string;
 
                 if (metadata.agentUuid) {
                     try {
                         const agent = await this.aiAgentService.getAgent(
-                            context.authInfo!.extra.user,
+                            user,
                             metadata.agentUuid,
                             undefined,
                             { includeSummaryContext: true },
@@ -1652,10 +1654,10 @@ export class McpService extends BaseService {
     }
 
     async getProjectUuidFromContext(context: McpProtocolContext) {
-        const { user, headerProjectUuid } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const user = context.authInfo?.extra.user;
+        const headerProjectUuid = context.authInfo?.extra.headerProjectUuid;
 
-        if (!user || !organizationUuid) {
+        if (!user || !user.organizationUuid) {
             return undefined;
         }
 
@@ -1665,49 +1667,46 @@ export class McpService extends BaseService {
 
         const contextRow = await this.mcpContextModel.getContext(
             user.userUuid,
-            organizationUuid,
+            user.organizationUuid,
         );
 
         return contextRow?.context.projectUuid;
     }
 
     async getTagsFromContext(context: McpProtocolContext) {
-        const { user } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const user = context.authInfo?.extra.user;
 
-        if (!user || !organizationUuid) {
+        if (!user || !user.organizationUuid) {
             return null;
         }
 
         const contextRow = await this.mcpContextModel.getContext(
             user.userUuid,
-            organizationUuid,
+            user.organizationUuid,
         );
 
-        return contextRow?.context.tags ?? null;
+        return contextRow?.context.tags || null;
     }
 
     async getAgentUuidFromContext(context: McpProtocolContext) {
-        const { user } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const user = context.authInfo?.extra.user;
 
-        if (!user || !organizationUuid) {
+        if (!user || !user.organizationUuid) {
             return null;
         }
 
         const contextRow = await this.mcpContextModel.getContext(
             user.userUuid,
-            organizationUuid,
+            user.organizationUuid,
         );
 
         return contextRow?.context.agentUuid ?? null;
     }
 
     async getActiveContextMetadata(context: McpProtocolContext) {
-        const { user } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const user = context.authInfo?.extra.user;
 
-        if (!user || !organizationUuid) {
+        if (!user || !user.organizationUuid) {
             return {
                 projectUuid: null,
                 projectName: null,
@@ -1719,7 +1718,7 @@ export class McpService extends BaseService {
 
         const contextRow = await this.mcpContextModel.getContext(
             user.userUuid,
-            organizationUuid,
+            user.organizationUuid,
         );
 
         if (!contextRow) {
@@ -1747,17 +1746,18 @@ export class McpService extends BaseService {
     async getMergedUserAttributes(
         context: McpProtocolContext,
     ): Promise<UserAttributeValueMap> {
-        const { user, headerUserAttributes } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const user = context.authInfo?.extra.user;
+        const headerUserAttributes =
+            context.authInfo?.extra.headerUserAttributes;
 
-        if (!user || !organizationUuid) {
+        if (!user || !user.organizationUuid) {
             return {};
         }
 
         // Get database defaults
         const dbAttributes =
             await this.userAttributesModel.getAttributeValuesForOrgMember({
-                organizationUuid,
+                organizationUuid: user.organizationUuid,
                 userUuid: user.userUuid,
             });
 
@@ -1778,10 +1778,11 @@ export class McpService extends BaseService {
     async getUserAttributeOverridesFromContext(
         context: McpProtocolContext,
     ): Promise<UserAttributeValueMap | undefined> {
-        const { user, headerUserAttributes } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const user = context.authInfo?.extra.user;
+        const headerUserAttributes =
+            context.authInfo?.extra.headerUserAttributes;
 
-        if (!user || !organizationUuid) {
+        if (!user || !user.organizationUuid) {
             return undefined;
         }
 
@@ -1792,7 +1793,7 @@ export class McpService extends BaseService {
         // Validate header attributes (admin + narrowing check)
         const dbAttributes =
             await this.userAttributesModel.getAttributeValuesForOrgMember({
-                organizationUuid,
+                organizationUuid: user.organizationUuid,
                 userUuid: user.userUuid,
             });
         const auditedAbility = this.createAuditedAbility(user);
@@ -1807,7 +1808,8 @@ export class McpService extends BaseService {
     }
 
     async resolveProjectUuid(context: McpProtocolContext) {
-        const { user, account, headerProjectUuid } = context.authInfo!.extra;
+        const headerProjectUuid = context.authInfo?.extra.headerProjectUuid;
+
         const projectUuid = await this.getProjectUuidFromContext(context);
         if (!projectUuid) {
             throw new ForbiddenError(
@@ -1819,10 +1821,13 @@ export class McpService extends BaseService {
         // otherwise any tool that doesn't re-check (e.g. list_explores) would
         // leak project metadata cross-tenant.
         if (headerProjectUuid && headerProjectUuid === projectUuid) {
+            const { user, account } = this.getAccount(context);
+
             const project = await this.projectService.getProject(
                 projectUuid,
                 account,
             );
+
             const auditedAbility = this.createAuditedAbility(user);
             if (
                 auditedAbility.cannot(
@@ -1930,13 +1935,8 @@ export class McpService extends BaseService {
         },
         context: McpProtocolContext,
     ): Promise<FindExploresFn> {
-        const { user, account } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const { user, account } = this.getAccount(context);
         const { projectUuid } = toolArgs;
-
-        if (!user || !organizationUuid || !account) {
-            throw new ForbiddenError();
-        }
 
         const project = await this.projectService.getProject(
             projectUuid,
@@ -2032,13 +2032,8 @@ export class McpService extends BaseService {
         toolArgs: Omit<ToolFindFieldsArgs, 'type'> & { projectUuid: string },
         context: McpProtocolContext,
     ): Promise<{ findFields: FindFieldFn; getExplore: GetExploreFn }> {
-        const { user, account } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const { user, account } = this.getAccount(context);
         const { projectUuid } = toolArgs;
-
-        if (!user || !organizationUuid || !account) {
-            throw new ForbiddenError();
-        }
 
         const project = await this.projectService.getProject(
             projectUuid,
@@ -2108,13 +2103,8 @@ export class McpService extends BaseService {
         toolArgs: Omit<ToolFindContentArgs, 'type'> & { projectUuid: string },
         context: McpProtocolContext,
     ): Promise<FindContentFn> {
-        const { user, account } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const { user, account } = this.getAccount(context);
         const { projectUuid } = toolArgs;
-
-        if (!user || !organizationUuid || !account) {
-            throw new ForbiddenError();
-        }
 
         const project = await this.projectService.getProject(
             projectUuid,
@@ -2177,13 +2167,8 @@ export class McpService extends BaseService {
         agentContext: AgentContext;
         runAsyncQuery: RunAsyncQueryFn;
     }> {
-        const { user, account } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const { user, account } = this.getAccount(context);
         const { projectUuid } = toolArgs;
-
-        if (!user || !organizationUuid || !account) {
-            throw new ForbiddenError();
-        }
 
         const project = await this.projectService.getProject(
             projectUuid,
@@ -2239,13 +2224,8 @@ export class McpService extends BaseService {
         },
         context: McpProtocolContext,
     ): Promise<SearchFieldValuesFn> {
-        const { user, account } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+        const { user, account } = this.getAccount(context);
         const { projectUuid } = toolArgs;
-
-        if (!user || !organizationUuid || !account) {
-            throw new ForbiddenError();
-        }
 
         const project = await this.projectService.getProject(
             projectUuid,
@@ -2345,18 +2325,16 @@ export class McpService extends BaseService {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    public getAccount(context: McpProtocolContext): {
-        user: SessionUser;
-        organizationUuid: string;
-        account: Account;
-    } {
-        const { user, account } = context.authInfo!.extra;
-        const { organizationUuid } = user;
+    public getAccount(context: McpProtocolContext) {
+        const user = context.authInfo?.extra.user;
+        const account = context.authInfo?.extra.account;
 
-        if (!user || !organizationUuid || !account) {
-            throw new ForbiddenError();
+        if (!user || !user.organizationUuid || !account) {
+            throw new ForbiddenError(
+                'MCP request is missing authenticated user context',
+            );
         }
-        return { user, organizationUuid, account };
+        return { user, account, organizationUuid: user.organizationUuid };
     }
 
     public canAccessMcp(context: McpProtocolContext): boolean {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -2,7 +2,6 @@ import { subject } from '@casl/ability';
 import {
     Account,
     AiResultType,
-    AnyType,
     ApiKeyAccount,
     CatalogType,
     CommercialFeatureFlags,
@@ -370,10 +369,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (
-                _args: Record<string, never>,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 this.trackToolCall(
                     getMcpContext(extra),
                     McpToolName.GET_LIGHTDASH_VERSION,
@@ -404,11 +400,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 try {
                     const { user } = this.getAccount(getMcpContext(extra));
 
@@ -478,11 +470,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const args = _args as Omit<ToolFindExploresArgsV3, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
@@ -554,11 +542,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const args = _args as Omit<ToolFindFieldsArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
@@ -609,11 +593,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const args = _args as Omit<ToolFindContentArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
@@ -665,7 +645,7 @@ export class McpService extends BaseService {
                     },
                 },
                 async (
-                    _args: Record<string, never>,
+                    _args,
                     extra: RequestHandlerExtra<
                         ServerRequest,
                         ServerNotification
@@ -731,18 +711,13 @@ export class McpService extends BaseService {
                         idempotentHint: true,
                     },
                 },
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 async (
-                    _args: AnyType,
+                    args,
                     extra: RequestHandlerExtra<
                         ServerRequest,
                         ServerNotification
                     >,
                 ) => {
-                    const args = _args as {
-                        projectUuid: string;
-                        tags?: string[];
-                    };
                     const { user, organizationUuid, account } = this.getAccount(
                         getMcpContext(extra),
                     );
@@ -827,10 +802,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (
-                _args: Record<string, never>,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const { user, organizationUuid } = this.getAccount(
                     getMcpContext(extra),
                 );
@@ -897,11 +869,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
-                const args = _args as { projectUuid?: string };
+            async (args, extra) => {
                 const { user } = this.getAccount(getMcpContext(extra));
 
                 await this.checkAiAgentsVisible(user);
@@ -949,10 +917,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const args = _args as { agentUuid: string };
                 const { user, organizationUuid } = this.getAccount(
                     getMcpContext(extra),
@@ -1032,10 +997,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (
-                _args: Record<string, never>,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const { user, organizationUuid } = this.getAccount(
                     getMcpContext(extra),
                 );
@@ -1092,10 +1054,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (
-                _args: Record<string, never>,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const { user, organizationUuid } = this.getAccount(
                     getMcpContext(extra),
                 );
@@ -1203,11 +1162,7 @@ export class McpService extends BaseService {
                 },
                 _meta: { ui: { resourceUri: chartResourceUri } },
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const projectUuid = await this.resolveProjectUuid(
                     getMcpContext(extra),
                 );
@@ -1440,11 +1395,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const args = _args as Omit<ToolSearchFieldValuesArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
@@ -1493,11 +1444,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const args = _args as { sql: string; limit?: number };
                 const { user, account } = this.getAccount(getMcpContext(extra));
                 const projectUuid = await this.resolveProjectUuid(
@@ -1581,10 +1528,7 @@ export class McpService extends BaseService {
                     idempotentHint: true,
                 },
             },
-            async (
-                _args: Record<string, never>,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const { user } = this.getAccount(getMcpContext(extra));
                 const projectUuid = await this.resolveProjectUuid(
                     getMcpContext(extra),
@@ -1617,11 +1561,7 @@ export class McpService extends BaseService {
                     'Guidelines for querying Lightdash data using MCP tools. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.',
                 argsSchema: {},
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            async (
-                _args: AnyType,
-                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-            ) => {
+            async (_args, extra) => {
                 const context = getMcpContext(extra);
                 const metadata = await this.getActiveContextMetadata(context);
 

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -36,13 +36,17 @@ import {
     toolSearchFieldValuesArgsSchema,
     UserAttributeValueMap,
 } from '@lightdash/common';
-import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
-import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
+// eslint-disable-next-line import/extensions
+import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+// eslint-disable-next-line import/extensions
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+// eslint-disable-next-line import/extensions
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import {
     ServerNotification,
     ServerRequest,
-} from '@modelcontextprotocol/sdk/types';
+    // eslint-disable-next-line import/extensions
+} from '@modelcontextprotocol/sdk/types.js';
 import * as Sentry from '@sentry/node';
 import { stringify } from 'csv-stringify/sync';
 import fs from 'fs/promises';

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -39,6 +39,7 @@ import {
     SchedulerTaskName,
     SchedulerWithLogs,
     SessionUser,
+    sleep,
     UnexpectedGoogleSheetsError,
     UpdateSchedulerAndTargetsWithoutId,
     UserSchedulersSummary,
@@ -1211,6 +1212,61 @@ export class SchedulerService extends BaseService {
             throw new ForbiddenError();
         }
         return { status: job.status, details: job.details };
+    }
+
+    /**
+     * Yields the job's status on a backoff cadence, stopping when the deadline
+     * is reached. Consumers iterate with `for await` and break out when they
+     * see a status they care about; the generator handles the sleep/backoff
+     * plumbing.
+     */
+    async *streamJobStatus(
+        account: Account,
+        jobId: string,
+        {
+            initialBackoffMs = 500,
+            maxBackoffMs = 2000,
+            timeoutMs = 5 * 60 * 1000,
+        }: {
+            initialBackoffMs?: number;
+            maxBackoffMs?: number;
+            timeoutMs?: number;
+        } = {},
+    ): AsyncGenerator<Pick<SchedulerLogDb, 'status' | 'details'>> {
+        const deadline = Date.now() + timeoutMs;
+        let backoffMs = initialBackoffMs;
+        while (Date.now() < deadline) {
+            // eslint-disable-next-line no-await-in-loop
+            yield await this.getJobStatus(account, jobId);
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(backoffMs);
+            backoffMs = Math.min(backoffMs * 2, maxBackoffMs);
+        }
+    }
+
+    /**
+     * Polls a scheduler job until it reaches COMPLETED or ERROR. Returns the
+     * final job state; throws if the timeout elapses first. Caller decides
+     * how to interpret COMPLETED vs ERROR.
+     */
+    async pollJobToCompletion(
+        account: Account,
+        jobId: string,
+        options: {
+            initialBackoffMs?: number;
+            maxBackoffMs?: number;
+            timeoutMs?: number;
+        } = {},
+    ): Promise<Pick<SchedulerLogDb, 'status' | 'details'>> {
+        for await (const job of this.streamJobStatus(account, jobId, options)) {
+            if (
+                job.status === SchedulerJobStatus.COMPLETED ||
+                job.status === SchedulerJobStatus.ERROR
+            ) {
+                return job;
+            }
+        }
+        throw new Error(`Scheduler job ${jobId} did not complete in time`);
     }
 
     async setJobStatus(

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -20,6 +20,7 @@ import {
     isUserWithOrg,
     isValidFrequency,
     isValidTimezone,
+    JobPollTimeoutError,
     JobStatusType,
     KnexPaginateArgs,
     KnexPaginatedData,
@@ -1258,7 +1259,11 @@ export class SchedulerService extends BaseService {
             timeoutMs?: number;
         } = {},
     ): Promise<Pick<SchedulerLogDb, 'status' | 'details'>> {
-        for await (const job of this.streamJobStatus(account, jobId, options)) {
+        const { timeoutMs = 5 * 60 * 1000 } = options;
+        for await (const job of this.streamJobStatus(account, jobId, {
+            ...options,
+            timeoutMs,
+        })) {
             if (
                 job.status === SchedulerJobStatus.COMPLETED ||
                 job.status === SchedulerJobStatus.ERROR
@@ -1266,7 +1271,7 @@ export class SchedulerService extends BaseService {
                 return job;
             }
         }
-        throw new Error(`Scheduler job ${jobId} did not complete in time`);
+        throw new JobPollTimeoutError(jobId, timeoutMs);
     }
 
     async setJobStatus(

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -787,3 +787,20 @@ export class InvalidSpaceStateError extends LightdashError {
         });
     }
 }
+
+export class JobPollTimeoutError extends LightdashError {
+    jobId: string;
+
+    timeoutMs: number;
+
+    constructor(jobId: string, timeoutMs: number) {
+        super({
+            message: `Scheduler job ${jobId} did not complete within ${timeoutMs}ms`,
+            name: 'JobPollTimeoutError',
+            statusCode: 504,
+            data: { jobId, timeoutMs },
+        });
+        this.jobId = jobId;
+        this.timeoutMs = timeoutMs;
+    }
+}


### PR DESCRIPTION
Closes: ZAP-403

## Summary

Pure cleanup pass over `McpService.ts` — every type cast, `AnyType`, `_args: any` + `eslint-disable`, and `!` non-null assertion on `authInfo!.extra` is gone. No external behavior changes. Backend typecheck is green.

## What changed

### Type safety
- **`McpProtocolContext` casts → typed Zod helper.** The 56 `extra as McpProtocolContext` sites are replaced with a single `getMcpContext(extra)` helper backed by `mcpProtocolContextSchema` (uses `z.custom<AuthInfo>()` + `z.intersection` so we don't re-spec the SDK's `AuthInfo` shape).
- **`AnyType` + `eslint-disable @typescript-eslint/no-explicit-any` removed** from all 11 tool-callback signatures. `_args` now infers from the per-tool Zod schema.
- **`_args as Omit<ToolXArgs, 'type'>` casts gone.** Made `getMcpCompatibleSchema` generic (`<TShape extends ZodRawShape>(schema: z.ZodObject<TShape>): TShape`) so the SDK's `registerTool` infers the callback's `args` type directly from `inputSchema`.
- **`result as AsyncIterable<{…}>` in `streamToolResult` gone.** Refactored to a generic with a `Symbol.asyncIterator in result` discriminator that TS narrows natively.
- **`job.details as { fileUrl?: … }` casts in `pollSqlJobToCompletion` gone.** Two small Zod schemas (`sqlJobCompletedDetailsSchema`, `sqlJobErrorDetailsSchema`) parse the loose `Record<string, any> \| null` shape at the boundary.
- **Redundant explicit type annotations dropped** where TS infers the same type from the initializer (e.g. `const readStream: Readable = await getFileStream(...)`).

### Consolidation
- **`authInfo!.extra` non-null asserts gone.** Every throw-on-missing-context path now flows through a single `McpService.getAccount(ctx)` (made `static`), which throws `ForbiddenError('MCP request is missing authenticated user context')`. Methods that *return defaults* on missing context (`getProjectUuidFromContext`, `getTagsFromContext`, etc.) are left alone — they keep their graceful early-return shape.
- **`getMcpContext(extra)` is cached per handler.** Previously some handlers called it 6-7× per request, re-parsing the SDK extra each time. Now it's `const ctx = getMcpContext(extra)` at the top of each handler.

### New scheduler primitive
- **`SchedulerService.streamJobStatus(account, jobId, opts?)`** — async generator that yields the job's status on a backoff cadence and stops at a configurable deadline. Replaces the previous `while (true) { … await sleep … }` pattern.
- **`SchedulerService.pollJobToCompletion(account, jobId, opts?)`** — `for await` over the generator, returns the first `COMPLETED \| ERROR` state, throws on timeout.
- McpService's `pollSqlJobToCompletion` is now a thin shape-extractor on top — 45 LoC → 25 LoC.

## Tally

| Pattern | Before | After |
|---|---:|---:|
| `extra as McpProtocolContext` | 56 | 0 |
| `_args: AnyType` + `eslint-disable` | 11 | 0 |
| `_args as Omit<…>` | 5 | 0 |
| `result as AsyncIterable<…>` | 1 | 0 |
| `job.details as { … }` | 2 | 0 |
| `authInfo!.extra` non-null asserts | 16 | 0 |
| `'TODO'` placeholder errors | 6 | 0 |
| **Total unsafe-type sites** | **97** | **0** |

## Notes

- No new dependencies. Backend typecheck passes. Behavior of every tool callback is preserved — the new validation paths surface the same failure modes that previously crashed with `TypeError: Cannot read property 'extra' of undefined`, but as a clean `ForbiddenError` instead.
- The Zod boundary on `authInfo.extra` uses `z.custom<T>()` for the inner complex types (`SessionUser`, accounts, `UserAttributeValueMap`) so we don't need to mirror their full shapes. Documented inline.
