### PR TITLE
fix(ai): always render explore + topMatchingFields blocks in findExplores

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -119,15 +119,14 @@ Usage Tips:
       "description": "Tool: findExplores
 
 Purpose:
-Returns an explore with all its fields, joined tables, AI hints and descriptions. When multiple explores match your search, also returns alternative explores and top 50 matching fields across ALL explores.
+Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
 - searchQuery: Full user query for finding relevant explores
 
 Output:
-- Selected explore with all fields and metadata (including fields from joined tables)
-- Alternative explores (if multiple matches) with searchRank scores
+- Matching explores with searchRank scores
 - Top matching fields with their explore names and searchRank scores
 ",
       "inputSchema": {

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -56,13 +56,13 @@ Look at the usageInVerifiedCharts attribute on every field in topMatchingFields.
 
 ### Step 4: Ambiguity check
 
-Count DISTINCT explores in topMatchingFields. If 2+ distinct explores appear with scores within ${AMBIGUITY_RANK_WINDOW} of each other:
+Count the distinct exploreName values across topMatchingFields. If 2+ distinct explores appear with scores within ${AMBIGUITY_RANK_WINDOW} of each other:
 
 - First check joined tables. If one explore's joinedTables include another entity the user mentioned, that explore can handle the whole query → status: "resolved". Proceed to Step 5.
 - Then check usageInCharts. If one explore's fields have meaningfully higher aggregate usage (${CHART_USAGE_TIEBREAKER_MULTIPLIER}x+), prefer it → status: "resolved". Proceed to Step 5.
 - If still tied (or all usages are 0 / equal) → status: "ambiguous". DO NOT call findFields. Call submitResult with the candidate explores and a suggestedQuestion.
 
-If only 1 distinct explore appears in topMatchingFields → status: "resolved". Proceed to Step 5.
+If only 1 distinct exploreName appears across topMatchingFields → status: "resolved". Proceed to Step 5.
 
 If findExplores returns nothing relevant at all → status: "no_match". Call submitResult.
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -833,15 +833,14 @@ Usage tips:
     "description": "Tool: findExplores
 
 Purpose:
-Returns an explore with all its fields, joined tables, AI hints and descriptions. When multiple explores match your search, also returns alternative explores and top 50 matching fields across ALL explores.
+Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
 - searchQuery: Full user query for finding relevant explores
 
 Output:
-- Selected explore with all fields and metadata (including fields from joined tables)
-- Alternative explores (if multiple matches) with searchRank scores
+- Matching explores with searchRank scores
 - Top matching fields with their explore names and searchRank scores
 ",
     "inputSchema": {

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -22,18 +22,42 @@ const generateExploreResponse = ({
     exploreSearchResults,
     topMatchingFields,
 }: Awaited<ReturnType<FindExploresFn>> & { searchQuery: string }) => {
-    const searchResultsXml =
-        exploreSearchResults && exploreSearchResults.length > 0 ? (
-            <searchResults
-                searchQuery={searchQuery}
-                count={exploreSearchResults.length}
-            >
-                <note>
-                    {exploreSearchResults.length === 1
-                        ? 'One explore matched your search. Call findFields for this explore to get all its dimensions and metrics.'
-                        : 'Multiple explores matched your search. Use topMatchingFields below and apply Rule 2 (ambiguity check) to determine which explore to use, then call findFields for that explore.'}
-                </note>
-                {exploreSearchResults.map((result) => (
+    const exploreCount = exploreSearchResults?.length ?? 0;
+    const fieldCount = topMatchingFields?.length ?? 0;
+
+    const searchResultsNote = (() => {
+        if (exploreCount === 0) {
+            return fieldCount > 0
+                ? 'No explore name/label/description/aiHints matched. Use topMatchingFields below and call findFields on the most relevant explore.'
+                : 'No explore matched your search. Try different terms or synonyms.';
+        }
+        if (exploreCount === 1) {
+            return 'One explore matched your search. Call findFields for this explore to get all its dimensions and metrics.';
+        }
+        return "Multiple explores matched. Pick the explore whose fields can answer the user's question (a follow-up query runs against a single explore), using topMatchingFields to compare field-level relevance. Then call findFields on it.";
+    })();
+
+    const topFieldsNote =
+        fieldCount === 0
+            ? 'No field-level matches either.'
+            : "Per-field matches across all explores. Each field's `exploreName` shows where it lives — pick the explore whose fields can answer the user's question.";
+
+    return (
+        <findExplores searchQuery={searchQuery}>
+            <description>
+                Two-pass catalog search whose goal is to identify the single
+                explore for a follow-up query: a query runs against exactly one
+                explore, so the chosen explore must contain the fields needed to
+                answer the user's question. `searchResults` lists explores whose
+                name/label/description/aiHints matched the query.
+                `topMatchingFields` lists individual fields whose
+                name/label/description matched, across all explores — use it to
+                identify or disambiguate the explore to dig into when no explore
+                matched directly, or when several matched.
+            </description>
+            <searchResults count={exploreCount}>
+                <note>{searchResultsNote}</note>
+                {exploreSearchResults?.map((result) => (
                     <alternative
                         name={result.name}
                         label={result.label}
@@ -71,19 +95,9 @@ const generateExploreResponse = ({
                     </alternative>
                 ))}
             </searchResults>
-        ) : null;
-
-    const topFieldsXml =
-        topMatchingFields && topMatchingFields.length > 0 ? (
-            <topMatchingFields count={topMatchingFields.length}>
-                <note>
-                    Here are the top matching fields across all explores. Use
-                    this to determine which explore is most relevant by applying
-                    Rule 2 (ambiguity check). Call findFields on the chosen
-                    explore to retrieve full field metadata including
-                    descriptions.
-                </note>
-                {topMatchingFields.map((field) => (
+            <topMatchingFields count={fieldCount}>
+                <note>{topFieldsNote}</note>
+                {topMatchingFields?.map((field) => (
                     <field
                         name={field.name}
                         label={field.label}
@@ -95,11 +109,8 @@ const generateExploreResponse = ({
                     />
                 ))}
             </topMatchingFields>
-        ) : null;
-
-    return `${searchResultsXml ? `${searchResultsXml.toString()}\n` : ''}${
-        topFieldsXml ? `${topFieldsXml.toString()}\n` : ''
-    }`;
+        </findExplores>
+    ).toString();
 };
 export const getFindExplores = ({
     findExplores,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -5,15 +5,14 @@ import { createToolSchema } from '../toolSchemaBuilder';
 export const TOOL_FIND_EXPLORES_DESCRIPTION = `Tool: findExplores
 
 Purpose:
-Returns an explore with all its fields, joined tables, AI hints and descriptions. When multiple explores match your search, also returns alternative explores and top 50 matching fields across ALL explores.
+Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
 - searchQuery: Full user query for finding relevant explores
 
 Output:
-- Selected explore with all fields and metadata (including fields from joined tables)
-- Alternative explores (if multiple matches) with searchRank scores
+- Matching explores with searchRank scores
 - Top matching fields with their explore names and searchRank scores
 `;
 


### PR DESCRIPTION
## Summary

Closes [ZAP-405](https://linear.app/lightdash/issue/ZAP-405/).

`find_explores` used conditional rendering — when the explore-level search returned zero hits, the `<searchResults>` block was omitted entirely and the response degraded to just `<topMatchingFields>`. The LLM consuming the response had no way to tell "we searched the explore catalog and found nothing" from "we didn't search." Pass also tightens the surrounding docstring + notes that had inaccurate or in-house jargon.

## Change

### Always-render
- Both `<searchResults>` and `<topMatchingFields>` now always render with `count` attributes — even when zero.
- Each block carries a `<note>` whose wording adapts to the populated / empty state.
- Both blocks live under a single `<findExplores>` root with a `<description>` that explains the two-pass design (explore-level full-text + field-level fallback) **and** why it matters: a follow-up query runs against exactly one explore, so the chosen explore must contain the fields needed to answer the user's question.

### Docstring + notes cleanup
- Removed the stale "Selected explore with all fields and metadata" promise from `TOOL_FIND_EXPLORES_DESCRIPTION` — the tool never returned that.
- Removed all "Rule 2 (ambiguity check)" references from notes + the `<description>` — Rule 2 isn't part of the LLM's context, so it was dead weight.
- Rewrote the multi-match note to point at the actual intent ("answer the user's question") rather than at quantity ("as many fields as possible").
- Replaced the technical "group by `exploreName`" framing in the field-fallback note with plain language ("each field's `exploreName` shows where it lives").