### PR TITLE
fix(ai-agent): exclude subagent children from rebuilt model history

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -3775,6 +3775,10 @@ export class AiAgentModel {
                 `${AiAgentToolResultTableName}.tool_call_id`,
             )
             .where(`${AiAgentToolCallTableName}.ai_prompt_uuid`, promptUuid)
+            // Subagent children are stored with `parent_tool_call_id` set so the
+            // thread viewer can render them nested. Exclude them from rebuilt
+            // model history — the parent tool's compact result is the handoff.
+            .whereNull(`${AiAgentToolCallTableName}.parent_tool_call_id`)
             .orderBy(`${AiAgentToolCallTableName}.created_at`, 'asc');
 
         return rows


### PR DESCRIPTION
## Summary

Foundation of the [ZAP-392](https://linear.app/lightdash/issue/ZAP-392) stack: explicitly filter subagent children out of the rebuilt model history when reconstructing a thread for the next prompt.

`getToolCallsAndResultsForPrompt` joins `ai_agent_tool_call` against `ai_agent_tool_result` to rehydrate past turns into the parent model's `messageHistory`. Subagent children (rows where `parent_tool_call_id IS NOT NULL`) must never end up in that history — the whole point of the `discoverFields` subagent is to keep their fat outputs out of the parent's context window.

Today the leak is *implicitly* prevented: the subagent never stores tool **results** (only tool **calls**), so the `LEFT JOIN` returns `result IS NULL` for children and they get filtered out one line below. PR #23116 in this stack starts persisting subagent results too, which would silently re-introduce the leak.

Move the filter from "happens to be excluded because of missing results" to "explicitly excluded by the parent-call-id column" so the invariant survives that next PR and any future observability/eval work that wants subagent results in the DB.

## Regression analysis

- **Behaviour with feature flag OFF (parent uses findExplores directly):** parent-level rows have `parent_tool_call_id = NULL` and are kept. Unchanged.
- **Behaviour with flag ON, threads pre-dating PR #23116:** subagent children already have only `tool_call` rows (no `tool_result`) — they were already excluded by the existing null-result filter. This PR continues to exclude them. Identical output.
- **Behaviour with flag ON, threads created after PR #23116:** subagent children will gain `tool_result` rows, and `parent_tool_call_id IS NOT NULL` on the call side will now drop them. Without this PR, those rows would leak into model history.
- **Mid-thread flag flips in either direction:** orthogonal to this change — the filter keys off the row's `parent_tool_call_id`, not the flag state.

No service-account / cross-project / role surface touched.

## Test plan

- [ ] `pnpm -F backend typecheck`
- [ ] Existing AI thread continuation flow renders the same history as before this PR
- [ ] Manually run a `discoverFields` turn (flag on), then a follow-up turn in the same thread. Inspect the model input messages — only the parent `discoverFields` tool-call/result pair should appear, no `findExplores`/`findFields` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)