### PR TITLE
fix: copy data app dashboard tiles when duplicating projects to preview

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -235,6 +235,30 @@ Implementation: `AppGenerateService.deleteApp` is the entry point. It delegates 
 `permanentDeleteApp`, which each enforce the appropriate manage scope (see [Permissions](#permissions) below) and
 handle sandbox/S3 cleanup.
 
+### Preview environments and promotion
+
+Data apps are **not yet duplicated** when a project is copied to a preview environment, and **not yet remapped**
+during cross-project promotion. The preview-copy step in `ProjectModel.duplicateContent` does copy
+`dashboard_tile_data_apps` rows — but it leaves their `app_uuid` pointing at the source project's app rather than
+creating a fresh `apps` row in the preview. The preview project ends up with zero `apps` rows of its own; any data
+app dashboard tile in the preview is a read-through window to the source project's app.
+
+What this means in practice:
+
+- **Preview rendering.** If the user opening the preview has view access to the source project's app, the tile
+  renders normally. Otherwise the existing `DashboardDataAppTile` error states show a "Data app not found" or
+  "No access" placeholder; the rest of the dashboard renders fine.
+- **Iterating inside the preview.** Not supported — the preview project has no `apps` row, so the AppGenerate page
+  isn't reachable from within the preview. Iteration still happens on the source project's app.
+- **Promote-back from preview to source.** Works: the tile's `app_uuid` is the source app's UUID, so the upstream
+  insert succeeds.
+- **Cross-project promotion between unrelated projects.** Data app tiles can be promoted but the tile's `app_uuid`
+  is not remapped — it stays pointing at the downstream project's app. Effectively the same read-through behavior
+  as previews.
+
+Full preview/promote support (copying `apps` + `app_versions` + S3 artifacts and remapping `app_uuid` during
+promotion) is tracked in [PROD-7778 follow-up](https://linear.app/lightdash/issue/PROD-7778/preview-environments-arent-considering-data-apps).
+
 ---
 
 ## Data Model

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -3151,6 +3151,10 @@ export class ProjectModel {
             await copyDashboardTileContent('dashboard_tile_markdowns');
             await copyDashboardTileContent('dashboard_tile_sql_charts');
             await copyDashboardTileContent('dashboard_tile_headings');
+            // Data app tiles are copied with `app_uuid` left pointing at the
+            // source project's app — the preview project gets no `apps` row of
+            // its own. See `docs/data-apps.md` Limitations.
+            await copyDashboardTileContent('dashboard_tile_data_apps');
 
             // Get AI Agents from the source project
             // Note: AI agents are an Enterprise Edition feature. The table may not exist

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { type DashboardDataAppTile } from '@lightdash/common';
+import { ProjectType, type DashboardDataAppTile } from '@lightdash/common';
 import { Box, Loader, Stack, Text } from '@mantine-8/core';
 import { IconAppsOff, IconPencil } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
@@ -9,6 +9,7 @@ import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken
 import { useGetApp } from '../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../features/apps/previewOrigin';
 import { DashboardTileComments } from '../../features/comments';
+import { useProject } from '../../hooks/useProject';
 import { useSpaceSummaries } from '../../hooks/useSpaces';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
@@ -50,6 +51,8 @@ const DataAppTile: FC<Props> = (props) => {
     );
 
     const previewOrigin = usePreviewOrigin();
+    const { data: project } = useProject(projectUuid);
+    const isPreviewProject = project?.type === ProjectType.PREVIEW;
     // Skip the network calls when the backend already told us the app is
     // gone — `useGetApp` would 404 anyway, but bypassing the request avoids
     // a noisy log entry and a wasted round trip on every dashboard load.
@@ -135,8 +138,12 @@ const DataAppTile: FC<Props> = (props) => {
                 {isNotFound ? (
                     <SuboptimalState
                         icon={IconAppsOff}
-                        title="Data app not found"
-                        description="This data app no longer exists. Edit the tile to pick another app."
+                        title="Data app not available"
+                        description={
+                            isPreviewProject
+                                ? "Data apps aren't duplicated into preview environments yet. You can however edit or remove the tile itself."
+                                : 'This data app no longer exists. Edit the tile to pick another app.'
+                        }
                     />
                 ) : isForbidden ? (
                     <SuboptimalState


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/PROD-7778/preview-environments-arent-considering-data-apps

### Description:
Preview-copy was skipping `dashboard_tile_data_apps`, which left dashboard tiles in a half-copied state (parent `dashboard_tiles` row present, child row missing). That surfaced as the empty-UUID Postgres crash from PROD-7778 when promoting the preview dashboard back.

Copy the rows with `app_uuid` preserved — the preview points read-through at the source project's app instead of getting its own `apps` row. Full duplication and promote remap is a follow-up; the limitation is documented in docs/data-apps.md and surfaced in the DashboardDataAppTile "not available" copy when the project is a PREVIEW.


<img width="5144" height="2018" alt="image" src="https://github.com/user-attachments/assets/518d07cf-2e0f-482e-adbb-6e61f7664c38" />
