### PR TITLE
fix(sql-runner): unblock Developer role from Write back to dbt

### DIFF
--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -1253,6 +1253,32 @@ describe('Project member permissions', () => {
                     ).toEqual(false);
                 });
             });
+
+            describe('SourceCode', () => {
+                it('can manage SourceCode on a non-protected branch', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('SourceCode', {
+                                projectUuid,
+                                isProtectedBranch: false,
+                            }),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot manage SourceCode on a protected branch', () => {
+                    expect(
+                        ability.can(
+                            'manage',
+                            subject('SourceCode', {
+                                projectUuid,
+                                isProtectedBranch: true,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
+            });
         });
         describe('when user is a viewer', () => {
             beforeEach(() => {

--- a/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
@@ -107,6 +107,7 @@ const SourceCodeEditorContent: FC = () => {
                 subject('SourceCode', {
                     organizationUuid: user.data?.organizationUuid,
                     projectUuid,
+                    isProtectedBranch: false,
                 }),
             ) ?? false,
         [user.data?.ability, user.data?.organizationUuid, projectUuid],

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -62,7 +62,11 @@ export const HeaderCreate: FC = () => {
     );
     const canWriteBackToDbt = !!user.data?.ability?.can(
         'manage',
-        subject('SourceCode', { organizationUuid, projectUuid }),
+        subject('SourceCode', {
+            organizationUuid,
+            projectUuid,
+            isProtectedBranch: false,
+        }),
     );
 
     const dispatch = useAppDispatch();


### PR DESCRIPTION
Closes: PROD-7767

## What this fixes

The default project Developer role grants `manage:SourceCode` only when the subject has `isProtectedBranch: false`. Two frontend gating checks built the CASL subject without that field, so CASL strict-matched `undefined === false`, returned false, and greyed out "Write back to dbt" in the SQL runner and the manage actions in the source-code editor for any user with the default Developer role.

## How

Pass `isProtectedBranch: false` explicitly in both subject builders:

- **`HeaderCreate.tsx`** — `canWriteBackToDbt` gate in the SQL runner header
- **`SourceCodeEditorContent.tsx`** — manage gate in the source-code editor

```
rule (Developer):   manage SourceCode { projectUuid, isProtectedBranch: false }
subject (before):                     { projectUuid }                          -> undefined !== false -> denied
subject (after):                      { projectUuid, isProtectedBranch: false } -> match            -> allowed
```

Both call sites always write through a feature branch via PR (per the convention in `GitIntegrationService`), so the gate answers "can write at all", not "can write to this specific branch". The editor toolbar still enforces real branch protection downstream.

## Who's affected

- **Project Developer (default role)** — before: denied (bug). After: allowed. *This is the gap we are closing.*
- **Project Admin (default role)** — before: allowed. After: allowed.
- **Org-level Developer** — before: allowed. After: allowed. The org rule carries no `isProtectedBranch` condition.
- **Custom role cloned from Developer** — before: allowed. After: allowed. Custom-role `SourceCode` rules carry no condition, which is why the cloned-Developer workaround unblocked users.
- **Project Viewer / Interactive Viewer** — before: denied. After: denied.

No known customer relied on the broken behaviour; the workaround was cloning Developer into a custom role.

## Test plan

- [x] `pnpm -F common test` — added regression tests for Developer `manage:SourceCode` on both `isProtectedBranch: false` (allowed) and `isProtectedBranch: true` (denied)
- [x] Manual: default-role Developer sees "Write back to dbt" enabled in the SQL runner
- [x] Manual: default-role Developer can use manage actions in the source-code editor
- [x] Manual: cloned-Developer custom role still works — no regression on the prior workaround