### PR TITLE
fix(data-apps): dedupe optimistic chat bubble against server history

### DIFF
--- a/packages/frontend/src/features/apps/utils/mergeChatMessages.test.ts
+++ b/packages/frontend/src/features/apps/utils/mergeChatMessages.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { mergeChatMessages, type ChatMessage } from './mergeChatMessages';
+
+const baseMessage: ChatMessage = {
+    role: 'user',
+    content: '',
+    imagePreviewUrls: [],
+    imageResourceIds: [],
+    charts: [],
+    dashboardName: null,
+    clarifications: [],
+    appUuid: null,
+    version: null,
+    timestamp: new Date('2026-05-15T10:00:00Z'),
+    userName: 'Test User',
+};
+
+describe('mergeChatMessages', () => {
+    it('returns history alone when local is empty', () => {
+        const history: ChatMessage[] = [
+            { ...baseMessage, content: 'prompt v1' },
+        ];
+        expect(mergeChatMessages(history, [], 1)).toEqual(history);
+    });
+
+    it('appends local entries when no version overlap with history', () => {
+        const history: ChatMessage[] = [
+            { ...baseMessage, content: 'old prompt' },
+            {
+                ...baseMessage,
+                role: 'assistant',
+                content: 'old reply',
+                version: 5,
+            },
+        ];
+        const local: ChatMessage[] = [
+            { ...baseMessage, content: 'new prompt', submittedAtVersion: 5 },
+        ];
+        // Server hasn't produced v6 yet — maxHistoryVersion still 5 — so the
+        // optimistic bubble must remain visible during the build.
+        const merged = mergeChatMessages(history, local, 5);
+        expect(merged).toHaveLength(3);
+        expect(merged[2].content).toBe('new prompt');
+    });
+
+    it('drops the optimistic user bubble once a higher version exists in history', () => {
+        // This is the duplicate-prompt bug: history has the just-built v10
+        // containing the user's prompt, AND localMessages still has the
+        // optimistic bubble for the same prompt. Without dedup, the chat
+        // renders the prompt twice.
+        const history: ChatMessage[] = [
+            { ...baseMessage, content: 'asdf' },
+            {
+                ...baseMessage,
+                role: 'assistant',
+                content: 'Server reply',
+                version: 10,
+            },
+        ];
+        const local: ChatMessage[] = [
+            { ...baseMessage, content: 'asdf', submittedAtVersion: 9 },
+        ];
+        const merged = mergeChatMessages(history, local, 10);
+        const userBubbles = merged.filter((m) => m.role === 'user');
+        expect(userBubbles).toHaveLength(1);
+        // The kept user bubble should be the server-sourced one (no
+        // submittedAtVersion marker), not the optimistic local copy.
+        expect(userBubbles[0].submittedAtVersion).toBeUndefined();
+    });
+
+    it('keeps the optimistic bubble across a same-prompt resubmit', () => {
+        // After v10 (built from "asdf") finishes, the user re-submits "asdf"
+        // again. The new optimistic bubble has submittedAtVersion=10, which
+        // equals (not less than) maxHistoryVersion=10 — so it stays visible
+        // until v11 arrives.
+        const history: ChatMessage[] = [
+            { ...baseMessage, content: 'asdf' },
+            {
+                ...baseMessage,
+                role: 'assistant',
+                content: 'Server reply for v10',
+                version: 10,
+            },
+        ];
+        const local: ChatMessage[] = [
+            { ...baseMessage, content: 'asdf', submittedAtVersion: 10 },
+        ];
+        const merged = mergeChatMessages(history, local, 10);
+        expect(merged.filter((m) => m.role === 'user')).toHaveLength(2);
+    });
+
+    it('drops the resubmit bubble once v11 has built', () => {
+        const history: ChatMessage[] = [
+            { ...baseMessage, content: 'asdf' },
+            {
+                ...baseMessage,
+                role: 'assistant',
+                content: 'Reply v10',
+                version: 10,
+            },
+            { ...baseMessage, content: 'asdf' },
+            {
+                ...baseMessage,
+                role: 'assistant',
+                content: 'Reply v11',
+                version: 11,
+            },
+        ];
+        const local: ChatMessage[] = [
+            { ...baseMessage, content: 'asdf', submittedAtVersion: 10 },
+        ];
+        const merged = mergeChatMessages(history, local, 11);
+        expect(merged.filter((m) => m.role === 'user')).toHaveLength(2);
+    });
+
+    it('never drops local assistant messages (error fallback bubbles)', () => {
+        // onError pushes an assistant error message into localMessages.
+        // It has no submittedAtVersion and must always survive the merge.
+        const history: ChatMessage[] = [
+            { ...baseMessage, content: 'asdf' },
+            {
+                ...baseMessage,
+                role: 'assistant',
+                content: 'Reply',
+                version: 10,
+            },
+        ];
+        const local: ChatMessage[] = [
+            {
+                ...baseMessage,
+                role: 'assistant',
+                content: 'Failed to generate app',
+            },
+        ];
+        const merged = mergeChatMessages(history, local, 10);
+        expect(merged).toContain(local[0]);
+    });
+
+    it('keeps optimistic bubbles that have no submittedAtVersion (legacy / mid-flight)', () => {
+        // submittedAtVersion is optional. If absent, the bubble is treated as
+        // un-acknowledged and kept — matches the pre-fix behaviour for
+        // anything authored before the field existed.
+        const history: ChatMessage[] = [
+            {
+                ...baseMessage,
+                role: 'assistant',
+                content: 'Reply',
+                version: 10,
+            },
+        ];
+        const local: ChatMessage[] = [
+            { ...baseMessage, content: 'legacy bubble' },
+        ];
+        const merged = mergeChatMessages(history, local, 10);
+        expect(merged).toContain(local[0]);
+    });
+});

