### PR TITLE
feat(ai-agent): stream response line-by-line instead of word-by-word

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -689,7 +689,7 @@ export const streamAgentResponse = async ({
             },
             experimental_transform: smoothStream({
                 delayInMs: 40,
-                chunking: 'word',
+                chunking: 'line',
             }),
             onError: ({ error }) => {
                 console.error(error);


### PR DESCRIPTION
## Summary

Switch the AI agent's `streamText` smoothing transform from word-level to line-level chunking in `streamAgentResponse` (`packages/backend/src/ee/services/ai/agents/agentV2.ts`). The model's text output is now buffered and flushed at newline boundaries instead of after every word.

```diff
 experimental_transform: smoothStream({
     delayInMs: 40,
-    chunking: 'word',
+    chunking: 'line',
 }),
```

`delayInMs: 40` is unchanged — each emitted chunk still has a 40ms cadence, but a chunk is now a full line rather than a single word.

## Why

Per-word streaming is visually busy and can overwhelm the chat UI's renderer (every word triggers a re-render of any inline markdown / code block in the message). Line-level streaming gives the user a more readable typing rhythm and lets the renderer parse complete markdown lines.

## Behavior change / regression analysis

- **Affected**: anyone using the streaming endpoint (`POST /api/v1/projects/{p}/aiAgents/{a}/threads/{t}/stream`) — both the in-app chat UI and Slack streaming. The visible cadence of token reveal changes.
- **Not affected**:
  - Non-streaming callers (`generateAgentThreadResponse`, evals) — they consume the final text and never see intermediate chunks.
  - Tool calls, reasoning, tool results — `smoothStream` only transforms `text-delta` events; tool/reasoning chunks pass through unchanged.
  - Final response text stored in the prompt — still the concatenation of all step text in `onFinish`.
- **Edge case**: model output that contains no `\n` (e.g. a single long unbroken paragraph) will only flush at stream end, so the user sees nothing until the response completes. In practice the agent's responses use markdown with line breaks, so this is rare; if it becomes a problem we can switch to a custom `ChunkDetector` that flushes on newline OR after N characters.

## Test plan

- [ ] Open an AI agent thread in the app and send a prompt that produces a multi-line markdown answer; confirm text appears one line at a time with ~40ms cadence.
- [ ] Confirm tool-call chips (find explores, find fields, run query) still render at the moment the tool call starts, not bunched at end of stream.
- [ ] Confirm reasoning text and the final stored response (`prompts.response` in DB) match the rendered text.
- [ ] Sanity check Slack streaming still updates the message progressively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)