### PR TITLE
chore: migrate to self-hosted Renovate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Supply-chain-sensitive files — require engineering team review
+.pnpmfile.cjs @lightdash/engineering
+.npmrc @lightdash/engineering
+pnpm-workspace.yaml @lightdash/engineering
+renovate.json @lightdash/engineering
+.github/workflows/ @lightdash/engineering

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,26 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: renovatebot/github-action@e084b5ac6fd1493e529082bbdd370ba14e12e2b0 # v46.3.3
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+          renovate-version: full
+        env:
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^pnpm install --lockfile-only --ignore-scripts$"]'
+          LOG_LEVEL: info

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "username": "lightdash-bot",
-  "gitAuthor": "lightdash-bot <bot@lightdash.com>",
+  "gitAuthor": "lightdash-bot <131011178+lightdash-bot@users.noreply.github.com>",
   "platform": "github",
   "onboarding": false,
   "requireConfig": "optional",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "username": "lightdash-bot",
+  "gitAuthor": "lightdash-bot <bot@lightdash.com>",
+  "platform": "github",
+  "onboarding": false,
+  "requireConfig": "optional",
+  "allowScripts": true,
+  "postUpgradeTasks": {
+    "commands": ["pnpm install --lockfile-only --ignore-scripts"],
+    "fileFilters": ["pnpm-lock.yaml"],
+    "executionMode": "update"
+  },
   "extends": [
     "config:recommended",
     ":dependencyDashboard",


### PR DESCRIPTION
## Summary

Moves from Mend-hosted Renovate to self-hosted via GitHub Actions so that `.pnpmfile.cjs` runs during lockfile generation. Mend blocks untrusted code, which means our pnpm lockfile checksum is generated incorrectly and CI installs fail.

- Add `.github/workflows/renovate.yml` — runs every 4h + manual dispatch
- Enable `allowScripts` in `renovate.json` for `.pnpmfile.cjs` resolution hooks
- Add `postUpgradeTasks` to regenerate lockfile with correct checksums
- Add `CODEOWNERS` for supply-chain-sensitive files (`.pnpmfile.cjs`, `.npmrc`, `pnpm-workspace.yaml`, `renovate.json`, workflows)
- Tightly anchor post-upgrade command regex to prevent injection
- Add minimum permissions block to workflow

## Before merging

- [ ] Create `RENOVATE_TOKEN` repo secret (PAT with `repo` scope, or GitHub App install token — scoped to this repo only)
- [ ] Disable Mend Renovate GitHub App on this repo
- [ ] Verify branch protection enforces code owner review + dismisses stale reviews

## Test plan

- [ ] After merging, trigger workflow manually via `workflow_dispatch` and verify Renovate creates a PR with correct lockfile checksums
- [ ] Verify `.pnpmfile.cjs` peer dep remapping is reflected in the generated lockfile