### PR TITLE
fix(ai-agent): dedupe discoverFields subagent yields to kill stream quadratic blowup

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
@@ -1,5 +1,6 @@
 import { Explore } from '@lightdash/common';
 import {
+    smoothStream,
     stepCountIs,
     streamText,
     tool,
@@ -117,6 +118,10 @@ export const runDiscoverFieldsAgent = (
         messages,
         abortSignal: args.abortSignal,
         experimental_context: new AgentContext(args.availableExplores),
+        experimental_transform: smoothStream({
+            delayInMs: 40,
+            chunking: 'line',
+        }),
         experimental_telemetry: getAgentTelemetryConfig(
             'discoverFieldsSubagent',
             args.telemetry,

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
@@ -169,14 +169,10 @@ type ToolArgs = {
  * handoff arrives already-typed — no JSON.parse, no fence stripping,
  * no post-stream coercion.
  *
- * Each iteration of `readUIMessageStream` yields the accumulated subagent
- * UIMessage as `metadata.streamingMessage` on the streaming tool output;
- * AI SDK forwards each as a preliminary `tool-result` chunk so the
- * frontend can render the trace live. The final yield extracts the
- * handoff from the submitResult tool call and renders the XML the parent
- * model sees via `toModelOutput`. Subagent's `storeToolCall` writes are
- * awaited before the final yield so the parent's tool-result row never
- * commits before the children rows.
+ * The final yield extracts the handoff from the submitResult tool call
+ * and renders the XML the parent model sees via `toModelOutput`.
+ * Subagent's `storeToolCall` writes are awaited before the final yield
+ * so the parent's tool-result row never commits before the children rows.
  */
 export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
     tool({
@@ -203,17 +199,40 @@ export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
                 );
 
                 let currentMessage: UIMessage | undefined;
+                // Yield only on tool-call structural changes; per-chunk
+                // yields re-emit the accumulated UIMessage and grow the
+                // parent stream quadratically.
+                let lastTraceSignature: string | null = null;
                 for await (const message of readUIMessageStream({
                     stream: stream.toUIMessageStream(),
                 })) {
                     currentMessage = message;
-                    yield {
-                        result: '',
-                        metadata: {
-                            status: 'streaming' as const,
-                            streamingMessage: message,
-                        },
-                    };
+                    const traceSignature = message.parts
+                        .filter((p) => p.type.startsWith('tool-'))
+                        .map((p) => {
+                            const toolPart = p as {
+                                type: string;
+                                toolCallId?: string;
+                                input?: unknown;
+                            };
+                            return `${toolPart.type}:${
+                                toolPart.toolCallId ?? ''
+                            }:${toolPart.input != null ? '1' : '0'}`;
+                        })
+                        .join('|');
+                    if (
+                        traceSignature &&
+                        traceSignature !== lastTraceSignature
+                    ) {
+                        lastTraceSignature = traceSignature;
+                        yield {
+                            result: '',
+                            metadata: {
+                                status: 'streaming' as const,
+                                streamingMessage: message,
+                            },
+                        };
+                    }
                 }
 
                 await flushPersistence();


### PR DESCRIPTION
## Summary

Fixes the live SSE stream from the AI agent blowing up to **235 MB** (observed in prod HAR) and OOM'ing the API pod. Two surgical changes inside the `discoverFields` subagent path.

### Root cause

`discoverFields/tool.tsx` is an async-generator tool that re-emits the subagent's whole accumulated `UIMessage` (`metadata.streamingMessage`) on every iteration of `readUIMessageStream`. Each iteration corresponds to one chunk from the subagent's `streamText`. The AI SDK forwards each yield as a `tool-result` chunk on the parent stream, so the parent SSE response carries N copies of a message that grows monotonically — **O(N²) bytes**. With a few-thousand-chunk subagent run, that reaches hundreds of MB.

The `chunking: 'word' → 'line'` fix in #23122 reduces parent text-delta granularity but does **not** touch the subagent's chunk rate or the tool-result re-emission pattern, so it cannot fix this on its own.

### Changes

- `discoverFields/tool.tsx`: yield only when the subagent's tool-call structure changes (a new `tool-*` part appears, or its `input` becomes non-null). Dedupe by a tiny signature. Drops yields from ~thousands → ≤ `SUBAGENT_STEP_CAP` (10). Payload shape is unchanged — `metadata.streamingMessage` still carries the accumulated `UIMessage`, so `LiveActivityCard.tsx` and `useAiAgentThreadStreamMutation.ts` are untouched.
- `discoverFields/agent.ts`: add `experimental_transform: smoothStream({ delayInMs: 40, chunking: 'line' })` to match the parent agent — reduces the subagent's own emission rate and the work `readUIMessageStream` does.

### Expected impact

```
pre-fix:  ~5000 yields × avg(50KB streamingMessage)   ≈ 250 MB   (observed: 235 MB)
post-fix: ≤10 yields  × avg(50KB–500KB)               ≈ 1–5 MB
```

### Measured (same-prompt HAR, dev env)

Captured two HARs against the same prompt, same dev stack, same agent — only difference is whether the dedupe commit was applied:

| | SSE response body | SSE events |
| --- | --- | --- |
| **Pre-fix** (revert) | **207.5 MB** (217 535 610 B) | (body too large for HAR exporter to serialize) |
| **Post-fix** | **0.97 MB** (992 084 B) | 404 events, avg ~2.4 KB |
| **Reduction** | **~219× (99.5%)** | — |

That's **~206 MB shaved off per `discoverFields` prompt's live stream**, on top of the FE saving the equivalent UIMessage re-parse + re-render work each yield (so DOM/CPU savings scale with the same factor).

`LiveActivityCard.tsx:255-278` only reads `parts[]` filtered to `tool-findExplores` / `tool-findFields` and extracts `toolCallId` + `input` — no text or reasoning. So structural dedup loses zero rendered detail; the trace renders identically.

## Regression analysis

| Scenario | Effect | Status |
| --- | --- | --- |
| Feature flag OFF (subagent never instantiated) | Code path unreachable; parent uses `findExplores`/`findFields` directly. | Identical |
| Feature flag ON, live stream | `LiveActivityCard` renders the same trace from `streamingMessage.parts`; structural signature changes exactly when the rendered trace would change. | Visually identical |
| Feature flag ON, thread reload (legacy / pre-#23116) | Final non-preliminary yield still carries the full `streamingMessage`, persisted into `AiAgentToolResult.metadata`. | Unchanged |
| Feature flag ON, thread reload (post-#23116, FK-row path) | Trace sourced from FK rows once #23117 lands; orthogonal to this PR. | Compatible |
| Subagent fails before any tool call | No structural change → no preliminary yield (was: per-chunk yields with empty trace). Catch block still emits the error yield. | Slightly better (silenced empty yields), no rendered change |

Cross-cuts: no role / service-account / cross-project surface touched. No DB shape changes. No API generation needed.

### Overlap with the ZAP-392 stack (#23115 → #23116 → #23117)

Complementary, not redundant:

- ZAP-392 #23117 explicitly leaves the live-stream path on `streamingMessage` (FK rows aren't populated until persistence catches up post-stream). So ZAP-392 alone does **not** shrink the 235 MB live stream.
- This PR shrinks the live stream now. The eventual "ZAP-392 PR 4" (not yet open) that drops `streamingMessage` from the live SSE entirely would supersede the dedup — at which point this code can be removed.
- File overlap with #23116 is `discoverFields/agent.ts`. Mechanical conflict on the `streamText` options block — semantically independent.

## Test plan

- [ ] `pnpm -F backend typecheck`
- [ ] `pnpm -F backend lint`
- [ ] Flag ON, send a discovery prompt. Network tab: SSE response for `/threads/.../stream` is on the order of **single-digit MB**, not hundreds of MB. Confirmed regression closed.
- [ ] Same run: `LiveActivityCard` expands to show the nested `findExplores`/`findFields` rows. Visually identical to current main.
- [ ] Subagent run that exercises multiple `findExplores`+`findFields` cycles: each new tool call appears in the trace as soon as its `input` becomes available (same latency feel as today).
- [ ] Thread reload after the run: persisted `streamingMessage` still drives the trace fallback — no regression for pre-#23117 threads.

