### PR TITLE
fix: add repository target and move bot identity to workflow env

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,5 +22,9 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
           renovate-version: full
         env:
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^pnpm install --lockfile-only --ignore-scripts$"]'
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_GIT_AUTHOR: "lightdash-bot <131011178+lightdash-bot@users.noreply.github.com>"
+          RENOVATE_USERNAME: lightdash-bot
+          RENOVATE_ALLOW_SCRIPTS: "true"
+          RENOVATE_ALLOWED_COMMANDS: '["^pnpm install --lockfile-only --ignore-scripts$"]'
           LOG_LEVEL: info

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "username": "lightdash-bot",
-  "gitAuthor": "lightdash-bot <131011178+lightdash-bot@users.noreply.github.com>",
-  "platform": "github",
-  "onboarding": false,
-  "requireConfig": "optional",
-  "allowScripts": true,
   "postUpgradeTasks": {
     "commands": ["pnpm install --lockfile-only --ignore-scripts"],
     "fileFilters": ["pnpm-lock.yaml"],


### PR DESCRIPTION
## Summary

Fixes two issues from the first Renovate run:

1. **`No repositories found`** — Renovate needs `RENOVATE_REPOSITORIES` to know which repo to scan
2. **gitAuthor warning** — Bot identity settings (`username`, `gitAuthor`) must be env vars in the workflow (read before repo config), not in `renovate.json` (read after repo discovery)

Also removes `platform`, `onboarding`, `requireConfig` from `renovate.json` — these are global/admin settings that belong in the workflow env, not repo config.

## Test plan

- [ ] Re-run workflow via `workflow_dispatch` — should discover the repo and scan for updates