### PR TITLE
fix(mcp): open CORS on OAuth discovery + MCP endpoints

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -317,6 +317,18 @@ export default class App {
     }
 
     private async initExpress(expressApp: Express) {
+        // Browser-based MCP clients (RFC 9728, OAuth-for-SPAs BCP) need
+        // CORS-open OAuth discovery + token endpoints and the MCP endpoint.
+        expressApp.use(
+            [
+                '/.well-known/oauth-protected-resource',
+                '/.well-known/oauth-authorization-server',
+                '/api/v1/oauth',
+                '/api/v1/mcp',
+            ],
+            cors({ origin: '*' }),
+        );
+
         // Cross-Origin Resource Sharing policy (CORS)
         // WARNING: this middleware should be mounted before the helmet middleware
         // (ideally at the top of the middleware stack)


### PR DESCRIPTION
## Summary

Browser-based MCP clients (Inspector, claude.ai's web UI) can't complete the OAuth flow against `irakli.lightdash.dev` (or any Lightdash deployment) because the OAuth discovery + token + register endpoints reject preflight requests from any origin outside the deployment's own `siteUrl` / configured allowlist.

This adds a single `cors({ origin: '*' })` middleware mounted on:

- `/.well-known/oauth-protected-resource` — RFC 9728 explicitly mandates CORS support
- `/.well-known/oauth-authorization-server` — RFC 8414 metadata, needed by browser clients to discover the AS
- `/api/v1/oauth` — covers `/register`, `/token`, `/revoke` (and incidentally `/authorize`, `/userinfo`, etc., which is safe — see below)
- `/api/v1/mcp` — the MCP endpoint itself

## Why it's safe to open `/api/v1/oauth` as a whole prefix

| Endpoint | Auth requirement | Risk from `Access-Control-Allow-Origin: *` |
|---|---|---|
| `/oauth/authorize` | Session | Browser top-level navigation — CORS isn't involved |
| `/oauth/userinfo` | Bearer token | Token still required; CORS doesn't grant access |
| `/oauth/clients` | Session cookie | `credentials: false` means browser won't send cookies → endpoint rejects anonymous |
| `/oauth/introspect` | Session cookie | Same as `/clients` |
| `/oauth/register`, `/token`, `/revoke` | Per OAuth specs (PKCE, client_id, etc.) | These are explicitly meant to be browser-callable per OAuth-for-SPAs BCP |

Opening CORS does not bypass any auth check — every endpoint enforces its own credential requirements.

## Spec references

- [RFC 9728 §3](https://datatracker.ietf.org/doc/html/rfc9728#section-3) — Protected Resource Metadata MUST be CORS-accessible
- [OAuth 2.0 for Browser-Based Apps BCP draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps-21) — token endpoint MUST support CORS for SPA clients