### PR TITLE
fix: replace user attributes in query selects

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -957,6 +957,68 @@ describe('Query builder', () => {
         ).toThrow(ForbiddenError);
     });
 
+    test('Should replace intrinsic user attributes in selected dimensions and metrics', () => {
+        const explore: Explore = {
+            ...EXPLORE,
+            tables: {
+                ...EXPLORE.tables,
+                table1: {
+                    ...EXPLORE.tables.table1,
+                    dimensions: {
+                        ...EXPLORE.tables.table1.dimensions,
+                        user_email_status: {
+                            type: DimensionType.STRING,
+                            name: 'user_email_status',
+                            label: 'user_email_status',
+                            table: 'table1',
+                            tableLabel: 'table1',
+                            fieldType: FieldType.DIMENSION,
+                            sql: `CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN \${TABLE}.shared ELSE 'other' END`,
+                            compiledSql: `CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN "table1".shared ELSE 'other' END`,
+                            tablesReferences: ['table1'],
+                            hidden: false,
+                        },
+                    },
+                    metrics: {
+                        ...EXPLORE.tables.table1.metrics,
+                        user_email_metric: {
+                            type: MetricType.SUM,
+                            fieldType: FieldType.METRIC,
+                            table: 'table1',
+                            tableLabel: 'table1',
+                            name: 'user_email_metric',
+                            label: 'user_email_metric',
+                            sql: `CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN \${TABLE}.number_column ELSE 0 END`,
+                            compiledSql: `SUM(CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN "table1".number_column ELSE 0 END)`,
+                            tablesReferences: ['table1'],
+                            hidden: false,
+                        },
+                    },
+                },
+            },
+        };
+
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...METRIC_QUERY,
+                dimensions: ['table1_user_email_status'],
+                metrics: ['table1_user_email_metric'],
+                sorts: [],
+                tableCalculations: [],
+                compiledTableCalculations: [],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(query).not.toContain('${ld.user.email}');
+        expect(query).toContain("'mock@lightdash.com' = 'mock@lightdash.com'");
+        expect(query).toContain('"table1_user_email_status"');
+        expect(query).toContain('"table1_user_email_metric"');
+    });
+
     it('buildQuery with row() table calculation should order by custom bin _order column', () => {
         const { query } = buildQuery({
             explore: EXPLORE,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -840,7 +840,14 @@ export class MetricQueryBuilder {
                 adapterType,
                 startOfWeek,
             );
-            selects[id] = `  ${sql} AS ${quotedAlias}`;
+            const sqlWithUserAttributes = replaceUserAttributesAsStrings(
+                sql,
+                intrinsicUserAttributes,
+                userAttributes,
+                warehouseSqlBuilder,
+                { noWrap: true },
+            );
+            selects[id] = `  ${sqlWithUserAttributes} AS ${quotedAlias}`;
         });
 
         if (customBinDimensionSql?.selects) {
@@ -1143,8 +1150,15 @@ export class MetricQueryBuilder {
                     return;
                 }
                 // Add select
+                const sqlWithUserAttributes = replaceUserAttributesAsStrings(
+                    metric.compiledSql,
+                    this.args.intrinsicUserAttributes,
+                    this.args.userAttributes ?? {},
+                    warehouseSqlBuilder,
+                    { noWrap: true },
+                );
                 selects.add(
-                    `  ${metric.compiledSql} AS ${fieldQuoteChar}${alias}${fieldQuoteChar}`,
+                    `  ${sqlWithUserAttributes} AS ${fieldQuoteChar}${alias}${fieldQuoteChar}`,
                 );
                 // Add tables
                 (metric.tablesReferences || [metric.table]).forEach((table) =>

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/coreQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/coreQueries.test.ts.snap
@@ -156,3 +156,25 @@ ORDER BY
 LIMIT
   5"
 `;
+
+exports[`MetricQueryBuilder snapshot: core queries matches snapshot for selected fields using intrinsic user attributes 1`] = `
+"SELECT
+  CASE
+    WHEN 'mock@lightdash.com' = 'mock@lightdash.com' THEN "table1".shared
+    ELSE 'other'
+  END AS "table1_user_email_status",
+  SUM(
+    CASE
+      WHEN 'mock@lightdash.com' = 'mock@lightdash.com' THEN "table1".number_column
+      ELSE 0
+    END
+  ) AS "table1_user_email_metric"
+FROM
+  "db"."schema"."table1" AS "table1"
+GROUP BY
+  1
+ORDER BY
+  "table1_user_email_metric" DESC
+LIMIT
+  10"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/coreQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/coreQueries.test.ts
@@ -1,4 +1,10 @@
 import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type Explore,
+} from '@lightdash/common';
+import {
     bigqueryClientMock,
     EXPLORE,
     EXPLORE_ALL_JOIN_TYPES_CHAIN,
@@ -102,6 +108,64 @@ describe('MetricQueryBuilder snapshot: core queries', () => {
                     dimensions: [],
                     metrics: ['table1_metric1'],
                     sorts: [],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers selected dimensions and metrics whose SQL depends on intrinsic user attributes,
+    // ensuring runtime user context is replaced before SELECT expressions reach the warehouse.
+    test('matches snapshot for selected fields using intrinsic user attributes', () => {
+        const explore: Explore = {
+            ...EXPLORE,
+            tables: {
+                ...EXPLORE.tables,
+                table1: {
+                    ...EXPLORE.tables.table1,
+                    dimensions: {
+                        ...EXPLORE.tables.table1.dimensions,
+                        user_email_status: {
+                            type: DimensionType.STRING,
+                            name: 'user_email_status',
+                            label: 'user_email_status',
+                            table: 'table1',
+                            tableLabel: 'table1',
+                            fieldType: FieldType.DIMENSION,
+                            sql: `CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN \${TABLE}.shared ELSE 'other' END`,
+                            compiledSql: `CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN "table1".shared ELSE 'other' END`,
+                            tablesReferences: ['table1'],
+                            hidden: false,
+                        },
+                    },
+                    metrics: {
+                        ...EXPLORE.tables.table1.metrics,
+                        user_email_metric: {
+                            type: MetricType.SUM,
+                            fieldType: FieldType.METRIC,
+                            table: 'table1',
+                            tableLabel: 'table1',
+                            name: 'user_email_metric',
+                            label: 'user_email_metric',
+                            sql: `CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN \${TABLE}.number_column ELSE 0 END`,
+                            compiledSql: `SUM(CASE WHEN \${ld.user.email} = 'mock@lightdash.com' THEN "table1".number_column ELSE 0 END)`,
+                            tablesReferences: ['table1'],
+                            hidden: false,
+                        },
+                    },
+                },
+            },
+        };
+
+        expect(
+            buildQuery({
+                explore,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY,
+                    dimensions: ['table1_user_email_status'],
+                    metrics: ['table1_user_email_metric'],
+                    sorts: [],
+                    tableCalculations: [],
+                    compiledTableCalculations: [],
                 },
             }),
         ).toMatchSnapshot();


### PR DESCRIPTION
## Summary

Fixes query compilation for selected dimension and metric SQL that references Lightdash user context variables such as `${ld.user.email}`.

Before this change, those variables were replaced in filter/sqlWhere paths but not in SELECT expressions. Valid model SQL could leak through to the warehouse as raw `${...}` syntax and Postgres failed with `syntax error at or near "$"`.

## Repro steps

Using the local Jaffle shop seed project:

1. Start the local dev stack and use project `3675b69e-8324-4110-bdca-059031aa8da3` (`Jaffle shop`).
2. Use the `orders` explore, which defines `orders_user_attribute_email_test` in `examples/full-jaffle-shop-demo/dbt/models/orders.yml` with `WHEN ${ld.user.email} = 'demo@lightdash.com'`.
3. Run an underlying-data query that selects all order fields and filters `orders_status = shipped`.
4. Observe the async query failing in `query_history` with `syntax error at or near "$"`.
5. Inspect `query_history.compiled_sql` for a failed query such as `bbd37028-383b-4268-a836-ce149c36145d`; the SELECT contains raw `${ld.user.email}` in `orders_user_attribute_email_test`.

## Root cause

`MetricQueryBuilder` emitted selected dimension SQL from `getTimezoneAwareDimensionSql(...)` directly into the SELECT list, and emitted selected metric `compiledSql` directly as well. Neither path called `replaceUserAttributesAsStrings(...)`, so supported user context syntax was not resolved before the SQL reached the warehouse.

## Fix

- Replace user attributes in selected dimension SQL after timezone-aware dimension SQL resolution and before aliasing.
- Replace user attributes in selected metric SQL before aliasing.
- Use `noWrap` so SELECT expressions keep their existing expression shape.

## Validation

- `pnpm -F backend test -- src/utils/QueryBuilder/MetricQueryBuilder.test.ts --runInBand`

Added regression coverage for selected dimensions and selected metrics containing `${ld.user.email}`.
