### PR TITLE
fix(query-sdk): pass settings.completed through Filter to API

### DIFF
--- a/packages/query-sdk/src/query.ts
+++ b/packages/query-sdk/src/query.ts
@@ -111,7 +111,14 @@ export class QueryBuilder {
                 fieldId: f.field,
                 operator: f.operator,
                 values,
-                settings: f.unit ? { unitOfTime: f.unit } : null,
+                settings: f.unit
+                    ? {
+                          unitOfTime: f.unit,
+                          ...(f.completed !== undefined && {
+                              completed: f.completed,
+                          }),
+                      }
+                    : null,
             };
         });
 

--- a/packages/query-sdk/src/types.ts
+++ b/packages/query-sdk/src/types.ts
@@ -34,6 +34,13 @@ export type Filter = {
     operator: FilterOperator;
     value?: FilterValue | FilterValue[];
     unit?: UnitOfTime;
+    /**
+     * For relative date filters (`inThePast`, `notInThePast`, etc.), restrict
+     * the range to fully completed periods. e.g. `inThePast` + `unit: 'weeks'`
+     * + `completed: true` means "the last N completed weeks" — the current,
+     * in-progress week is excluded.
+     */
+    completed?: boolean;
 };
 
 export type Sort = {
@@ -102,7 +109,7 @@ export type InternalFilterDefinition = {
     fieldId: string;
     operator: string;
     values: FilterValue[];
-    settings: { unitOfTime: UnitOfTime } | null;
+    settings: { unitOfTime: UnitOfTime; completed?: boolean } | null;
 };
 
 export type QueryDefinition = {

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -420,6 +420,7 @@ type Filter = {
     operator: FilterOperator;
     value?: FilterValue | FilterValue[];
     unit?: UnitOfTime; // required for date/time operators
+    completed?: boolean; // for `inThePast`/`notInThePast`: restrict to fully completed periods
 };
 ```
 
@@ -428,7 +429,7 @@ type Filter = {
 | Comparison | `equals`, `notEquals`, `greaterThan`, `lessThan`, `greaterThanOrEqual`, `lessThanOrEqual` | Multi-value: `value: ['a', 'b']` |
 | Null | `isNull`, `notNull` | No `value` needed |
 | String | `startsWith`, `endsWith`, `include`, `doesNotInclude` | |
-| Date/time | `inThePast`, `notInThePast`, `inTheNext`, `inTheCurrent`, `notInTheCurrent` | Requires `unit`: `'days'`/`'weeks'`/`'months'`/`'quarters'`/`'years'` |
+| Date/time | `inThePast`, `notInThePast`, `inTheNext`, `inTheCurrent`, `notInTheCurrent` | Requires `unit`: `'days'`/`'weeks'`/`'months'`/`'quarters'`/`'years'`. Add `completed: true` to `inThePast`/`notInThePast` to exclude the current in-progress period — e.g. `{ operator: 'inThePast', unit: 'weeks', value: 4, completed: true }` means "the last 4 completed weeks", not including this week. |
 | Range | `inBetween`, `notInBetween` | |
 
 ### User context


### PR DESCRIPTION
### Description:
The SDK's `Filter` type was missing the `completed` field, and the `filters()` builder only mapped `unit → settings.unitOfTime`. The backend has supported `settings.completed: boolean` on date filters all along, so passing it from the SDK silently dropped before the request left.

Adds `completed?: boolean` to `Filter` and `InternalFilterDefinition.settings`, plumbs it through the `filters()` mapping, and documents it in `skill.md` so generated data apps use it directly instead of monkey-patching `QueryBuilder.prototype.filters`.