### PR TITLE
fix(scheduler): use translated Slack error in delivery failure email [SPK-460]

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -915,7 +915,7 @@ export class SlackClient {
             })
             .catch((e) => {
                 if (getSlackErrorCode(e) === 'invalid_blocks') {
-                    Logger.warn(
+                    Logger.error(
                         `Slack invalid_blocks error for channel ${channel}`,
                         {
                             blocks: JSON.stringify(slackMessageArgs.blocks),

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3845,7 +3845,7 @@ export default class SchedulerTask {
                         user.email,
                         scheduler.name,
                         schedulerUrl,
-                        getErrorMessage(e),
+                        translatedSlackError?.error ?? getErrorMessage(e),
                     );
                 }
             } catch (emailError) {


### PR DESCRIPTION
Closes: SPK-460
Relates: SPK-417, #22424

### Description:

Follow-up to [SPK-417](https://linear.app/lightdash/issue/SPK-417). The previous fix added `translateSlackError` and applied it to the `scheduler_log` row, but the failure-notification email sent to the scheduler creator still passed the raw `getErrorMessage(e)` — so recipients kept seeing `"An API error occurred: invalid_blocks"` in their inbox.

This one-line change at `SchedulerTask.ts:3848` uses `translatedSlackError?.error ?? getErrorMessage(e)`, mirroring the scheduler-log path on line 3810 so the email body and the log entry stay in sync. Non-Slack failures and Slack codes not in `SLACK_USER_FACING_ERROR_MESSAGES` fall back to `getErrorMessage(e)` — behavior unchanged for those.