### PR TITLE
fix(ee): interpolate column name in ai_agent_tool_call length check

### DIFF
--- a/packages/backend/src/ee/database/migrations/20260513165925_add_parent_tool_call_id_to_ai_agent_tool_call.ts
+++ b/packages/backend/src/ee/database/migrations/20260513165925_add_parent_tool_call_id_to_ai_agent_tool_call.ts
@@ -12,7 +12,11 @@ export async function up(knex: Knex): Promise<void> {
     await knex.schema.alterTable(AiAgentToolCallTableName, (table) => {
         table.text(ColumnName).nullable();
         table.index(['ai_prompt_uuid', ColumnName], IndexName);
-        table.check('length(??) <= 128', [ColumnName], CheckConstraintName);
+        // `length(?? )` does not work here: `table.check()` treats bindings
+        // as value placeholders, not identifier placeholders, so `??` would
+        // expand to `$1$2` in the generated SQL. Interpolate the column name
+        // directly — it's an internal constant, not user input.
+        table.check(`length(${ColumnName}) <= 128`, [], CheckConstraintName);
     });
 }
 


### PR DESCRIPTION
## Summary

The `20260513165925_add_parent_tool_call_id_to_ai_agent_tool_call` migration uses Knex's `??` identifier placeholder inside `table.check()`, but `table.check(predicate, bindings, name)` treats the `bindings` array as **value** placeholders, not identifier placeholders. Knex expands `??` as two positional binds → `\$1\$2`, producing invalid SQL:

\`\`\`
alter table "ai_agent_tool_call" add constraint ai_agent_tool_call_parent_tool_call_id_length_check
  check(length(\$1\$2) <= 128)
                ^ syntax error at or near "\$2"
\`\`\`

Result: `pnpm migrate-production` exits 1 on any fresh DB, so every PR preview deploy hangs in `CrashLoopBackOff` (server never starts → readiness probe never goes green → Okteto `--wait` times out at 15m).

## Fix

Interpolate the column name directly. `ColumnName` is an in-file constant, not user input, so there's no injection risk.

\`\`\`ts
table.check(\`length(\${ColumnName}) <= 128\`, [], CheckConstraintName);
\`\`\`

Same SQL semantics as intended, generates `check(length(parent_tool_call_id) <= 128)`.