### PR TITLE
refactor(ai): remove AiAgentRunSql feature flag

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3848,23 +3848,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             createChange,
         } = this.getAiAgentDependencies(user, prompt);
 
-        const canRunSqlFlag = await this.featureFlagService.get({
-            user,
-            featureFlagId: CommercialFeatureFlags.AiAgentRunSql,
-        });
-
         const enableSqlMode = options.enableSqlMode ?? false;
 
-        // For Slack prompts: only allow runSql when the org requires OAuth.
-        // Without OAuth, Slack messages run as a workspace-default user, so
-        // both the feature flag and the SqlRunner CASL check evaluate against
-        // that default — meaning ANYONE in the Slack workspace could trigger
-        // SQL execution under a different person's permissions. Fail-closed.
-        // Three-way gate: org-level flag, per-call CASL ability (added below),
-        // and per-thread toggle from the web client (default false for any
-        // caller that doesn't pass it — Slack/eval paths pass `true` to
-        // preserve their flag-only gating).
-        let canRunSql = canRunSqlFlag.enabled && enableSqlMode;
+        let canRunSql = enableSqlMode;
+        // Without OAuth, Slack messages run as a workspace-default user — the CASL check below would evaluate against that default, letting anyone in the workspace trigger SQL under another person's identity. Fail-closed.
         if (canRunSql && isSlackPrompt(prompt) && user.organizationUuid) {
             const slackSettings =
                 await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(

--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -5,5 +5,4 @@ export enum CommercialFeatureFlags {
     ServiceAccounts = 'service-accounts',
     OrganizationWarehouseCredentials = 'organization-warehouse-credentials',
     CustomRoles = 'custom-roles',
-    AiAgentRunSql = 'ai-agent-run-sql',
 }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentSqlModeAvailable.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentSqlModeAvailable.ts
@@ -1,22 +1,17 @@
-// True when the per-prompt "SQL mode" toggle should be visible: the
-// `ai-agent-run-sql` feature flag is on AND the user holds the same
-// `manage:SqlRunner` CASL ability the SQL Runner page requires. Without
-// both, the toggle never renders and the agent stays in the semantic
-// layer regardless.
+// True when the per-prompt "SQL mode" toggle should be visible: the user
+// holds the same `manage:SqlRunner` CASL ability the SQL Runner page
+// requires. Without it the toggle never renders and the agent stays in
+// the semantic layer regardless.
 
 import { subject } from '@casl/ability';
-import { CommercialFeatureFlags } from '@lightdash/common';
-import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 
 export const useAiAgentSqlModeAvailable = (
     projectUuid: string | undefined,
 ): boolean => {
     const { user } = useApp();
-    const flag = useServerFeatureFlag(CommercialFeatureFlags.AiAgentRunSql);
 
     if (!projectUuid || !user.data) return false;
-    if (flag.isLoading || !flag.data?.enabled) return false;
 
     return (
         user.data.ability.can(


### PR DESCRIPTION
## Summary

Removes the `AiAgentRunSql` commercial feature flag, making the runSql / listWarehouseTables / describeWarehouseTable tools available to all users who can already use the SQL Runner page.

The flag was rollout-control posture for the original ship (PR #22923, 6 days ago). The feature is stable, the per-call human approval gate (PR #22924) is live, and the per-thread SQL mode toggle remains the deliberate human-in-the-loop check.

Stacked on top of #23202.

## Gates before and after

| Layer | Before this PR | After this PR | Note |
|---|---|---|---|
| Org-level commercial flag (`ai-agent-run-sql`) | ✅ | ❌ removed | Was rollout-control, not pricing |
| Per-thread `enableSqlMode` toggle | ✅ | ✅ | Web user must flip "SQL mode" on per thread; Slack/eval pass `true` |
| `manage:SqlRunner` CASL ability | ✅ | ✅ | Same scope the SQL Runner page requires |
| Per-call `waitForSqlApproval` approval flow | ✅ | ✅ | User clicks approve on each SQL call (PR #22924) |
| Slack `aiRequireOAuth` fail-closed | ✅ | ✅ | Without OAuth, fail-closed because messages run as workspace-default user |

Net: org admins lose a kill-switch for the *option*. Users still must opt in per-thread, hold the CASL ability, and approve each call.

## Regression analysis

- **Users currently on the flag**: zero functional change.
- **Users currently off the flag, with `manage:SqlRunner`**: now see the SQL mode toggle in the UI (`useAiAgentSqlModeAvailable` now only checks CASL). Tool stays unregistered until they flip the toggle. Each call still requires explicit human approval.
- **Users without `manage:SqlRunner`**: zero change — `canRunSql` still resolves to `false` deep in the registration path.
- **Slack with `aiRequireOAuth=false`**: zero change — still fail-closed.
- **Service accounts**: same as before — service-account CASL would have to grant `manage:SqlRunner` for the tool to register; not a default scope.
- **Eval suite**: same as before — passes `enableSqlMode: true`, CASL evaluated per the suite's user.
- **MCP**: not touched.

## Files

- `packages/common/src/ee/commercialFeatureFlags.ts` — remove `AiAgentRunSql` enum entry
- `packages/backend/src/ee/services/AiAgentService/AiAgentService.ts` — drop the `featureFlagService.get(...)` call; `canRunSql = enableSqlMode` instead of `canRunSqlFlag.enabled && enableSqlMode`; comment slimmed to the non-obvious bit (Slack OAuth fail-closed)
- `packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentSqlModeAvailable.ts` — drop the `useServerFeatureFlag` check; toggle visibility now only gated by CASL

## Test plan

- [x] `pnpm -F common typecheck`
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F frontend typecheck`
- [ ] Manual: as a user with `manage:SqlRunner` and no flag set, confirm "SQL mode" toggle appears in the launcher
- [ ] Manual: flip the toggle on, ask a SQL-requiring question, confirm the per-call approval modal still fires
- [ ] Manual: as a user without `manage:SqlRunner`, confirm the toggle does not appear
- [ ] Manual: as a Slack user with `aiRequireOAuth=false`, confirm runSql is still fail-closed (log line "Disabling runSql for Slack prompt...")

🤖 Generated with [Claude Code](https://claude.com/claude-code)