--- a/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
+++ b/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
@@ -1,0 +1,47 @@
+import { type AppClarification } from '@lightdash/common';
+import { type ChartKind } from '@lightdash/common';
+
+export type ChatChart = {
+    name: string;
+    uuid: string;
+    chartKind?: ChartKind;
+};
+
+export type ChatMessage = {
+    role: 'user' | 'assistant';
+    content: string;
+    imagePreviewUrls: string[];
+    imageResourceIds: string[];
+    charts: ChatChart[];
+    dashboardName: string | null;
+    clarifications: AppClarification[];
+    appUuid: string | null;
+    version: number | null;
+    timestamp: Date;
+    userName: string | null;
+    // For optimistic (local) user bubbles only. Records the latest server
+    // version number known at submit time. The bubble is dropped from the
+    // merged view once the server has produced a higher version — that's the
+    // signal the server has acknowledged the prompt and it now lives in
+    // `history` as a v_n bubble. Resubmitting the same prompt later still
+    // shows the optimistic bubble because the new `submittedAtVersion` is the
+    // current latest, so the comparison hasn't tripped yet.
+    submittedAtVersion?: number;
+};
+
+/**
+ * Merge server-side history with the optimistic local message queue, dropping
+ * any optimistic user bubble whose corresponding server version has already
+ * landed in history. Tested in `mergeChatMessages.test.ts`.
+ */
+export function mergeChatMessages(
+    history: ChatMessage[],
+    local: ChatMessage[],
+    maxHistoryVersion: number,
+): ChatMessage[] {
+    const dedupedLocal = local.filter((msg) => {
+        if (msg.submittedAtVersion === undefined) return true;
+        return msg.submittedAtVersion >= maxHistoryVersion;
+    });
+    return [...history, ...dedupedLocal];
+}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -107,6 +107,11 @@ import { useIterateApp } from '../features/apps/hooks/useIterateApp';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import QueryInspector from '../features/apps/QueryInspector';
 import { getTemplate } from '../features/apps/templates';
