### PR TITLE
fix(table-calc): scroll required Name field into view on failed save

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -276,6 +276,7 @@ const TableCalculationModal: FC<Props> = ({
         null,
     );
     const formulaFormRef = useRef<FormulaFormHandle>(null);
+    const nameInputRef = useRef<HTMLInputElement>(null);
 
     const [sqlGeneratedByAi, setSqlGeneratedByAi] = useState(false);
     const [formulaGeneratedByAi, setFormulaGeneratedByAi] = useState(false);
@@ -386,7 +387,17 @@ const TableCalculationModal: FC<Props> = ({
 
     const handleConfirm = useCallback(() => {
         const validation = form.validate();
-        if (validation.hasErrors) return;
+        if (validation.hasErrors) {
+            // Name lives at the bottom of the modal body; on viewports
+            // shorter than the modal, the validation message renders
+            // off-screen and Save appears to silently no-op.
+            nameInputRef.current?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+            });
+            nameInputRef.current?.focus({ preventScroll: true });
+            return;
+        }
 
         const { name, sql, formula, format, type } = form.values;
         try {
@@ -959,6 +970,7 @@ const TableCalculationModal: FC<Props> = ({
                 />
 
                 <TextInput
+                    ref={nameInputRef}
                     label="Name"
                     required
                     placeholder="E.g. Cumulative order count"


### PR DESCRIPTION
## Summary

Closes [PROD-7757](https://linear.app/lightdash/issue/PROD-7757).

The `Create Table Calculation` modal places the required `Name` input at the bottom of the body. On viewports shorter than the modal's max height (~700–800px laptops), the input sits below the fold of the modal's `ScrollArea`. Clicking **Create formula** with an empty `Name` triggers `form.validate()`, which sets the error in state — but the error message renders off-screen and the save handler silently returns. From the user's POV the button looks broken.

Surfaced during a customer demo. The customer assumed the formula language couldn't express what they wanted (their actual issue — Redshift `int / int` truncation — is fixed in #23100) and tried to swap to SQL, then couldn't tell why nothing was happening when they clicked Create formula.

## Fix

Attach a ref to the `Name` `TextInput`; on validation failure, scroll it into view and focus it. `preventScroll: true` on focus so it doesn't fight the smooth scroll.

```tsx
const nameInputRef = useRef<HTMLInputElement>(null);

const handleConfirm = useCallback(() => {
    const validation = form.validate();
    if (validation.hasErrors) {
        nameInputRef.current?.scrollIntoView({
            behavior: 'smooth',
            block: 'center',
        });
        nameInputRef.current?.focus({ preventScroll: true });
        return;
    }
    // ... unchanged
});
```

Scoped to `Name` because the save button is already disabled when SQL/Formula is invalid — `Name` is the only field that can produce a click-then-error path through this handler. If we ever add another required field, generalising via `Object.keys(errors)[0]` and a ref map is a one-liner.

## Regression analysis

- **Happy path** (Name filled): unchanged. `validation.hasErrors` is false, the new branch never fires.
- **Empty Name** (the bug): now scrolls + focuses the input. Mantine then shows its native red error border + "Name is required" message in-frame.
- **Duplicate Name**: same fix applies — `validateName` already produces an error for duplicates; the scroll path makes it visible.
- **Tall viewports** where Name is already in view: `scrollIntoView({ block: 'center' })` is effectively a no-op (the field is already centered enough that scroll-to-center matches current state). No flicker.

## Verification

Manual, locally, viewport 1200×680px:

| Scenario | Before | After |
|---|---|---|
| Type formula, click Create formula with empty Name | Nothing visibly happens; user scrolls down to find the error | Modal scrolls to Name, input focuses, "Name is required" error visible in-frame |
| Type formula + Name, click Create formula | Modal closes, calc created | Unchanged |

Screenshots in the Linear ticket.

## Out of scope

PROD-7758 (`Use SQL instead` toggle invisible at typical viewport heights) is a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)