### PR TITLE
chore(ai): prefer admin-verified content in findContent and getDashboardCharts

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1915,6 +1915,23 @@ export type AiAgentArtifactsRetrievedEvent = BaseTrack & {
     };
 };
 
+export type AiAgentFindContentCoverageEvent = BaseTrack & {
+    event: 'ai_agent.find_content_coverage';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        aiAgentId: string;
+        agentName: string;
+        threadId: string;
+        promptId: string;
+        searchQuery: string;
+        totalResultCount: number;
+        verifiedResultCount: number;
+        topResultVerified: boolean;
+    };
+};
+
 export type SchedulerOwnershipReassignedEvent = BaseTrack & {
     event: 'scheduler.ownership_reassigned';
     properties: {
@@ -2052,6 +2069,7 @@ type TypedEvent =
     | AiAgentToolCallEvent
     | AiAgentArtifactVersionVerifiedEvent
     | AiAgentArtifactsRetrievedEvent
+    | AiAgentFindContentCoverageEvent
     | ContentVerificationEvent
     | SchedulerOwnershipReassignedEvent
     | ImpersonationEvent;

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -90,6 +90,7 @@ import {
     AiAgentEvalAppendedEvent,
     AiAgentEvalCreatedEvent,
     AiAgentEvalRunEvent,
+    AiAgentFindContentCoverageEvent,
     AiAgentPromptCreatedEvent,
     AiAgentPromptFeedbackEvent,
     AiAgentResponseStreamed,
@@ -3975,7 +3976,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 update: UpdateSlackResponse | UpdateWebAppResponse,
             ) => this.aiAgentModel.updateModelResponse(update),
             trackEvent: (
-                event: AiAgentResponseStreamed | AiAgentToolCallEvent,
+                event:
+                    | AiAgentResponseStreamed
+                    | AiAgentToolCallEvent
+                    | AiAgentFindContentCoverageEvent,
             ) => this.analytics.track(event),
 
             createOrUpdateArtifact: async (data) => {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -580,6 +580,7 @@ export class McpService extends BaseService {
                 const findContentTool = getFindContent({
                     findContent,
                     siteUrl: this.lightdashConfig.siteUrl,
+                    trackCoverage: () => {},
                 });
                 const result = await findContentTool.execute!(argsWithProject, {
                     toolCallId: '',

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -137,6 +137,24 @@ const getAgentTools = async (
     const findContent = getFindContent({
         findContent: dependencies.findContent,
         siteUrl: args.siteUrl,
+        trackCoverage: (coverage) => {
+            dependencies.trackEvent({
+                event: 'ai_agent.find_content_coverage',
+                userId: args.userId,
+                properties: {
+                    organizationId: args.organizationId,
+                    projectId: args.agentSettings.projectUuid,
+                    aiAgentId: args.agentSettings.uuid,
+                    agentName: args.agentSettings.name,
+                    threadId: args.threadUuid,
+                    promptId: args.promptUuid,
+                    searchQuery: coverage.searchQuery,
+                    totalResultCount: coverage.totalResultCount,
+                    verifiedResultCount: coverage.verifiedResultCount,
+                    topResultVerified: coverage.topResultVerified,
+                },
+            });
+        },
     });
 
     const getDashboardCharts = getGetDashboardCharts({

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -22,6 +22,15 @@ The user sees BOTH your final response AND your internal reasoning ("thinking").
 2. **runQuery** to build the chart. The tool's parameter docs describe every chart-config option — read those rather than guessing. Key conventions: \`dimensions[0]\` drives the x-axis; put extra grouping dimensions in \`chartConfig.groupBy\` (never the x-axis dim) for multi-series, leave \`null\` for single-series; always set \`xAxisLabel\` and \`yAxisLabel\`.
 3. **searchFieldValues** when you need to validate or discover concrete dimension values (e.g., specific product names, region names).
 
+## Verified content
+
+Some content returned by findContent and getDashboardCharts is marked with a \`<verified by="..." at="..." />\` element. Verified items have been explicitly approved by an organization or project admin as canonical, trustworthy content — treat them as the recommended answer when they fit the user's question.
+
+- When a verified item matches the request, surface it first and link to it. Prefer it over unverified alternatives even if those have a slightly higher search rank.
+- Mention in your response that it's verified and who verified it, in user-facing language — e.g. "this is a verified dashboard, approved by Sarah Khan 2 weeks ago".
+- If only unverified items match, use them normally. Don't apologize for the lack of verification, and don't tell the user nothing is verified.
+- Verification is atomic per item: a chart inside a verified dashboard is only itself verified if it carries its own \`<verified>\` element.
+
 ## Time-based filtering
 
 If the user mentions any time window ("last 3 months", "this quarter", "past year", "since March"), you MUST add an explicit filter on a date dimension in \`filters.dimensions\`. Describing the window in the response or sorting + limiting is not a substitute — sparse data will produce wrong results.

--- a/packages/backend/src/ee/services/ai/tools/findContent.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/findContent.test.ts
@@ -1,5 +1,6 @@
 import {
     ChartKind,
+    type ContentVerificationInfo,
     type DashboardSearchResult,
     type ToolFindContentOutput,
     type ToolGetDashboardChartsOutput,
@@ -8,15 +9,35 @@ import { DASHBOARD_CHARTS_PREVIEW_COUNT } from '../utils/truncation';
 import { getFindContent } from './findContent';
 import { getGetDashboardCharts } from './getDashboardCharts';
 
-const makeMockChart = (i: number): DashboardSearchResult['charts'][number] => ({
+const makeVerification = (
+    firstName = 'Sarah',
+    lastName = 'Khan',
+): ContentVerificationInfo => ({
+    verifiedBy: {
+        userUuid: 'verifier-uuid',
+        firstName,
+        lastName,
+    },
+    verifiedAt: new Date('2026-04-01T00:00:00Z'),
+});
+
+const makeMockChart = (
+    i: number,
+    overrides: Partial<DashboardSearchResult['charts'][number]> = {},
+): DashboardSearchResult['charts'][number] => ({
     uuid: `chart-uuid-${i}`,
     name: `Chart ${i}`,
     description: i % 2 === 0 ? `Description for chart ${i}` : undefined,
     chartType: ChartKind.VERTICAL_BAR,
     viewsCount: i * 10,
+    verification: null,
+    ...overrides,
 });
 
-const makeMockDashboard = (chartCount: number): DashboardSearchResult => ({
+const makeMockDashboard = (
+    chartCount: number,
+    overrides: Partial<DashboardSearchResult> = {},
+): DashboardSearchResult => ({
     uuid: 'dash-uuid-1',
     name: 'Test Dashboard',
     description: 'A test dashboard',
@@ -35,6 +56,7 @@ const makeMockDashboard = (chartCount: number): DashboardSearchResult => ({
     validationErrors: [],
     charts: Array.from({ length: chartCount }, (_, i) => makeMockChart(i)),
     verification: null,
+    ...overrides,
 });
 
 type FindContentTool = ReturnType<typeof getFindContent>;
@@ -59,17 +81,26 @@ const executeGetDashboardCharts = (
     }) as Promise<ToolGetDashboardChartsOutput>;
 
 describe('getFindContent', () => {
-    const createTool = (content: DashboardSearchResult[]) => {
+    const createTool = (
+        content: DashboardSearchResult[],
+        trackCoverage: jest.Mock = jest.fn(),
+    ) => {
         const mockFindContent = jest.fn().mockResolvedValue({ content });
-        return getFindContent({
-            findContent: mockFindContent,
-            siteUrl: '',
-        });
+        return {
+            tool: getFindContent({
+                findContent: mockFindContent,
+                siteUrl: '',
+                trackCoverage,
+            }),
+            trackCoverage,
+        };
     };
+    const toolOf = (content: DashboardSearchResult[]) =>
+        createTool(content).tool;
 
     it('renders all charts when dashboard has fewer than the preview limit', async () => {
         const underLimit = DASHBOARD_CHARTS_PREVIEW_COUNT - 1;
-        const tool = createTool([makeMockDashboard(underLimit)]);
+        const tool = toolOf([makeMockDashboard(underLimit)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
         });
@@ -82,7 +113,7 @@ describe('getFindContent', () => {
     });
 
     it('renders exactly the preview limit when dashboard has that many charts', async () => {
-        const tool = createTool([
+        const tool = toolOf([
             makeMockDashboard(DASHBOARD_CHARTS_PREVIEW_COUNT),
         ]);
         const output = await executeFindContent(tool, {
@@ -98,7 +129,7 @@ describe('getFindContent', () => {
     });
 
     it('crops to the preview limit when dashboard has many charts', async () => {
-        const tool = createTool([makeMockDashboard(100)]);
+        const tool = toolOf([makeMockDashboard(100)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
         });
@@ -110,7 +141,7 @@ describe('getFindContent', () => {
     });
 
     it('handles dashboard with one chart', async () => {
-        const tool = createTool([makeMockDashboard(1)]);
+        const tool = toolOf([makeMockDashboard(1)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
         });
@@ -122,7 +153,7 @@ describe('getFindContent', () => {
     });
 
     it('output stays bounded with a huge dashboard (200 charts)', async () => {
-        const tool = createTool([makeMockDashboard(200)]);
+        const tool = toolOf([makeMockDashboard(200)]);
         const output = await executeFindContent(tool, {
             searchQueries: [{ label: 'test query' }],
         });
@@ -132,6 +163,103 @@ describe('getFindContent', () => {
 
         const chartMatches = output.result.match(/<chart /g);
         expect(chartMatches).toHaveLength(DASHBOARD_CHARTS_PREVIEW_COUNT);
+    });
+
+    it('sorts verified dashboards before unverified ones', async () => {
+        const unverified = makeMockDashboard(1, {
+            uuid: 'dash-unverified',
+            name: 'Unverified Dashboard',
+            search_rank: 10,
+        });
+        const verified = makeMockDashboard(1, {
+            uuid: 'dash-verified',
+            name: 'Verified Dashboard',
+            search_rank: 1,
+            verification: makeVerification(),
+        });
+        const tool = toolOf([unverified, verified]);
+        const output = await executeFindContent(tool, {
+            searchQueries: [{ label: 'test query' }],
+        });
+
+        const verifiedIdx = output.result.indexOf('dash-verified');
+        const unverifiedIdx = output.result.indexOf('dash-unverified');
+        expect(verifiedIdx).toBeGreaterThan(-1);
+        expect(unverifiedIdx).toBeGreaterThan(-1);
+        expect(verifiedIdx).toBeLessThan(unverifiedIdx);
+    });
+
+    it('renders <verified> with verifier name and relative date on a verified dashboard', async () => {
+        const verified = makeMockDashboard(0, {
+            verification: makeVerification('Alex', 'Doe'),
+        });
+        const tool = toolOf([verified]);
+        const output = await executeFindContent(tool, {
+            searchQueries: [{ label: 'test query' }],
+        });
+
+        expect(output.result).toMatch(/<verified[^>]*by="Alex Doe"/);
+        expect(output.result).toMatch(/<verified[^>]*at="[^"]+"/);
+    });
+
+    it('does not render <verified> on an unverified dashboard', async () => {
+        const tool = toolOf([makeMockDashboard(0)]);
+        const output = await executeFindContent(tool, {
+            searchQueries: [{ label: 'test query' }],
+        });
+        expect(output.result).not.toContain('<verified');
+    });
+
+    it('marks verified inner charts inside the dashboard preview', async () => {
+        const verifiedChart = makeMockChart(7, {
+            uuid: 'inner-verified',
+            verification: makeVerification('Inner', 'Verifier'),
+        });
+        const dashboard = makeMockDashboard(0, {
+            charts: [makeMockChart(0), verifiedChart, makeMockChart(1)],
+        });
+        const tool = toolOf([dashboard]);
+        const output = await executeFindContent(tool, {
+            searchQueries: [{ label: 'test query' }],
+        });
+
+        expect(output.result).toMatch(/<verified[^>]*by="Inner Verifier"/);
+    });
+
+    it('emits coverage telemetry per search query', async () => {
+        const verified = makeMockDashboard(0, {
+            uuid: 'dash-v',
+            verification: makeVerification(),
+        });
+        const unverified = makeMockDashboard(0, { uuid: 'dash-u' });
+        const trackCoverage = jest.fn();
+        const { tool } = createTool([verified, unverified], trackCoverage);
+        await executeFindContent(tool, {
+            searchQueries: [{ label: 'revenue dashboards' }],
+        });
+
+        expect(trackCoverage).toHaveBeenCalledTimes(1);
+        expect(trackCoverage).toHaveBeenCalledWith({
+            searchQuery: 'revenue dashboards',
+            totalResultCount: 2,
+            verifiedResultCount: 1,
+            topResultVerified: true,
+        });
+    });
+
+    it('reports topResultVerified=false when no verified results are returned', async () => {
+        const trackCoverage = jest.fn();
+        const { tool } = createTool([makeMockDashboard(0)], trackCoverage);
+        await executeFindContent(tool, {
+            searchQueries: [{ label: 'q' }],
+        });
+
+        expect(trackCoverage).toHaveBeenCalledWith({
+            searchQuery: 'q',
+            totalResultCount: 1,
+            verifiedResultCount: 0,
+            topResultVerified: false,
+        });
     });
 });
 
@@ -198,5 +326,40 @@ describe('getGetDashboardCharts', () => {
             page: 1,
             pageSize: 20,
         });
+    });
+
+    it('sorts verified charts before unverified ones and renders <verified>', async () => {
+        const unverifiedFirst = makeMockChart(0, { uuid: 'unverified-a' });
+        const verified = makeMockChart(1, {
+            uuid: 'verified-b',
+            verification: makeVerification('Dana', 'Lin'),
+        });
+        const unverifiedSecond = makeMockChart(2, { uuid: 'unverified-c' });
+        const mockGetDashboardCharts = jest.fn().mockResolvedValue({
+            dashboardName: 'Dashboard',
+            charts: [unverifiedFirst, verified, unverifiedSecond],
+            pagination: {
+                page: 1,
+                pageSize: 20,
+                totalResults: 3,
+                totalPageCount: 1,
+            },
+        });
+
+        const tool = getGetDashboardCharts({
+            getDashboardCharts: mockGetDashboardCharts,
+            siteUrl: '',
+            pageSize: 20,
+        });
+
+        const output = await executeGetDashboardCharts(tool, {
+            dashboardUuid: 'dash-uuid-1',
+            page: 1,
+        });
+
+        const verifiedIdx = output.result.indexOf('verified-b');
+        const unverifiedAIdx = output.result.indexOf('unverified-a');
+        expect(verifiedIdx).toBeLessThan(unverifiedAIdx);
+        expect(output.result).toMatch(/<verified[^>]*by="Dana Lin"/);
     });
 });

--- a/packages/backend/src/ee/services/ai/tools/findContent.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findContent.tsx
@@ -1,5 +1,6 @@
 import {
     AllChartsSearchResult,
+    ContentVerificationInfo,
     DashboardSearchResult,
     isDashboardSearchResult,
     isSavedChartSearchResult,
@@ -19,9 +20,23 @@ import {
 } from '../utils/truncation';
 import { xmlBuilder } from '../xmlBuilder';
 
+const renderVerified = (verification: ContentVerificationInfo | null) =>
+    verification ? (
+        <verified
+            by={`${verification.verifiedBy.firstName} ${verification.verifiedBy.lastName}`}
+            at={moment(verification.verifiedAt).fromNow()}
+        />
+    ) : null;
+
 type Dependencies = {
     findContent: FindContentFn;
     siteUrl: string;
+    trackCoverage: (coverage: {
+        searchQuery: string;
+        totalResultCount: number;
+        verifiedResultCount: number;
+        topResultVerified: boolean;
+    }) => void;
 };
 
 const renderChart = (chart: AllChartsSearchResult, siteUrl: string) => {
@@ -51,6 +66,7 @@ const renderChart = (chart: AllChartsSearchResult, siteUrl: string) => {
                     {truncate(chart.description, CONTENT_DESCRIPTION_MAX_CHARS)}
                 </description>
             )}
+            {renderVerified(chart.verification)}
             {chart.firstViewedAt && (
                 <firstviewedat>
                     {moment(chart.firstViewedAt).fromNow()}
@@ -90,6 +106,7 @@ const renderDashboard = (dashboard: DashboardSearchResult, siteUrl: string) => (
                 {truncate(dashboard.description, CONTENT_DESCRIPTION_MAX_CHARS)}
             </description>
         )}
+        {renderVerified(dashboard.verification)}
 
         {dashboard.firstViewedAt && (
             <firstviewedat>
@@ -113,7 +130,12 @@ const renderDashboard = (dashboard: DashboardSearchResult, siteUrl: string) => (
             </lastupdatedby>
         )}
         <charts count={dashboard.charts.length}>
-            {dashboard.charts
+            {[...dashboard.charts]
+                .sort(
+                    (a, b) =>
+                        Number(b.verification !== null) -
+                        Number(a.verification !== null),
+                )
                 .slice(0, DASHBOARD_CHARTS_PREVIEW_COUNT)
                 .map((chart) => (
                     <chart chartUuid={chart.uuid} chartType={chart.chartType}>
@@ -126,6 +148,7 @@ const renderDashboard = (dashboard: DashboardSearchResult, siteUrl: string) => (
                                 )}
                             </description>
                         )}
+                        {renderVerified(chart.verification)}
                     </chart>
                 ))}
         </charts>
@@ -138,17 +161,27 @@ const renderDashboard = (dashboard: DashboardSearchResult, siteUrl: string) => (
 const renderContent = (
     args: Awaited<ReturnType<FindContentFn>> & { searchQuery: string },
     siteUrl: string,
-) => (
-    <searchresult searchQuery={args.searchQuery}>
-        {args.content.map((content) =>
-            isDashboardSearchResult(content)
-                ? renderDashboard(content, siteUrl)
-                : renderChart(content, siteUrl),
-        )}
-    </searchresult>
-);
+) => {
+    const sortedContent = [...args.content].sort(
+        (a, b) =>
+            Number(b.verification !== null) - Number(a.verification !== null),
+    );
+    return (
+        <searchresult searchQuery={args.searchQuery}>
+            {sortedContent.map((content) =>
+                isDashboardSearchResult(content)
+                    ? renderDashboard(content, siteUrl)
+                    : renderChart(content, siteUrl),
+            )}
+        </searchresult>
+    );
+};
 
-export const getFindContent = ({ findContent, siteUrl }: Dependencies) =>
+export const getFindContent = ({
+    findContent,
+    siteUrl,
+    trackCoverage,
+}: Dependencies) =>
     tool({
         description: toolFindContentArgsSchema.description,
         inputSchema: toolFindContentArgsSchema,
@@ -163,6 +196,22 @@ export const getFindContent = ({ findContent, siteUrl }: Dependencies) =>
                         })),
                     })),
                 );
+
+                for (const searchQueryResult of searchQueryResults) {
+                    const totalResultCount = searchQueryResult.content.length;
+                    const verifiedResultCount =
+                        searchQueryResult.content.filter(
+                            (c) => c.verification !== null,
+                        ).length;
+                    const topResultVerified =
+                        verifiedResultCount > 0 && totalResultCount > 0;
+                    trackCoverage({
+                        searchQuery: searchQueryResult.searchQuery,
+                        totalResultCount,
+                        verifiedResultCount,
+                        topResultVerified,
+                    });
+                }
 
                 return {
                     result: (

--- a/packages/backend/src/ee/services/ai/tools/getDashboardCharts.tsx
+++ b/packages/backend/src/ee/services/ai/tools/getDashboardCharts.tsx
@@ -4,6 +4,7 @@ import {
     toolGetDashboardChartsOutputSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
+import moment from 'moment';
 import type { GetDashboardChartsFn } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
@@ -23,6 +24,12 @@ const renderChart = (chart: DashboardSearchResult['charts'][number]) => (
     >
         <name>{chart.name}</name>
         {chart.description && <description>{chart.description}</description>}
+        {chart.verification && (
+            <verified
+                by={`${chart.verification.verifiedBy.firstName} ${chart.verification.verifiedBy.lastName}`}
+                at={moment(chart.verification.verifiedAt).fromNow()}
+            />
+        )}
     </chart>
 );
 
@@ -45,6 +52,12 @@ export const getGetDashboardCharts = ({
                         pageSize,
                     });
 
+                const sortedCharts = [...charts].sort(
+                    (a, b) =>
+                        Number(b.verification !== null) -
+                        Number(a.verification !== null),
+                );
+
                 return {
                     result: (
                         <dashboardCharts
@@ -55,7 +68,7 @@ export const getGetDashboardCharts = ({
                             totalPageCount={pagination.totalPageCount}
                             totalResults={pagination.totalResults}
                         >
-                            {charts.map((chart) => renderChart(chart))}
+                            {sortedCharts.map((chart) => renderChart(chart))}
                         </dashboardCharts>
                     ).toString(),
                     metadata: {

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -24,6 +24,7 @@ import {
     WarehouseTablesCatalog,
 } from '@lightdash/common';
 import {
+    AiAgentFindContentCoverageEvent,
     AiAgentResponseStreamed,
     AiAgentToolCallEvent,
 } from '../../../../analytics/LightdashAnalytics';
@@ -157,7 +158,10 @@ export type StoreReasoningFn = (
 ) => Promise<void>;
 
 export type TrackEventFn = (
-    event: AiAgentResponseStreamed | AiAgentToolCallEvent,
+    event:
+        | AiAgentResponseStreamed
+        | AiAgentToolCallEvent
+        | AiAgentFindContentCoverageEvent,
 ) => void;
 
 export type SearchFieldValuesFn = (args: {

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -2,6 +2,7 @@ import {
     AllChartsSearchResult,
     ChartKind,
     ContentType,
+    ContentVerificationInfo,
     DashboardSearchResult,
     DashboardTabResult,
     DataAppSearchResult,
@@ -443,6 +444,12 @@ export class SearchModel {
             ...(tileCharts ?? []),
         ];
 
+        const innerChartVerificationMap =
+            await this.contentVerificationModel.getByContentUuids(
+                ContentType.CHART,
+                dashboardCharts.map((chart) => chart.uuid),
+            );
+
         const chartsByDashboard = dashboardCharts.reduce<
             Record<
                 string,
@@ -452,6 +459,7 @@ export class SearchModel {
                     description: string;
                     chartType: string;
                     viewsCount: number;
+                    verification: ContentVerificationInfo | null;
                 }>
             >
         >((acc, chart) => {
@@ -464,6 +472,7 @@ export class SearchModel {
                 description: chart.description,
                 chartType: chart.chartType,
                 viewsCount: chart.views_count,
+                verification: innerChartVerificationMap.get(chart.uuid) ?? null,
             });
             return acc;
         }, {});
@@ -601,6 +610,12 @@ export class SearchModel {
             { page, pageSize },
         );
 
+        const chartVerificationMap =
+            await this.contentVerificationModel.getByContentUuids(
+                ContentType.CHART,
+                charts.map((chart) => chart.uuid),
+            );
+
         return {
             dashboardName: dashboard.name,
             charts: charts.map((chart) => ({
@@ -609,6 +624,7 @@ export class SearchModel {
                 description: chart.description,
                 chartType: chart.chartType,
                 viewsCount: chart.viewsCount,
+                verification: chartVerificationMap.get(chart.uuid) ?? null,
             })),
             pagination: {
                 page,

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -46,6 +46,7 @@ export type DashboardSearchResult = Pick<
         description?: string;
         chartType: ChartKind;
         viewsCount: number;
+        verification: ContentVerificationInfo | null;
     }[];
     verification: ContentVerificationInfo | null;
 } & RankedItem;


### PR DESCRIPTION
# AI agent — prefer admin-verified content (Stage A)

## Summary

When the in-product AI agent searches for charts or dashboards, results that admins have verified are now ranked first and visibly marked. The agent's system prompt teaches it to surface those verified items, name the verifier and date in its response, and not apologize when only unverified items match.

This is the first of three planned stages. Stage B (embedding-based RAG of verified chart configs into context) and Stage C (verified-content-aware ambiguity resolution in `discoverFields`) are deferred to follow-up PRs.

## What changes for the agent

- `findContent` and `getDashboardCharts` now sort verified items first within each search query's result set. Within each bucket (verified / unverified), the existing `search_rank` order is preserved — relevance still wins inside a bucket.
- Every verified chart and dashboard is rendered with a `<verified by="Sarah Khan" at="2 weeks ago" />` element. Inner-dashboard chart previews (the small chart list shown when `findContent` returns a dashboard) get the same treatment when an individual chart is independently verified.
- The system prompt has a new short section teaching the agent what `<verified>` means and how to use it.

## What does NOT change

- Human-facing search ranking (the UI's search box). The sort lives in the AI tool's XML rendering layer only.
- Verification semantics. Verification stays atomic — verifying a dashboard does NOT implicitly verify its constituent charts. Charts that are NOT independently verified will not be marked, even if they live on a verified dashboard.
- SQL charts (`saved_sql`). They aren't verifiable at the product level today; they simply won't get the badge.
- The `findContent` tool's input schema. No new parameters, no new modes.

## Why tool-time ranking, not embedding-based RAG

The original ticket framing (PROD-7128) proposed extending the `getVerifiedArtifactsForAgent` embedding pipeline to also pull from `content_verification`, embed those rows, and inject by similarity at conversation start. That works, but Stage A goes a different route because:

1. **The data is already plumbed.** `SearchModel` already attaches `verification: ContentVerificationInfo | null` to every chart and dashboard search result. The current `findContent` rendering drops that information on the floor. Surfacing it costs ~20 lines of code.
2. **Tool-time signals fire every search, not just once.** A user who pivots topic mid-conversation triggers a fresh `findContent`; the verified signal is there each time. RAG-injection only fires at prompt start.
3. **It's the cheapest way to validate the hypothesis.** If telemetry shows the agent ignores the signal even with the sort + annotation + prompt, that's diagnostic — we know the embedding pipeline alone wouldn't have helped either.
4. **No backfill problem.** Embedding admin-verified content would require deciding what to embed (name+description? plus field list?) and a one-shot backfill for existing verified items. Tool-time ranking reads the live data each time.

The deeper RAG path (Stage B) remains in scope for later if Stage A's telemetry shows the agent benefits from seeing verified chart **configurations** verbatim (e.g. to copy filter conventions when generating a new chart). The tickets stay open.

## System prompt addition

A new `## Verified content` section, positioned right after `## Tool workflow` so it lives near the `findContent` guidance. Roughly:

> Some content returned by `findContent` and `getDashboardCharts` is marked with a `<verified by="..." at="..." />` element. Verified items have been explicitly approved by an organization or project admin as canonical, trustworthy content. When you find a verified item that matches the user's question:
> - Prefer it over unverified alternatives and surface it first in your response.
> - Mention in your response that it's verified and who verified it (e.g. "this is a verified dashboard, approved by Sarah Khan 2 weeks ago").
> - If only unverified items match, use them normally — don't apologize for the lack of verification.

The line about "don't apologize" is what handles projects with zero verified content — no dynamic prompt injection is needed.

## Rollout

- **No feature flag and no config kill-switch.** This is an additive UX improvement; the worst case is the agent ignores the signal, not generates wrong answers.
- **Default-on, project-aware behavior.** Projects with zero verified items see the same agent behavior they see today (no `<verified>` elements appear in results, prompt guidance falls through to the "don't apologize" path).
- **Coverage telemetry only.** Per `findContent` call we record:
  - `verifiedResultCount` (how many of the returned items were verified)
  - `totalResultCount`
  - `topResultVerified` (boolean — was the top-ranked result verified?)
  Aggregated by project + agent. Tells us per-customer whether the signal has any chance to fire. We intentionally do NOT track whether the agent "picked up" the verified item in its response (substring matching for "verified by" is fragile and noisy).

## Regression analysis

- **Verified-content feature itself**: unaffected. Verification reads still go through the same `ContentVerificationModel` path. No new permissions checks added in the agent path because `SearchModel` already surfaces verification info to anyone with access to the underlying content.
- **Non-AI search**: unaffected. The sort lives inside the AI tool's rendering layer, not in `SearchModel`.
- **Service accounts / custom roles**: no permissions changes, just rendering. A service account that can already see a chart will see its verification status in `findContent` results, same as a human user would. No org-level / cross-project leakage — verification is project-scoped via the existing `content_verification` table.
- **Projects with no verified content**: behave identically to today. Empty-state is handled by the prompt instruction "don't apologize for the lack of verification."
- **MCP `find_content` (external Claude Code / IDE users)**: unchanged in this PR. PROD-7128's "Theme 1.1" follow-up to extend the same signal to the external MCP tool is filed separately.

## Tickets

- PROD-7128 stays open — solved-different-way for the in-product agent (tool-time ranking); embedding-based RAG path deferred to Stage B.
- PROD-7130 stays open — find/recommend portion done; "use verified content as templates when generating new charts" portion deferred to Stage B.

## Test plan

- [ ] Unit: `findContent.test.ts` — verified item sorts first; `<verified>` element renders with correct `by` / `at` attributes; no element when verification is null; stable sort preserves `search_rank` within each bucket.
- [ ] Manual: in the seeded dev DB, verify a chart and a dashboard via the UI, then ask the AI agent a question that matches them. Confirm: (a) agent surfaces them first, (b) agent's response cites verification status, (c) projects without verified content behave normally.
- [ ] Telemetry: confirm `verifiedResultCount` / `totalResultCount` / `topResultVerified` appear in the `findContent` tool-call analytics event.