### PR TITLE
feat: standardize managed agent tool list results with limits and formatting

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -47,6 +47,11 @@ import {
 } from '../../clients/ManagedAgentClient';
 import { ManagedAgentModel } from '../../models/ManagedAgentModel';
 import type { ServiceAccountModel } from '../../models/ServiceAccountModel';
+import {
+    formatManagedAgentToolListResult,
+    getManagedAgentToolResultLimit,
+    summarizeManagedAgentBrokenContent,
+} from './toolResults';
 
 type RunsCursor = { startedAt: Date; runUuid: string };
 
@@ -1697,7 +1702,7 @@ export class ManagedAgentService extends BaseService {
     ): Promise<string> {
         const actions = await this.managedAgentModel.getRecentActions(
             projectUuid,
-            limit ?? 50,
+            getManagedAgentToolResultLimit(limit, 50),
         );
         const visibleActions = (
             await Promise.all(
@@ -1713,7 +1718,7 @@ export class ManagedAgentService extends BaseService {
                 ),
             )
         ).filter((action): action is ManagedAgentAction => action !== null);
-        return JSON.stringify(
+        return formatManagedAgentToolListResult(
             visibleActions.map((a) => ({
                 action_uuid: a.actionUuid,
                 action_type: a.actionType,
@@ -1757,7 +1762,7 @@ export class ManagedAgentService extends BaseService {
                 }),
             )
         ).filter((item) => item !== null);
-        return JSON.stringify(
+        return formatManagedAgentToolListResult(
             visibleItems.map((item) => ({
                 uuid: item.contentUuid,
                 name: item.contentName,
@@ -1821,7 +1826,9 @@ export class ManagedAgentService extends BaseService {
                 }),
             )
         ).filter((validation) => validation !== null);
-        return JSON.stringify(visibleValidations);
+        return formatManagedAgentToolListResult(
+            summarizeManagedAgentBrokenContent(visibleValidations),
+        );
     }
 
     private async handleGetPreviewProjects(
@@ -1851,9 +1858,15 @@ export class ManagedAgentService extends BaseService {
                         : null,
                 ),
             )
-        ).filter((preview) => preview !== null);
+        )
+            .filter((preview) => preview !== null)
+            .sort(
+                (a, b) =>
+                    new Date(a.createdAt).getTime() -
+                    new Date(b.createdAt).getTime(),
+            );
 
-        return JSON.stringify(
+        return formatManagedAgentToolListResult(
             visiblePreviews.map((p) => ({
                 uuid: p.projectUuid,
                 name: p.name,
@@ -1920,7 +1933,7 @@ export class ManagedAgentService extends BaseService {
             this.analyticsModel.getLastViewedAtForDashboards(dashboardUuids),
         ]);
 
-        return JSON.stringify(
+        return formatManagedAgentToolListResult(
             allItems.map((item) => ({
                 uuid: item.uuid,
                 name: item.name,
@@ -2548,7 +2561,7 @@ chartConfig:
         projectUuid: string,
         input: Record<string, unknown>,
     ): Promise<string> {
-        const limit = (input.limit as number) ?? 30;
+        const limit = getManagedAgentToolResultLimit(input.limit, 30);
         const days = (input.days as number) ?? 30;
 
         const questions = await this.managedAgentModel.getUserQuestions(
@@ -2557,7 +2570,7 @@ chartConfig:
             limit,
         );
 
-        return JSON.stringify(
+        return formatManagedAgentToolListResult(
             questions.map((q) => ({
                 question: q.prompt,
                 asked_by: q.userName,
@@ -2572,7 +2585,7 @@ chartConfig:
         input: Record<string, unknown>,
     ): Promise<string> {
         const thresholdMs = (input.threshold_ms as number) ?? 2000;
-        const limit = (input.limit as number) ?? 20;
+        const limit = getManagedAgentToolResultLimit(input.limit, 20);
 
         const slowQueries = await this.managedAgentModel.getSlowQueries(
             projectUuid,
@@ -2600,7 +2613,7 @@ chartConfig:
             )
         ).filter((query) => query !== null);
 
-        return JSON.stringify(
+        return formatManagedAgentToolListResult(
             visibleQueries.map((q) => ({
                 execution_time_ms: q.executionTimeMs,
                 execution_time_seconds: (q.executionTimeMs / 1000).toFixed(1),

--- a/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/toolResults.ts
@@ -1,0 +1,102 @@
+import type { ValidationResponse } from '@lightdash/common';
+
+export const MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT = 100;
+export const MANAGED_AGENT_BROKEN_CONTENT_ERROR_LIMIT = 10;
+
+export const getManagedAgentToolResultLimit = (
+    requestedLimit: unknown,
+    defaultLimit: number,
+): number => {
+    if (
+        typeof requestedLimit !== 'number' ||
+        !Number.isFinite(requestedLimit)
+    ) {
+        return defaultLimit;
+    }
+
+    return Math.min(
+        Math.max(Math.floor(requestedLimit), 1),
+        MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
+    );
+};
+
+type ManagedAgentToolListResult<T> = {
+    items: T[];
+    total_count: number;
+    returned_count: number;
+    truncated: boolean;
+    omitted_count: number;
+};
+
+export const formatManagedAgentToolListResult = <T>(
+    items: T[],
+    limit = MANAGED_AGENT_TOOL_RESULT_ITEM_LIMIT,
+): string => {
+    const limitedItems = items.slice(0, limit);
+    return JSON.stringify({
+        items: limitedItems,
+        total_count: items.length,
+        returned_count: limitedItems.length,
+        truncated: items.length > limitedItems.length,
+        omitted_count: Math.max(items.length - limitedItems.length, 0),
+    } satisfies ManagedAgentToolListResult<T>);
+};
+
+type ManagedAgentBrokenContentItem = {
+    uuid: string;
+    name: string;
+    type: 'chart' | 'dashboard';
+    source: ValidationResponse['source'];
+    error_count: number;
+    errors: {
+        error: string;
+        error_type: ValidationResponse['errorType'];
+    }[];
+    errors_truncated: boolean;
+};
+
+export const summarizeManagedAgentBrokenContent = (
+    validations: {
+        uuid: string;
+        name: string;
+        type: 'chart' | 'dashboard';
+        error: string;
+        error_type: ValidationResponse['errorType'];
+        source: ValidationResponse['source'];
+    }[],
+): ManagedAgentBrokenContentItem[] => {
+    const byContentUuid = new Map<string, ManagedAgentBrokenContentItem>();
+
+    validations.forEach((validation) => {
+        const existing = byContentUuid.get(validation.uuid);
+        if (!existing) {
+            byContentUuid.set(validation.uuid, {
+                uuid: validation.uuid,
+                name: validation.name,
+                type: validation.type,
+                source: validation.source,
+                error_count: 1,
+                errors: [
+                    {
+                        error: validation.error,
+                        error_type: validation.error_type,
+                    },
+                ],
+                errors_truncated: false,
+            });
+            return;
+        }
+
+        existing.error_count += 1;
+        if (existing.errors.length < MANAGED_AGENT_BROKEN_CONTENT_ERROR_LIMIT) {
+            existing.errors.push({
+                error: validation.error,
+                error_type: validation.error_type,
+            });
+        } else {
+            existing.errors_truncated = true;
+        }
+    });
+
+    return [...byContentUuid.values()];
+};


### PR DESCRIPTION
Closes:

### Description:

Introduces a consistent formatting layer for tool list results returned by the managed agent. Instead of returning raw `JSON.stringify` output, tool results are now wrapped in a structured envelope that includes `items`, `total_count`, `returned_count`, `truncated`, and `omitted_count` fields. This gives the agent better visibility into whether results have been cut off.

A `getManagedAgentToolResultLimit` helper is added to safely parse and clamp requested limits between `1` and a maximum of `100`, replacing ad-hoc inline casts.

For broken content (validation errors), results are now grouped by content UUID rather than returning one entry per validation error. Each grouped item includes an `error_count`, a list of up to 10 individual errors, and an `errors_truncated` flag if there are more.

Preview projects are now sorted by `createdAt` ascending before being returned.