### PR TITLE
feat(ai-agent): persist subagent findExplores/findFields tool results

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -139,6 +139,7 @@ const getAgentTools = async (
                   getExplore: dependencies.getExplore,
                   updateProgress: dependencies.updateProgress,
                   storeToolCall: dependencies.storeToolCall,
+                  storeToolResults: dependencies.storeToolResults,
               },
           )
         : null;

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
@@ -1,4 +1,4 @@
-import { Explore } from '@lightdash/common';
+import { AgentToolOutput, Explore } from '@lightdash/common';
 import {
     smoothStream,
     stepCountIs,
@@ -20,6 +20,13 @@ import { getDiscoverFieldsSystemPrompt } from './systemPrompt';
 
 const SUBAGENT_STEP_CAP = 10;
 
+const SUBAGENT_PERSISTED_TOOL_NAMES = ['findExplores', 'findFields'] as const;
+type SubagentPersistedToolName = (typeof SUBAGENT_PERSISTED_TOOL_NAMES)[number];
+const isSubagentPersistedToolName = (
+    name: string,
+): name is SubagentPersistedToolName =>
+    (SUBAGENT_PERSISTED_TOOL_NAMES as readonly string[]).includes(name);
+
 export type DiscoverFieldsAgentDependencies = Pick<
     AiAgentDependencies,
     | 'findExplores'
@@ -27,6 +34,7 @@ export type DiscoverFieldsAgentDependencies = Pick<
     | 'getExplore'
     | 'updateProgress'
     | 'storeToolCall'
+    | 'storeToolResults'
 >;
 
 export type DiscoverFieldsAgentArgs = {
@@ -127,29 +135,48 @@ export const runDiscoverFieldsAgent = (
             args.telemetry,
         ),
         onChunk: ({ chunk }) => {
-            if (
-                chunk.type !== 'tool-call' ||
-                (chunk.toolName !== 'findExplores' &&
-                    chunk.toolName !== 'findFields')
-            ) {
+            if (chunk.type === 'tool-call') {
+                if (!isSubagentPersistedToolName(chunk.toolName)) return;
+                inflightWrites.push(
+                    dependencies
+                        .storeToolCall({
+                            promptUuid: args.promptUuid,
+                            toolCallId: chunk.toolCallId,
+                            toolName: chunk.toolName,
+                            toolArgs: (chunk.input as object) ?? {},
+                            parentToolCallId: args.parentToolCallId,
+                        })
+                        .catch((err) => {
+                            Logger.error(
+                                '[DiscoverFieldsSubagent] storeToolCall failed',
+                                err,
+                            );
+                        }),
+                );
                 return;
             }
-            inflightWrites.push(
-                dependencies
-                    .storeToolCall({
-                        promptUuid: args.promptUuid,
-                        toolCallId: chunk.toolCallId,
-                        toolName: chunk.toolName,
-                        toolArgs: (chunk.input as object) ?? {},
-                        parentToolCallId: args.parentToolCallId,
-                    })
-                    .catch((err) => {
-                        Logger.error(
-                            '[DiscoverFieldsSubagent] storeToolCall failed',
-                            err,
-                        );
-                    }),
-            );
+            if (chunk.type === 'tool-result') {
+                if (!isSubagentPersistedToolName(chunk.toolName)) return;
+                const output = chunk.output as AgentToolOutput;
+                inflightWrites.push(
+                    dependencies
+                        .storeToolResults([
+                            {
+                                promptUuid: args.promptUuid,
+                                toolCallId: chunk.toolCallId,
+                                toolName: chunk.toolName,
+                                result: output.result,
+                                metadata: output.metadata,
+                            },
+                        ])
+                        .catch((err) => {
+                            Logger.error(
+                                '[DiscoverFieldsSubagent] storeToolResults failed',
+                                err,
+                            );
+                        }),
+                );
+            }
         },
     });
 


### PR DESCRIPTION
## Summary

Second PR of the [ZAP-392](https://linear.app/lightdash/issue/ZAP-392) stack. Persist the `discoverFields` subagent's `findExplores`/`findFields` tool **results** to `ai_agent_tool_result`, linked back to the parent `discoverFields` call via `parent_tool_call_id`.

Before this PR the subagent stored tool **calls** (with `parent_tool_call_id` set) but not the matching results — those lived only as opaque JSONB inside the parent row's `metadata.streamingMessage` (the full AI SDK `UIMessage` with all `parts`). That:

- left half-orphaned `tool_call` rows in the DB,
- made any "what did findExplores return on these N runs?" analytics need a nested JSON walker that knows the AI SDK message shape,
- and tied the thread-viewer trace rendering to a UIMessage shape the SDK reserves the right to change (it did between v5 and v6).

Extend the subagent's `onChunk` to handle `tool-result` chunks the same way it already handles `tool-call`: push a `storeToolResults` promise into `inflightWrites`, awaited by `flushPersistence` before the parent's `discoverFields` row commits. Extract the persisted-tool allow-list into a typed guard so the same set is shared between both branches and is easy to extend.

PR #23115 (stack base) already moved the "subagent children don't leak into model history" guarantee from "happens to work because results aren't persisted" to an explicit `whereNull('parent_tool_call_id')` filter — so this PR cannot regress context-window size for the parent agent.

## Regression analysis

Four dimensions to verify: feature-flag state, thread vintage, mid-thread flag flips, and parent-vs-subagent stream chunks.

| Scenario | Effect | Status |
| --- | --- | --- |
| Flag OFF, before & after this PR | Subagent never instantiated; new `storeToolResults` branch never fires. Parent uses `findExplores`/`findFields` directly, results stored by the existing parent `onChunk`. | Identical |
| Flag ON, threads created before this PR | Existing `tool_call` rows with no matching `tool_result` — already filtered from history by PR #23115. UI's `metadata.streamingMessage` path keeps rendering nested trace. | Identical |
| Flag ON, threads created after this PR | `tool_call` + `tool_result` rows present, both filtered from history by PR #23115. Parent model sees the same compact XML handoff as today. | Compact XML preserved |
| Mid-thread flag flip OFF → ON | Old parent-level rows (parent_tool_call_id=NULL) keep rehydrating into history; new turn's subagent children are filtered. | Compatible |
| Mid-thread flag flip ON → OFF | Old `discoverFields` handoff stays in history (already in `ToolNameSchema`); new turns use parent-level `findExplores`. | Compatible |

Parent and subagent run on separate `streamText` streams: parent `onChunk` only sees `discoverFields` chunks, subagent `onChunk` only sees `findExplores`/`findFields`/`submitResult` chunks. No double-writes or races.

No service-account / cross-project / role surface touched.

## Test plan

- [ ] `pnpm -F backend typecheck`
- [ ] `pnpm -F backend lint`
- [ ] Flag ON: run a fresh `discoverFields` turn. After it completes, `psql -c "SELECT tool_name, parent_tool_call_id IS NOT NULL AS is_child FROM ai_agent_tool_result r JOIN ai_agent_tool_call c USING (tool_call_id) WHERE r.ai_prompt_uuid = '<uuid>'"` returns rows for `findExplores`/`findFields` with `is_child = true`.
- [ ] Same flag-on run: send a follow-up turn in the same thread. Confirm the parent model's `messageHistory` (debuglog) contains exactly one `discoverFields` tool-call/result, no `findExplores`/`findFields` entries.
- [ ] Flag OFF: identical AI-agent flow as before; no subagent rows ever created.
- [ ] Thread viewer still renders the nested `findExplores`/`findFields` rows under "Discovering fields" on reload (sourced from `metadata.streamingMessage` until PR #23117 swaps the source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)