### PR TITLE
fix(timezone): symmetric source/target short-circuit on filter literals

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1501,6 +1501,7 @@ export class MetricQueryBuilder {
                 this.args.explore.caseSensitive ?? true,
                 baseDimensionSql,
                 this.args.useTimezoneAwareDateTrunc,
+                this.columnTimezone,
             ),
         );
 

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -2920,5 +2920,46 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             );
             expect(sql).not.toContain('toDateTime(');
         });
+
+        test('Postgres: non-matching source/target preserves the AT TIME ZONE wrap', () => {
+            const sql = renderFilterRuleSql(
+                equalsFilter,
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.POSTGRES,
+                'America/New_York',
+                true,
+                undefined,
+                true,
+                DimensionType.TIMESTAMP,
+                'UTC',
+            );
+            expect(sql).toContain("AT TIME ZONE 'America/New_York'");
+            expect(sql).toContain("'2024-01-15'::timestamp");
+        });
+
+        test('ClickHouse: non-matching source/target preserves the toDateTime wrap', () => {
+            const sql = renderFilterRuleSql(
+                equalsFilter,
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.CLICKHOUSE,
+                'America/New_York',
+                true,
+                undefined,
+                true,
+                DimensionType.TIMESTAMP,
+                'UTC',
+            );
+            expect(sql).toContain(
+                "toDateTime('2024-01-15', 'America/New_York')",
+            );
+        });
     });
 });

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -2802,4 +2802,123 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             expect(sql).not.toContain('TIMESTAMP(');
         });
     });
+
+    describe('target tz === source tz short-circuit (mirrors dim-side resolveTimezoneWrap)', () => {
+        test('BigQuery: UTC project tz + UTC source drops the TIMESTAMP wrap on the literal', () => {
+            const sql = renderFilterRuleSql(
+                equalsFilter,
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.BIGQUERY,
+                'UTC',
+                true,
+                undefined,
+                true,
+                DimensionType.TIMESTAMP,
+                'UTC',
+            );
+            expect(sql).not.toContain('TIMESTAMP(');
+            expect(sql).toContain("'2024-01-15'");
+        });
+
+        test('BigQuery: UTC project tz + undefined source (defaults to UTC) drops the wrap', () => {
+            const sql = renderFilterRuleSql(
+                equalsFilter,
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.BIGQUERY,
+                'UTC',
+                true,
+                undefined,
+                true,
+                DimensionType.TIMESTAMP,
+            );
+            expect(sql).not.toContain('TIMESTAMP(');
+        });
+
+        test('BigQuery: matching non-UTC source/target drops the wrap', () => {
+            const sql = renderFilterRuleSql(
+                equalsFilter,
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.BIGQUERY,
+                'America/New_York',
+                true,
+                undefined,
+                true,
+                DimensionType.TIMESTAMP,
+                'America/New_York',
+            );
+            expect(sql).not.toContain('TIMESTAMP(');
+        });
+
+        test('BigQuery: non-matching source/target preserves the wrap', () => {
+            const sql = renderFilterRuleSql(
+                equalsFilter,
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.BIGQUERY,
+                'America/New_York',
+                true,
+                undefined,
+                true,
+                DimensionType.TIMESTAMP,
+                'UTC',
+            );
+            expect(sql).toContain(
+                "TIMESTAMP('2024-01-15', 'America/New_York')",
+            );
+        });
+
+        test('Postgres: matching source/target drops the AT TIME ZONE wrap on the literal', () => {
+            const sql = renderFilterRuleSql(
+                equalsFilter,
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.POSTGRES,
+                'UTC',
+                true,
+                undefined,
+                true,
+                DimensionType.TIMESTAMP,
+                'UTC',
+            );
+            expect(sql).not.toContain('AT TIME ZONE');
+            expect(sql).not.toContain('::timestamp');
+        });
+
+        test('ClickHouse: matching source/target drops the toDateTime wrap on the literal', () => {
+            const sql = renderFilterRuleSql(
+                equalsFilter,
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.CLICKHOUSE,
+                'UTC',
+                true,
+                undefined,
+                true,
+                DimensionType.TIMESTAMP,
+                'UTC',
+            );
+            expect(sql).not.toContain('toDateTime(');
+        });
+    });
 });

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -26,7 +26,11 @@ import { convertToBooleanValue } from '../utils/booleanConverter';
 import { formatDate } from '../utils/formatting';
 import { getItemId } from '../utils/item';
 import { getMomentDateWithCustomStartOfWeek } from '../utils/time';
