### PR TITLE
feat(database): configurable migration list validation

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -110,6 +110,7 @@ export const lightdashConfigMock: LightdashConfig = {
         connectionUri: undefined,
         maxConnections: undefined,
         minConnections: undefined,
+        allowMissingMigrations: false,
     },
     intercom: {
         appId: '',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1023,6 +1023,7 @@ export type LightdashConfig = {
         connectionUri: string | undefined;
         maxConnections: number | undefined;
         minConnections: number | undefined;
+        allowMissingMigrations: boolean;
     };
     allowMultiOrgs: boolean;
     maxPayloadSize: string;
@@ -1794,6 +1795,8 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable('PGMAXCONNECTIONS'),
             minConnections:
                 getIntegerFromEnvironmentVariable('PGMINCONNECTIONS'),
+            allowMissingMigrations:
+                process.env.ALLOW_MISSING_MIGRATIONS === 'true',
         },
         auth: {
             pat: {

--- a/packages/backend/src/knexfile.ts
+++ b/packages/backend/src/knexfile.ts
@@ -10,6 +10,9 @@ const CONNECTION = lightdashConfig.database.connectionUri
     ? parse(lightdashConfig.database.connectionUri)
     : {};
 
+const ALLOW_MISSING_MIGRATIONS =
+    process.env.ALLOW_MISSING_MIGRATIONS === 'true';
+
 export const DEFAULT_DB_MAX_CONNECTIONS = 10;
 
 // Condition to be removed once we require Postgres vector extension
@@ -40,6 +43,8 @@ const development: Knex.Config<Knex.PgConnectionConfig> = {
         tableName: 'knex_migrations',
         extension: 'ts',
         loadExtensions: ['.ts'],
+        // Allow migations to be missing in some cases
+        disableMigrationsListValidation: ALLOW_MISSING_MIGRATIONS,
     },
     seeds: {
         directory: [

--- a/packages/backend/src/knexfile.ts
+++ b/packages/backend/src/knexfile.ts
@@ -10,9 +10,6 @@ const CONNECTION = lightdashConfig.database.connectionUri
     ? parse(lightdashConfig.database.connectionUri)
     : {};
 
-const ALLOW_MISSING_MIGRATIONS =
-    process.env.ALLOW_MISSING_MIGRATIONS === 'true';
-
 export const DEFAULT_DB_MAX_CONNECTIONS = 10;
 
 // Condition to be removed once we require Postgres vector extension
@@ -43,8 +40,8 @@ const development: Knex.Config<Knex.PgConnectionConfig> = {
         tableName: 'knex_migrations',
         extension: 'ts',
         loadExtensions: ['.ts'],
-        // Allow migations to be missing in some cases
-        disableMigrationsListValidation: ALLOW_MISSING_MIGRATIONS,
+        disableMigrationsListValidation:
+            lightdashConfig.database.allowMissingMigrations,
     },
     seeds: {
         directory: [


### PR DESCRIPTION
## Summary

- Adds `ALLOW_MISSING_MIGRATIONS` env var to disable Knex's migration list validation, allowing old code to run against a newer database during rollbacks
- Routes the config through `lightdashConfig.database.allowMissingMigrations` instead of reading `process.env` directly in knexfile, matching existing codebase patterns

Based on #23035 by @DonoA — thank you!

## Context

When rolling back code (e.g. v2 → v1) while the database stays on v2, Knex's `migrate.status()` throws because it finds migrations in the `knex_migrations` table that don't exist as files on disk. This causes the health check to fail and Kubernetes marks the pod as unhealthy.

Setting `ALLOW_MISSING_MIGRATIONS=true` disables this validation. It only suppresses the "DB ahead of code" check — pending migrations (code ahead of DB) are still correctly detected.

## Test plan

- [ ] Deploy with `ALLOW_MISSING_MIGRATIONS` unset — verify health check works normally
- [ ] Deploy old code against a newer DB without the flag — verify health check fails
- [ ] Deploy old code against a newer DB with `ALLOW_MISSING_MIGRATIONS=true` — verify health check passes with warning