### PR TITLE
fix(pivot-sort): stringify pivot_values when copying chart versions

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2846,9 +2846,11 @@ export class ProjectModel {
                 SavedChartCustomSqlDimensionsTableName,
                 [],
             );
-            await copyChartVersionContent('saved_queries_version_sorts', [
-                'saved_queries_version_sort_id',
-            ]);
+            await copyChartVersionContent(
+                'saved_queries_version_sorts',
+                ['saved_queries_version_sort_id'],
+                { pivot_values: (value: AnyType) => JSON.stringify(value) },
+            );
             await copyChartVersionContent('saved_queries_version_fields', [
                 'saved_queries_version_field_id',
             ]);


### PR DESCRIPTION
Adds the missing `pivot_values` JSON.stringify preprocessor to `copyChartVersionContent('saved_queries_version_sorts', ...)`. Without it, duplicating a project that contains a chart with a non-null pivot sort anchor would fail with `invalid input syntax for type json` — same class of bug fixed for `additional_metrics.filters` in #6703 and `custom_dimensions.custom_range` in #8566.

Relates to [PROD-6986](https://linear.app/lightdash/issue/PROD-6986/allow-sorting-by-pivot-column-values-in-table-charts).