-import { dateTruncTimezoneConversions, WeekDay } from '../utils/timeFrames';
+import {
+    dateTruncTimezoneConversions,
+    isTimezoneRoundTripNoOp,
+    WeekDay,
+} from '../utils/timeFrames';
 
 /**
  * Formats computed Date boundaries for relative date operators (IN_THE_PAST, etc.)
@@ -285,14 +289,23 @@ const renderDateOrTimestampFilterSql = (
     startOfWeek: WeekDay | null | undefined = undefined,
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
+    sourceTimezone?: string,
 ): string => {
     // When startOfWeek is not explicitly configured, use the warehouse's default
     // to ensure JS-side week boundaries match the warehouse's DATE_TRUNC behavior.
     const effectiveStartOfWeek =
         startOfWeek ?? getDefaultStartOfWeek(adapterType);
 
+    // Mirror the dim-side `resolveTimezoneWrap` short-circuit: when target tz
+    // equals source tz, dropping the literal's TIMESTAMP cast keeps both sides
+    // symmetric (a custom dim SQL emitting DATETIME can otherwise mismatch a
+    // TIMESTAMP boundary on BigQuery).
+    const wrapTimezoneLiteral =
+        !!useTimezoneAwareDateTrunc &&
+        !isTimezoneRoundTripNoOp(timezone, sourceTimezone);
+
     const castValue = (value: string): string => {
-        if (useTimezoneAwareDateTrunc) {
+        if (wrapTimezoneLiteral) {
             // Column is a timestamptz (round-trip through project TZ). Tag
             // the literal in project TZ so coercion aligns with the column.
             const { toUTC } = dateTruncTimezoneConversions[adapterType];
@@ -600,6 +613,7 @@ export const renderDateFilterSql = (
     startOfWeek: WeekDay | null | undefined = undefined,
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
+    sourceTimezone?: string,
 ): string => {
     const effectiveTimezone = boundaryDateFormatter ? timezone : 'UTC';
     const effectiveFormatter =
@@ -615,6 +629,7 @@ export const renderDateFilterSql = (
         startOfWeek,
         baseDimensionSql,
         useTimezoneAwareDateTrunc,
+        sourceTimezone,
     );
 };
 
@@ -628,6 +643,7 @@ export const renderTimestampFilterSql = (
     startOfWeek: WeekDay | null | undefined = undefined,
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
+    sourceTimezone?: string,
 ): string =>
     renderDateOrTimestampFilterSql(
         dimensionSql,
@@ -639,6 +655,7 @@ export const renderTimestampFilterSql = (
         startOfWeek,
         baseDimensionSql,
         useTimezoneAwareDateTrunc,
+        sourceTimezone,
     );
 
 export const renderBooleanFilterSql = (
@@ -751,6 +768,7 @@ export const renderFilterRuleSql = (
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
     baseTimeIntervalDimensionType?: DimensionType,
+    sourceTimezone?: string,
 ): string => {
     if (filterRule.disabled) {
         return `1=1`; // When filter is disabled, we want to return all rows
@@ -806,6 +824,7 @@ export const renderFilterRuleSql = (
                 startOfWeek,
                 baseDimensionSql,
                 wrapLiteralAsTimestamptz,
+                sourceTimezone,
             );
         }
         case DimensionType.TIMESTAMP:
@@ -849,6 +868,7 @@ export const renderFilterRuleSqlFromField = (
     exploreCaseSensitive: boolean = true,
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
+    sourceTimezone?: string,
 ): string => {
     const fieldType = isCompiledCustomSqlDimension(field)
         ? field.dimensionType
@@ -888,5 +908,6 @@ export const renderFilterRuleSqlFromField = (
         baseDimensionSql,
         useTimezoneAwareDateTrunc,
         baseTimeIntervalDimensionType,
+        sourceTimezone,
     );
 };

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -170,6 +170,17 @@ describe('TimeFrames', () => {
                     tz,
                 ),
             ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    undefined,
+                    tz,
+                    tz,
+                ),
+            ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
         });
 
         test('BigQuery 2-arg TIMESTAMP_TRUNC keeps original expr unchanged (DATETIME overload still applies)', () => {
@@ -1006,6 +1017,17 @@ describe('TimeFrames', () => {
                     'America/New_York',
                 ),
             ).toEqual(`EXTRACT(MONTH FROM ${col})`);
+            expect(
+                getSqlForDatePart(
+                    SupportedDbtAdapter.POSTGRES,
+                    TimeFrames.DAY_OF_WEEK_INDEX,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    'America/New_York',
+                    'America/New_York',
+                ),
+            ).toEqual(`DATE_PART('DOW', ${col})`);
         });
 
         test('DATE base dimension with timezone short-circuits (no wrap)', () => {
@@ -1208,6 +1230,17 @@ describe('TimeFrames', () => {
                     'America/New_York',
                 ),
             ).toEqual(`TO_CHAR(${col}, 'FMMonth')`);
+            expect(
+                getSqlForDatePartName(
+                    SupportedDbtAdapter.BIGQUERY,
+                    TimeFrames.MONTH_NAME,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    null,
+                    'America/New_York',
+                    'America/New_York',
+                ),
+            ).toEqual(`FORMAT_DATETIME('%B', ${col})`);
         });
 
         test.each([

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -679,18 +679,25 @@ const warehouseConfigs: Record<SupportedDbtAdapter, WarehouseConfig> = {
  * performed in the project TZ and the result is converted back to a proper
  * UTC instant so downstream consumers apply .tz(project_tz) uniformly.
  */
