### PR TITLE
feat(data-apps): preview older versions from chat

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -177,23 +177,28 @@ is cleared on refresh so the new query run isn't mixed with stale entries from t
 
 By default the preview iframe loads the **latest ready** version of the app — it auto-bumps every time a new iteration
 finishes building. Users can override that and pin the preview to any earlier ready version: each ready assistant
-bubble's meta row carries a "v{n}" badge plus a small `⋯` kebab menu (rendered by `ChatBubbleMeta` via its optional
-`version` prop). The badge itself is a non-interactive label; the menu currently exposes a single **Preview this
-version** entry that calls `setPinnedVersion(v)`. The preview is then derived as `pinnedVersion ?? latestReadyVersion`,
-so polling refetches that don't change the latest version do **not** kick the user back to a newer build.
+bubble's meta row carries a "v{n}" badge (rendered by `ChatBubbleMeta` via its optional `version` prop) that is
+itself the click target. The preview is then derived as `pinnedVersion ?? latestReadyVersion`, so polling refetches
+that don't change the latest version do **not** kick the user back to a newer build.
 
 The chip has two visual states, mirroring the active-version pattern used by branch-switchers like Linear /
 ChatGPT's response-version selector:
 
-- **Inactive** — `Badge variant="light" color="gray"`, no icon. The kebab's "Preview this version" item is enabled.
-- **Active** (currently previewed) — `Badge variant="light" color="indigo"` with an `IconEye` left section. The
-  indigo matches the username accent already used in `ChatBubbleMeta` so the active state reads as "the live one"
-  without introducing a new color. The kebab's "Preview this version" item is disabled (it would be a no-op).
+- **Inactive** — `Badge variant="light" color="gray"` rendered as `component="button"`; hovering shows a "Preview
+  this version" tooltip; clicking pins the preview to that version.
+- **Active** (currently previewed) — `Badge variant="light" color="indigo"` with an `IconEye` left section; not
+  interactive. The indigo matches the username accent already used in `ChatBubbleMeta` so the active state reads as
+  "the live one" without introducing a new color.
 
-When a pinned version differs from the latest ready one, the preview header additionally shows a small `Badge` chip
-("Viewing v{n}", `variant="light" color="orange"` — same convention as the "Pending" indicator in
-`UsersTable`/`CredentialsTable`) next to the refresh button. Hovering reveals a tooltip naming the latest version;
-clicking the badge clears the pin and returns the iframe to the latest build.
+Per-version actions beyond "preview this one" (e.g. the upcoming "Restore as new version" flow) will live elsewhere
+on the bubble — not stacked into the meta row — so the chip stays purely about *which version is shown*.
+
+When a pinned version differs from the latest ready one, the **prompt input area is replaced** with an info
+`Callout`: title `"You're viewing version {n}"`, body explaining that new prompts always continue from the latest
+build, plus a **Return to latest (v{m})** button that calls `setPin(null)`. The whole chat input (textarea, picker
+buttons, submit) is hidden in this state — iterations always branch from the latest build, so allowing the user to
+type while viewing an older version would imply an edit-from-here semantics that doesn't exist. Locking the input
+removes that ambiguity.
 
 **Pin lifecycle (all derived, no `useEffect → setState` chain — that pattern is flagged by the lightdash frontend
 review rules):**

--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -173,6 +173,45 @@ a `previewRefreshKey` counter that gets baked into the iframe URL as `&r={key}`.
 which forces the browser to reload the iframe; the served bundle and the JWT are unaffected. The query inspector panel
 is cleared on refresh so the new query run isn't mixed with stale entries from the previous load.
 
