### PR TITLE
fix(pivot-sort): emit column_ranking CTE on Databricks without row dimensions

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -4494,6 +4494,68 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(pivotQueryBody).toContain('cr.`col_idx`');
         });
 
+        test('Pivot SQL on Databricks emits column_ranking CTE for metric sort without row dimensions (#PROD-5983)', () => {
+            // https://linear.app/lightdash/issue/PROD-5983
+            // Repro: pivot chart on Databricks with metric-based sorting and
+            // NO row dimensions. The precomputed-rankings path was gated on
+            // indexColumns.length > 0, so this case fell through to inline
+            // `DENSE_RANK() OVER (ORDER BY <metric>_column_anchor.<value>, ...)`
+            // inside pivot_query. Spark inlines the column_anchor CTE and can't
+            // resolve the qualified column reference inside the Window ORDER BY,
+            // producing `Cannot find column index for attribute
+            // '<metric>_column_anchor_value'`.
+            // Expectation: column_ranking is emitted (self-contained, with its
+            // JOIN to column_anchor scoped inside the CTE), pivot_query joins
+            // it for col_idx, and row_index is a literal 1 since there are no
+            // row dimensions. row_ranking is NOT emitted — nothing to rank.
+            const mockDatabricksBuilder = {
+                getFieldQuoteChar: () => '`',
+                getAdapterType: () => SupportedDbtAdapter.DATABRICKS,
+                getStartOfWeek: () => WeekDay.MONDAY,
+                getNullSafeEqualSql: defaultNullSafeEqualSql,
+            } as unknown as WarehouseSqlBuilder;
+
+            const pivotConfiguration = {
+                indexColumn: [],
+                valuesColumns: [
+                    {
+                        reference: 'count',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupByColumns: [{ reference: 'event' }],
+                sortBy: [
+                    { reference: 'count', direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockDatabricksBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // column_ranking must exist — that's the whole point of this fix.
+            expect(result).toContain('column_ranking AS (');
+
+            // row_ranking and row_anchor have no work without row dimensions.
+            expect(result).not.toContain('row_ranking AS (');
+            expect(result).not.toContain('`count_row_anchor`');
+
+            // pivot_query must take the precomputed-rankings shape:
+            //   - no inline DENSE_RANK (the bug shape that references
+            //     <metric>_column_anchor inside a Window ORDER BY),
+            //   - row_index is a literal 1,
+            //   - column_index comes from the joined column_ranking CTE.
+            const pivotQueryRegex = /pivot_query AS \(([^)]+)\)/;
+            const pivotQueryBody = result.match(pivotQueryRegex)?.[1] ?? '';
+            expect(pivotQueryBody).not.toContain('DENSE_RANK');
+            expect(pivotQueryBody).toContain('1 AS `row_index`');
+            expect(pivotQueryBody).toContain('cr.`col_idx`');
+        });
+
         test('nullsFirst on a value-column sort propagates through anchor CTE and row_index (#19202)', () => {
             // https://github.com/lightdash/lightdash/issues/19202
             // Repro: SQL pivot pipeline + sort by a metric with nullsFirst

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -996,10 +996,14 @@ export class PivotQueryBuilder {
             ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
         );
 
-        // Check if we need row anchor CTEs (only when sorting by a metric value AND have index columns)
-        // When sorting by a metric, we need additional CTEs to identify the "first pivot column"
-        // and compute row anchor values from that specific column only.
-        // When there are no index columns, row sorting is not needed (all rows have row_index = 1)
+        // When sorting by a metric value, we need the column_ranking CTE so
+        // that pivot_query can read col_idx from a precomputed scope instead
+        // of emitting an inline Window ORDER BY that references the sibling
+        // *_column_anchor CTE — Databricks/Spark inlines those CTEs and can't
+        // resolve the cross-CTE column reference inside a Window function.
+        // Row anchor CTEs (and the anchor_column CTE that feeds them) only
+        // make sense when there are row dimensions to rank — without them
+        // every row has row_index = 1.
         const hasMetricSort = valuesColumns?.some((valCol) =>
             sortBy?.some((sort) => sort.reference === valCol.reference),
         );
@@ -1011,8 +1015,7 @@ export class PivotQueryBuilder {
         let rowAnchorQueries: Record<string, { cteName: string; sql: string }> =
             {};
 
-        if (needsRowAnchor) {
-            // Generate column_ranking CTE
+        if (hasMetricSort) {
             const columnRankingSQL = this.getColumnRankingSQL(
                 groupByColumns,
                 valuesColumns,
@@ -1021,48 +1024,52 @@ export class PivotQueryBuilder {
             );
             columnRankingCTE = `column_ranking AS (${columnRankingSQL})`;
 
-            // Any pinned sort upgrades the shared anchor_column to per-metric
-            // anchors so two metrics can pin different columns independently.
-            const hasAnyPin =
-                sortBy?.some((s) => s.pivotValues?.length) ?? false;
+            if (needsRowAnchor) {
+                // Any pinned sort upgrades the shared anchor_column to per-metric
+                // anchors so two metrics can pin different columns independently.
+                const hasAnyPin =
+                    sortBy?.some((s) => s.pivotValues?.length) ?? false;
 
-            const perMetricAnchorCte = new Map<string, string>();
+                const perMetricAnchorCte = new Map<string, string>();
 
-            if (hasAnyPin && valuesColumns) {
-                valuesColumns.forEach((valCol) => {
-                    const sortConfig = sortBy?.find(
-                        (s) => s.reference === valCol.reference,
-                    );
-                    if (!sortConfig) return;
-                    const anchorCteName = `${valCol.reference}_anchor_column`;
-                    const anchorSQL = this.getAnchorColumnSQL(
+                if (hasAnyPin && valuesColumns) {
+                    valuesColumns.forEach((valCol) => {
+                        const sortConfig = sortBy?.find(
+                            (s) => s.reference === valCol.reference,
+                        );
+                        if (!sortConfig) return;
+                        const anchorCteName = `${valCol.reference}_anchor_column`;
+                        const anchorSQL = this.getAnchorColumnSQL(
+                            groupByColumns,
+                            sortBy,
+                            sortConfig.pivotValues,
+                        );
+                        anchorColumnCTEs.push(
+                            `${q}${anchorCteName}${q} AS (${anchorSQL})`,
+                        );
+                        perMetricAnchorCte.set(valCol.reference, anchorCteName);
+                    });
+                } else {
+                    const anchorColumnSQL = this.getAnchorColumnSQL(
                         groupByColumns,
                         sortBy,
-                        sortConfig.pivotValues,
                     );
-                    anchorColumnCTEs.push(
-                        `${q}${anchorCteName}${q} AS (${anchorSQL})`,
-                    );
-                    perMetricAnchorCte.set(valCol.reference, anchorCteName);
-                });
-            } else {
-                const anchorColumnSQL = this.getAnchorColumnSQL(
+                    anchorColumnCTEs = [
+                        `anchor_column AS (${anchorColumnSQL})`,
+                    ];
+                }
+
+                rowAnchorQueries = this.getRowAnchorCTEs(
+                    indexColumns,
+                    valuesColumns,
                     groupByColumns,
                     sortBy,
+                    hasAnyPin ? perMetricAnchorCte : undefined,
                 );
-                anchorColumnCTEs = [`anchor_column AS (${anchorColumnSQL})`];
+                rowAnchorCTEs = Object.values(rowAnchorQueries).map(
+                    ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
+                );
             }
-
-            rowAnchorQueries = this.getRowAnchorCTEs(
-                indexColumns,
-                valuesColumns,
-                groupByColumns,
-                sortBy,
-                hasAnyPin ? perMetricAnchorCte : undefined,
-            );
-            rowAnchorCTEs = Object.values(rowAnchorQueries).map(
-                ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
-            );
         }
 
         // Combine all queries for the metricFirstValueQueries map (used by getPivotQuerySQL)
@@ -1429,15 +1436,17 @@ export class PivotQueryBuilder {
             sortBy,
         );
 
-        // When metric sorting with index columns is active (needsRowAnchor),
-        // compute rankings in separate CTEs instead of inline Window functions.
-        // This prevents Databricks/Spark from failing when it inlines CTEs and
-        // can't resolve anchor column references in Window ORDER BY clauses.
-        const needsPrecomputedRankings =
-            columnRankingCTE !== null && indexColumns.length > 0;
+        // When metric sorting is active, compute rankings in separate CTEs
+        // instead of inline Window functions. This prevents Databricks/Spark
+        // from failing when it inlines CTEs and can't resolve anchor column
+        // references in Window ORDER BY clauses. row_ranking is only needed
+        // when there are row dimensions to rank — column_ranking handles the
+        // no-row-dim case on its own (pivot_query emits a literal `1` for
+        // row_index).
+        const needsPrecomputedRankings = columnRankingCTE !== null;
 
         let rowRankingCTE: string | null = null;
-        if (needsPrecomputedRankings) {
+        if (needsPrecomputedRankings && indexColumns.length > 0) {
             // Extract only row anchor queries for the row_ranking CTE
             const rowAnchorQueries = Object.fromEntries(
                 Object.entries(metricFirstValueQueries).filter(([key]) =>


### PR DESCRIPTION
Closes: [PROD-5983](https://linear.app/lightdash/issue/PROD-5983)

## Summary

Pivot charts on Databricks failed with `Cannot find column index for attribute '<metric>_column_anchor_value'` when the user sorted by a metric and had no row dimensions (groupBy columns only, no index columns). Dimension-sort pivots and metric-sort pivots *with* row dimensions were unaffected, as were Postgres / BigQuery / Snowflake (which materialize CTEs and could resolve the cross-CTE reference).

## Root cause

The precomputed-rankings path was gated on `needsRowAnchor = hasMetricSort && indexColumns.length > 0`. With metric sort but zero row dimensions, that gate failed, `column_ranking` was never emitted, and `pivot_query` fell back to an inline `DENSE_RANK() OVER (ORDER BY <metric>_column_anchor.<value>, ...)` that reaches across into a sibling CTE.

```ts
// Before — column_ranking only emitted when there are row dimensions to rank.
const needsRowAnchor = hasMetricSort && indexColumns.length > 0;
if (needsRowAnchor) {
    columnRankingCTE = `column_ranking AS (${columnRankingSQL})`;
    // ... anchor_column + row_anchor + row_ranking ...
}

// And the pivot_query gate:
const needsPrecomputedRankings =
    columnRankingCTE !== null && indexColumns.length > 0;
```

Postgres / BigQuery / Snowflake materialize CTEs, so the cross-CTE column reference resolved. Databricks (Spark) inlines CTEs and cannot resolve a qualified column from an inlined sibling CTE inside a Window `ORDER BY` — hence the runtime error in production.

## Fix

Split the gate. `column_ranking` is now emitted whenever there is metric sort; the row-anchor pipeline (`anchor_column`, per-metric anchors, `row_anchor`, `row_ranking`) stays gated on `needsRowAnchor`. `pivot_query` takes the precomputed-rankings shape whenever `column_ranking` exists, and only joins `row_ranking` when there are index columns — otherwise `row_index` is a literal `1`.

```
                    metric sort?
                         |
              +----------+----------+
              |                     |
             no                    yes
              |                     |
        inline path         column_ranking CTE
                                    |
                          indexColumns.length > 0?
                                    |
                         +----------+----------+
                         |                     |
                        no                    yes
                         |                     |
                row_index = 1          anchor_column
                                       + row_anchor
                                       + row_ranking
```

- `packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts` — emit `column_ranking` on any metric sort; keep `anchor_column` / `row_anchor` / `row_ranking` behind `needsRowAnchor`; flip `needsPrecomputedRankings` to `columnRankingCTE !== null` and only attach `row_ranking` when index columns exist.
- `packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts` — regression test pinning the Databricks shape: `column_ranking` present, `row_ranking` absent, `pivot_query` has no inline `DENSE_RANK`, `row_index = 1`, `col_idx` comes from `cr`.

## Test plan

- [x] `pnpm -F backend typecheck && pnpm -F backend lint`
- [x] `pnpm -F backend test PivotQueryBuilder` — added regression `Pivot SQL on Databricks emits column_ranking CTE for metric sort without row dimensions (#PROD-5983)` passes alongside the existing suite
- [ ] Manual: repro from PROD-5983 on a Databricks project — pivot with groupBy + metric sort + no row dimensions runs without the `Cannot find column index` error
- [ ] Manual: regression-check unaffected shapes — metric sort *with* row dimensions, dimension sort, and the same pivots on Postgres / BigQuery / Snowflake