+import {
+    mergeChatMessages,
+    type ChatChart,
+    type ChatMessage,
+} from '../features/apps/utils/mergeChatMessages';
 import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
@@ -135,33 +140,8 @@ function parseElementRefLabel(label: string): ElementRef | null {
     return { tag: m[1] ?? '', text: m[2] ?? '', loc: m[3] ?? '' };
 }
 
-type ChatChart = {
-    name: string;
-    uuid: string;
-    chartKind?: ChartKind;
-};
-
-type ChatMessage = {
-    role: 'user' | 'assistant';
-    content: string;
-    imagePreviewUrls: string[];
-    imageResourceIds: string[];
-    charts: ChatChart[];
-    dashboardName: string | null;
-    clarifications: AppClarification[];
-    appUuid: string | null;
-    version: number | null;
-    // Wall-clock time for the meta line on the bubble. For user messages,
-    // when the prompt was submitted; for terminal assistant messages
-    // (ready/error), when the build transitioned (`statusUpdatedAt`).
-    // The mid-build/clarifying placeholder doesn't render meta at all, so
-    // this field has no effect on in-progress state.
-    timestamp: Date;
-    // Display name of the version author for `role === 'user'` bubbles.
-    // Assistant bubbles always pass `null` — they intentionally render
-    // nameless.
-    userName: string | null;
-};
+// ChatChart and ChatMessage are imported from `features/apps/utils/mergeChatMessages`
+// alongside the merge helper, so the type and the merge logic stay collocated.
 
 const AppResourceImage: FC<{
     projectUuid: string;
@@ -730,10 +710,25 @@ const AppGenerate: FC = () => {
         });
     }, [allVersions, activeAppUuid]);
 
-    // Merge: history messages first, then any optimistic local messages
+    // Highest server-known version number, used by `mergeChatMessages` to drop
+    // optimistic local bubbles whose corresponding server version has already
+    // landed in history.
+    const maxHistoryVersion = useMemo(
+        () => allVersions.reduce((max, v) => Math.max(max, v.version), 0),
+        [allVersions],
+    );
+
+    // Merge history with the optimistic queue, dropping any local user bubble
+    // whose `submittedAtVersion` is older than `maxHistoryVersion` — see
+    // `mergeChatMessages` for the dedup contract.
     const messages = useMemo(
-        () => [...historyMessages, ...localMessages],
-        [historyMessages, localMessages],
+        () =>
+            mergeChatMessages(
+                historyMessages,
+                localMessages,
+                maxHistoryVersion,
+            ),
+        [historyMessages, localMessages, maxHistoryVersion],
     );
 
     // The starter-template wizard only shows for v1 of a brand-new app -
@@ -1201,6 +1196,12 @@ const AppGenerate: FC = () => {
                         [user.data?.firstName, user.data?.lastName]
                             .filter((s): s is string => !!s && s.length > 0)
                             .join(' ') || null,
+                    // Snapshot the highest server version known at submit time.
+                    // Once history catches up past this number the optimistic
+                    // bubble is dropped by `mergeChatMessages` — even if the
+                    // brittle `serverVersionCount`-based clear effect misses
+                    // a transition.
+                    submittedAtVersion: maxHistoryVersion,
                 },
             ]);
             promptEditorRef.current?.clear();


### PR DESCRIPTION
### Description:
The chat panel concatenated `historyMessages + localMessages` with no dedup. A cleanup `useEffect` keyed on `serverVersionCount` was supposed to clear the optimistic queue once history grew, but the count can stay the same across an iteration (the in-memory version cache occasionally resets and rebuilds with the same length), in which case the effect never fires and the just-submitted prompt renders twice — once from history, once from `localMessages` — until the page is refreshed.

Stamp each optimistic user bubble with `submittedAtVersion = max known version at submit time` and drop it at merge time once `maxHistoryVersion > submittedAtVersion`. This guarantee holds regardless of whether the count-based cleanup effect fires.
