### PR TITLE
fix(pivot): resolve ${ld.parameters.*} in pivot cells and totals

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1,3 +1,4 @@
+import { type ItemsMap } from '../types/field';
 import {
     convertSqlPivotedRowsToPivotData,
     pivotQueryResults,
@@ -1581,6 +1582,184 @@ describe('visibleMetricFieldIds in pivotQueryResults', () => {
         ]);
         // 3 pages × 2 metrics = 6 data columns
         expect(result.dataColumnCount).toBe(6);
+    });
+});
+
+describe('parameter-aware cell formatting (PROD-437)', () => {
+    // Metric formats that reference ${ld.parameters.*} can't be evaluated by
+    // the backend (parameter values live on the client), so its `.formatted`
+    // string carries the literal placeholder. For flat tables, useColumns
+    // overlays a per-cell re-format. The pivot pipeline used to skip this
+    // overlay — every cell, total and pivoted-metric header rendered the
+    // unresolved format. This block covers the equivalent overlay in
+    // pivotQueryResults / convertSqlPivotedRowsToPivotData.
+
+    const PARAMETER_FORMAT = '${ld.parameters.currency=="eur"?"€":"$"}0,0.00';
+
+    const getFieldWithParameterFormat = (
+        fieldId: string,
+    ): ItemsMap[string] | undefined => {
+        const field = getFieldMock(fieldId);
+        if (field && fieldId === 'payments_total_revenue') {
+            // `format` on TableCalculation is a CustomFormat object, but we
+            // know payments_total_revenue is a Metric — cast to satisfy the
+            // union's intersection.
+            return { ...field, format: PARAMETER_FORMAT } as ItemsMap[string];
+        }
+        return field;
+    };
+
+    const PIVOT_CONFIG_WITH_TOTALS = {
+        pivotDimensions: ['payments_payment_method'],
+        metricsAsRows: false,
+        columnOrder: [
+            'payments_payment_method',
+            'orders_order_date_year',
+            'payments_total_revenue',
+        ],
+        hiddenMetricFieldIds: [],
+        columnTotals: true,
+        rowTotals: true,
+    };
+
+    const METRIC_QUERY_PIVOTED = {
+        dimensions: ['payments_payment_method', 'orders_order_date_year'],
+        metrics: ['payments_total_revenue'],
+        tableCalculations: [],
+        additionalMetrics: [],
+        customDimensions: [],
+    };
+
+    it('pivotQueryResults reformats pivoted cells with active parameters', () => {
+        const result = pivotQueryResults({
+            getField: getFieldWithParameterFormat,
+            getFieldLabel: (fieldId) => fieldId,
+            pivotConfig: PIVOT_CONFIG_WITH_TOTALS,
+            metricQuery: METRIC_QUERY_PIVOTED,
+            rows: NON_PIVOTED_ROWS,
+            options: { maxColumns: 60 },
+            parameters: { currency: 'eur' },
+        });
+
+        // First data row, first pivoted-metric cell (raw 493.78) — used to
+        // render the unresolved `${...}493.78` placeholder verbatim.
+        const firstCell =
+            result.retrofitData.allCombinedData[0]
+                ?.payments_payment_method__payments_total_revenue__0;
+        expect(firstCell?.value).toEqual({
+            raw: 493.78,
+            formatted: '€493.78',
+        });
+    });
+
+    it('pivotQueryResults reformats row totals with active parameters', () => {
+        const result = pivotQueryResults({
+            getField: getFieldWithParameterFormat,
+            getFieldLabel: (fieldId) => fieldId,
+            pivotConfig: PIVOT_CONFIG_WITH_TOTALS,
+            metricQuery: METRIC_QUERY_PIVOTED,
+            rows: NON_PIVOTED_ROWS,
+            options: { maxColumns: 60 },
+            parameters: { currency: 'eur' },
+        });
+
+        // combinedRetrofit's formatItemValue call previously passed
+        // `undefined` for parameters, dropping the currency symbol from
+        // row-total cells.
+        const firstRowTotal =
+            result.retrofitData.allCombinedData[0]?.['row-total-0'];
+        expect(firstRowTotal?.value).toEqual({
+            raw: 1746.77,
+            formatted: '€1,746.77',
+        });
+    });
+
+    it('pivotQueryResults leaves output unchanged when parameters are omitted (backwards compat)', () => {
+        const result = pivotQueryResults({
+            getField: getFieldWithParameterFormat,
+            getFieldLabel: (fieldId) => fieldId,
+            pivotConfig: PIVOT_CONFIG_WITH_TOTALS,
+            metricQuery: METRIC_QUERY_PIVOTED,
+            rows: NON_PIVOTED_ROWS,
+            options: { maxColumns: 60 },
+        });
+
+        // No parameters supplied → reformat helper short-circuits, backend
+        // `.formatted` is forwarded verbatim.
+        const firstCell =
+            result.retrofitData.allCombinedData[0]
+                ?.payments_payment_method__payments_total_revenue__0;
+        expect(firstCell?.value).toEqual({
+            raw: 493.78,
+            formatted: '493.78',
+        });
+
+        // Row total falls back to default-formatted numeric (no currency
+        // symbol) — matches pre-PR behaviour.
+        const firstRowTotal =
+            result.retrofitData.allCombinedData[0]?.['row-total-0'];
+        expect(firstRowTotal?.value.raw).toBe(1746.77);
+        expect(firstRowTotal?.value.formatted).not.toMatch(/€/);
+    });
+
+    it('pivotQueryResults does not touch cells whose format is not parameter-based', () => {
+        // Same input, with and without `parameters`. The metric returned by
+        // getFieldMock has no `format`, so the reformat helper short-circuits
+        // on the `'format' in item` check — results must be byte-identical.
+        const without = pivotQueryResults({
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            pivotConfig: PIVOT_CONFIG_WITH_TOTALS,
+            metricQuery: METRIC_QUERY_PIVOTED,
+            rows: NON_PIVOTED_ROWS,
+            options: { maxColumns: 60 },
+        });
+        const withParams = pivotQueryResults({
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            pivotConfig: PIVOT_CONFIG_WITH_TOTALS,
+            metricQuery: METRIC_QUERY_PIVOTED,
+            rows: NON_PIVOTED_ROWS,
+            options: { maxColumns: 60 },
+            parameters: { currency: 'eur' },
+        });
+        expect(withParams).toStrictEqual(without);
+    });
+
+    it('convertSqlPivotedRowsToPivotData reformats cells and row totals with active parameters', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: SQL_PIVOTED_ROWS,
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: true,
+                columnTotals: true,
+                metricsAsRows: false,
+                columnOrder: [
+                    'payments_payment_method',
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldWithParameterFormat,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+            parameters: { currency: 'eur' },
+        });
+
+        const firstCell =
+            result.retrofitData.allCombinedData[0]
+                ?.payments_payment_method__payments_total_revenue__0;
+        expect(firstCell?.value).toEqual({
+            raw: 493.78,
+            formatted: '€493.78',
+        });
+
+        const firstRowTotal =
+            result.retrofitData.allCombinedData[0]?.['row-total-0'];
+        expect(firstRowTotal?.value).toEqual({
+            raw: 1746.77,
+            formatted: '€1,746.77',
+        });
     });
 });
 

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -12,6 +12,7 @@ import {
     type ItemsMap,
 } from '../types/field';
 import { type MetricQuery } from '../types/metricQuery';
