### PR TITLE
feat(observability): re-land wide-event logs for dashboard loads, project compiles, and validation runs

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1263,6 +1263,13 @@ export class ProjectModel {
         );
     }
 
+    async getCachedExploreNames(projectUuid: string): Promise<string[]> {
+        const rows = await this.database(CachedExploreTableName)
+            .select<{ name: string }[]>('name')
+            .where('project_uuid', projectUuid);
+        return rows.map((row) => row.name);
+    }
+
     async findVirtualViewsFromCache(
         projectUuid: string,
     ): Promise<Record<string, Explore | ExploreError>> {

--- a/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
@@ -95,9 +95,13 @@ describe('DashboardService - Content Verification', () => {
         pinnedListModel: {} as unknown as PinnedListModel,
         schedulerModel: {} as unknown as SchedulerModel,
         schedulerService: {} as unknown as SchedulerService,
-        savedChartModel: {} as unknown as SavedChartModel,
+        savedChartModel: {
+            getInfoForAvailableFilters: jest.fn(async () => []),
+        } as unknown as SavedChartModel,
         savedChartService: {} as unknown as SavedChartService,
-        projectModel: {} as unknown as ProjectModel,
+        projectModel: {
+            getCachedExploreNames: jest.fn(async () => []),
+        } as unknown as ProjectModel,
         slackClient: {} as unknown as SlackClient,
         schedulerClient: {} as unknown as SchedulerClient,
         catalogModel: {} as unknown as CatalogModel,

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -78,6 +78,11 @@ const savedChartModel = {
         uuid: 'chart_uuid',
         projectUuid: 'project_uuid',
     })),
+    getInfoForAvailableFilters: jest.fn(async () => []),
+};
+
+const projectModel = {
+    getCachedExploreNames: jest.fn(async () => []),
 };
 
 const schedulerModel = {
@@ -143,7 +148,7 @@ describe('DashboardService', () => {
         schedulerService: {} as SchedulerService,
         savedChartModel: savedChartModel as unknown as SavedChartModel,
         savedChartService: {} as SavedChartService, // Mock for test
-        projectModel: {} as ProjectModel,
+        projectModel: projectModel as unknown as ProjectModel,
         slackClient: {} as SlackClient,
         schedulerClient: {} as SchedulerClient,
         catalogModel: {} as CatalogModel,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -521,7 +521,142 @@ export class DashboardService
             },
         });
 
+        // Wide observability event for diagnosing stale dashboard filter references
+        // (e.g. PROD-5931). Best-effort — never block the request on logging errors.
+        try {
+            await this.logDashboardLoadedEvent(dashboard);
+        } catch (err) {
+            this.logger.warn('dashboard.loaded log failed', {
+                dashboardUuid: dashboard.uuid,
+                err: err instanceof Error ? err.message : String(err),
+            });
+        }
+
         return dashboard;
