### PR TITLE
fix: add recreateClosed to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "commitMessageExtra": "({{updateType}})",
+  "recreateClosed": true,
   "labels": ["dependencies"],
   "dependencyDashboardApproval": false,
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary

Add `recreateClosed: true` so Renovate recreates PRs that were closed without merging (needed because we just cleaned up all unsigned PRs to let the GitHub App recreate them with signed commits).

## Test plan

- [ ] Trigger `workflow_dispatch` — Renovate should recreate the security PRs with verified commits