### PR TITLE
feat(filters): allow dashboard editors to lock filters (PROD-7564)

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -56,6 +56,7 @@ import {
     SavedChartsInfoForDashboardAvailableFilters,
     SessionAccount,
     SortField,
+    stripOverridesForLockedFilters,
     UpdateEmbed,
     UserAccessControls,
     UserAttributeValueMap,
@@ -966,7 +967,6 @@ export class EmbedService extends BaseService {
         return chart;
     }
 
-    // eslint-disable-next-line class-methods-use-this
     private async _getAppliedDashboardFilters(
         account: AnonymousAccount,
         explore: Explore,
@@ -976,23 +976,50 @@ export class EmbedService extends BaseService {
     ) {
         const availableFieldIds = getAvailableFilterFieldIds(explore);
 
-        let appliedDashboardFilters = getDashboardFiltersForTileAndTables(
-            tileUuid,
-            availableFieldIds,
-            dashboard.filters,
-        );
+        let effectiveFilters: DashboardFilters = dashboard.filters;
+
         if (
             dashboardFilters &&
             isFilterInteractivityEnabled(account.access.filtering)
         ) {
-            appliedDashboardFilters = getDashboardFiltersForTileAndTables(
-                tileUuid,
-                availableFieldIds,
-                dashboardFilters,
+            const { filters: safeOverrides, droppedCount } =
+                stripOverridesForLockedFilters(
+                    dashboard.filters,
+                    dashboardFilters,
+                );
+
+            if (droppedCount > 0) {
+                this.logger.debug(
+                    `Stripped ${droppedCount} embed filter override(s) targeting locked dashboard filters on dashboard ${dashboard.uuid}`,
+                );
+            }
+
+            const lockedDimensions = dashboard.filters.dimensions.filter(
+                (rule) => rule.locked,
             );
+            const lockedMetrics = dashboard.filters.metrics.filter(
+                (rule) => rule.locked,
+            );
+            const lockedTableCalculations =
+                dashboard.filters.tableCalculations.filter(
+                    (rule) => rule.locked,
+                );
+
+            effectiveFilters = {
+                dimensions: [...lockedDimensions, ...safeOverrides.dimensions],
+                metrics: [...lockedMetrics, ...safeOverrides.metrics],
+                tableCalculations: [
+                    ...lockedTableCalculations,
+                    ...safeOverrides.tableCalculations,
+                ],
+            };
         }
 
-        return appliedDashboardFilters;
+        return getDashboardFiltersForTileAndTables(
+            tileUuid,
+            availableFieldIds,
+            effectiveFilters,
+        );
     }
 
     async executeAsyncDashboardTileQuery({

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -45,6 +45,7 @@ import {
     isExploreError,
     isFilterableDimension,
     isFilterInteractivityEnabled,
+    isFilterLockedOnTab,
     isParameterInteractivityEnabled,
     MetricQuery,
     NotFoundError,
@@ -56,7 +57,7 @@ import {
     SavedChartsInfoForDashboardAvailableFilters,
     SessionAccount,
     SortField,
-    stripOverridesForLockedFilters,
+    stripOverridesForLockedFiltersOnTab,
     UpdateEmbed,
     UserAccessControls,
     UserAttributeValueMap,
@@ -976,6 +977,11 @@ export class EmbedService extends BaseService {
     ) {
         const availableFieldIds = getAvailableFilterFieldIds(explore);
 
+        // Look up which tab this tile belongs to so we can evaluate lock state
+        // for the right tab. Tiles created before tabs may have null/undefined.
+        const tile = dashboard.tiles.find((t) => t.uuid === tileUuid);
+        const tileTabUuid = tile?.tabUuid ?? undefined;
+
         let effectiveFilters: DashboardFilters = dashboard.filters;
 
         if (
@@ -983,26 +989,27 @@ export class EmbedService extends BaseService {
             isFilterInteractivityEnabled(account.access.filtering)
         ) {
             const { filters: safeOverrides, droppedCount } =
-                stripOverridesForLockedFilters(
+                stripOverridesForLockedFiltersOnTab(
                     dashboard.filters,
                     dashboardFilters,
+                    tileTabUuid,
                 );
 
             if (droppedCount > 0) {
                 this.logger.debug(
-                    `Stripped ${droppedCount} embed filter override(s) targeting locked dashboard filters on dashboard ${dashboard.uuid}`,
+                    `Stripped ${droppedCount} embed filter override(s) targeting filters locked on tab ${tileTabUuid} (dashboard ${dashboard.uuid})`,
                 );
             }
 
             const lockedDimensions = dashboard.filters.dimensions.filter(
-                (rule) => rule.locked,
+                (rule) => isFilterLockedOnTab(rule, tileTabUuid),
             );
-            const lockedMetrics = dashboard.filters.metrics.filter(
-                (rule) => rule.locked,
+            const lockedMetrics = dashboard.filters.metrics.filter((rule) =>
+                isFilterLockedOnTab(rule, tileTabUuid),
             );
             const lockedTableCalculations =
-                dashboard.filters.tableCalculations.filter(
-                    (rule) => rule.locked,
+                dashboard.filters.tableCalculations.filter((rule) =>
+                    isFilterLockedOnTab(rule, tileTabUuid),
                 );
 
             effectiveFilters = {

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -147,6 +147,16 @@ export enum FeatureFlags {
      * no regression.
      */
     AiDiscoverFieldsSubagent = 'ai-discover-fields-subagent',
+
+    /**
+     * Allow dashboard editors to mark individual dashboard filters as locked.
+     * Locked filters are visible to viewers but cannot be edited from view
+     * mode, and URL/embed filter overrides targeting a locked filter's field
+     * are ignored. Gates the authoring UI; the override-stripping behaviour
+     * always runs regardless of the flag so saved-locked filters stay safe
+     * if the flag is later turned off.
+     */
+    LockDashboardFilters = 'lock-dashboard-filters',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -401,6 +401,10 @@ export const applyDimensionOverrides = (
                 return {
                     ...override,
                     tileTargets: dimension.tileTargets,
+                    // Lock state belongs to the saved dashboard and must not
+                    // be assertable from URL/scheduler overrides — always
+                    // re-apply the saved rule's lockedTabUuids.
+                    lockedTabUuids: dimension.lockedTabUuids,
                 };
             }
             return dimension;

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -184,7 +184,7 @@ export type FilterDashboardToRule = DashboardFilterRule & {
 
 export type DashboardFilterRuleOverride = Omit<
     DashboardFilterRule,
-    'tileTargets'
+    'tileTargets' | 'lockedTabUuids'
 >;
 
 export type DateFilterSettings = {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -167,6 +167,7 @@ export type DashboardFilterRule<
     tileTargets?: Record<string, DashboardTileTarget>;
     label: undefined | string;
     singleValue?: boolean;
+    locked?: boolean;
 };
 
 export type FilterDashboardToRule = DashboardFilterRule & {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -167,7 +167,13 @@ export type DashboardFilterRule<
     tileTargets?: Record<string, DashboardTileTarget>;
     label: undefined | string;
     singleValue?: boolean;
-    locked?: boolean;
+    /**
+     * Tab UUIDs where this filter is locked. When the active tab is in this
+     * list, viewers see the filter but cannot change it, and URL / embed
+     * filter overrides targeting the same field are ignored on that tab.
+     * Empty or omitted means the filter is not locked anywhere.
+     */
+    lockedTabUuids?: string[];
 };
 
 export type FilterDashboardToRule = DashboardFilterRule & {

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -22,6 +22,7 @@ import {
     overrideChartFilter,
     reduceRequiredDimensionFiltersToFilterRules,
     resetRequiredFilterRules,
+    stripOverridesForLockedFilters,
     trackWhichTimeBasedMetricFiltersToOverride,
 } from './filters';
 import {
@@ -1219,5 +1220,175 @@ describe('applyDashboardFiltersForTile', () => {
             target: { fieldId: 'orders_status' },
             values: [true],
         });
+    });
+});
+
+describe('stripOverridesForLockedFilters', () => {
+    const makeRule = (
+        id: string,
+        fieldId: string,
+        tableName: string,
+        opts: { locked?: boolean; values?: unknown[] } = {},
+    ): DashboardFilterRule => ({
+        id,
+        operator: FilterOperator.EQUALS,
+        target: { fieldId, tableName },
+        values: opts.values ?? ['x'],
+        label: undefined,
+        ...(opts.locked !== undefined ? { locked: opts.locked } : {}),
+    });
+
+    test('drops override rules that target a locked saved field', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [
+                makeRule('o-1', 'orders_status', 'orders', {
+                    values: ['returned'],
+                }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFilters(saved, overrides);
+        expect(result.filters.dimensions).toEqual([]);
+        expect(result.droppedCount).toBe(1);
+    });
+
+    test('keeps override rules that target a different field', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'orders_amount', 'orders')],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFilters(saved, overrides);
+        expect(result.filters.dimensions).toHaveLength(1);
+        expect(result.filters.dimensions[0].id).toBe('o-1');
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('does not cross filter groups (dim lock does not strip metric override)', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [],
+            metrics: [makeRule('o-1', 'orders_status', 'orders')],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFilters(saved, overrides);
+        expect(result.filters.metrics).toHaveLength(1);
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('does not strip overrides when saved filter is not locked', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', { locked: false }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'orders_status', 'orders')],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFilters(saved, overrides);
+        expect(result.filters.dimensions).toHaveLength(1);
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('matches on both fieldId and tableName (same fieldId different table is kept)', () => {
+        const saved = {
+            dimensions: [makeRule('s-1', 'status', 'orders', { locked: true })],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'status', 'customers')],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFilters(saved, overrides);
+        expect(result.filters.dimensions).toHaveLength(1);
+        expect(result.filters.dimensions[0].id).toBe('o-1');
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('empty overrides yields empty result', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFilters(saved, overrides);
+        expect(result.filters.dimensions).toEqual([]);
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('no locked filters means identity', () => {
+        const saved = {
+            dimensions: [makeRule('s-1', 'orders_status', 'orders')],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'orders_status', 'orders')],
+            metrics: [makeRule('o-2', 'orders_amount', 'orders')],
+            tableCalculations: [makeRule('o-3', 'profit_pct', 'orders')],
+        };
+        const result = stripOverridesForLockedFilters(saved, overrides);
+        expect(result.filters).toEqual(overrides);
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('reports total dropped count across all groups', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
+            ],
+            metrics: [
+                makeRule('s-2', 'orders_total_sales', 'orders', {
+                    locked: true,
+                }),
+            ],
+            tableCalculations: [
+                makeRule('s-3', 'profit_pct', 'orders', { locked: true }),
+            ],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'orders_status', 'orders')],
+            metrics: [makeRule('o-2', 'orders_total_sales', 'orders')],
+            tableCalculations: [makeRule('o-3', 'profit_pct', 'orders')],
+        };
+        const result = stripOverridesForLockedFilters(saved, overrides);
+        expect(result.filters.dimensions).toEqual([]);
+        expect(result.filters.metrics).toEqual([]);
+        expect(result.filters.tableCalculations).toEqual([]);
+        expect(result.droppedCount).toBe(3);
     });
 });

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -22,7 +22,7 @@ import {
     overrideChartFilter,
     reduceRequiredDimensionFiltersToFilterRules,
     resetRequiredFilterRules,
-    stripOverridesForLockedFilters,
+    stripOverridesForLockedFiltersOnTab,
     trackWhichTimeBasedMetricFiltersToOverride,
 } from './filters';
 import {
@@ -1223,25 +1223,29 @@ describe('applyDashboardFiltersForTile', () => {
     });
 });
 
-describe('stripOverridesForLockedFilters', () => {
+describe('stripOverridesForLockedFiltersOnTab', () => {
+    const TAB_A = 'tab-a';
+    const TAB_B = 'tab-b';
     const makeRule = (
         id: string,
         fieldId: string,
         tableName: string,
-        opts: { locked?: boolean; values?: unknown[] } = {},
+        opts: { lockedTabUuids?: string[]; values?: unknown[] } = {},
     ): DashboardFilterRule => ({
         id,
         operator: FilterOperator.EQUALS,
         target: { fieldId, tableName },
         values: opts.values ?? ['x'],
         label: undefined,
-        ...(opts.locked !== undefined ? { locked: opts.locked } : {}),
+        ...(opts.lockedTabUuids ? { lockedTabUuids: opts.lockedTabUuids } : {}),
     });
 
-    test('drops override rules that target a locked saved field', () => {
+    test('drops override on a tab where the rule is locked', () => {
         const saved = {
             dimensions: [
-                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: [TAB_A],
+                }),
             ],
             metrics: [],
             tableCalculations: [],
@@ -1255,15 +1259,45 @@ describe('stripOverridesForLockedFilters', () => {
             metrics: [],
             tableCalculations: [],
         };
-        const result = stripOverridesForLockedFilters(saved, overrides);
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            TAB_A,
+        );
         expect(result.filters.dimensions).toEqual([]);
         expect(result.droppedCount).toBe(1);
     });
 
-    test('keeps override rules that target a different field', () => {
+    test('keeps override on a tab where the rule is NOT locked', () => {
         const saved = {
             dimensions: [
-                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: [TAB_A],
+                }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'orders_status', 'orders')],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            TAB_B,
+        );
+        expect(result.filters.dimensions).toHaveLength(1);
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('keeps override on a different field even if a sibling field is locked', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: [TAB_A],
+                }),
             ],
             metrics: [],
             tableCalculations: [],
@@ -1273,16 +1307,21 @@ describe('stripOverridesForLockedFilters', () => {
             metrics: [],
             tableCalculations: [],
         };
-        const result = stripOverridesForLockedFilters(saved, overrides);
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            TAB_A,
+        );
         expect(result.filters.dimensions).toHaveLength(1);
-        expect(result.filters.dimensions[0].id).toBe('o-1');
         expect(result.droppedCount).toBe(0);
     });
 
-    test('does not cross filter groups (dim lock does not strip metric override)', () => {
+    test('does not cross filter groups (dim lock leaves metric overrides alone)', () => {
         const saved = {
             dimensions: [
-                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: [TAB_A],
+                }),
             ],
             metrics: [],
             tableCalculations: [],
@@ -1292,32 +1331,22 @@ describe('stripOverridesForLockedFilters', () => {
             metrics: [makeRule('o-1', 'orders_status', 'orders')],
             tableCalculations: [],
         };
-        const result = stripOverridesForLockedFilters(saved, overrides);
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            TAB_A,
+        );
         expect(result.filters.metrics).toHaveLength(1);
         expect(result.droppedCount).toBe(0);
     });
 
-    test('does not strip overrides when saved filter is not locked', () => {
+    test('matches on both fieldId and tableName', () => {
         const saved = {
             dimensions: [
-                makeRule('s-1', 'orders_status', 'orders', { locked: false }),
+                makeRule('s-1', 'status', 'orders', {
+                    lockedTabUuids: [TAB_A],
+                }),
             ],
-            metrics: [],
-            tableCalculations: [],
-        };
-        const overrides = {
-            dimensions: [makeRule('o-1', 'orders_status', 'orders')],
-            metrics: [],
-            tableCalculations: [],
-        };
-        const result = stripOverridesForLockedFilters(saved, overrides);
-        expect(result.filters.dimensions).toHaveLength(1);
-        expect(result.droppedCount).toBe(0);
-    });
-
-    test('matches on both fieldId and tableName (same fieldId different table is kept)', () => {
-        const saved = {
-            dimensions: [makeRule('s-1', 'status', 'orders', { locked: true })],
             metrics: [],
             tableCalculations: [],
         };
@@ -1326,69 +1355,81 @@ describe('stripOverridesForLockedFilters', () => {
             metrics: [],
             tableCalculations: [],
         };
-        const result = stripOverridesForLockedFilters(saved, overrides);
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            TAB_A,
+        );
         expect(result.filters.dimensions).toHaveLength(1);
-        expect(result.filters.dimensions[0].id).toBe('o-1');
         expect(result.droppedCount).toBe(0);
     });
 
-    test('empty overrides yields empty result', () => {
+    test('undefined tabUuid means nothing is stripped', () => {
         const saved = {
             dimensions: [
-                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
-            ],
-            metrics: [],
-            tableCalculations: [],
-        };
-        const overrides = {
-            dimensions: [],
-            metrics: [],
-            tableCalculations: [],
-        };
-        const result = stripOverridesForLockedFilters(saved, overrides);
-        expect(result.filters.dimensions).toEqual([]);
-        expect(result.droppedCount).toBe(0);
-    });
-
-    test('no locked filters means identity', () => {
-        const saved = {
-            dimensions: [makeRule('s-1', 'orders_status', 'orders')],
-            metrics: [],
-            tableCalculations: [],
-        };
-        const overrides = {
-            dimensions: [makeRule('o-1', 'orders_status', 'orders')],
-            metrics: [makeRule('o-2', 'orders_amount', 'orders')],
-            tableCalculations: [makeRule('o-3', 'profit_pct', 'orders')],
-        };
-        const result = stripOverridesForLockedFilters(saved, overrides);
-        expect(result.filters).toEqual(overrides);
-        expect(result.droppedCount).toBe(0);
-    });
-
-    test('reports total dropped count across all groups', () => {
-        const saved = {
-            dimensions: [
-                makeRule('s-1', 'orders_status', 'orders', { locked: true }),
-            ],
-            metrics: [
-                makeRule('s-2', 'orders_total_sales', 'orders', {
-                    locked: true,
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: [TAB_A],
                 }),
             ],
-            tableCalculations: [
-                makeRule('s-3', 'profit_pct', 'orders', { locked: true }),
-            ],
+            metrics: [],
+            tableCalculations: [],
         };
         const overrides = {
             dimensions: [makeRule('o-1', 'orders_status', 'orders')],
-            metrics: [makeRule('o-2', 'orders_total_sales', 'orders')],
-            tableCalculations: [makeRule('o-3', 'profit_pct', 'orders')],
+            metrics: [],
+            tableCalculations: [],
         };
-        const result = stripOverridesForLockedFilters(saved, overrides);
-        expect(result.filters.dimensions).toEqual([]);
-        expect(result.filters.metrics).toEqual([]);
-        expect(result.filters.tableCalculations).toEqual([]);
-        expect(result.droppedCount).toBe(3);
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            undefined,
+        );
+        expect(result.filters.dimensions).toHaveLength(1);
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('rule locked on multiple tabs is enforced on each', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: [TAB_A, TAB_B],
+                }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'orders_status', 'orders')],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const a = stripOverridesForLockedFiltersOnTab(saved, overrides, TAB_A);
+        const b = stripOverridesForLockedFiltersOnTab(saved, overrides, TAB_B);
+        expect(a.droppedCount).toBe(1);
+        expect(b.droppedCount).toBe(1);
+    });
+
+    test('empty lockedTabUuids never strips', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: [],
+                }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'orders_status', 'orders')],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            TAB_A,
+        );
+        expect(result.filters.dimensions).toHaveLength(1);
+        expect(result.droppedCount).toBe(0);
     });
 });

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -908,10 +908,22 @@ export const getDashboardFiltersForTile = (
     ]),
 });
 
-const buildLockedTargetKeys = (rules: DashboardFilterRule[]): Set<string> => {
+export const isFilterLockedOnTab = (
+    rule: Pick<DashboardFilterRule, 'lockedTabUuids'>,
+    tabUuid: string | undefined,
+): boolean => {
+    if (!rule.lockedTabUuids || rule.lockedTabUuids.length === 0) return false;
+    if (!tabUuid) return false;
+    return rule.lockedTabUuids.includes(tabUuid);
+};
+
+const buildLockedTargetKeysForTab = (
+    rules: DashboardFilterRule[],
+    tabUuid: string | undefined,
+): Set<string> => {
     const keys = new Set<string>();
     rules.forEach((rule) => {
-        if (rule.locked) {
+        if (isFilterLockedOnTab(rule, tabUuid)) {
             keys.add(`${rule.target.tableName}::${rule.target.fieldId}`);
         }
     });
@@ -942,21 +954,27 @@ export type StripOverridesForLockedFiltersResult = {
     droppedCount: number;
 };
 
-export const stripOverridesForLockedFilters = (
+/**
+ * Drop override rules that target a field whose saved filter is locked on the
+ * given tab. When `tabUuid` is undefined nothing is stripped — lock state only
+ * applies when we know which tab is being evaluated.
+ */
+export const stripOverridesForLockedFiltersOnTab = (
     saved: DashboardFilters,
     overrides: DashboardFilters,
+    tabUuid: string | undefined,
 ): StripOverridesForLockedFiltersResult => {
     const dimensions = dropRulesTargetingLockedFields(
         overrides.dimensions,
-        buildLockedTargetKeys(saved.dimensions),
+        buildLockedTargetKeysForTab(saved.dimensions, tabUuid),
     );
     const metrics = dropRulesTargetingLockedFields(
         overrides.metrics,
-        buildLockedTargetKeys(saved.metrics),
+        buildLockedTargetKeysForTab(saved.metrics, tabUuid),
     );
     const tableCalculations = dropRulesTargetingLockedFields(
         overrides.tableCalculations,
-        buildLockedTargetKeys(saved.tableCalculations),
+        buildLockedTargetKeysForTab(saved.tableCalculations, tabUuid),
     );
     return {
         filters: {

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -908,6 +908,69 @@ export const getDashboardFiltersForTile = (
     ]),
 });
 
+const buildLockedTargetKeys = (rules: DashboardFilterRule[]): Set<string> => {
+    const keys = new Set<string>();
+    rules.forEach((rule) => {
+        if (rule.locked) {
+            keys.add(`${rule.target.tableName}::${rule.target.fieldId}`);
+        }
+    });
+    return keys;
+};
+
+const dropRulesTargetingLockedFields = (
+    overrideRules: DashboardFilterRule[],
+    lockedKeys: Set<string>,
+): { kept: DashboardFilterRule[]; droppedCount: number } => {
+    if (lockedKeys.size === 0) {
+        return { kept: overrideRules, droppedCount: 0 };
+    }
+    let droppedCount = 0;
+    const kept = overrideRules.filter((rule) => {
+        const key = `${rule.target.tableName}::${rule.target.fieldId}`;
+        if (lockedKeys.has(key)) {
+            droppedCount += 1;
+            return false;
+        }
+        return true;
+    });
+    return { kept, droppedCount };
+};
+
+export type StripOverridesForLockedFiltersResult = {
+    filters: DashboardFilters;
+    droppedCount: number;
+};
+
+export const stripOverridesForLockedFilters = (
+    saved: DashboardFilters,
+    overrides: DashboardFilters,
+): StripOverridesForLockedFiltersResult => {
+    const dimensions = dropRulesTargetingLockedFields(
+        overrides.dimensions,
+        buildLockedTargetKeys(saved.dimensions),
+    );
+    const metrics = dropRulesTargetingLockedFields(
+        overrides.metrics,
+        buildLockedTargetKeys(saved.metrics),
+    );
+    const tableCalculations = dropRulesTargetingLockedFields(
+        overrides.tableCalculations,
+        buildLockedTargetKeys(saved.tableCalculations),
+    );
+    return {
+        filters: {
+            dimensions: dimensions.kept,
+            metrics: metrics.kept,
+            tableCalculations: tableCalculations.kept,
+        },
+        droppedCount:
+            dimensions.droppedCount +
+            metrics.droppedCount +
+            tableCalculations.droppedCount,
+    };
+};
+
 const combineFilterGroups = (
     a: FilterGroup | undefined,
     b: FilterGroup | undefined,

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.module.css
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.module.css
@@ -13,6 +13,28 @@
     background-color: rgba(var(--mantine-color-background-0), 0.7);
 }
 
+.lockSlot {
+    display: inline-flex;
+    align-items: center;
+    max-width: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition:
+        max-width 200ms ease,
+        opacity 150ms ease 50ms;
+}
+
+.button:hover .lockSlot,
+.button:focus-within .lockSlot {
+    max-width: 24px;
+    opacity: 1;
+}
+
+.lockSlotActive {
+    display: inline-flex;
+    align-items: center;
+}
+
 .label {
     max-width: 800px;
     white-space: nowrap;

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -38,6 +38,8 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import FilterConfiguration from '../FilterConfiguration';
 import { hasFilterValueSet } from '../FilterConfiguration/utils';
 import classes from './Filter.module.css';
@@ -85,6 +87,7 @@ const Filter: FC<Props> = ({
     const isLockFilterEnabled =
         lockDashboardFiltersFlag?.enabled ?? import.meta.env.DEV;
     const isLockedOnActiveTab = isFilterLockedOnTab(filterRule, activeTabUuid);
+    const { track } = useTracking();
     const sqlChartTilesMetadata = useDashboardTileStatusContext(
         (c) => c.sqlChartTilesMetadata,
     );
@@ -339,6 +342,27 @@ const Filter: FC<Props> = ({
                                                                               ...existing,
                                                                               activeTabUuid,
                                                                           ];
+                                                                track({
+                                                                    name: EventName.DASHBOARD_FILTER_LOCK_TOGGLED,
+                                                                    properties:
+                                                                        {
+                                                                            action: isLockedOnActiveTab
+                                                                                ? 'unlock'
+                                                                                : 'lock',
+                                                                            dashboardUuid:
+                                                                                dashboard?.uuid,
+                                                                            tabUuid:
+                                                                                activeTabUuid,
+                                                                            fieldId:
+                                                                                filterRule
+                                                                                    .target
+                                                                                    .fieldId,
+                                                                            tableName:
+                                                                                filterRule
+                                                                                    .target
+                                                                                    .tableName,
+                                                                        },
+                                                                });
                                                                 onUpdate({
                                                                     ...filterRule,
                                                                     lockedTabUuids:

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -1,6 +1,7 @@
 import {
     applyDefaultTileTargets,
     DimensionType,
+    FeatureFlags,
     getFilterTypeFromItemType,
     type DashboardFilterableField,
     type DashboardFilterRule,
@@ -10,6 +11,7 @@ import {
     Badge,
     Box,
     Button,
+    Group,
     HoverCard,
     Indicator,
     Popover,
@@ -18,7 +20,12 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { useDisclosure, useId } from '@mantine-8/hooks';
-import { IconGripVertical, IconX } from '@tabler/icons-react';
+import {
+    IconGripVertical,
+    IconLock,
+    IconLockOpen,
+    IconX,
+} from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import {
     formatDisplayValue,
@@ -27,6 +34,7 @@ import {
     getFilterRuleTables,
 } from '../../../components/common/Filters/FilterInputs/utils';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import FilterConfiguration from '../FilterConfiguration';
@@ -68,6 +76,11 @@ const Filter: FC<Props> = ({
     const allFilterableFields = useDashboardContext(
         (c) => c.allFilterableFields,
     );
+    const { data: lockDashboardFiltersFlag } = useServerFeatureFlag(
+        FeatureFlags.LockDashboardFilters,
+    );
+    const isLockFilterEnabled =
+        lockDashboardFiltersFlag?.enabled ?? import.meta.env.DEV;
     const sqlChartTilesMetadata = useDashboardTileStatusContext(
         (c) => c.sqlChartTilesMetadata,
     );
@@ -187,6 +200,8 @@ const Filter: FC<Props> = ({
     const hasUnsetRequiredFilter =
         filterRule.required && !hasFilterValueSet(filterRule);
 
+    const isReadOnlyLocked = !!filterRule.locked && !isEditMode && !isTemporary;
+
     const handleClose = useCallback(() => {
         if (isPopoverOpen) onPopoverClose();
         closeSubPopover();
@@ -210,7 +225,7 @@ const Filter: FC<Props> = ({
                 closeOnClickOutside={!isSubPopoverOpen}
                 onClose={handleClose}
                 onDismiss={!isSubPopoverOpen ? handleClose : undefined}
-                disabled={disabled}
+                disabled={disabled || isReadOnlyLocked}
                 transitionProps={{ transition: 'pop-top-left' }}
                 withArrow
                 shadow="md"
@@ -239,9 +254,15 @@ const Filter: FC<Props> = ({
                     >
                         <Tooltip
                             fz="xs"
-                            label={orphanedTooltip}
-                            disabled={!isOrphaned}
+                            label={
+                                isReadOnlyLocked
+                                    ? 'Locked by the dashboard editor — switch to edit mode to change it'
+                                    : orphanedTooltip
+                            }
+                            disabled={!isOrphaned && !isReadOnlyLocked}
                             withinPortal
+                            multiline
+                            maw={300}
                         >
                             <Button
                                 pos="relative"
@@ -274,26 +295,94 @@ const Filter: FC<Props> = ({
                                     )
                                 }
                                 rightSection={
-                                    (isEditMode || isTemporary) && (
-                                        <ActionIcon
-                                            onClick={onRemove}
-                                            size="xs"
-                                            color="dark"
-                                            radius="xl"
-                                            variant="subtle"
-                                        >
-                                            <MantineIcon
-                                                size="sm"
-                                                icon={IconX}
-                                            />
-                                        </ActionIcon>
-                                    )
+                                    <Group gap={2} wrap="nowrap">
+                                        {isLockFilterEnabled &&
+                                            isEditMode &&
+                                            !isTemporary && (
+                                                <span
+                                                    className={
+                                                        filterRule.locked
+                                                            ? classes.lockSlotActive
+                                                            : classes.lockSlot
+                                                    }
+                                                >
+                                                    <Tooltip
+                                                        fz="xs"
+                                                        label={
+                                                            filterRule.locked
+                                                                ? 'Unlock filter'
+                                                                : 'Lock filter for viewers'
+                                                        }
+                                                        withinPortal
+                                                    >
+                                                        <ActionIcon
+                                                            onClick={(e) => {
+                                                                e.stopPropagation();
+                                                                onUpdate({
+                                                                    ...filterRule,
+                                                                    locked: !filterRule.locked,
+                                                                });
+                                                            }}
+                                                            size="xs"
+                                                            color="dark"
+                                                            radius="xl"
+                                                            variant="subtle"
+                                                            aria-label={
+                                                                filterRule.locked
+                                                                    ? 'Unlock filter'
+                                                                    : 'Lock filter for viewers'
+                                                            }
+                                                        >
+                                                            <MantineIcon
+                                                                size="sm"
+                                                                icon={
+                                                                    filterRule.locked
+                                                                        ? IconLock
+                                                                        : IconLockOpen
+                                                                }
+                                                            />
+                                                        </ActionIcon>
+                                                    </Tooltip>
+                                                </span>
+                                            )}
+                                        {!isEditMode && filterRule.locked && (
+                                            <span
+                                                className={
+                                                    classes.lockSlotActive
+                                                }
+                                                aria-label="Filter is locked"
+                                            >
+                                                <MantineIcon
+                                                    size="sm"
+                                                    icon={IconLock}
+                                                    color="gray"
+                                                />
+                                            </span>
+                                        )}
+                                        {(isEditMode || isTemporary) && (
+                                            <ActionIcon
+                                                onClick={onRemove}
+                                                size="xs"
+                                                color="dark"
+                                                radius="xl"
+                                                variant="subtle"
+                                            >
+                                                <MantineIcon
+                                                    size="sm"
+                                                    icon={IconX}
+                                                />
+                                            </ActionIcon>
+                                        )}
+                                    </Group>
                                 }
-                                onClick={() =>
-                                    isPopoverOpen
-                                        ? handleClose()
-                                        : onPopoverOpen(popoverId)
-                                }
+                                onClick={() => {
+                                    if (isReadOnlyLocked) return;
+                                    if (isPopoverOpen) {
+                                        handleClose();
+                                    } else {
+                                        onPopoverOpen(popoverId);
+                                    }
+                                }}
                             >
                                 <Box
                                     style={{

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -27,7 +27,7 @@ import {
     IconLockOpen,
     IconX,
 } from '@tabler/icons-react';
-import { useCallback, useMemo, type FC } from 'react';
+import { useCallback, useMemo, type FC, type MouseEvent } from 'react';
 import {
     formatDisplayValue,
     getConditionalRuleLabel,
@@ -88,6 +88,39 @@ const Filter: FC<Props> = ({
         lockDashboardFiltersFlag?.enabled ?? import.meta.env.DEV;
     const isLockedOnActiveTab = isFilterLockedOnTab(filterRule, activeTabUuid);
     const { track } = useTracking();
+    const handleLockToggle = useCallback(
+        (e: MouseEvent) => {
+            e.stopPropagation();
+            if (!activeTabUuid) return;
+            const existing = filterRule.lockedTabUuids ?? [];
+            const nextTabUuids = isLockedOnActiveTab
+                ? existing.filter((uuid) => uuid !== activeTabUuid)
+                : [...existing, activeTabUuid];
+            track({
+                name: EventName.DASHBOARD_FILTER_LOCK_TOGGLED,
+                properties: {
+                    action: isLockedOnActiveTab ? 'unlock' : 'lock',
+                    dashboardUuid: dashboard?.uuid,
+                    tabUuid: activeTabUuid,
+                    fieldId: filterRule.target.fieldId,
+                    tableName: filterRule.target.tableName,
+                },
+            });
+            onUpdate({
+                ...filterRule,
+                lockedTabUuids:
+                    nextTabUuids.length > 0 ? nextTabUuids : undefined,
+            });
+        },
+        [
+            activeTabUuid,
+            dashboard?.uuid,
+            filterRule,
+            isLockedOnActiveTab,
+            onUpdate,
+            track,
+        ],
+    );
     const sqlChartTilesMetadata = useDashboardTileStatusContext(
         (c) => c.sqlChartTilesMetadata,
     );
@@ -324,54 +357,9 @@ const Filter: FC<Props> = ({
                                                         withinPortal
                                                     >
                                                         <ActionIcon
-                                                            onClick={(e) => {
-                                                                e.stopPropagation();
-                                                                const existing =
-                                                                    filterRule.lockedTabUuids ??
-                                                                    [];
-                                                                const nextTabUuids =
-                                                                    isLockedOnActiveTab
-                                                                        ? existing.filter(
-                                                                              (
-                                                                                  uuid,
-                                                                              ) =>
-                                                                                  uuid !==
-                                                                                  activeTabUuid,
-                                                                          )
-                                                                        : [
-                                                                              ...existing,
-                                                                              activeTabUuid,
-                                                                          ];
-                                                                track({
-                                                                    name: EventName.DASHBOARD_FILTER_LOCK_TOGGLED,
-                                                                    properties:
-                                                                        {
-                                                                            action: isLockedOnActiveTab
-                                                                                ? 'unlock'
-                                                                                : 'lock',
-                                                                            dashboardUuid:
-                                                                                dashboard?.uuid,
-                                                                            tabUuid:
-                                                                                activeTabUuid,
-                                                                            fieldId:
-                                                                                filterRule
-                                                                                    .target
-                                                                                    .fieldId,
-                                                                            tableName:
-                                                                                filterRule
-                                                                                    .target
-                                                                                    .tableName,
-                                                                        },
-                                                                });
-                                                                onUpdate({
-                                                                    ...filterRule,
-                                                                    lockedTabUuids:
-                                                                        nextTabUuids.length >
-                                                                        0
-                                                                            ? nextTabUuids
-                                                                            : undefined,
-                                                                });
-                                                            }}
+                                                            onClick={
+                                                                handleLockToggle
+                                                            }
                                                             size="xs"
                                                             color="dark"
                                                             radius="xl"

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -3,6 +3,7 @@ import {
     DimensionType,
     FeatureFlags,
     getFilterTypeFromItemType,
+    isFilterLockedOnTab,
     type DashboardFilterableField,
     type DashboardFilterRule,
 } from '@lightdash/common';
@@ -73,6 +74,8 @@ const Filter: FC<Props> = ({
     const dashboard = useDashboardContext((c) => c.dashboard);
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
+    const activeTab = useDashboardContext((c) => c.activeTab);
+    const activeTabUuid = activeTab?.uuid;
     const allFilterableFields = useDashboardContext(
         (c) => c.allFilterableFields,
     );
@@ -81,6 +84,7 @@ const Filter: FC<Props> = ({
     );
     const isLockFilterEnabled =
         lockDashboardFiltersFlag?.enabled ?? import.meta.env.DEV;
+    const isLockedOnActiveTab = isFilterLockedOnTab(filterRule, activeTabUuid);
     const sqlChartTilesMetadata = useDashboardTileStatusContext(
         (c) => c.sqlChartTilesMetadata,
     );
@@ -200,7 +204,7 @@ const Filter: FC<Props> = ({
     const hasUnsetRequiredFilter =
         filterRule.required && !hasFilterValueSet(filterRule);
 
-    const isReadOnlyLocked = !!filterRule.locked && !isEditMode && !isTemporary;
+    const isReadOnlyLocked = isLockedOnActiveTab && !isEditMode && !isTemporary;
 
     const handleClose = useCallback(() => {
         if (isPopoverOpen) onPopoverClose();
@@ -298,10 +302,11 @@ const Filter: FC<Props> = ({
                                     <Group gap={2} wrap="nowrap">
                                         {isLockFilterEnabled &&
                                             isEditMode &&
-                                            !isTemporary && (
+                                            !isTemporary &&
+                                            activeTabUuid && (
                                                 <span
                                                     className={
-                                                        filterRule.locked
+                                                        isLockedOnActiveTab
                                                             ? classes.lockSlotActive
                                                             : classes.lockSlot
                                                     }
@@ -309,18 +314,38 @@ const Filter: FC<Props> = ({
                                                     <Tooltip
                                                         fz="xs"
                                                         label={
-                                                            filterRule.locked
-                                                                ? 'Unlock filter'
-                                                                : 'Lock filter for viewers'
+                                                            isLockedOnActiveTab
+                                                                ? 'Unlock filter on this tab'
+                                                                : 'Lock filter on this tab'
                                                         }
                                                         withinPortal
                                                     >
                                                         <ActionIcon
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
+                                                                const existing =
+                                                                    filterRule.lockedTabUuids ??
+                                                                    [];
+                                                                const nextTabUuids =
+                                                                    isLockedOnActiveTab
+                                                                        ? existing.filter(
+                                                                              (
+                                                                                  uuid,
+                                                                              ) =>
+                                                                                  uuid !==
+                                                                                  activeTabUuid,
+                                                                          )
+                                                                        : [
+                                                                              ...existing,
+                                                                              activeTabUuid,
+                                                                          ];
                                                                 onUpdate({
                                                                     ...filterRule,
-                                                                    locked: !filterRule.locked,
+                                                                    lockedTabUuids:
+                                                                        nextTabUuids.length >
+                                                                        0
+                                                                            ? nextTabUuids
+                                                                            : undefined,
                                                                 });
                                                             }}
                                                             size="xs"
@@ -328,15 +353,15 @@ const Filter: FC<Props> = ({
                                                             radius="xl"
                                                             variant="subtle"
                                                             aria-label={
-                                                                filterRule.locked
-                                                                    ? 'Unlock filter'
-                                                                    : 'Lock filter for viewers'
+                                                                isLockedOnActiveTab
+                                                                    ? 'Unlock filter on this tab'
+                                                                    : 'Lock filter on this tab'
                                                             }
                                                         >
                                                             <MantineIcon
                                                                 size="sm"
                                                                 icon={
-                                                                    filterRule.locked
+                                                                    isLockedOnActiveTab
                                                                         ? IconLock
                                                                         : IconLockOpen
                                                                 }
@@ -345,12 +370,12 @@ const Filter: FC<Props> = ({
                                                     </Tooltip>
                                                 </span>
                                             )}
-                                        {!isEditMode && filterRule.locked && (
+                                        {!isEditMode && isLockedOnActiveTab && (
                                             <span
                                                 className={
                                                     classes.lockSlotActive
                                                 }
-                                                aria-label="Filter is locked"
+                                                aria-label="Filter is locked on this tab"
                                             >
                                                 <MantineIcon
                                                     size="sm"

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -355,7 +355,7 @@ const FilterConfiguration: FC<Props> = ({
     );
 
     const isLockedRequiredMissingValue =
-        !!draftFilterRule?.locked &&
+        !!draftFilterRule?.lockedTabUuids?.length &&
         !!draftFilterRule?.required &&
         !hasFilterValueSet(draftFilterRule);
 

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -354,6 +354,15 @@ const FilterConfiguration: FC<Props> = ({
         isCreatingNew,
     );
 
+    const isLockedRequiredMissingValue =
+        !!draftFilterRule?.locked &&
+        !!draftFilterRule?.required &&
+        !hasFilterValueSet(draftFilterRule);
+
+    const applyDisabledTooltipLabel = isLockedRequiredMissingValue
+        ? 'A locked, required filter must have a value'
+        : 'Filter field and value required';
+
     return (
         <Stack>
             <Tabs
@@ -538,14 +547,16 @@ const FilterConfiguration: FC<Props> = ({
                     )}
 
                 <Tooltip
-                    label="Filter field and value required"
-                    disabled={!isApplyDisabled}
+                    label={applyDisabledTooltipLabel}
+                    disabled={!isApplyDisabled && !isLockedRequiredMissingValue}
                 >
                     <Box>
                         <Button
                             size="xs"
                             variant="filled"
-                            disabled={isApplyDisabled}
+                            disabled={
+                                isApplyDisabled || isLockedRequiredMissingValue
+                            }
                             onClick={() => {
                                 setSelectedTabId(FilterTabs.SETTINGS);
 

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.ts
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.ts
@@ -7,6 +7,35 @@ import { useEffect, useReducer, useRef } from 'react';
 import { useLocation } from 'react-router';
 import useToaster from './toaster/useToaster';
 
+// Lock state is metadata of the saved dashboard, not something the URL
+// should be able to assert. Strip `lockedTabUuids` from URL-provided
+// override rules so a stale shared link can't keep a filter "locked"
+// after an editor has removed the lock from the saved dashboard.
+const sanitizeOverrideRule = (
+    rule: DashboardFilterRuleOverride & { lockedTabUuids?: string[] },
+): DashboardFilterRuleOverride => {
+    const { lockedTabUuids: _, ...rest } = rule;
+    return rest;
+};
+
+const sanitizeOverrideState = (state: {
+    dimensions?: (DashboardFilterRuleOverride & {
+        lockedTabUuids?: string[];
+    })[];
+    metrics?: (DashboardFilterRuleOverride & {
+        lockedTabUuids?: string[];
+    })[];
+    tableCalculations?: (DashboardFilterRuleOverride & {
+        lockedTabUuids?: string[];
+    })[];
+}): Record<keyof DashboardFilters, DashboardFilterRuleOverride[]> => ({
+    dimensions: (state.dimensions ?? []).map(sanitizeOverrideRule),
+    metrics: (state.metrics ?? []).map(sanitizeOverrideRule),
+    tableCalculations: (state.tableCalculations ?? []).map(
+        sanitizeOverrideRule,
+    ),
+});
+
 export const hasSavedFiltersOverrides = (
     overrides: DashboardFilters | undefined,
 ) =>
@@ -88,12 +117,17 @@ export const useSavedDashboardFiltersOverrides = () => {
         reducer,
         overridesForSavedDashboardFiltersParam,
         (param) => {
-            if (!param) return { dimensions: [], metrics: [] };
+            const empty = {
+                dimensions: [],
+                metrics: [],
+                tableCalculations: [],
+            };
+            if (!param) return empty;
             try {
-                return JSON.parse(param);
+                return sanitizeOverrideState(JSON.parse(param));
             } catch {
                 parseErrorRef.current = true;
-                return { dimensions: [], metrics: [] };
+                return empty;
             }
         },
     );
@@ -109,7 +143,7 @@ export const useSavedDashboardFiltersOverrides = () => {
     }, [showToastWarning]);
 
     const addSavedFilterOverride = (
-        { tileTargets, ...item }: DashboardFilterRule,
+        { tileTargets, lockedTabUuids, ...item }: DashboardFilterRule,
         category: FilterCategory = 'dimensions',
     ) => {
         dispatch({
@@ -120,7 +154,7 @@ export const useSavedDashboardFiltersOverrides = () => {
     };
 
     const removeSavedFilterOverride = (
-        { tileTargets, ...item }: DashboardFilterRule,
+        { tileTargets, lockedTabUuids, ...item }: DashboardFilterRule,
         category: FilterCategory = 'dimensions',
     ) => {
         dispatch({

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -10,6 +10,7 @@ import {
     isDashboardChartTileType,
     isStandardDateGranularity,
     isSubDayGranularity,
+    stripOverridesForLockedFilters,
     type Dashboard,
     type DashboardFilterableField,
     type DashboardFilterRule,
@@ -97,7 +98,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 }) => {
     const { search, pathname } = useLocation();
     const navigate = useNavigate();
-    const { showToastWarning } = useToaster();
+    const { showToastWarning, showToastInfo } = useToaster();
+    const hasNotifiedLockedOverrideRef = useRef(false);
 
     const { dashboardUuid, tabUuid, mode } = useParams<{
         dashboardUuid: string;
@@ -707,6 +709,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             // Step 1: Start with base filters
             let updatedDashboardFilters = clone(currentDashboard.filters);
 
+            let droppedLockedOverrides = 0;
+
             // Step 2: Apply SDK Filters
             // For SDK mode, SDK filters replace embedded dashboard filters
             const sdkFilters =
@@ -726,16 +730,35 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                     return;
                 }
 
-                updatedDashboardFilters.dimensions = sdkFilters.map(
-                    (sdkFilter) =>
-                        convertSdkFilterToDashboardFilter(
-                            sdkFilter,
-                            filterableFieldsByTileUuid,
-                        ),
+                const convertedSdkFilters = sdkFilters.map((sdkFilter) =>
+                    convertSdkFilterToDashboardFilter(
+                        sdkFilter,
+                        filterableFieldsByTileUuid,
+                    ),
                 );
+                const sdkStripResult = stripOverridesForLockedFilters(
+                    currentDashboard.filters,
+                    {
+                        dimensions: convertedSdkFilters,
+                        metrics: [],
+                        tableCalculations: [],
+                    },
+                );
+                droppedLockedOverrides += sdkStripResult.droppedCount;
+                updatedDashboardFilters.dimensions =
+                    sdkStripResult.filters.dimensions;
             }
 
-            // Apply overrides from URL
+            // Apply overrides from URL — but never override locked saved filters
+            if (hasSavedFiltersOverrides(overrides)) {
+                const urlStripResult = stripOverridesForLockedFilters(
+                    currentDashboard.filters,
+                    overrides,
+                );
+                overrides = urlStripResult.filters;
+                droppedLockedOverrides += urlStripResult.droppedCount;
+            }
+
             if (embed.mode === 'direct') {
                 // For direct mode, only read from URL if not SDK mode
                 if (hasSavedFiltersOverrides(overrides)) {
@@ -765,6 +788,20 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 }
             }
 
+            if (
+                droppedLockedOverrides > 0 &&
+                !hasNotifiedLockedOverrideRef.current
+            ) {
+                hasNotifiedLockedOverrideRef.current = true;
+                showToastInfo({
+                    title: 'Locked dashboard filter',
+                    subtitle:
+                        droppedLockedOverrides === 1
+                            ? 'A filter override from your URL was ignored because the dashboard editor locked that filter.'
+                            : `${droppedLockedOverrides} filter overrides from your URL were ignored because the dashboard editor locked those filters.`,
+                });
+            }
+
             // Step 3: Apply interactivity filtering for embedded dashboards
             updatedDashboardFilters = applyInteractivityFiltering(
                 updatedDashboardFilters,
@@ -783,6 +820,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         applyInteractivityFiltering,
         savedChartUuidsAndTileUuids,
         filterableFieldsByTileUuid,
+        showToastInfo,
     ]);
 
     // Updates url with temp and overridden filters and deep compare to avoid unnecessary re-renders for dashboardTemporaryFilters
@@ -849,21 +887,29 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             dashboard?.filters &&
             hasSavedFiltersOverrides(overridesForSavedDashboardFilters)
         ) {
+            const { filters: safeOverrides } = stripOverridesForLockedFilters(
+                dashboard.filters,
+                overridesForSavedDashboardFilters,
+            );
+
+            if (!hasSavedFiltersOverrides(safeOverrides)) {
+                return;
+            }
+
             setDashboardFilters((prevFilters) => {
                 const updated: DashboardFilters = {
                     ...prevFilters,
                     dimensions: applyDimensionOverrides(
                         prevFilters,
-                        overridesForSavedDashboardFilters,
+                        safeOverrides,
                     ),
                 };
 
-                if (overridesForSavedDashboardFilters.metrics?.length > 0) {
+                if (safeOverrides.metrics?.length > 0) {
                     updated.metrics = prevFilters.metrics.map((metric) => {
-                        const override =
-                            overridesForSavedDashboardFilters.metrics.find(
-                                (m) => m.id === metric.id,
-                            );
+                        const override = safeOverrides.metrics.find(
+                            (m) => m.id === metric.id,
+                        );
                         return override
                             ? { ...override, tileTargets: metric.tileTargets }
                             : metric;
@@ -934,6 +980,29 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             }
         }
     });
+
+    // Strip URL-provided temporary filters that conflict with a locked saved
+    // filter, once the saved dashboard data is available.
+    useEffect(() => {
+        if (!dashboard?.filters) return;
+        const { filters: safeTemporaryFilters, droppedCount } =
+            stripOverridesForLockedFilters(
+                dashboard.filters,
+                dashboardTemporaryFilters,
+            );
+        if (droppedCount === 0) return;
+        setDashboardTemporaryFilters(safeTemporaryFilters);
+        if (!hasNotifiedLockedOverrideRef.current) {
+            hasNotifiedLockedOverrideRef.current = true;
+            showToastInfo({
+                title: 'Locked dashboard filter',
+                subtitle:
+                    droppedCount === 1
+                        ? 'A temporary filter from your URL was ignored because the dashboard editor locked that filter.'
+                        : `${droppedCount} temporary filters from your URL were ignored because the dashboard editor locked those filters.`,
+            });
+        }
+    }, [dashboard?.filters, dashboardTemporaryFilters, showToastInfo]);
 
     // Apply default date zoom granularity when dashboard loads (if no URL override).
     // Uses a ref for `search` so URL changes don't re-trigger this effect —

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -10,7 +10,7 @@ import {
     isDashboardChartTileType,
     isStandardDateGranularity,
     isSubDayGranularity,
-    stripOverridesForLockedFilters,
+    stripOverridesForLockedFiltersOnTab,
     type Dashboard,
     type DashboardFilterableField,
     type DashboardFilterRule,
@@ -742,24 +742,27 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                         filterableFieldsByTileUuid,
                     ),
                 );
-                const sdkStripResult = stripOverridesForLockedFilters(
+                const sdkStripResult = stripOverridesForLockedFiltersOnTab(
                     currentDashboard.filters,
                     {
                         dimensions: convertedSdkFilters,
                         metrics: [],
                         tableCalculations: [],
                     },
+                    activeTab?.uuid,
                 );
                 droppedLockedOverrides += sdkStripResult.droppedCount;
                 updatedDashboardFilters.dimensions =
                     sdkStripResult.filters.dimensions;
             }
 
-            // Apply overrides from URL — but never override locked saved filters
+            // Apply overrides from URL — but never override filters locked on
+            // the currently active tab.
             if (hasSavedFiltersOverrides(overrides)) {
-                const urlStripResult = stripOverridesForLockedFilters(
+                const urlStripResult = stripOverridesForLockedFiltersOnTab(
                     currentDashboard.filters,
                     overrides,
+                    activeTab?.uuid,
                 );
                 overrides = urlStripResult.filters;
                 droppedLockedOverrides += urlStripResult.droppedCount;
@@ -827,6 +830,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         savedChartUuidsAndTileUuids,
         filterableFieldsByTileUuid,
         showToastInfo,
+        activeTab,
     ]);
 
     // Updates url with temp and overridden filters and deep compare to avoid unnecessary re-renders for dashboardTemporaryFilters
@@ -893,10 +897,12 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             dashboard?.filters &&
             hasSavedFiltersOverrides(overridesForSavedDashboardFilters)
         ) {
-            const { filters: safeOverrides } = stripOverridesForLockedFilters(
-                dashboard.filters,
-                overridesForSavedDashboardFilters,
-            );
+            const { filters: safeOverrides } =
+                stripOverridesForLockedFiltersOnTab(
+                    dashboard.filters,
+                    overridesForSavedDashboardFilters,
+                    activeTab?.uuid,
+                );
 
             if (!hasSavedFiltersOverrides(safeOverrides)) {
                 return;
@@ -925,7 +931,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 return updated;
             });
         }
-    }, [dashboard?.filters, overridesForSavedDashboardFilters]);
+    }, [dashboard?.filters, overridesForSavedDashboardFilters, activeTab]);
 
     // Gets filters and dateZoom from URL and storage after redirect
     useMount(() => {
@@ -987,14 +993,16 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         }
     });
 
-    // Strip URL-provided temporary filters that conflict with a locked saved
-    // filter, once the saved dashboard data is available.
+    // Strip temporary filters that conflict with a filter locked on the
+    // currently active tab. Re-runs whenever the active tab changes so the
+    // lock evaluation always reflects the tab being viewed.
     useEffect(() => {
         if (!dashboard?.filters) return;
         const { filters: safeTemporaryFilters, droppedCount } =
-            stripOverridesForLockedFilters(
+            stripOverridesForLockedFiltersOnTab(
                 dashboard.filters,
                 dashboardTemporaryFilters,
+                activeTab?.uuid,
             );
         if (droppedCount === 0) return;
         setDashboardTemporaryFilters(safeTemporaryFilters);
@@ -1004,11 +1012,16 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 title: 'Locked dashboard filter',
                 subtitle:
                     droppedCount === 1
-                        ? 'A temporary filter was ignored because the dashboard editor locked that filter.'
-                        : `${droppedCount} temporary filters were ignored because the dashboard editor locked those filters.`,
+                        ? 'A temporary filter was ignored because the dashboard editor locked it on this tab.'
+                        : `${droppedCount} temporary filters were ignored because the dashboard editor locked them on this tab.`,
             });
         }
-    }, [dashboard?.filters, dashboardTemporaryFilters, showToastInfo]);
+    }, [
+        dashboard?.filters,
+        dashboardTemporaryFilters,
+        showToastInfo,
+        activeTab,
+    ]);
 
     // Apply default date zoom granularity when dashboard loads (if no URL override).
     // Uses a ref for `search` so URL changes don't re-trigger this effect —

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -833,6 +833,38 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         activeTab,
     ]);
 
+    // Derive the effective temporary filters by stripping any that would
+    // conflict with a filter locked on the currently active tab. Done at
+    // read time (useMemo) rather than write-back-to-state so the user's
+    // intent is preserved when they switch tabs — temp filters re-appear
+    // on tabs where the saved filter isn't locked.
+    const {
+        filters: safeTemporaryFilters,
+        droppedCount: lockedTemporaryDroppedCount,
+    } = useMemo(() => {
+        if (!dashboard?.filters) {
+            return { filters: dashboardTemporaryFilters, droppedCount: 0 };
+        }
+        return stripOverridesForLockedFiltersOnTab(
+            dashboard.filters,
+            dashboardTemporaryFilters,
+            activeTab?.uuid,
+        );
+    }, [dashboard?.filters, dashboardTemporaryFilters, activeTab]);
+
+    useEffect(() => {
+        if (lockedTemporaryDroppedCount === 0) return;
+        if (hasNotifiedLockedOverrideRef.current) return;
+        hasNotifiedLockedOverrideRef.current = true;
+        showToastInfo({
+            title: 'Locked dashboard filter',
+            subtitle:
+                lockedTemporaryDroppedCount === 1
+                    ? 'A temporary filter was ignored because the dashboard editor locked it on this tab.'
+                    : `${lockedTemporaryDroppedCount} temporary filters were ignored because the dashboard editor locked them on this tab.`,
+        });
+    }, [lockedTemporaryDroppedCount, showToastInfo]);
+
     // Updates url with temp and overridden filters and deep compare to avoid unnecessary re-renders for dashboardTemporaryFilters
     // Only sync URL in regular dashboards or 'direct' embed mode (not 'sdk' mode)
     useDeepCompareEffect(() => {
@@ -844,15 +876,15 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         const newParams = new URLSearchParams(search);
 
         if (
-            dashboardTemporaryFilters?.dimensions?.length === 0 &&
-            dashboardTemporaryFilters?.metrics?.length === 0
+            safeTemporaryFilters?.dimensions?.length === 0 &&
+            safeTemporaryFilters?.metrics?.length === 0
         ) {
             newParams.delete('tempFilters');
         } else {
             newParams.set(
                 'tempFilters',
                 JSON.stringify(
-                    compressDashboardFiltersToParam(dashboardTemporaryFilters),
+                    compressDashboardFiltersToParam(safeTemporaryFilters),
                 ),
             );
         }
@@ -884,7 +916,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         }
     }, [
         dashboardFilters,
-        dashboardTemporaryFilters,
+        safeTemporaryFilters,
         navigate,
         pathname,
         overridesForSavedDashboardFilters,
@@ -993,36 +1025,6 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         }
     });
 
-    // Strip temporary filters that conflict with a filter locked on the
-    // currently active tab. Re-runs whenever the active tab changes so the
-    // lock evaluation always reflects the tab being viewed.
-    useEffect(() => {
-        if (!dashboard?.filters) return;
-        const { filters: safeTemporaryFilters, droppedCount } =
-            stripOverridesForLockedFiltersOnTab(
-                dashboard.filters,
-                dashboardTemporaryFilters,
-                activeTab?.uuid,
-            );
-        if (droppedCount === 0) return;
-        setDashboardTemporaryFilters(safeTemporaryFilters);
-        if (!hasNotifiedLockedOverrideRef.current) {
-            hasNotifiedLockedOverrideRef.current = true;
-            showToastInfo({
-                title: 'Locked dashboard filter',
-                subtitle:
-                    droppedCount === 1
-                        ? 'A temporary filter was ignored because the dashboard editor locked it on this tab.'
-                        : `${droppedCount} temporary filters were ignored because the dashboard editor locked them on this tab.`,
-            });
-        }
-    }, [
-        dashboard?.filters,
-        dashboardTemporaryFilters,
-        showToastInfo,
-        activeTab,
-    ]);
-
     // Apply default date zoom granularity when dashboard loads (if no URL override).
     // Uses a ref for `search` so URL changes don't re-trigger this effect —
     // it should only fire when the configured default changes (initial load + after saves).
@@ -1106,18 +1108,18 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         return {
             dimensions: [
                 ...dashboardFilters.dimensions,
-                ...dashboardTemporaryFilters?.dimensions,
+                ...safeTemporaryFilters?.dimensions,
             ],
             metrics: [
                 ...dashboardFilters.metrics,
-                ...dashboardTemporaryFilters?.metrics,
+                ...safeTemporaryFilters?.metrics,
             ],
             tableCalculations: [
                 ...dashboardFilters.tableCalculations,
-                ...dashboardTemporaryFilters?.tableCalculations,
+                ...safeTemporaryFilters?.tableCalculations,
             ],
         };
-    }, [dashboardFilters, dashboardTemporaryFilters]);
+    }, [dashboardFilters, safeTemporaryFilters]);
 
     // Watch for filter changes and emit events (skip initial render)
     useEffect(() => {
@@ -1473,7 +1475,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setActiveTab,
         setDashboardTemporaryFilters,
         dashboardFilters,
-        dashboardTemporaryFilters,
+        dashboardTemporaryFilters: safeTemporaryFilters,
         addDimensionDashboardFilter,
         updateDimensionDashboardFilter,
         removeDimensionDashboardFilter,

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -110,6 +110,12 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         tabUuid?: string;
         mode?: string;
     };
+
+    // Reset the "locked filter override" toast guard on dashboard navigation
+    // so each dashboard gets a fresh chance to notify the viewer.
+    useEffect(() => {
+        hasNotifiedLockedOverrideRef.current = false;
+    }, [dashboardUuid]);
     const isEditMode = mode === 'edit';
 
     const {
@@ -797,8 +803,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                     title: 'Locked dashboard filter',
                     subtitle:
                         droppedLockedOverrides === 1
-                            ? 'A filter override from your URL was ignored because the dashboard editor locked that filter.'
-                            : `${droppedLockedOverrides} filter overrides from your URL were ignored because the dashboard editor locked those filters.`,
+                            ? 'A filter override was ignored because the dashboard editor locked that filter.'
+                            : `${droppedLockedOverrides} filter overrides were ignored because the dashboard editor locked those filters.`,
                 });
             }
 
@@ -998,8 +1004,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 title: 'Locked dashboard filter',
                 subtitle:
                     droppedCount === 1
-                        ? 'A temporary filter from your URL was ignored because the dashboard editor locked that filter.'
-                        : `${droppedCount} temporary filters from your URL were ignored because the dashboard editor locked those filters.`,
+                        ? 'A temporary filter was ignored because the dashboard editor locked that filter.'
+                        : `${droppedCount} temporary filters were ignored because the dashboard editor locked those filters.`,
             });
         }
     }, [dashboard?.filters, dashboardTemporaryFilters, showToastInfo]);

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -8,6 +8,7 @@ import {
     getFilterInteractivityValue,
     getItemId,
     isDashboardChartTileType,
+    isFilterLockedOnTab,
     isStandardDateGranularity,
     isSubDayGranularity,
     stripOverridesForLockedFiltersOnTab,
@@ -752,8 +753,20 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                     activeTab?.uuid,
                 );
                 droppedLockedOverrides += sdkStripResult.droppedCount;
-                updatedDashboardFilters.dimensions =
-                    sdkStripResult.filters.dimensions;
+                // SDK filters replace embedded dashboard filters, but
+                // locked saved filters must be preserved — otherwise an
+                // SDK consumer could drop a lock by simply not sending
+                // a filter for that field. Mirrors how EmbedService
+                // merges locked saved rules with safe overrides
+                // server-side.
+                const lockedSavedDimensions =
+                    currentDashboard.filters.dimensions.filter((rule) =>
+                        isFilterLockedOnTab(rule, activeTab?.uuid),
+                    );
+                updatedDashboardFilters.dimensions = [
+                    ...lockedSavedDimensions,
+                    ...sdkStripResult.filters.dimensions,
+                ];
             }
 
             // Apply overrides from URL — but never override filters locked on

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -513,6 +513,17 @@ type DashboardUiVersionToggledEvent = {
     };
 };
 
+type DashboardFilterLockToggledEvent = {
+    name: EventName.DASHBOARD_FILTER_LOCK_TOGGLED;
+    properties: {
+        action: 'lock' | 'unlock';
+        dashboardUuid: string | undefined;
+        tabUuid: string | undefined;
+        fieldId: string;
+        tableName: string;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | SetupStepClickedEvent
@@ -555,7 +566,8 @@ export type EventData =
     | ThemeToggledEvent
     | DashboardUiVersionToggledEvent
     | TableCalculationSaveEvent
-    | FormulaTableCalculationAiGenerateClickedEvent;
+    | FormulaTableCalculationAiGenerateClickedEvent
+    | DashboardFilterLockToggledEvent;
 
 export type IdentifyData = {
     id: string;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -98,6 +98,7 @@ export enum EventName {
     LANDING_RUN_QUERY_CLICKED = 'landing_run_query.click',
     SETUP_STEP_CLICKED = 'setup_step.click',
     ADD_FILTER_CLICKED = 'add_filter.click',
+    DASHBOARD_FILTER_LOCK_TOGGLED = 'dashboard_filter_lock.toggled',
     GO_TO_LINK_CLICKED = 'go_to_link.click',
     ADD_CUSTOM_METRIC_CLICKED = 'add_custom_metric.click',
     REMOVE_CUSTOM_METRIC_CLICKED = 'remove_custom_metric.click',


### PR DESCRIPTION
## Summary

Adds **per-tab** filter locking on dashboards. Editors can lock a filter on individual tabs; viewers on a locked tab see the filter but can't change it, and URL/embed filter overrides targeting the locked field are ignored on that tab. Shipped behind the `lock-dashboard-filters` feature flag.

- New optional `lockedTabUuids?: string[]` on `DashboardFilterRule` (stored in the existing JSONB column — no migration).
- Hover-revealed lock/unlock toggle in the filter chip's right side (edit mode). Clicking adds or removes the currently-viewed tab from `lockedTabUuids`. There is intentionally no UI to lock globally or on multiple tabs at once — by design, locking is always scoped to the active tab.
- Lock indicator on the chip only shows when the active tab is in `lockedTabUuids`. Switching tabs updates the indicator immediately.
- Override stripping is **tab-aware** at three input boundaries:
  - URL `?filters=` saved-filter overrides
  - URL `?tempFilters=` runtime filters
  - Embed SDK `externalFilters`
  Each strip evaluates lock state against the active tab (frontend) or the tile's `tabUuid` (backend embed).
- One-time toast when overrides are dropped because of a lock on the current tab; toast guard resets on dashboard navigation.

Relates to PROD-7564.

## Data model

```ts
type DashboardFilterRule = {
    ...
    lockedTabUuids?: string[];  // tabs where this filter is locked
};
```

Empty/omitted = not locked anywhere.

## Safety

Designed for safe deploy independent of release:

- Type change is additive optional — old saved filters parse as `lockedTabUuids: undefined`.
- The strip helper (`stripOverridesForLockedFiltersOnTab`) is a pure identity when no rule has a non-empty `lockedTabUuids` or when `tabUuid` is undefined. Backend `_getAppliedDashboardFilters` rewrite preserves bit-for-bit behaviour when no locked rules exist.
- Flag off → chip toggle button never renders, lock state is treated as absent, no UI surface visible.
- Flag on per-org → that org's editors get the chip toggle on tabbed dashboards; only locked dashboards diverge in behaviour.
- No DB migration. No new API endpoints. No `generate-api` regeneration needed.

## Architecture notes

- Frontend: `DashboardProvider` resolves lock state against `activeTab.uuid` (from `useDashboardContext`). `activeTab` is added to the deps of the strip useEffects so re-evaluation fires on tab navigation.
- Backend: `EmbedService._getAppliedDashboardFilters` resolves lock state against the tile's `tabUuid` (looked up via `dashboard.tiles.find(t => t.uuid === tileUuid).tabUuid`) — because the backend doesn't know which tab the user is viewing, it uses the only tab-related context it has: the querying tile's tab.
- Helper `isFilterLockedOnTab(rule, tabUuid)` is exported from `@lightdash/common` and reused on both sides.

## Verified

Tested end-to-end on a Jaffle dashboard with two tabs and a filter `lockedTabUuids: [TabA]`:
- **Chip indicator**: Tab A → `"Filter is locked on this tab"`. Tab B → no indicator. Toggling A↔B updates immediately.
- **URL override**: Tab A + `?tempFilters=...` → param stripped, locked value wins. Tab B + same param → param preserved, override applied.
- **Toggle (edit mode)**: Click on Tab B → `lockedTabUuids` becomes `[TabA, TabB]`. Click again on Tab B → `lockedTabUuids` becomes `[TabA]`. Tab A's lock state is preserved across both transitions.
- **46/46 common unit tests pass** (`pnpm -F common test`).

## Test plan

- [ ] In an org with the flag on, hover any filter chip in dashboard **edit mode** on a tabbed dashboard — an open-padlock button slides in next to the X.
- [ ] Click the padlock — the icon switches to closed for the active tab. Save. Reload. Lock indicator persists on that tab.
- [ ] Switch to another tab — the lock indicator disappears (filter not locked on that tab). Switch back — it returns.
- [ ] In edit mode, click the padlock on a second tab → `lockedTabUuids` now contains both tabs. Confirm via SQL or by reloading and seeing both tabs show the locked indicator.
- [ ] Append `?tempFilters=...` targeting a locked field while viewing a locked tab — URL is cleaned, locked value is honoured, one-time toast appears.
- [ ] Same URL on an unlocked tab — URL preserves the param, override is applied.
- [ ] Generate an embed JWT with `externalFilters` targeting a locked field — server-side queries on tiles in the locked tab use the saved value; queries on tiles in an unlocked tab use the override.
- [ ] Turn the flag off → chip toggle disappears, but existing locked filters keep being enforced server-side (safety valve).

## Known limitation

When a `?tempFilters=` URL is loaded on a tab where the filter is locked, the override is stripped from state. Switching to an unlocked tab does **not** restore the stripped override — state mutation is one-way. The proper fix (per-tile derived state via `useMemo` rather than state-level strip) is captured in a React-review follow-up and deferred to a later PR. In practice this only affects users who manually craft `tempFilters` URLs and then switch tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)