+    }
+
+    private async logDashboardLoadedEvent(dashboard: Dashboard): Promise<void> {
+        const STALE_SAMPLE_CAP = 10;
+
+        const cachedExploreNames = new Set(
+            await this.projectModel.getCachedExploreNames(
+                dashboard.projectUuid,
+            ),
+        );
+
+        const chartTileUuids = dashboard.tiles
+            .filter(isDashboardChartTileType)
+            .map((tile) => tile.properties.savedChartUuid)
+            .filter((uuid): uuid is string => Boolean(uuid));
+
+        const chartInfos = chartTileUuids.length
+            ? await this.savedChartModel.getInfoForAvailableFilters(
+                  chartTileUuids,
+              )
+            : [];
+
+        const chartTables = new Set(
+            chartInfos.map((chart) => chart.tableName).filter(Boolean),
+        );
+        const chartTablesMissing = [...chartTables].filter(
+            (name) => !cachedExploreNames.has(name),
+        );
+
+        const staleFilterTargets: Array<{
+            path: string;
+            tableName: string;
+            fieldId: string;
+        }> = [];
+        const staleTileTargets: Array<{
+            path: string;
+            tableName: string;
+            fieldId: string;
+        }> = [];
+
+        const dimensions = dashboard.filters?.dimensions ?? [];
+        dimensions.forEach((dim, dimIndex) => {
+            const target = dim.target as
+                | {
+                      tableName?: string;
+                      fieldId?: string;
+                      isSqlColumn?: boolean;
+                  }
+                | undefined;
+            if (
+                target?.tableName &&
+                target.fieldId &&
+                !target.isSqlColumn &&
+                !cachedExploreNames.has(target.tableName)
+            ) {
+                staleFilterTargets.push({
+                    path: `dimensions[${dimIndex}].target`,
+                    tableName: target.tableName,
+                    fieldId: target.fieldId,
+                });
+            }
+
+            const { tileTargets } = dim as {
+                tileTargets?: Record<string, unknown>;
+            };
+            if (tileTargets) {
+                Object.entries(tileTargets).forEach(([tileUuid, raw]) => {
+                    if (!raw || typeof raw !== 'object') {
+                        return;
+                    }
+                    const tt = raw as {
+                        tableName?: string;
+                        fieldId?: string;
+                        isSqlColumn?: boolean;
+                    };
+                    if (
+                        tt.tableName &&
+                        tt.fieldId &&
+                        !tt.isSqlColumn &&
+                        !cachedExploreNames.has(tt.tableName)
+                    ) {
+                        staleTileTargets.push({
+                            path: `dimensions[${dimIndex}].tileTargets.${tileUuid}`,
+                            tableName: tt.tableName,
+                            fieldId: tt.fieldId,
+                        });
+                    }
+                });
+            }
+        });
+
+        const filterDimensionCount = dimensions.length;
+        const filterMetricCount = dashboard.filters?.metrics?.length ?? 0;
+        const tileTargetCount = dimensions.reduce(
+            (acc, dim) =>
+                acc +
+                Object.keys(
+                    (dim as { tileTargets?: Record<string, unknown> })
+                        .tileTargets ?? {},
+                ).length,
+            0,
+        );
+
+        this.logger.info('dashboard.loaded', {
+            projectUuid: dashboard.projectUuid,
+            organizationUuid: dashboard.organizationUuid,
+            dashboardUuid: dashboard.uuid,
+            dashboardVersionUuid: dashboard.versionUuid,
+
+            tileCount: dashboard.tiles.length,
+            chartTileCount: chartTileUuids.length,
+            filterDimensionCount,
+            filterMetricCount,
+            tileTargetCount,
+
+            cachedExploreCount: cachedExploreNames.size,
+            chartTablesMissingCount: chartTablesMissing.length,
+            staleFilterTargetCount: staleFilterTargets.length,
+            staleTileTargetCount: staleTileTargets.length,
+
+            chartTablesMissing: chartTablesMissing.slice(0, STALE_SAMPLE_CAP),
+            staleFilterTargets: staleFilterTargets.slice(0, STALE_SAMPLE_CAP),
+            staleTileTargets: staleTileTargets.slice(0, STALE_SAMPLE_CAP),
+        });
     }
 
     static findChartsThatBelongToDashboard(

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -155,6 +155,7 @@ const projectModel = {
     })),
     findExploreByTableName: jest.fn(async () => validExplore),
     getAllExploresFromCache: jest.fn(async () => ({})),
