### PR TITLE
fix: correct renovatebot action SHA and deduplicate config

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: renovatebot/github-action@e084b5ac6fd1493e529082bbdd370ba14e12e2b0 # v46.3.3
+      - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
           renovate-version: full

--- a/renovate.json
+++ b/renovate.json
@@ -18,8 +18,6 @@
     "group:monorepos",
     "helpers:pinGitHubActionDigests"
   ],
-  "allowScripts": true,
-  "ignoreScripts": false,
   "osvVulnerabilityAlerts": true,
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "none",


### PR DESCRIPTION
## Summary

- Fix `renovatebot/github-action` SHA pin — the previous SHA didn't exist, causing workflow failure
- Remove duplicate `allowScripts` and stale `ignoreScripts: false` from `renovate.json`

## Test plan

- [ ] Re-run Renovate workflow via `workflow_dispatch` and verify it starts successfully