+// Source defaults to UTC when unset (matches `getColumnTimezone`). A wrap when
+// target equals source is semantically a no-op and defeats partition pruning
+// on warehouses like BigQuery — every wrap site (dim trunc, extract, format,
+// filter literal) shares this predicate so symmetry is enforced centrally.
+export const isTimezoneRoundTripNoOp = (
+    timezone: string,
+    sourceTimezone?: string,
+): boolean => timezone === (sourceTimezone ?? 'UTC');
+
 // Returns the resolved (timezone, sourceTimezone) when the dim needs a tz
 // wrap, else null. Wrap conditions: TIMESTAMP-typed dim AND a target timezone
-// AND target != source (defaulting to UTC). Wrapping when target equals source
-// produces semantically-identical SQL that defeats partition pruning on
-// warehouses like BigQuery.
+// AND target != source.
 const resolveTimezoneWrap = (
     type: DimensionType,
     timezone?: string,
     sourceTimezone?: string,
 ): { timezone: string; sourceTimezone?: string } | null => {
     if (type !== DimensionType.TIMESTAMP || !timezone) return null;
-    if (timezone === (sourceTimezone ?? 'UTC')) return null;
+    if (isTimezoneRoundTripNoOp(timezone, sourceTimezone)) return null;
     return { timezone, sourceTimezone };
 };
 


### PR DESCRIPTION
Closes GLITCH-445

## Problem

After GLITCH-444 short-circuited the timezone wrap on the SELECT side when target tz === source tz (defaulting to UTC), the filter side still emitted the `TIMESTAMP(literal, tz)` wrap unconditionally. When a custom dimension `sql:` returns DATETIME (e.g., a `timestamp_add(...)` time-shifter on a non-TIMESTAMP base), BigQuery rejects the comparison:

```
No matching signature for operator >= for argument types: DATETIME, TIMESTAMP
```

## Fix

Apply the same target-vs-source predicate on the filter literal in `renderDateOrTimestampFilterSql`, mirroring the dim-side `resolveTimezoneWrap` short-circuit. The predicate `isTimezoneRoundTripNoOp(target, source)` is exported from `timeFrames.ts` so all wrap sites (TRUNC, EXTRACT, FORMAT, filter literal) share one source of truth.

## Behavior matrix

| `EnableTimezoneSupport` | target===source | Before | After |
|---|---|---|---|
| off | any | bare literal | bare literal (identical) |
| on | no | tz-wrapped literal | tz-wrapped literal (identical) |
| on | yes | tz-wrapped literal | bare literal (the fix) |

Only the third row changes. 100% no-op when the flag is off.

## Test plan

- [x] `common` tests: 266/266 (filtersCompiler + timeFrames), incl. 6 new regression tests for BigQuery / Postgres / ClickHouse covering UTC=UTC, matching non-UTC, non-matching, and undefined-source cases
- [x] `backend` QueryBuilder tests: 386/386 + 60/60 snapshots
- [x] `common` + `backend` typecheck + lint clean
- [x] Live verified against local BigQuery jaffle shop via `/compileQuery`: `(TIMESTAMP_TRUNC(\`customers\`.created, MONTH)) <= ('2026-05-01')` (bare literal, no wrap)