### PR TITLE
ci: bump E2E API job timeout from 10 to 20 minutes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -342,7 +342,7 @@ jobs:
 
   api-tests:
     if: needs.files-changed.outputs.backend == 'true'
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: depot-ubuntu-24.04-4
     needs: [preview, files-changed]
     name: "E2E: API (Vitest)"


### PR DESCRIPTION
## Summary

Bump the `E2E: API (Vitest)` job timeout from **10 → 20 minutes**.

The job kept hitting its 10-minute limit and getting cancelled (e.g. [run 25916234703](https://github.com/lightdash/lightdash/actions/runs/25916234703/job/76176657955)). Between setup (checkout, sfw, pnpm install, common-build, BigQuery credentials) and the Vitest API suite against a preview environment, the total runtime has been tipping over budget. Matches the headroom of the neighboring E2E App jobs (30m).

## Test plan

- [ ] Confirm CI for this PR completes within the new 20m budget.