### PR TITLE
ci: skip okteto preview for renovate bot and docs PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -119,7 +119,7 @@ jobs:
     name: Select Tests to Run
     runs-on: depot-ubuntu-24.04-4
     outputs:
-      preview: ${{ steps.changes.outputs.preview == 'true' || contains(github.event.pull_request.body, 'deploy-preview') || contains(github.event.pull_request.body, 'test-all') }}
+      preview: ${{ (steps.changes.outputs.preview == 'true' && github.event.pull_request.user.login != 'lightdash-renovate-bot[bot]' && !startsWith(github.event.pull_request.title, 'docs')) || contains(github.event.pull_request.body, 'deploy-preview') || contains(github.event.pull_request.body, 'test-all') }}
       frontend: ${{ steps.changes.outputs.frontend == 'true' || contains(github.event.pull_request.body, 'test-frontend') || contains(github.event.pull_request.body, 'test-all') }}
       backend: ${{ steps.changes.outputs.backend == 'true' || contains(github.event.pull_request.body, 'test-backend') || contains(github.event.pull_request.body, 'test-all') }}
       timezone: ${{ steps.changes.outputs.timezone == 'true' || contains(github.event.pull_request.body, 'test-timezone') || contains(github.event.pull_request.body, 'test-all') }}


### PR DESCRIPTION
## Summary
- Skip Okteto preview deployment and E2E tests for PRs authored by `lightdash-renovate-bot[bot]` and PRs with titles starting with `docs`
- Saves Okteto resources when batch-merging dependency updates
- Add `deploy-preview` to the PR body to override and force a preview

## Test plan
- [ ] Verify existing PRs from renovate bot no longer trigger preview deployments
- [ ] Verify a docs PR doesn't trigger preview
- [ ] Verify adding `deploy-preview` to PR body still forces a preview