### PR TITLE
docs: updated Python version requirement in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -434,7 +434,7 @@ the `/etc/hosts` configuration in your computer otherwise it will fail with a `D
 To setup Development Environment without Docker you need following pre-requisites before running Lightdash:
 
 -   node >= v18.x (20 is preferred)
--   python >= 3.3
+-   python >= 3.8
 -   pnpm
 -   postgres >= 12
 -   dbt 1.7.x aliased to `dbt1.7`


### PR DESCRIPTION
## Summary
The "Setup Development Environment without Docker" section lists `python >= 3.3` as a prerequisite, but that's not accurate. The setup installs `dbt-core==1.7.*` and `dbt-postgres==1.7.*`, which require Python 3.8 or later. Python 3.3 reached end-of-life in 2017 and would fail immediately when attempting to install any of the required packages.

## How to reproduce
Follow the non-Docker setup in CONTRIBUTING.md on a machine running Python 3.4–3.7. The `pip install 'dbt-core==1.7.*'` step will fail with a compatibility error.

## Test plan
Confirm the prerequisites list in the "Setup Development Environment without Docker" section now reads `python >= 3.8`.