### PR TITLE
fix(service-accounts): bypass email verification lookup in getUserAttributes

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -187,6 +187,12 @@ const userAttributesModel = {
     getAttributeValuesForOrgMember: jest.fn(async () => ({})),
 };
 
+const emailModel = {
+    getPrimaryEmailStatus: jest.fn(async (_userUuid: string) => ({
+        isVerified: true,
+    })),
+};
+
 const schedulerClient = {
     deleteScheduledPreAggregateCronJobsForProject: jest.fn(
         async () => undefined,
@@ -233,11 +239,7 @@ const getMockedProjectService = (
             findForProjectWithSecrets: jest.fn(async () => undefined),
         } as unknown as UserWarehouseCredentialsModel,
         warehouseAvailableTablesModel: {} as WarehouseAvailableTablesModel,
-        emailModel: {
-            getPrimaryEmailStatus: (userUuid: string) => ({
-                isVerified: true,
-            }),
-        } as unknown as EmailModel,
+        emailModel: emailModel as unknown as EmailModel,
         schedulerClient: schedulerClient as unknown as SchedulerClient,
         downloadFileModel: {} as unknown as DownloadFileModel,
         fileStorageClient: {} as FileStorageClient,
@@ -2160,6 +2162,49 @@ describe('ProjectService', () => {
                     exploreName,
                 ),
             ).rejects.toThrow(ForbiddenError);
+        });
+    });
+
+    describe('getUserAttributes', () => {
+        // jest.clearAllMocks() in the outer afterEach does not drain
+        // mockImplementationOnce queues — reset the email mock per test so
+        // queued rejections don't leak between cases.
+        beforeEach(() => {
+            emailModel.getPrimaryEmailStatus.mockReset();
+            emailModel.getPrimaryEmailStatus.mockResolvedValue({
+                isVerified: true,
+            });
+        });
+
+        test('skips email lookup for service accounts and returns empty intrinsic attributes', async () => {
+            // Real service-account principals have no row in `emails`, so
+            // getPrimaryEmailStatus throws NotFoundError. Simulate that to
+            // prove the bypass runs before the lookup.
+            emailModel.getPrimaryEmailStatus.mockImplementation(() => {
+                throw new NotFoundError(
+                    "Cannot find matching verification status for user's email",
+                );
+            });
+
+            const serviceAccount = buildAccount({
+                accountType: 'service-account',
+            });
+
+            const result = await service.getUserAttributes({
+                account: serviceAccount,
+            });
+
+            expect(result.intrinsicUserAttributes).toEqual({});
+            expect(emailModel.getPrimaryEmailStatus).not.toHaveBeenCalled();
+        });
+
+        test('still attaches intrinsic email attributes for session users', async () => {
+            const result = await service.getUserAttributes({ account });
+
+            expect(emailModel.getPrimaryEmailStatus).toHaveBeenCalledWith(
+                account.user.id,
+            );
+            expect(result.intrinsicUserAttributes).not.toEqual({});
         });
     });
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -740,6 +740,13 @@ export class ProjectService extends BaseService {
                 userUuid: userId || '',
             });
 
+        // Service accounts have no email and no row in the `emails` table —
+        // `getPrimaryEmailStatus` would 404. They also have no intrinsic
+        // email attributes to attach.
+        if (account?.isServiceAccount()) {
+            return { userAttributes, intrinsicUserAttributes: {} };
+        }
+
         const emailStatus = await this.emailModel.getPrimaryEmailStatus(userId);
         const intrinsicUserAttributes = emailStatus.isVerified
             ? getIntrinsicUserAttributes({ email })


### PR DESCRIPTION
Closes [PROD-7760](https://linear.app/lightdash/issue/PROD-7760/service-accounts-cannot-run-queries-notfounderror-on-email)
Closes #23103

## Summary

Service-account tokens (`ldsvc_…`) authenticate fine and metadata routes work, but every explore/query route returns 404 `NotFoundError: Cannot find matching verification status for user's email`. This blocks the entire query surface (including MCP `run_metric_query` / `search_field_values`) for any service account, regardless of role.

## Root cause

`ProjectService.getUserAttributes()` unconditionally calls `emailModel.getPrimaryEmailStatus(userId)` to decide whether to attach `intrinsicUserAttributes`. The model joins `users` against `emails WHERE is_primary = true` — service-account principals have no row in `emails`, so the join returns nothing and the model throws `NotFoundError`. The JWT-embed branch in the same function already short-circuits before this lookup; service accounts had no equivalent.

Metadata/browse routes don't pass through `getUserAttributes`, which is why they work.

- `packages/backend/src/services/ProjectService/ProjectService.ts` — bypass call site
- `packages/backend/src/models/EmailModel.ts:57` — the failing join

## Fix

Short-circuit the lookup for service-account principals (detected via `account.isServiceAccount()`) and return `intrinsicUserAttributes: {}`. Service accounts have no email, so there's nothing to attach. Other `getPrimaryEmailStatus` callers are human-only flows (login, OTP, email verification) and don't need changes.

Notably, service accounts are **not** given a synthetic email — that would leak into `createdBy`/audit attribution and user-attribute filters.

## Verification

Reproduced and confirmed the fix end-to-end against a local SA token (`email: null`, `isPending: true`, `isActive: false`):

| Step | Before fix | After fix |
|---|---|---|
| Stash fix, restart backend, `POST /explores/orders/runQuery` | 404 `Cannot find matching verification status for user's email` | — |
| Pop stash, `POST /explores/orders/runQuery` (Interactive Viewer SA) | — | 200 — 5 status rows with order counts |
| Viewer SA → `runQuery` | 404 (verification) | 403 (CASL — expected for read-only role) |

Unit tests added in `ProjectService.test.ts` lock both directions: SA path returns empty `intrinsicUserAttributes` even when the email model throws; session-user path still calls `getPrimaryEmailStatus` and attaches intrinsic attributes.

## Out of scope

- Per-project scoping for service accounts (org-wide-only is a separate, known limitation).
- Frontend "activate your account" gate that can appear when an SA-owned identity is viewed in the UI.