+    getCachedExploreNames: jest.fn(async () => []),
     saveExploresToCache: jest.fn(async () => ({ cachedExploreUuids: [] })),
     updateDefaultUserSpaces: jest.fn(async () => undefined),
 };

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1848,6 +1848,21 @@ export class ProjectService extends BaseService {
         const prevMetricsTreeNodes =
             await this.catalogModel.getAllMetricsTreeNodes(projectUuid);
 
+        // Best-effort: capture the explore names already in cache so we can
+        // emit an added/removed diff after the new explores are written
+        // (PROD-5931). Wrapped because this fetch must never interrupt the
+        // compile flow if the DB has a transient error.
+        let previousExploreNames: string[] | null = null;
+        try {
+            previousExploreNames =
+                await this.projectModel.getCachedExploreNames(projectUuid);
+        } catch (err) {
+            this.logger.warn('compile.completed previous-names fetch failed', {
+                projectUuid,
+                err: err instanceof Error ? err.message : String(err),
+            });
+        }
+
         const { cachedExploreUuids } =
             await this.projectModel.saveExploresToCache(projectUuid, explores);
         const { organizationUuid } =
@@ -1856,6 +1871,49 @@ export class ProjectService extends BaseService {
         this.logger.info(
             `Saved ${cachedExploreUuids.length} explores to cache for project ${projectUuid}`,
         );
+
+        // Wide observability event for explore lifecycle. Pair with the
+        // `dashboard.loaded` event to correlate "table removed at T1" with
+        // "dashboard loaded with stale reference at T2".
+        try {
+            const NAME_SAMPLE_CAP = 50;
+            const newNames = explores.map((explore) => explore.name);
+            const previousNameSet = new Set(previousExploreNames ?? []);
+            const newNameSet = new Set(newNames);
+            const removed = (previousExploreNames ?? []).filter(
+                (name) => !newNameSet.has(name),
+            );
+            const added = newNames.filter((name) => !previousNameSet.has(name));
+
+            this.logger.info('compile.completed', {
+                projectUuid,
+                organizationUuid,
+                jobUuid: jobUuid ?? null,
+                compilationSource,
+                requestMethod: requestMethod ?? null,
+                cliVersion: cliVersion ?? null,
+                // null distinguishes "fetch failed" from "no previous explores"
+                previousExploreCount: previousExploreNames?.length ?? null,
+                newExploreCount: newNames.length,
+                addedExploreCount:
+                    previousExploreNames === null ? null : added.length,
+                removedExploreCount:
+                    previousExploreNames === null ? null : removed.length,
+                addedExploreNames:
+                    previousExploreNames === null
+                        ? null
+                        : added.slice(0, NAME_SAMPLE_CAP),
+                removedExploreNames:
+                    previousExploreNames === null
+                        ? null
+                        : removed.slice(0, NAME_SAMPLE_CAP),
+            });
+        } catch (err) {
+            this.logger.warn('compile.completed log failed', {
+                projectUuid,
+                err: err instanceof Error ? err.message : String(err),
+            });
+        }
 
         const compilationReport = calculateCompilationReport({ explores });
         const project = await this.projectModel.get(projectUuid);

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -780,6 +780,79 @@ export class ValidationService extends BaseService {
                         return acc;
                     }, []);
 
+                    // Wide observability event for diagnosing validation
+                    // suppression (related to PROD-5931). Per-dashboard summary
+                    // of inputs vs outputs, with a capped sample of tile targets
+                    // that passed all checks without producing an error — these
+                    // are the suspicious ones to inspect when the bell icon is
+                    // silent but a stale filter exists.
+                    try {
+                        const SAMPLE_CAP = 5;
+                        const tileTargetSummaries = dashboardTileTargets.map(
+                            (tt) => {
+                                if (!tt) {
+                                    return { kind: 'falsy' as const };
+                                }
+                                if (!isDashboardFieldTarget(tt)) {
+                                    return { kind: 'notFieldTarget' as const };
+                                }
+                                if (tt.isSqlColumn) {
+                                    return { kind: 'sqlColumn' as const };
+                                }
+                                return {
+                                    kind: 'processed' as const,
+                                    fieldId: tt.fieldId,
+                                    tableName: tt.tableName,
+                                    fieldIdInExistingFields:
+                                        existingFieldIds.includes(tt.fieldId),
+                                };
+                            },
+                        );
+                        const counts = tileTargetSummaries.reduce(
+                            (acc, t) => {
+                                acc[t.kind] = (acc[t.kind] ?? 0) + 1;
+                                return acc;
+                            },
+                            {} as Record<string, number>,
+                        );
+                        const processedWithoutError =
+                            tileTargetSummaries.filter(
+                                (t) =>
+                                    t.kind === 'processed' &&
+                                    t.fieldIdInExistingFields,
+                            );
+
+                        this.logger.info('validation.dashboardScanned', {
+                            projectUuid,
+                            dashboardUuid: uuid,
+                            existingFieldIdCount: existingFieldIds.length,
+                            filterRuleCount: dashboardFilterRules.length,
+                            tileTargetCount: dashboardTileTargets.length,
+                            filterErrorCount: filterErrors.length,
+                            tileTargetErrorCount: tileTargetErrors.length,
+                            chartErrorCount: chartErrors.length,
+                            tileTargetSkippedFalsyCount: counts.falsy ?? 0,
+                            tileTargetSkippedNotFieldTargetCount:
+                                counts.notFieldTarget ?? 0,
+                            tileTargetSkippedSqlColumnCount:
+                                counts.sqlColumn ?? 0,
+                            tileTargetProcessedCount: counts.processed ?? 0,
+                            tileTargetProcessedWithoutErrorCount:
+                                processedWithoutError.length,
+                            tileTargetProcessedWithoutErrorSamples:
+                                processedWithoutError.slice(0, SAMPLE_CAP),
+                        });
+                    } catch (e) {
+                        this.logger.warn(
+                            'validation.dashboardScanned log failed',
+                            {
+                                projectUuid,
+                                dashboardUuid: uuid,
+                                err: e instanceof Error ? e.message : String(e),
+                            },
+                        );
+                    }
+
                     return [
                         ...filterErrors,
                         ...tileTargetErrors,

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -600,7 +600,7 @@ export class ValidationService extends BaseService {
         brokenCharts: Pick<CreateChartValidation, 'chartUuid' | 'name'>[],
         dashboardUuid?: string,
     ): Promise<CreateDashboardValidation[]> {
-        const existingFieldIds = existingFields.map(getItemId);
+        const existingFieldIds = new Set(existingFields.map(getItemId));
 
         // Pre-build Map for O(1) broken chart lookup instead of O(n) array.find()
         const brokenChartMap = new Map(
@@ -631,13 +631,13 @@ export class ValidationService extends BaseService {
                         fieldName,
                     }: {
                         acc: CreateDashboardValidation[];
-                        fieldIds: string[];
+                        fieldIds: Set<string>;
                         fieldId: string;
                     } & Pick<
                         CreateDashboardValidation,
                         'error' | 'errorType' | 'fieldName'
                     >) => {
-                        if (!fieldIds?.includes(fieldId)) {
+                        if (!fieldIds?.has(fieldId)) {
                             return [
                                 ...acc,
                                 {
@@ -804,7 +804,7 @@ export class ValidationService extends BaseService {
                                     fieldId: tt.fieldId,
                                     tableName: tt.tableName,
                                     fieldIdInExistingFields:
-                                        existingFieldIds.includes(tt.fieldId),
+                                        existingFieldIds.has(tt.fieldId),
                                 };
                             },
                         );
@@ -825,7 +825,7 @@ export class ValidationService extends BaseService {
                         this.logger.info('validation.dashboardScanned', {
                             projectUuid,
                             dashboardUuid: uuid,
-                            existingFieldIdCount: existingFieldIds.length,
+                            existingFieldIdCount: existingFieldIds.size,
                             filterRuleCount: dashboardFilterRules.length,
                             tileTargetCount: dashboardTileTargets.length,
                             filterErrorCount: filterErrors.length,


### PR DESCRIPTION
Related to: PROD-5931 (https://github.com/lightdash/lightdash/issues/21130)

Re-lands #23086 (which was reverted in #23118 while we investigated an OOM crashloop on the analytics instance). The OOM was subsequently traced to an unrelated 219× SSE-stream blowup in the `discoverFields` AI subagent (fixed in #23126, tripwire tracked in ZAP-398) — this PR is not implicated.

## What's in here

Three structured `Logger.info` wide events to help diagnose stale dashboard filter references in production without shipping a behavioural fix:

- **`dashboard.loaded`** (`DashboardService.getByIdOrSlug`) — fires on every dashboard render. Walks top-level filter targets and per-tile `tileTargets`, surfaces any field/table pointing at an explore no longer in `cached_explore`.
- **`compile.completed`** (`ProjectService.saveExploresToCacheAndIndexCatalog`) — fires on every project compile. Reports the diff of explore names vs the previously cached set; lets us correlate "table removed at T1" with "dashboard loaded with stale reference at T2".
- **`validation.dashboardScanned`** (`ValidationService.validateDashboards`) — fires once per dashboard validated. Breaks down filter rules, tile targets, error categories, and silent-suppression buckets. Helps diagnose why some dashboards have known-broken filter state but no validation errors recorded.

All three events are wrapped in try/catch so a logging failure can never affect the underlying request.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] `npx jest DashboardService` (22 pass)
- [x] `npx jest ProjectService` (59 pass)
- [x] `npx jest ValidationService` (21 pass)
- [x] Verified all three events fire on the local debug-local instance with the right shape and stale-reference detection (see prior PR #23086 description for sample payloads)
- [ ] **Perf testing under analytics-scale load before merge** — see internal notes for specific concerns

## Performance concerns to address before merge

A perf-testing follow-up will stress-test the validation path under analytics-scale data shape (250 explores × 25k field IDs × many dashboards). Specific hot-spots flagged for measurement: `existingFieldIds.includes(...)` is O(N) inside a per-tile-target loop; `dashboard.loaded` adds two DB queries per render. Mitigations on standby if needed: convert the includes() check to a `Set<string>`, gate by feature flag, and/or skip the event above a payload-size threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)