### PR TITLE
fix(bigquery): add drive oauth scopes for BigQuery external tables

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -26,6 +26,7 @@ export const lightdashConfigMock: LightdashConfig = {
             enableGCloudADC: false,
             enabled: false,
             includeBigqueryScope: false,
+            enableBigqueryDriveScope: false,
         },
         okta: {
             loginPath: '',

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -799,6 +799,19 @@ test('should set groups.enabled only when the environment variable is set', () =
     expect(falseConfig.groups.enabled).toBe(false);
 });
 
+test('should enable BigQuery Drive scope only when AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE is true', () => {
+    const undefinedConfig = parseConfig();
+    expect(undefinedConfig.auth.google.enableBigqueryDriveScope).toBe(false);
+
+    process.env.AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE = 'true';
+    const trueConfig = parseConfig();
+    expect(trueConfig.auth.google.enableBigqueryDriveScope).toBe(true);
+
+    process.env.AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE = 'false';
+    const falseConfig = parseConfig();
+    expect(falseConfig.auth.google.enableBigqueryDriveScope).toBe(false);
+});
+
 describe('getMultiProjectSetupConfig', () => {
     beforeEach(() => {
         delete process.env.LD_SETUP_PROJECTS;

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1434,6 +1434,7 @@ export type AuthGoogleConfig = {
      * See PROD-7783.
      */
     includeBigqueryScope: boolean;
+    enableBigqueryDriveScope: boolean;
 };
 
 type AuthOktaConfig = {
@@ -1863,6 +1864,8 @@ export const parseConfig = (): LightdashConfig => {
                 enableGCloudADC: process.env.AUTH_ENABLE_GCLOUD_ADC === 'true',
                 includeBigqueryScope:
                     process.env.AUTH_GOOGLE_INCLUDE_BIGQUERY_SCOPE === 'true',
+                enableBigqueryDriveScope:
+                    process.env.AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE === 'true',
             },
             okta: {
                 oauth2Issuer: process.env.AUTH_OKTA_OAUTH_ISSUER,

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -428,10 +428,14 @@ apiV1Router.get(
     lightdashConfig.auth.google.loginPath,
     storeOIDCRedirect,
     (req, res, next) => {
-        const { includeBigqueryScope } = lightdashConfig.auth.google;
+        const { includeBigqueryScope, enableBigqueryDriveScope } =
+            lightdashConfig.auth.google;
         const scope = ['profile', 'email'];
         if (includeBigqueryScope) {
             scope.push('https://www.googleapis.com/auth/bigquery');
+            if (enableBigqueryDriveScope) {
+                scope.push('https://www.googleapis.com/auth/drive.readonly');
+            }
         }
         passport.authenticate('google', {
             scope,
@@ -465,17 +469,24 @@ apiV1Router.get(
     }),
 );
 
-apiV1Router.get(
-    '/login/bigquery',
-    storeOIDCRedirect,
+apiV1Router.get('/login/bigquery', storeOIDCRedirect, (req, res, next) => {
+    const { enableBigqueryDriveScope } = lightdashConfig.auth.google;
+    const scope = [
+        'profile',
+        'email',
+        'https://www.googleapis.com/auth/bigquery',
+    ];
+    if (enableBigqueryDriveScope) {
+        scope.push('https://www.googleapis.com/auth/drive.readonly');
+    }
     passport.authenticate('google', {
-        scope: ['profile', 'email', 'https://www.googleapis.com/auth/bigquery'],
+        scope,
         accessType: 'offline',
         prompt: 'consent',
         session: false,
         includeGrantedScopes: true,
-    }),
-);
+    })(req, res, next);
+});
 
 // path to start the OAuth flow
 apiV1Router.get(

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -45,6 +45,65 @@ describe('BigqueryWarehouseClient', () => {
     });
 });
 
+describe('BigqueryWarehouseClient drive scope', () => {
+    const getBigQueryConstructorOptions = async (
+        driveScopeSetting?: 'false' | 'true',
+    ) => {
+        const { env } = process;
+        let options: Record<string, unknown> = {};
+        process.env = {
+            ...env,
+            ...(driveScopeSetting
+                ? { AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE: driveScopeSetting }
+                : {}),
+        };
+
+        try {
+            jest.resetModules();
+            jest.doMock('@google-cloud/bigquery', () => ({
+                BigQuery: jest.fn((opts) => {
+                    options = opts ?? {};
+                    return { createQueryJob: jest.fn() };
+                }),
+                Dataset: jest.fn(),
+            }));
+            const { BigqueryWarehouseClient: Client } =
+                await import('./BigqueryWarehouseClient');
+            void new Client(credentials);
+            return options;
+        } finally {
+            process.env = env;
+            jest.dontMock('@google-cloud/bigquery');
+        }
+    };
+
+    it.each<
+        [
+            driveScopeSetting: 'false' | 'true' | undefined,
+            expectedScopes: string[] | undefined,
+        ]
+    >([
+        [undefined, undefined],
+        ['false', undefined],
+        [
+            'true',
+            [
+                'https://www.googleapis.com/auth/bigquery',
+                'https://www.googleapis.com/auth/drive.readonly',
+            ],
+        ],
+    ])('drive scope %s', async (driveScopeSetting, expectedScopes) => {
+        const bigQueryConstructorOptions =
+            await getBigQueryConstructorOptions(driveScopeSetting);
+
+        if (expectedScopes) {
+            expect(bigQueryConstructorOptions.scopes).toEqual(expectedScopes);
+        } else {
+            expect(bigQueryConstructorOptions).not.toHaveProperty('scopes');
+        }
+    });
+});
+
 describe('BigqueryWarehouseClient.sanitizeLabelsWithValues', () => {
     let warnSpy: jest.SpyInstance;
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -231,6 +231,15 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 location: credentials.location || undefined,
                 maxRetries: credentials.retries,
                 apiEndpoint: credentials.accessUrl || undefined,
+                // drive.readonly is required for BigQuery external tables backed by Google Sheets/Drive.
+                ...(process.env.AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE === 'true'
+                    ? {
+                          scopes: [
+                              'https://www.googleapis.com/auth/bigquery',
+                              'https://www.googleapis.com/auth/drive.readonly',
+                          ],
+                      }
+                    : {}),
 
                 ...(credentials.authenticationType ===
                 BigqueryAuthenticationType.ADC


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19636

### Description

- Querying BigQuery external tables backed by Google Sheets/Drive can fail with `Permission denied while getting Drive credentials`.
- [BigQuery docs](https://cloud.google.com/bigquery/docs/query-drive-data) confirm that `drive.readonly` OAuth scope is required for Drive-backed external tables.
- This PR adds `AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE` ENV variable to conditionally include `drive.readonly` across all BigQuery auth paths.
- Defaults to off; self-hosted operators using their own OAuth app can enable it during rollout.

### Changes

| Auth path | Effect when `AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE=true` |
|---|---|
| `/login/bigquery` | Adds `drive.readonly` to OAuth consent |
| `/login/google` | Adds `drive.readonly` only when `AUTH_GOOGLE_INCLUDE_BIGQUERY_SCOPE=true` |
| Service Account / ADC | Adds `drive.readonly` to BigQuery SDK `scopes` option |

#### Note
- drive.readonly only works if the Sheets/Drive file is shared with the Google identity used for the query.
- Existing OAuth users authenticated without Drive scope will need to re-authenticate after enabling the flag.

### Test plan

> `FLAG` = `AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE`

- [x] `pnpm -F @lightdash/warehouses test`
- [x] `pnpm -F @lightdash/warehouses typecheck`
- [x] `pnpm -F @lightdash/warehouses lint`
- [x] `pnpm -F backend test`
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] FLAG unset: no Drive scope in OAuth consent (`/login/bigquery`, `/login/google`)
- [x] FLAG=true: SA-based external table query succeeds (no `Permission denied`)
- [x] FLAG=true + `AUTH_GOOGLE_INCLUDE_BIGQUERY_SCOPE=true`: both OAuth paths show BigQuery + Drive scopes
- [x] FLAG=true + `AUTH_GOOGLE_INCLUDE_BIGQUERY_SCOPE=false`: `/login/google` does NOT add Drive scope alone

#### Screenshots

- External table configuration

  <img width="480" alt="External table configuration" src="https://github.com/user-attachments/assets/aa29a22c-bc43-4317-8c9e-df68b54be570" />

- Google OAuth consent screen for BigQuery connection (with `AUTH_ENABLE_BIGQUERY_DRIVE_SCOPE=true`)
  <img width="411" alt="BigQuery OAuth Connection screen" src="https://github.com/user-attachments/assets/6e27bad8-37c0-42c4-8063-20b5ed3b2f15" />

- SQL Runner query result from Google Sheets external table

  <img width="760" alt="SQL Runner query result" src="https://github.com/user-attachments/assets/6a37f11d-9eea-4956-b8fb-a8882f16cecb" />