+import { type ParametersValuesMap } from '../types/parameters';
 import {
     type PivotColumn,
     type PivotConfig,
@@ -49,6 +50,7 @@ type PivotQueryResultsArgs = {
     };
     getField: FieldFunction;
     getFieldLabel: FieldLabelFunction;
+    parameters?: ParametersValuesMap;
 };
 
 type RecursiveRecord<T = unknown> = {
@@ -232,6 +234,7 @@ const combinedRetrofit = (
     data: PivotData,
     getField: FieldFunction,
     getFieldLabel: FieldLabelFunction,
+    parameters?: ParametersValuesMap,
 ) => {
     const indexValues = data.indexValues.length ? data.indexValues : [[]];
     const baseIdInfo = last(data.headerValues);
@@ -264,7 +267,7 @@ const combinedRetrofit = (
         if (!isSummable(item)) {
             return null;
         }
-        const formattedValue = formatItemValue(item, total, false, undefined);
+        const formattedValue = formatItemValue(item, total, false, parameters);
 
         return {
             raw: total,
@@ -279,7 +282,7 @@ const combinedRetrofit = (
         if (!field || !field.fieldId) throw new Error('Invalid pivot data');
         const item = getField(field.fieldId);
 
-        const formattedValue = formatItemValue(item, total, false, undefined);
+        const formattedValue = formatItemValue(item, total, false, parameters);
 
         return {
             raw: total,
@@ -530,6 +533,7 @@ export const pivotQueryResults = ({
     getField,
     getFieldLabel,
     groupedSubtotals,
+    parameters,
 }: PivotQueryResultsArgs): PivotData => {
     if (rows.length === 0) {
         throw new Error('Cannot pivot results with no rows');
@@ -881,7 +885,7 @@ export const pivotQueryResults = ({
         },
         groupedSubtotals,
     };
-    return combinedRetrofit(pivotData, getField, getFieldLabel);
+    return combinedRetrofit(pivotData, getField, getFieldLabel, parameters);
 };
 
 /**
@@ -897,6 +901,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     getFieldLabel,
     groupedSubtotals,
     columnLimit,
+    parameters,
 }: {
     rows: ResultRow[];
     pivotDetails: NonNullable<ReadyQueryResultsPage['pivotDetails']>;
@@ -913,6 +918,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     getFieldLabel: FieldLabelFunction;
     groupedSubtotals: PivotQueryResultsArgs['groupedSubtotals'];
     columnLimit?: number;
+    parameters?: ParametersValuesMap;
 }): PivotData => {
     if (rows.length === 0) {
         throw new Error('Cannot convert SQL pivoted results with no rows');
@@ -1030,7 +1036,7 @@ export const convertSqlPivotedRowsToPivotData = ({
                               field,
                               pivotValue.value,
                               true,
-                              undefined,
+                              parameters,
                           )
                         : String(pivotValue.value));
                 const allColumnsWithSamePivotValues = columns.filter(
@@ -1408,7 +1414,7 @@ export const convertSqlPivotedRowsToPivotData = ({
                               field,
                               rowTotalValue,
                               false,
-                              undefined,
+                              parameters,
                           )
                         : String(rowTotalValue);
 
@@ -1512,7 +1518,7 @@ export const convertSqlPivotedRowsToPivotData = ({
         groupedSubtotals,
     };
 
-    return combinedRetrofit(pivotData, getField, getFieldLabel);
+    return combinedRetrofit(pivotData, getField, getFieldLabel, parameters);
 };
 
 export type PivotResultsDataCell = {

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1,6 +1,7 @@
 import isNumber from 'lodash/isNumber';
 import last from 'lodash/last';
 import { type Entries } from 'type-fest';
+import { LightdashParameters } from '../compiler/parameters';
 import type { ReadyQueryResultsPage } from '../index';
 import { UnexpectedIndexError, UnexpectedServerError } from '../types/errors';
 import {
@@ -32,6 +33,29 @@ import {
 type FieldFunction = (fieldId: string) => ItemsMap[string] | undefined;
 
 type FieldLabelFunction = (fieldId: string) => string | undefined;
+
+// Backend `.formatted` strings don't resolve ${ld.parameters.*} placeholders
+// (parameters live on the client). For flat tables, useColumns re-formats per
+// cell. The pivot path stores backend values verbatim, so we do the same
+// per-cell overlay here whenever the field's format references parameters.
+const reformatCellWithParameters = (
+    value: ResultValue | null | undefined,
+    item: ItemsMap[string] | undefined,
+    parameters: ParametersValuesMap | undefined,
+): ResultValue | null | undefined => {
+    if (!value || !item || !parameters) return value;
+    if (!('format' in item) || typeof item.format !== 'string') return value;
+    if (
+        !item.format.includes(`\${${LightdashParameters.PREFIX_SHORT}`) &&
+        !item.format.includes(`\${${LightdashParameters.PREFIX}`)
+    ) {
+        return value;
+    }
+    return {
+        raw: value.raw,
+        formatted: formatItemValue(item, value.raw, false, parameters),
+    };
+};
 
 type PivotQueryResultsArgs = {
     pivotConfig: PivotConfig;
@@ -748,7 +772,13 @@ export const pivotQueryResults = ({
         const row = rows[nRow];
         for (let nMetric = 0; nMetric < metrics.length; nMetric += 1) {
             const metric = metrics[nMetric];
-            const { value } = row?.[metric.fieldId] ?? {};
+            const { value: rawCellValue } = row?.[metric.fieldId] ?? {};
+            const value =
+                reformatCellWithParameters(
+                    rawCellValue,
+                    getField(metric.fieldId),
+                    parameters,
+                ) ?? null;
 
             const rowKeys = [
                 ...indexDimensions.map((d) => row[d].value.raw),
@@ -1184,7 +1214,11 @@ export const convertSqlPivotedRowsToPivotData = ({
                     );
 
                     return matchingColumn && row[matchingColumn.pivotColumnName]
-                        ? row[matchingColumn.pivotColumnName].value
+                        ? (reformatCellWithParameters(
+                              row[matchingColumn.pivotColumnName].value,
+                              getField(metric),
+                              parameters,
+                          ) ?? null)
                         : null;
                 });
 
@@ -1203,7 +1237,11 @@ export const convertSqlPivotedRowsToPivotData = ({
 
             return filteredValuesColumns.map((valueCol) =>
                 row[valueCol.pivotColumnName]
-                    ? row[valueCol.pivotColumnName].value
+                    ? (reformatCellWithParameters(
+                          row[valueCol.pivotColumnName].value,
+                          getField(valueCol.referenceField),
+                          parameters,
+                      ) ?? null)
                     : null,
             );
         });
@@ -1397,7 +1435,15 @@ export const convertSqlPivotedRowsToPivotData = ({
                       }__${colIndex}`;
 
                 if (row[valueCol.pivotColumnName]) {
-                    combinedRow[fieldId] = row[valueCol.pivotColumnName];
+                    const cell = row[valueCol.pivotColumnName];
+                    const reformatted = reformatCellWithParameters(
+                        cell.value,
+                        getField(valueCol.referenceField),
+                        parameters,
+                    );
+                    combinedRow[fieldId] = reformatted
+                        ? { value: reformatted }
+                        : cell;
                 }
             });
 

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1441,9 +1441,14 @@ export const convertSqlPivotedRowsToPivotData = ({
                         getField(valueCol.referenceField),
                         parameters,
                     );
-                    combinedRow[fieldId] = reformatted
-                        ? { value: reformatted }
-                        : cell;
+                    // Helper short-circuits to the input value reference when
+                    // no reformat is needed — fall back to `cell` in that case
+                    // so we don't allocate a fresh wrapper per non-parameterised
+                    // cell.
+                    combinedRow[fieldId] =
+                        reformatted && reformatted !== cell.value
+                            ? { value: reformatted }
+                            : cell;
                 }
             });
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -272,6 +272,7 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         getField,
         getFieldLabel,
         columnLimit,
+        parameters,
     });
 
     const cellContextMenu = useCallback(

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -8,6 +8,7 @@ import {
     selectColumnOrder,
     selectCustomDimensions,
     selectIsEditMode,
+    selectParameters,
     selectTableCalculations,
     selectTableName,
     useExplorerDispatch,
@@ -72,6 +73,7 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
     const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
     const tableCalculations = useExplorerSelector(selectTableCalculations);
     const customDimensions = useExplorerSelector(selectCustomDimensions);
+    const parameters = useExplorerSelector(selectParameters);
 
     // Get chart config for column properties
     const chartConfig = useExplorerSelector(selectChartConfig);
@@ -382,6 +384,7 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
                 getField={getField}
                 showSubtotals={false}
                 isMinimal={false}
+                parameters={parameters}
             />
         );
     };

--- a/packages/frontend/src/components/Explorer/ResultsCard/usePivotTableData.ts
+++ b/packages/frontend/src/components/Explorer/ResultsCard/usePivotTableData.ts
@@ -1,5 +1,6 @@
 import type {
     ItemsMap,
+    ParametersValuesMap,
     PivotData,
     ReadyQueryResultsPage,
     ResultRow,
@@ -19,6 +20,7 @@ type UsePivotTableDataArgs = {
     getField: (fieldId: string) => ItemsMap[string] | undefined;
     getFieldLabel: (fieldId: string | null | undefined) => string | undefined;
     columnLimit?: number;
+    parameters?: ParametersValuesMap;
 };
 
 type PivotTableDataState = {
@@ -44,6 +46,7 @@ export function usePivotTableData({
     getField,
     getFieldLabel,
     columnLimit,
+    parameters,
 }: UsePivotTableDataArgs): PivotTableDataState {
     const worker = useWorker(createWorker);
     const [state, setState] = useState<PivotTableDataState>({
@@ -74,6 +77,7 @@ export function usePivotTableData({
             getFieldLabel,
             groupedSubtotals: undefined,
             columnLimit,
+            parameters,
         };
     }, [
         enabled,
@@ -83,6 +87,7 @@ export function usePivotTableData({
         getField,
         getFieldLabel,
         columnLimit,
+        parameters,
     ]);
 
     useEffect(() => {

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -50,6 +50,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
         resultsData,
         isLoading,
         isEditMode,
+        parameters,
     } = useVisualizationContext();
 
     const hasSignaledScreenshotReady = useRef(false);
@@ -296,6 +297,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 visualizationConfig.chartConfig.columnProperties
                             }
                             onColumnWidthChange={onColumnWidthChange}
+                            parameters={parameters}
                             {...rest}
                         />
                         {showResultsTotal && (

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -15,6 +15,7 @@ import {
     type ConditionalFormattingMinMaxMap,
     type ConditionalFormattingRowFields,
     type ItemsMap,
+    type ParametersValuesMap,
     type PivotData,
     type ResultRow,
     type ResultValue,
@@ -156,6 +157,7 @@ type PivotTableProps = BoxProps & // TODO: remove this
         isMinimal: boolean;
         isDashboard?: boolean;
         onColumnWidthChange?: (fieldId: string, width: number) => void;
+        parameters?: ParametersValuesMap;
     };
 
 const PivotTable: FC<PivotTableProps> = ({
@@ -171,6 +173,7 @@ const PivotTable: FC<PivotTableProps> = ({
     isMinimal = false,
     isDashboard = false,
     onColumnWidthChange,
+    parameters,
     ...tableProps
 }) => {
     const { colorScheme } = useMantineColorScheme();
@@ -434,7 +437,12 @@ const PivotTable: FC<PivotTableProps> = ({
 
                                 return (
                                     <Text span fw={600}>
-                                        {formatItemValue(item, subtotalValue)}
+                                        {formatItemValue(
+                                            item,
+                                            subtotalValue,
+                                            false,
+                                            parameters,
+                                        )}
                                     </Text>
                                 );
                             }
@@ -461,6 +469,7 @@ const PivotTable: FC<PivotTableProps> = ({
         columnProperties,
         frozenLayout,
         rowNumberWidth,
+        parameters,
     ]);
 
     // Minimum table width so auto columns don't get squeezed to zero
@@ -511,14 +520,19 @@ const PivotTable: FC<PivotTableProps> = ({
             if (!isSummable(item)) {
                 return null;
             }
-            const formattedValue = formatItemValue(item, total);
+            const formattedValue = formatItemValue(
+                item,
+                total,
+                false,
+                parameters,
+            );
 
             return {
                 raw: total,
                 formatted: formattedValue,
             };
         },
-        [data.headerValues, getField],
+        [data.headerValues, getField, parameters],
     );
 
     const getMetricAsRowColumnTotalValueFromAxis = useCallback(
@@ -528,14 +542,19 @@ const PivotTable: FC<PivotTableProps> = ({
 
             const item = getField(value.fieldId);
 
-            const formattedValue = formatItemValue(item, total);
+            const formattedValue = formatItemValue(
+                item,
+                total,
+                false,
+                parameters,
+            );
 
             return {
                 raw: total,
                 formatted: formattedValue,
             };
         },
-        [data.columnTotalFields, getField],
+        [data.columnTotalFields, getField, parameters],
     );
 
     const getUnderlyingFieldValues = useCallback(

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -373,6 +373,7 @@ const useTableConfig = (
                     getField,
                     getFieldLabel,
                     groupedSubtotals,
+                    parameters,
                 })
                 .then((data) => {
                     setPivotTableData({
@@ -400,6 +401,7 @@ const useTableConfig = (
                     },
                     getField,
                     getFieldLabel,
+                    parameters,
                 })
                 .then((data) => {
                     setPivotTableData({
@@ -430,6 +432,7 @@ const useTableConfig = (
         worker,
         pivotTableMaxColumnLimit,
         groupedSubtotals,
+        parameters,
     ]);
 
     // Remove columnProperties from map if the column has been removed from results


### PR DESCRIPTION
Closes: PROD-437

## Summary

Metrics whose `format` references `${ld.parameters.*}` rendered the unresolved placeholder (or a raw number with no currency symbol) in pivot tables. Flat tables already overlay a frontend re-format via `useColumns`; the pivot path stored backend `.formatted` strings verbatim, so cells, row totals, column totals and subtotals all lost the parameter-driven prefix.

Affected: pivoted explores and pivoted Simple Table charts (both the legacy worker pivot and the SQL-pivot path). Unaffected: flat tables, and backend export paths (`pivotResultsAsCsv` / `pivotResultsAsData`) which still pass `undefined` since parameter state lives in the browser.

## Root cause

Parameter values live on the client, so the backend's `.formatted` string cannot resolve `${ld.parameters.*}`. Four `formatItemValue` call sites in `pivotQueryResults.ts` and three in `<PivotTable>` passed `undefined` for `parameters`:

```ts
// pivotQueryResults.ts — combinedRetrofit row/column total
const formattedValue = formatItemValue(item, total, false, undefined);
//                                                       ^^^^^^^^^
//                                            parameters dropped → "493.78"
```

The placeholder format string (`${ld.parameters.currency=="eur"?"€":"$"}0,0.00`) was carried through unchanged, then `formatItemValue` ran without the values needed to evaluate the expression.

## Fix

Plumb an optional `parameters: ParametersValuesMap` through the pivot pipeline and add a `reformatCellWithParameters` overlay in the worker that re-runs `formatItemValue` only when a field's `format` mentions `${ld.parameters.*}` or `${lightdash.parameters.*}`. Non-parameterised formats short-circuit and return the original `value` reference, so the common path skips a fresh wrapper allocation.

- `packages/common/src/pivot/pivotQueryResults.ts` - add `parameters` arg to `pivotQueryResults`, `convertSqlPivotedRowsToPivotData`, and `combinedRetrofit`; introduce `reformatCellWithParameters`; pass `parameters` to all `formatItemValue` call sites.
- `packages/frontend/src/components/common/PivotTable/index.tsx` - thread `parameters` into the subtotal, metric column total, and metricsAsRows column total `formatItemValue` calls (and into `useCallback` deps).
- `packages/frontend/src/hooks/tableVisualization/useTableConfig.ts`, `usePivotTableData.ts`, `ExplorerResults.tsx`, `SimpleTable/index.tsx` - read `parameters` from the explorer selector and pass it down; add to `useMemo` / `useEffect` deps so the worker re-runs when a parameter toggles.
- Backend export paths intentionally still pass `undefined` - addressed separately.

## Before / after

```
                         cell      row total
                       -------    ---------
  Before (broken)      493.78     1,746.77
  After  (currency=eur) EUR 493.78  EUR 1,746.77
  After  (currency=usd) USD 493.78  USD 1,746.77
  No parameters        493.78     1,746.77      <- unchanged (backwards compat)
```

## Test plan

- [x] `pnpm -F common test` - new `parameter-aware cell formatting (PROD-437)` suite in `pivotQueryResults.test.ts` covers both `pivotQueryResults` and `convertSqlPivotedRowsToPivotData`:
  - pivoted cell reformats with active parameters
  - row total reformats with active parameters (the `combinedRetrofit` path)
  - output is byte-identical when `parameters` is omitted (backwards compat)
  - non-parameterised formats are untouched (short-circuit guard)
- [ ] Manual: open an explore with a metric whose format references `${ld.parameters.currency}`, pivot by a dimension, toggle the parameter - cells, row totals, column totals and subtotals all flip currency symbol.
- [ ] Manual: verify flat tables and non-parameterised pivots still render identically.