+### Previewing older versions
+
+By default the preview iframe loads the **latest ready** version of the app — it auto-bumps every time a new iteration
+finishes building. Users can override that and pin the preview to any earlier ready version: each ready assistant
+bubble's meta row carries a "v{n}" badge plus a small `⋯` kebab menu (rendered by `ChatBubbleMeta` via its optional
+`version` prop). The badge itself is a non-interactive label; the menu currently exposes a single **Preview this
+version** entry that calls `setPinnedVersion(v)`. The preview is then derived as `pinnedVersion ?? latestReadyVersion`,
+so polling refetches that don't change the latest version do **not** kick the user back to a newer build.
+
+The chip has two visual states, mirroring the active-version pattern used by branch-switchers like Linear /
+ChatGPT's response-version selector:
+
+- **Inactive** — `Badge variant="light" color="gray"`, no icon. The kebab's "Preview this version" item is enabled.
+- **Active** (currently previewed) — `Badge variant="light" color="indigo"` with an `IconEye` left section. The
+  indigo matches the username accent already used in `ChatBubbleMeta` so the active state reads as "the live one"
+  without introducing a new color. The kebab's "Preview this version" item is disabled (it would be a no-op).
+
+When a pinned version differs from the latest ready one, the preview header additionally shows a small `Badge` chip
+("Viewing v{n}", `variant="light" color="orange"` — same convention as the "Pending" indicator in
+`UsersTable`/`CredentialsTable`) next to the refresh button. Hovering reveals a tooltip naming the latest version;
+clicking the badge clears the pin and returns the iframe to the latest build.
+
+**Pin lifecycle (all derived, no `useEffect → setState` chain — that pattern is flagged by the lightdash frontend
+review rules):**
+
+- The pin state is `{ appUuid, version, pinnedAtLatest }`. `pinnedAtLatest` is a snapshot of the latest ready
+  version at the moment of pinning.
+- `effectivePinnedVersion` is derived from `pin` in a `useMemo` and returns `null` (so the preview falls back to
+  the latest ready) when **any** of these hold: the pin's `appUuid` no longer matches `activeAppUuid` (user navigated
+  to a different app); a newer ready version exists than `pinnedAtLatest` (a fresh iteration finished — the user
+  authored a new prompt and almost certainly wants to see the result); or the pinned version is no longer in the
+  ready set.
+- Polling cycles where `latestReadyVersion.version` doesn't change leave the pin valid — the derivation only flips
+  when one of the invalidation conditions becomes true, not on every refetch.
+
+This is read-only — pinning an older version is preview-only and does **not** mutate `app_versions` or change which
+version is served outside the generation page (the public `/preview` route still shows the latest ready version). A
+true "restore this version as v_next" flow is a separate, later step ([GLITCH-443](https://linear.app/lightdash/issue/GLITCH-443)).
+
 ### Deletion
 
 Deleting an app goes through a single `DELETE /apps/{appUuid}` endpoint that routes to one of two modes based on the

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -23,12 +23,12 @@ type Props = {
      *  (the configured preview-host), or the parent's own origin in the
      *  same-origin fallback case. */
     expectedPreviewOrigin: string;
-    /** Stable identity for the served bundle (e.g. `${appUuid}:${version}`).
-     *  Drives the inspector/screenshot availability resets — changes here
-     *  mean a new bundle whose SDK capabilities are unknown, so we re-await
-     *  the announces. A pure URL bump (e.g. the manual refresh counter)
-     *  keeps this stable so the Inspect/Screenshot buttons don't flash off
-     *  and back on. */
+    /** Stable identity scope for the SDK capability handshake — typically the
+     *  app UUID. Drives the inspector/screenshot availability resets, so a
+     *  change here means a new app whose SDK capabilities are unknown and we
+     *  re-await the announces. Pure URL bumps (manual refresh counter) and
+     *  version switches within the same app keep this stable so the
+     *  Inspect/Screenshot buttons don't flicker off-then-back-on each time. */
     identityKey: string;
     onQueryEvent?: (event: QueryEvent) => void;
     onElementSelected?: (event: ElementSelectedEvent) => void;

--- a/packages/frontend/src/features/apps/ChatBubbleMeta.module.css
+++ b/packages/frontend/src/features/apps/ChatBubbleMeta.module.css
@@ -17,3 +17,7 @@
     flex-shrink: 0;
     white-space: nowrap;
 }
+
+.versionMenuTrigger {
+    margin-left: -4px;
+}

--- a/packages/frontend/src/features/apps/ChatBubbleMeta.module.css
+++ b/packages/frontend/src/features/apps/ChatBubbleMeta.module.css
@@ -18,6 +18,7 @@
     white-space: nowrap;
 }
 
-.versionMenuTrigger {
-    margin-left: -4px;
+.versionChip {
+    cursor: pointer;
+    border: 0;
 }

--- a/packages/frontend/src/features/apps/ChatBubbleMeta.tsx
+++ b/packages/frontend/src/features/apps/ChatBubbleMeta.tsx
@@ -1,5 +1,5 @@
-import { ActionIcon, Badge, Group, Menu, Text, Tooltip } from '@mantine-8/core';
-import { IconDots, IconEye } from '@tabler/icons-react';
+import { Badge, Group, Text, Tooltip } from '@mantine-8/core';
+import { IconEye } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { type FC } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
@@ -10,10 +10,8 @@ type VersionInfo = {
     version: number;
     /** True when the preview iframe is currently showing this version. */
     isActive: boolean;
-    /** Click handler for the kebab menu's "Preview this version" item.
-     *  Required even when `isActive` — the menu item is disabled in that
-     *  case, but a missing handler would be a wiring bug, not a valid
-     *  state, so the type stays non-optional. */
+    /** Click handler — pin the preview to this version. Required so a future
+     *  caller can't silently render a dead chip; ignored when `isActive`. */
     onPreview: () => void;
 };
 
@@ -26,10 +24,13 @@ type Props = {
     userName: string | null;
     /**
      * Version chip rendered on the left of the row for assistant replies
-     * tied to a specific ready version. The chip is a non-interactive
-     * label — actions live in the kebab menu on the right (`⋯`). For now
-     * the only entry is "Preview this version"; "Restore as new version"
-     * is the next thing to add (see GLITCH-443).
+     * tied to a specific ready version. The chip itself is the click
+     * target: clicking the (inactive) chip pins the preview to that
+     * version. Active chip renders in indigo with an eye icon and is
+     * non-interactive.
+     *
+     * Further per-version actions (e.g. "Restore as new version") live
+     * elsewhere on the bubble — not in this meta row.
      */
     version?: VersionInfo;
 };
@@ -38,8 +39,7 @@ type Props = {
  * Header row rendered inside a chat bubble. The left slot holds the sender
  * name (user bubbles) or a clickable version badge (assistant replies tied
  * to a ready version); the right slot holds the relative timestamp with a
- * tooltip for the absolute date, optionally followed by a version-actions
- * kebab menu.
+ * tooltip for the absolute date.
  */
 const ChatBubbleMeta: FC<Props> = ({ timestamp, userName, version }) => {
     const timeAgo = useTimeAgo(timestamp);
@@ -60,20 +60,36 @@ const ChatBubbleMeta: FC<Props> = ({ timestamp, userName, version }) => {
                     {userName}
                 </Text>
             )}
-            {version && (
-                <Badge
-                    size="sm"
-                    variant="light"
-                    color={version.isActive ? 'indigo' : 'gray'}
-                    leftSection={
-                        version.isActive ? (
-                            <MantineIcon icon={IconEye} size={10} />
-                        ) : undefined
-                    }
-                >
-                    v{version.version}
-                </Badge>
-            )}
+            {version &&
+                (version.isActive ? (
+                    <Badge
+                        size="sm"
+                        variant="light"
+                        color="indigo"
+                        leftSection={<MantineIcon icon={IconEye} size={10} />}
+                    >
+                        v{version.version}
+                    </Badge>
+                ) : (
+                    <Tooltip
+                        position="top-start"
+                        fz="xs"
+                        offset={2}
+                        label="Preview this version"
+                    >
+                        <Badge
+                            size="sm"
+                            variant="light"
+                            color="gray"
+                            component="button"
+                            type="button"
+                            onClick={version.onPreview}
+                            className={classes.versionChip}
+                        >
+                            v{version.version}
+                        </Badge>
+                    </Tooltip>
+                ))}
             <Tooltip
                 position={userName ? 'top-end' : 'top-start'}
                 fz="xs"
@@ -84,38 +100,6 @@ const ChatBubbleMeta: FC<Props> = ({ timestamp, userName, version }) => {
                     {timeAgo}
                 </Text>
             </Tooltip>
-            {version && (
-                <Menu
-                    shadow="md"
-                    position="bottom-end"
-                    withinPortal
-                    withArrow
-                    arrowPosition="center"
-                >
-                    <Menu.Target>
-                        <ActionIcon
-                            variant="subtle"
-                            size="xs"
-                            color="ldGray.6"
-                            className={classes.versionMenuTrigger}
-                            aria-label="Version actions"
-                        >
-                            <MantineIcon icon={IconDots} size={12} />
-                        </ActionIcon>
-                    </Menu.Target>
-                    <Menu.Dropdown>
-                        <Menu.Item
-                            leftSection={
-                                <MantineIcon icon={IconEye} size={14} />
-                            }
-                            disabled={version.isActive}
-                            onClick={version.onPreview}
-                        >
-                            Preview this version
-                        </Menu.Item>
-                    </Menu.Dropdown>
-                </Menu>
-            )}
         </Group>
     );
 };

--- a/packages/frontend/src/features/apps/ChatBubbleMeta.tsx
+++ b/packages/frontend/src/features/apps/ChatBubbleMeta.tsx
@@ -1,37 +1,78 @@
-import { Group, Text, Tooltip } from '@mantine-8/core';
+import { ActionIcon, Badge, Group, Menu, Text, Tooltip } from '@mantine-8/core';
+import { IconDots, IconEye } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { type FC } from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
 import { useTimeAgo } from '../../hooks/useTimeAgo';
 import classes from './ChatBubbleMeta.module.css';
+
+type VersionInfo = {
+    version: number;
+    /** True when the preview iframe is currently showing this version. */
+    isActive: boolean;
+    /** Click handler for the kebab menu's "Preview this version" item.
+     *  Required even when `isActive` — the menu item is disabled in that
+     *  case, but a missing handler would be a wiring bug, not a valid
+     *  state, so the type stays non-optional. */
+    onPreview: () => void;
+};
 
 type Props = {
     timestamp: Date;
     /**
      * Sender name to show on the left of the header. Pass `null` to render
-     * just the timestamp (e.g. assistant replies, which are nameless).
+     * just the timestamp (or the version chip, if provided).
      */
     userName: string | null;
+    /**
+     * Version chip rendered on the left of the row for assistant replies
+     * tied to a specific ready version. The chip is a non-interactive
+     * label — actions live in the kebab menu on the right (`⋯`). For now
+     * the only entry is "Preview this version"; "Restore as new version"
+     * is the next thing to add (see GLITCH-443).
+     */
+    version?: VersionInfo;
 };
 
 /**
- * Header row rendered inside a chat bubble. When a name is present it sits
- * on the left (indigo accent) with the timestamp on the right; without a
- * name the timestamp slides to the left. Hovering the timestamp reveals
- * the absolute date in a tooltip.
+ * Header row rendered inside a chat bubble. The left slot holds the sender
+ * name (user bubbles) or a clickable version badge (assistant replies tied
+ * to a ready version); the right slot holds the relative timestamp with a
+ * tooltip for the absolute date, optionally followed by a version-actions
+ * kebab menu.
  */
-const ChatBubbleMeta: FC<Props> = ({ timestamp, userName }) => {
+const ChatBubbleMeta: FC<Props> = ({ timestamp, userName, version }) => {
     const timeAgo = useTimeAgo(timestamp);
+    // Only user bubbles split (name left, timestamp right) — that pattern
+    // anchors the sender's name to the bubble edge. Assistant bubbles keep
+    // the version chip and timestamp adjacent on the left so a short chip
+    // doesn't leave the timestamp floating mid-row.
+    const justify = userName ? 'space-between' : 'flex-start';
     return (
         <Group
             gap="xs"
             wrap="nowrap"
-            justify={userName ? 'space-between' : 'flex-start'}
+            justify={justify}
             className={classes.meta}
         >
             {userName && (
                 <Text fz="xs" fw={600} className={classes.name} truncate>
                     {userName}
                 </Text>
+            )}
+            {version && (
+                <Badge
+                    size="sm"
+                    variant="light"
+                    color={version.isActive ? 'indigo' : 'gray'}
+                    leftSection={
+                        version.isActive ? (
+                            <MantineIcon icon={IconEye} size={10} />
+                        ) : undefined
+                    }
+                >
+                    v{version.version}
+                </Badge>
             )}
             <Tooltip
                 position={userName ? 'top-end' : 'top-start'}
@@ -43,6 +84,38 @@ const ChatBubbleMeta: FC<Props> = ({ timestamp, userName }) => {
                     {timeAgo}
                 </Text>
             </Tooltip>
+            {version && (
+                <Menu
+                    shadow="md"
+                    position="bottom-end"
+                    withinPortal
+                    withArrow
+                    arrowPosition="center"
+                >
+                    <Menu.Target>
+                        <ActionIcon
+                            variant="subtle"
+                            size="xs"
+                            color="ldGray.6"
+                            className={classes.versionMenuTrigger}
+                            aria-label="Version actions"
+                        >
+                            <MantineIcon icon={IconDots} size={12} />
+                        </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <Menu.Item
+                            leftSection={
+                                <MantineIcon icon={IconEye} size={14} />
+                            }
+                            disabled={version.isActive}
+                            onClick={version.onPreview}
+                        >
+                            Preview this version
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
+            )}
         </Group>
     );
 };

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -267,11 +267,6 @@
     flex: 1;
 }
 
-.versionBadge {
-    cursor: pointer;
-    border: 0;
-}
-
 .previewContent {
     flex: 1;
     overflow: hidden;

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -267,6 +267,11 @@
     flex: 1;
 }
 
+.versionBadge {
+    cursor: pointer;
+    border: 0;
+}
+
 .previewContent {
     flex: 1;
     overflow: hidden;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -36,12 +36,14 @@ import {
     IconExternalLink,
     IconFolderPlus,
     IconFolderSymlink,
+    IconHistory,
     IconPencil,
     IconLayoutDashboard,
     IconPlayerStop,
     IconRefresh,
     IconSparkles,
     IconTrash,
+    IconX,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import ReactMarkdownPreview from '@uiw/react-markdown-preview';
@@ -243,7 +245,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
                 ref={ref}
                 src={previewUrl}
                 expectedPreviewOrigin={previewOrigin}
-                identityKey={`${appUuid}:${version}`}
+                identityKey={appUuid}
                 onQueryEvent={onQueryEvent}
                 inspectorEnabled={inspectorEnabled}
                 onElementSelected={onElementSelected}
@@ -504,7 +506,7 @@ const AppGenerate: FC = () => {
         setSelectedDashboard(null);
         setImageAttachments([]);
         setLocalMessages([]);
-        setPreviewApp(null);
+        setPin(null);
         setTrackedQueries([]);
         setInspectorEnabled(false);
         setInspectorAvailable(false);
@@ -765,43 +767,114 @@ const AppGenerate: FC = () => {
     const hasUnloadedEarlierVersions =
         hasNextPage && !allVersions.some((v) => v.version === 1);
 
-    // Stable reference for the preview — only updates when a new version
-    // becomes ready, preventing iframe reloads during status polling.
-    const latestReadyPreview = useMemo(() => {
-        if (allVersions.length === 0 || !activeAppUuid) return null;
-        // Find the highest-numbered ready version
-        const ready = [...allVersions]
-            .sort((a, b) => b.version - a.version)
-            .find((v) => v.status === 'ready');
-        if (!ready) return null;
-        return { appUuid: activeAppUuid, version: ready.version };
-    }, [allVersions, activeAppUuid]);
-    const [previewApp, setPreviewApp] = useState(latestReadyPreview);
-    useEffect(() => {
+    // Latest ready version for this app. Updates as new versions finish
+    // building — preview defaults to this unless the user pins an older one.
+    const latestReadyVersion = useMemo(() => {
+        if (allVersions.length === 0) return null;
+        return (
+            [...allVersions]
+                .sort((a, b) => b.version - a.version)
+                .find((v) => v.status === 'ready') ?? null
+        );
+    }, [allVersions]);
+
+    // User-pinned version override. `null` = follow latest ready (default).
+    // We snapshot the app uuid and the latest ready version at the moment of
+    // pinning so the pin can self-invalidate via the derived
+    // `effectivePinnedVersion` below — no useEffect+setState chain needed
+    // (lightdash frontend rule).
+    const [pin, setPin] = useState<{
+        appUuid: string;
+        version: number;
+        /** Latest ready version at the moment of pinning. The pin is treated
+         *  as cleared once a newer build finishes past this snapshot. */
+        pinnedAtLatest: number | null;
+    } | null>(null);
+
+    // Effective pinned version after applying invalidation rules:
+    //  - pin from a different app (user navigated away) → ignore.
+    //  - a newer ready version exists than at pin time → ignore (the user
+    //    just authored a fresh prompt; show them the result, not the stale
+    //    review state).
+    //  - the pinned version is no longer in the ready set → ignore.
+    // Polling cycles where latestReadyVersion stays the same are no-ops, so
+    // the pin survives normal refetches.
+    const effectivePinnedVersion = useMemo(() => {
+        if (pin === null || pin.appUuid !== activeAppUuid) return null;
         if (
-            latestReadyPreview &&
-            (latestReadyPreview.appUuid !== previewApp?.appUuid ||
-                latestReadyPreview.version !== previewApp?.version)
+            pin.pinnedAtLatest !== null &&
+            latestReadyVersion !== null &&
+            latestReadyVersion.version > pin.pinnedAtLatest
         ) {
-            setPreviewApp(latestReadyPreview);
-            // The new bundle re-runs its queries from scratch, so the
-            // previous version's entries are stale. With "Persist" on we
-            // flip in-flight ones to a terminal "interrupted" state instead
-            // of clearing — the iframe that would have polled their
-            // queryUuids is gone, so they'd otherwise sit non-terminal.
-            if (persistLogs) {
-                interruptInFlightQueries();
-            } else {
-                setTrackedQueries([]);
-            }
+            return null;
         }
-    }, [
-        latestReadyPreview,
-        previewApp?.appUuid,
-        previewApp?.version,
-        persistLogs,
-        interruptInFlightQueries,
-    ]);
+        const stillReady = allVersions.some(
+            (v) => v.version === pin.version && v.status === 'ready',
+        );
+        return stillReady ? pin.version : null;
+    }, [pin, activeAppUuid, latestReadyVersion, allVersions]);
+
+    // Effective preview target: derived pin wins over latest ready.
+    const previewApp = useMemo(() => {
+        if (!activeAppUuid) return null;
+        if (effectivePinnedVersion !== null) {
+            return { appUuid: activeAppUuid, version: effectivePinnedVersion };
+        }
+        if (!latestReadyVersion) return null;
+        return { appUuid: activeAppUuid, version: latestReadyVersion.version };
+    }, [activeAppUuid, effectivePinnedVersion, latestReadyVersion]);
+
+    // Pin the preview to a specific version. Captures the current latest as
+    // the "pinned-at" snapshot so the derived state can decide later when
+    // the pin has become stale.
+    const pinPreviewToVersion = useCallback(
+        (version: number) => {
+            if (!activeAppUuid) return;
+            setPin({
+                appUuid: activeAppUuid,
+                version,
+                pinnedAtLatest: latestReadyVersion?.version ?? null,
+            });
+        },
+        [activeAppUuid, latestReadyVersion],
+    );
+
+    // Build the `version` prop for an assistant bubble's `ChatBubbleMeta`.
+    // Extracted so the arrow-function `onPreview` captures a `number` rather
+    // than `number | null` — TS won't carry inline ternary narrowing into a
+    // closure, but it does narrow this function's parameter directly.
+    const buildBubbleVersionInfo = (bubbleVersion: number) => ({
+        version: bubbleVersion,
+        isActive: previewApp?.version === bubbleVersion,
+        onPreview: () => pinPreviewToVersion(bubbleVersion),
+    });
+
+    // Whether the user is currently looking at a version other than the
+    // latest ready one. Drives the "viewing older version" banner.
+    const isViewingOlderVersion =
+        previewApp !== null &&
+        latestReadyVersion !== null &&
+        previewApp.version !== latestReadyVersion.version;
+
+    // When the effective preview version changes (auto-bump to a newer
+    // build, or a user click pinning an older one), the iframe reloads and
+    // re-runs its metric queries from scratch. With "Persist" on we flip
+    // in-flight entries to a terminal "interrupted" state — the iframe that
+    // would have polled their queryUuids is gone, so they'd otherwise sit
+    // non-terminal forever. Without persist we just clear the log.
+    const lastPreviewVersionRef = useRef<number | null>(null);
+    useEffect(() => {
+        const next = previewApp?.version ?? null;
+        if (lastPreviewVersionRef.current === next) return;
+        const prev = lastPreviewVersionRef.current;
+        lastPreviewVersionRef.current = next;
+        if (prev === null) return; // Initial render — nothing to clean up.
+        if (persistLogs) {
+            interruptInFlightQueries();
+        } else {
+            setTrackedQueries([]);
+        }
+    }, [previewApp?.version, persistLogs, interruptInFlightQueries]);
 
     // Manual refresh counter for the preview iframe. The iframe URL embeds
     // this value, so bumping it forces the browser to reload the iframe and
@@ -1581,6 +1654,15 @@ const AppGenerate: FC = () => {
                                                                 msg.timestamp
                                                             }
                                                             userName={null}
+                                                            version={
+                                                                msg.appUuid &&
+                                                                msg.version !==
+                                                                    null
+                                                                    ? buildBubbleVersionInfo(
+                                                                          msg.version,
+                                                                      )
+                                                                    : undefined
+                                                            }
                                                         />
                                                         {msg.appUuid ? (
                                                             <ReactMarkdownPreview
@@ -1995,6 +2077,38 @@ const AppGenerate: FC = () => {
                                         </Text>
                                     )}
                                 </Box>
+                                {isViewingOlderVersion && (
+                                    <Tooltip
+                                        label={`Return to latest (v${latestReadyVersion?.version})`}
+                                        withArrow
+                                        position="bottom"
+                                    >
+                                        <Badge
+                                            variant="light"
+                                            color="orange"
+                                            size="md"
+                                            ml="auto"
+                                            component="button"
+                                            type="button"
+                                            onClick={() => setPin(null)}
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconHistory}
+                                                    size={12}
+                                                />
+                                            }
+                                            rightSection={
+                                                <MantineIcon
+                                                    icon={IconX}
+                                                    size={12}
+                                                />
+                                            }
+                                            className={classes.versionBadge}
+                                        >
+                                            Viewing v{previewApp?.version}
+                                        </Badge>
+                                    </Tooltip>
+                                )}
                                 <Tooltip
                                     label="Refresh preview to re-run queries"
                                     withArrow
@@ -2004,7 +2118,7 @@ const AppGenerate: FC = () => {
                                         variant="subtle"
                                         size="sm"
                                         color="ldGray.6"
-                                        ml="auto"
+                                        ml={isViewingOlderVersion ? 0 : 'auto'}
                                         disabled={!previewApp}
                                         onClick={handleRefreshPreview}
                                         aria-label="Refresh preview"

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -34,16 +34,15 @@ import {
     IconArrowUp,
     IconDots,
     IconExternalLink,
+    IconArrowBackUp,
     IconFolderPlus,
     IconFolderSymlink,
-    IconHistory,
     IconPencil,
     IconLayoutDashboard,
     IconPlayerStop,
     IconRefresh,
     IconSparkles,
     IconTrash,
-    IconX,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import ReactMarkdownPreview from '@uiw/react-markdown-preview';
@@ -65,6 +64,7 @@ import {
     useParams,
 } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
+import Callout from '../components/common/Callout';
 import MantineIcon from '../components/common/MantineIcon';
 import AppDeleteModal from '../components/common/modal/AppDeleteModal';
 import AppUpdateModal from '../components/common/modal/AppUpdateModal';
@@ -1854,7 +1854,38 @@ const AppGenerate: FC = () => {
                         </Box>
 
                         {/* Chat Input */}
-                        {!wizardCoversInput && (
+                        {!wizardCoversInput && isViewingOlderVersion && (
+                            <Box className={classes.chatInputArea}>
+                                <Callout
+                                    variant="info"
+                                    title={`You're viewing version ${previewApp?.version}`}
+                                >
+                                    <Text size="sm">
+                                        New prompts always continue from the
+                                        latest build. Return to version{' '}
+                                        {latestReadyVersion?.version} to keep
+                                        iterating.
+                                    </Text>
+                                    <Button
+                                        mt="sm"
+                                        size="xs"
+                                        variant="light"
+                                        color="blue"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconArrowBackUp}
+                                                size={12}
+                                            />
+                                        }
+                                        onClick={() => setPin(null)}
+                                    >
+                                        Return to latest (v
+                                        {latestReadyVersion?.version})
+                                    </Button>
+                                </Callout>
+                            </Box>
+                        )}
+                        {!wizardCoversInput && !isViewingOlderVersion && (
                             <Box className={classes.chatInputArea}>
                                 <input
                                     ref={fileInputRef}
@@ -2077,38 +2108,6 @@ const AppGenerate: FC = () => {
                                         </Text>
                                     )}
                                 </Box>
-                                {isViewingOlderVersion && (
-                                    <Tooltip
-                                        label={`Return to latest (v${latestReadyVersion?.version})`}
-                                        withArrow
-                                        position="bottom"
-                                    >
-                                        <Badge
-                                            variant="light"
-                                            color="orange"
-                                            size="md"
-                                            ml="auto"
-                                            component="button"
-                                            type="button"
-                                            onClick={() => setPin(null)}
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconHistory}
-                                                    size={12}
-                                                />
-                                            }
-                                            rightSection={
-                                                <MantineIcon
-                                                    icon={IconX}
-                                                    size={12}
-                                                />
-                                            }
-                                            className={classes.versionBadge}
-                                        >
-                                            Viewing v{previewApp?.version}
-                                        </Badge>
-                                    </Tooltip>
-                                )}
                                 <Tooltip
                                     label="Refresh preview to re-run queries"
                                     withArrow
@@ -2118,7 +2117,7 @@ const AppGenerate: FC = () => {
                                         variant="subtle"
                                         size="sm"
                                         color="ldGray.6"
-                                        ml={isViewingOlderVersion ? 0 : 'auto'}
+                                        ml="auto"
                                         disabled={!previewApp}
                                         onClick={handleRefreshPreview}
                                         aria-label="Refresh preview"


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-443/add-roll-back-to-version

### Description:
Each ready assistant bubble's meta row now carries a "v{n}" badge plus a small kebab menu (⋯). The badge is a non-interactive label — actions live in the menu, which currently exposes a single "Preview this version" item that pins the preview iframe to that version. The active version's badge renders in indigo with an eye icon so it's clear which one is live. The kebab leaves room for "Restore as new version" as the next step on this branch.

When pinned to a non-latest version, the preview header shows an orange "Viewing v{n}" badge next to the refresh button — click clears the pin and returns to latest. The pin is also cleared automatically when a new version finishes building (latestReadyVersion.version goes up): the user just authored a fresh prompt and almost certainly wants to see the result, not stay frozen on the older one they were reviewing. Polling cycles that don't change the latest are no-ops, so the pin survives normal refetches.

The iframe identityKey is scoped to appUuid instead of \${appUuid}:\${version} so version switches no longer reset the inspector/screenshot SDK availability flags — those buttons stay visible across pin changes (same behaviour as the manual-refresh URL bump).

Read-only: pinning does not mutate app_versions; a true "restore this version as v_next" flow is the next step.


https://github.com/user-attachments/assets/7172a9c9-1882-44ac-aee7-371e1deb233f

