### PR TITLE
feat(ai): teach discoverFields subagent to prefer verified-chart fields

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -136,6 +136,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentModel: models.getAiAgentModel(),
                     changesetModel: models.getChangesetModel(),
                     catalogModel: models.getCatalogModel(),
+                    contentVerificationModel:
+                        models.getContentVerificationModel(),
                     groupsModel: models.getGroupsModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     slackClient: clients.getSlackClient(),

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -112,6 +112,7 @@ import {
     CatalogSearchContext,
 } from '../../../models/CatalogModel/CatalogModel';
 import { ChangesetModel } from '../../../models/ChangesetModel';
+import { ContentVerificationModel } from '../../../models/ContentVerificationModel';
 import { GroupsModel } from '../../../models/GroupsModel';
 import { OpenIdIdentityModel } from '../../../models/OpenIdIdentitiesModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
@@ -213,6 +214,7 @@ type AiAgentServiceDependencies = {
     catalogService: CatalogService;
     catalogModel: CatalogModel;
     changesetModel: ChangesetModel;
+    contentVerificationModel: ContentVerificationModel;
     searchModel: SearchModel;
     featureFlagService: FeatureFlagService;
     groupsModel: GroupsModel;
@@ -270,6 +272,8 @@ export class AiAgentService extends BaseService {
     private readonly catalogModel: CatalogModel;
 
     private readonly changesetModel: ChangesetModel;
+
+    private readonly contentVerificationModel: ContentVerificationModel;
 
     private readonly featureFlagService: FeatureFlagService;
 
@@ -338,6 +342,7 @@ export class AiAgentService extends BaseService {
         this.catalogService = dependencies.catalogService;
         this.catalogModel = dependencies.catalogModel;
         this.changesetModel = dependencies.changesetModel;
+        this.contentVerificationModel = dependencies.contentVerificationModel;
         this.searchModel = dependencies.searchModel;
         this.featureFlagService = dependencies.featureFlagService;
         this.groupsModel = dependencies.groupsModel;
@@ -3203,6 +3208,24 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             );
         };
 
+        let verifiedFieldUsagePromise: Promise<Map<string, number>> | null =
+            null;
+        const getVerifiedFieldUsage = () => {
+            if (!verifiedFieldUsagePromise) {
+                verifiedFieldUsagePromise =
+                    this.contentVerificationModel.getVerifiedFieldUsage(
+                        projectUuid,
+                    );
+            }
+            return verifiedFieldUsagePromise;
+        };
+        const lookupVerifiedChartUsage = (
+            verifiedUsage: Map<string, number>,
+            tableName: string,
+            fieldName: string,
+            fieldType: string,
+        ) => verifiedUsage.get(`${tableName}_${fieldName}::${fieldType}`) ?? 0;
+
         const findExplores: FindExploresFn = (args) =>
             wrapSentryTransaction('AiAgent.findExplores', args, async () => {
                 const agentSettings = await this.getAgentSettings(user, prompt);
@@ -3266,6 +3289,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         filteredExplores,
                     });
 
+                const verifiedFieldUsage = await getVerifiedFieldUsage();
                 const topMatchingFields = fieldSearchResults.data
                     .filter((item) => item.type === CatalogType.Field)
                     .map((field) => ({
@@ -3276,6 +3300,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         searchRank: field.searchRank,
                         description: field.description,
                         chartUsage: field.chartUsage ?? 0,
+                        verifiedChartUsage: lookupVerifiedChartUsage(
+                            verifiedFieldUsage,
+                            field.tableName,
+                            field.name,
+                            field.fieldType,
+                        ),
                     }));
 
                 return {
@@ -3316,7 +3346,18 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     (item) => item.type === CatalogType.Field,
                 );
 
-                return { fields: catalogFields, pagination };
+                const verifiedFieldUsage = await getVerifiedFieldUsage();
+                const enrichedFields = catalogFields.map((field) => ({
+                    ...field,
+                    verifiedChartUsage: lookupVerifiedChartUsage(
+                        verifiedFieldUsage,
+                        field.tableName,
+                        field.name,
+                        field.fieldType,
+                    ),
+                }));
+
+                return { fields: enrichedFields, pagination };
             });
 
         const updateProgress: UpdateProgressFn = (progress) =>

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -30,32 +30,40 @@ Execute these steps in order. Do NOT skip steps.
 
 Scan the user's query for a domain word that matches an explore name (singular/plural counts — "order" matches "orders"). Call findExplores with the full user query.
 
-- If exactly one explore matches with searchRank > 0.7 and there's a clear context word match → status: "resolved". Proceed to Step 4.
+- If exactly one explore matches with searchRank > 0.7 and there's a clear context word match → status: "resolved". Proceed to Step 5.
 - If no clear context match → continue to Step 2.
 
 ### Step 2: AI hints check
 
 Look at the topMatchingFields and exploreSearchResults from findExplores. Compare their aiHints + descriptions against the user's intent.
 
-- If one explore's aiHints semantically match the request and it appears with searchRank > 0.6 → status: "resolved". Proceed to Step 4.
+- If one explore's aiHints semantically match the request and it appears with searchRank > 0.6 → status: "resolved". Proceed to Step 5.
 - Otherwise → continue to Step 3.
 
-### Step 3: Ambiguity check
+### Step 3: Verified-content fast path
+
+Verified charts are admin-approved as canonical for this project — when an admin has marked a chart as verified, they've explicitly endorsed the metrics and explore it uses as the authoritative answer for that kind of question. This is the strongest decision signal available; trust it.
+
+Look at the usageInVerifiedCharts attribute on every field in topMatchingFields.
+
+- If exactly one candidate explore has fields with usageInVerifiedCharts > 0 and all other candidate explores have usageInVerifiedCharts = 0 across all their fields → status: "resolved" for that explore. The admin has already answered the question. Do NOT enter the ambiguity check below. Do NOT enumerate alternatives to the user. Proceed directly to Step 5.
+- Otherwise (multiple explores have verified usage, or none do) → continue to Step 4.
+
+### Step 4: Ambiguity check
 
 Count DISTINCT explores in topMatchingFields. If 2+ distinct explores appear with scores within 0.15 of each other:
 
-- First check joined tables. If one explore's joinedTables include another entity the user mentioned, that explore can handle the whole query → status: "resolved". Proceed to Step 4.
-- Then check usageInVerifiedCharts on the fields. Verified charts are admin-approved as canonical for this project. If exactly one explore has fields with non-zero usageInVerifiedCharts and all the others have zero, that's the answer → status: "resolved". Do NOT also present the alternatives to the user; verification IS the decision. Proceed to Step 4.
-- Then check usageInCharts. If one explore's fields have meaningfully higher aggregate usage (3x+), prefer it → status: "resolved". Proceed to Step 4.
+- First check joined tables. If one explore's joinedTables include another entity the user mentioned, that explore can handle the whole query → status: "resolved". Proceed to Step 5.
+- Then check usageInCharts. If one explore's fields have meaningfully higher aggregate usage (3x+), prefer it → status: "resolved". Proceed to Step 5.
 - If still tied (or all usages are 0 / equal) → status: "ambiguous". DO NOT call findFields. Call submitResult with the candidate explores and a suggestedQuestion.
 
-If only 1 distinct explore appears in topMatchingFields → status: "resolved". Proceed to Step 4.
+If only 1 distinct explore appears in topMatchingFields → status: "resolved". Proceed to Step 5.
 
 If findExplores returns nothing relevant at all → status: "no_match". Call submitResult.
 
-**Generic metric queries are ALWAYS ambiguous**: "what's our revenue?", "show me cost", "total sales" without context — if multiple explores have similar metrics, return "ambiguous".
+**Generic metric queries are ambiguous unless Step 3 resolved them**: "what's our revenue?", "show me cost", "total sales" without context — if multiple explores have similar metrics AND no single explore carries the verified-content signal, return "ambiguous".
 
-### Step 4: Field shortlist
+### Step 5: Field shortlist
 
 Call findFields on the chosen explore with the user's intent as the search query.
 
@@ -66,7 +74,7 @@ Pick a FILTERED set of fields the parent will plausibly need:
 - Filter dimensions hinted at in the query.
 - Useful joined-table fields when the explore exposes them.
 
-When two candidate fields are equally relevant, prefer the one with non-zero usageInVerifiedCharts — admins have endorsed that field as canonical for this project. Use this as a tiebreaker, not as a hard filter: a clearly more relevant field with verifiedChartUsage=0 still beats an irrelevant field with verifiedChartUsage=5.
+When two candidate fields are equally relevant, prefer the one with non-zero usageInVerifiedCharts — admins have endorsed that field as canonical for this project. Use this as a tiebreaker, not as a hard filter: a clearly more relevant field with usageInVerifiedCharts=0 still beats an irrelevant field with usageInVerifiedCharts=5.
 
 **Joined vs base table fields with similar names**: base tables represent events (an order, a visit, a payment) — their fields describe attributes at the time of that event. Joined tables represent entities (a customer, a product) — their fields describe persistent attributes. When the user mentions an entity by name and both tables expose a similar-looking field, prefer the joined-table field unless the description clearly says event-level granularity. Set isFromJoinedTable accordingly so the parent can display the right marker.
 

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -45,8 +45,9 @@ Look at the topMatchingFields and exploreSearchResults from findExplores. Compar
 Count DISTINCT explores in topMatchingFields. If 2+ distinct explores appear with scores within 0.15 of each other:
 
 - First check joined tables. If one explore's joinedTables include another entity the user mentioned, that explore can handle the whole query → status: "resolved". Proceed to Step 4.
-- Then check usageInCharts on the fields. If one explore's fields have meaningfully higher aggregate usage (3x+), prefer it → status: "resolved". Proceed to Step 4.
-- If still tied (or all usageInCharts are 0 / equal) → status: "ambiguous". DO NOT call findFields. Call submitResult with the candidate explores and a suggestedQuestion.
+- Then check usageInVerifiedCharts on the fields. Verified charts are admin-approved as canonical for this project; their fields are the authoritative ones. If one explore has fields appearing in verified charts and the other has none, prefer the explore with verified usage → status: "resolved". Proceed to Step 4.
+- Then check usageInCharts. If one explore's fields have meaningfully higher aggregate usage (3x+), prefer it → status: "resolved". Proceed to Step 4.
+- If still tied (or all usages are 0 / equal) → status: "ambiguous". DO NOT call findFields. Call submitResult with the candidate explores and a suggestedQuestion.
 
 If only 1 distinct explore appears in topMatchingFields → status: "resolved". Proceed to Step 4.
 
@@ -64,6 +65,8 @@ Pick a FILTERED set of fields the parent will plausibly need:
 - Relevant date dimensions at appropriate granularities (e.g. include both order_date and order_date_month if the user might want either).
 - Filter dimensions hinted at in the query.
 - Useful joined-table fields when the explore exposes them.
+
+When two candidate fields are equally relevant, prefer the one with non-zero usageInVerifiedCharts — admins have endorsed that field as canonical for this project. Use this as a tiebreaker, not as a hard filter: a clearly more relevant field with verifiedChartUsage=0 still beats an irrelevant field with verifiedChartUsage=5.
 
 **Joined vs base table fields with similar names**: base tables represent events (an order, a visit, a payment) — their fields describe attributes at the time of that event. Joined tables represent entities (a customer, a product) — their fields describe persistent attributes. When the user mentions an entity by name and both tables expose a similar-looking field, prefer the joined-table field unless the description clearly says event-level granularity. Set isFromJoinedTable accordingly so the parent can display the right marker.
 

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -2,6 +2,11 @@ import { Explore } from '@lightdash/common';
 import { SystemModelMessage } from 'ai';
 import { renderAvailableExplores } from '../../prompts/availableExplores';
 
+const CONTEXT_MATCH_SEARCH_RANK_MIN = 0.7;
+const AI_HINTS_SEARCH_RANK_MIN = 0.6;
+const AMBIGUITY_RANK_WINDOW = 0.15;
+const CHART_USAGE_TIEBREAKER_MULTIPLIER = 3;
+
 const TEMPLATE = `You are the data-discovery subagent for the Lightdash AI Analyst.
 
 Your sole job is to take the user's question and return a structured handoff describing which explore and which fields the parent agent should use to answer it. You do NOT answer the user, build queries, or produce visualizations.
@@ -30,14 +35,14 @@ Execute these steps in order. Do NOT skip steps.
 
 Scan the user's query for a domain word that matches an explore name (singular/plural counts — "order" matches "orders"). Call findExplores with the full user query.
 
-- If exactly one explore matches with searchRank > 0.7 and there's a clear context word match → status: "resolved". Proceed to Step 5.
+- If exactly one explore matches with searchRank > ${CONTEXT_MATCH_SEARCH_RANK_MIN} and there's a clear context word match → status: "resolved". Proceed to Step 5.
 - If no clear context match → continue to Step 2.
 
 ### Step 2: AI hints check
 
 Look at the topMatchingFields and exploreSearchResults from findExplores. Compare their aiHints + descriptions against the user's intent.
 
-- If one explore's aiHints semantically match the request and it appears with searchRank > 0.6 → status: "resolved". Proceed to Step 5.
+- If one explore's aiHints semantically match the request and it appears with searchRank > ${AI_HINTS_SEARCH_RANK_MIN} → status: "resolved". Proceed to Step 5.
 - Otherwise → continue to Step 3.
 
 ### Step 3: Verified-content fast path
@@ -51,10 +56,10 @@ Look at the usageInVerifiedCharts attribute on every field in topMatchingFields.
 
 ### Step 4: Ambiguity check
 
-Count DISTINCT explores in topMatchingFields. If 2+ distinct explores appear with scores within 0.15 of each other:
+Count DISTINCT explores in topMatchingFields. If 2+ distinct explores appear with scores within ${AMBIGUITY_RANK_WINDOW} of each other:
 
 - First check joined tables. If one explore's joinedTables include another entity the user mentioned, that explore can handle the whole query → status: "resolved". Proceed to Step 5.
-- Then check usageInCharts. If one explore's fields have meaningfully higher aggregate usage (3x+), prefer it → status: "resolved". Proceed to Step 5.
+- Then check usageInCharts. If one explore's fields have meaningfully higher aggregate usage (${CHART_USAGE_TIEBREAKER_MULTIPLIER}x+), prefer it → status: "resolved". Proceed to Step 5.
 - If still tied (or all usages are 0 / equal) → status: "ambiguous". DO NOT call findFields. Call submitResult with the candidate explores and a suggestedQuestion.
 
 If only 1 distinct explore appears in topMatchingFields → status: "resolved". Proceed to Step 5.

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -45,7 +45,7 @@ Look at the topMatchingFields and exploreSearchResults from findExplores. Compar
 Count DISTINCT explores in topMatchingFields. If 2+ distinct explores appear with scores within 0.15 of each other:
 
 - First check joined tables. If one explore's joinedTables include another entity the user mentioned, that explore can handle the whole query → status: "resolved". Proceed to Step 4.
-- Then check usageInVerifiedCharts on the fields. Verified charts are admin-approved as canonical for this project; their fields are the authoritative ones. If one explore has fields appearing in verified charts and the other has none, prefer the explore with verified usage → status: "resolved". Proceed to Step 4.
+- Then check usageInVerifiedCharts on the fields. Verified charts are admin-approved as canonical for this project. If exactly one explore has fields with non-zero usageInVerifiedCharts and all the others have zero, that's the answer → status: "resolved". Do NOT also present the alternatives to the user; verification IS the decision. Proceed to Step 4.
 - Then check usageInCharts. If one explore's fields have meaningfully higher aggregate usage (3x+), prefer it → status: "resolved". Proceed to Step 4.
 - If still tied (or all usages are 0 / equal) → status: "ambiguous". DO NOT call findFields. Call submitResult with the candidate explores and a suggestedQuestion.
 

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -92,6 +92,7 @@ const generateExploreResponse = ({
                         fieldType={field.fieldType}
                         searchRank={field.searchRank?.toFixed(3) ?? 'N/A'}
                         usageInCharts={field.chartUsage ?? 0}
+                        usageInVerifiedCharts={field.verifiedChartUsage ?? 0}
                     />
                 ))}
             </topMatchingFields>
@@ -148,6 +149,8 @@ export const getFindExplores = ({
                                     fieldType: field.fieldType,
                                     searchRank: field.searchRank,
                                     chartUsage: field.chartUsage,
+                                    verifiedChartUsage:
+                                        field.verifiedChartUsage,
                                 }),
                             ),
                         },

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -51,6 +51,7 @@ const renderField = (catalogField: CatalogField, explore?: Explore) => {
             )}
             searchRank={catalogField.searchRank}
             chartUsage={catalogField.chartUsage}
+            verifiedChartUsage={catalogField.verifiedChartUsage ?? 0}
             isFromJoinedTable={isFromJoinedTable}
         >
             {isFromJoinedTable && explore && (
@@ -169,6 +170,8 @@ export const getFindFields = ({
                                             fieldType: field.fieldType,
                                             searchRank: field.searchRank,
                                             chartUsage: field.chartUsage,
+                                            verifiedChartUsage:
+                                                field.verifiedChartUsage,
                                         }),
                                     ),
                                     pagination:

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -51,7 +51,7 @@ const renderField = (catalogField: CatalogField, explore?: Explore) => {
             )}
             searchRank={catalogField.searchRank}
             chartUsage={catalogField.chartUsage}
-            verifiedChartUsage={catalogField.verifiedChartUsage ?? 0}
+            usageInVerifiedCharts={catalogField.verifiedChartUsage ?? 0}
             isFromJoinedTable={isFromJoinedTable}
         >
             {isFromJoinedTable && explore && (

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -57,6 +57,7 @@ export type FindExploresFn = (args: {
         searchRank?: number;
         description?: string;
         chartUsage?: number;
+        verifiedChartUsage?: number;
     }>;
 }>;
 

--- a/packages/backend/src/models/ContentVerificationModel.ts
+++ b/packages/backend/src/models/ContentVerificationModel.ts
@@ -1,5 +1,6 @@
 import {
     ContentType,
+    DBFieldTypes,
     type ContentVerificationInfo,
     type VerifiedContentListItem,
 } from '@lightdash/common';
@@ -9,7 +10,11 @@ import {
     type CreateDbContentVerification,
 } from '../database/entities/contentVerification';
 import { DashboardsTableName } from '../database/entities/dashboards';
-import { SavedChartsTableName } from '../database/entities/savedCharts';
+import {
+    SavedChartsTableName,
+    SavedChartVersionFieldsTableName,
+    SavedChartVersionsTableName,
+} from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 
@@ -218,5 +223,59 @@ export class ContentVerificationModel {
             },
             verifiedAt: row.verified_at,
         }));
+    }
+
+    async getVerifiedFieldUsage(
+        projectUuid: string,
+    ): Promise<Map<string, number>> {
+        const rows = await this.database(ContentVerificationTableName)
+            .innerJoin(
+                SavedChartsTableName,
+                `${ContentVerificationTableName}.content_uuid`,
+                `${SavedChartsTableName}.saved_query_uuid`,
+            )
+            .innerJoin(
+                SavedChartVersionsTableName,
+                `${SavedChartsTableName}.saved_query_id`,
+                `${SavedChartVersionsTableName}.saved_query_id`,
+            )
+            .innerJoin(
+                SavedChartVersionFieldsTableName,
+                `${SavedChartVersionsTableName}.saved_queries_version_id`,
+                `${SavedChartVersionFieldsTableName}.saved_queries_version_id`,
+            )
+            .where(`${ContentVerificationTableName}.project_uuid`, projectUuid)
+            .where(
+                `${ContentVerificationTableName}.content_type`,
+                ContentType.CHART,
+            )
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .where(
+                `${SavedChartVersionsTableName}.saved_queries_version_id`,
+                this.database.raw(
+                    `(SELECT MAX(saved_queries_version_id) FROM ${SavedChartVersionsTableName} WHERE saved_query_id = ${SavedChartsTableName}.saved_query_id)`,
+                ),
+            )
+            .groupBy(
+                `${SavedChartVersionFieldsTableName}.name`,
+                `${SavedChartVersionFieldsTableName}.field_type`,
+            )
+            .select({
+                field_id: `${SavedChartVersionFieldsTableName}.name`,
+                field_type: `${SavedChartVersionFieldsTableName}.field_type`,
+                usage: this.database.raw(
+                    `count(distinct ${SavedChartsTableName}.saved_query_id)`,
+                ),
+            });
+
+        const result = new Map<string, number>();
+        for (const row of rows as Array<{
+            field_id: string;
+            field_type: DBFieldTypes;
+            usage: string;
+        }>) {
+            result.set(`${row.field_id}::${row.field_type}`, Number(row.usage));
+        }
+        return result;
     }
 }

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -76,6 +76,7 @@ export const findExploresRankingMetadataSchema = z.object({
                 fieldType: z.string(),
                 searchRank: z.number().nullable().optional(),
                 chartUsage: z.number().nullable().optional(),
+                verifiedChartUsage: z.number().nullable().optional(),
             }),
         )
         .optional(),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
@@ -44,6 +44,7 @@ export const findFieldsRankingMetadataSchema = z.object({
                     fieldType: z.string(),
                     searchRank: z.number().nullable().optional(),
                     chartUsage: z.number().nullable().optional(),
+                    verifiedChartUsage: z.number().nullable().optional(),
                 }),
             ),
             pagination: z

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -89,6 +89,7 @@ export type CatalogField = Pick<
         tags?: string[]; // Tags from table, for filtering
         categories: Pick<Tag, 'name' | 'color' | 'tagUuid' | 'yamlReference'>[]; // Tags manually added by the user in the catalog
         chartUsage: number | undefined;
+        verifiedChartUsage?: number;
         icon: CatalogItemIcon | null;
         aiHints: string[] | null;
         searchRank?: number;


### PR DESCRIPTION
# AI agent — verified-content tiebreaker in field discovery (Stage C)

## Summary

Teach the `discoverFields` subagent to prefer fields and explores that admins have endorsed via the existing content verification feature. When the subagent is breaking a tie between explores, or shortlisting fields for the parent agent, it now sees per-field `usageInVerifiedCharts` alongside the existing `usageInCharts` count — and the system prompt instructs it to use the verified count as a sharper tiebreaker (subordinate to agent-specific instructions).

This is the second of three planned stages. Stage A (verified-first ranking + `<verified>` marker in `findContent` / `getDashboardCharts`) shipped in #23208. Stage B (embedding-based RAG of verified chart configs into the generation context) is still deferred.

## What changes for the agent

- Every `<field>` rendered by `findExplores` and `findFields` now carries an additional `usageInVerifiedCharts={N}` attribute alongside `usageInCharts`. `N` is the number of admin-verified charts in the project that use this field.
- `discoverFields/systemPrompt.ts` Step 3 (explore ambiguity check) now uses `usageInVerifiedCharts` as a sharper tiebreaker before falling through to raw chart usage.
- `discoverFields/systemPrompt.ts` Step 4 (field shortlisting) instructs the subagent to prefer fields with non-zero `usageInVerifiedCharts` between equally-relevant alternatives — explicitly as a tiebreaker, not a hard filter, so a clearly more relevant field with `verifiedChartUsage=0` still wins over an irrelevant verified one.
- Agent-specific instructions (`{{agent_instruction}}` block at the prompt tail) keep their existing precedence by virtue of positional recency. No "OVERRIDE" prepend is added.

## What does NOT change

- Schema. **No migration, no new column on `catalog_search`, no hooks in verify/unverify/chart-save.** The signal is computed live at agent-call time via a single grouped query.
- The Spotlight / catalog UI. Verification metadata exists on `catalog_search` results no differently than before; only the AI agent's service-layer wrapper enriches with the new count.
- Verification semantics. Still atomic — a verified dashboard's constituent charts don't get counted unless they themselves are verified.

## Implementation

- **New query: `ContentVerificationModel.getVerifiedFieldUsage(projectUuid)`** — returns `Map<"${fieldId}::${fieldType}", number>` keyed by the chart-field-usage table's natural key (`saved_queries_version_fields.name` is already the fieldId format `${table}_${field}`). One GROUP BY on `content_verification → saved_queries → latest saved_queries_version → saved_queries_version_fields` filtered to `content_type=CHART` and soft-delete-aware.
- **Enrichment in the AI service-layer wrappers** (`AiAgentService.findExplores`, `AiAgentService.findFields`). Both fetch the map lazily via a closure-scoped memo so the same agent run pays for it at most once, and attach `verifiedChartUsage` to each catalog item before returning.
- **Type surface**: `CatalogField.verifiedChartUsage?: number` in `@lightdash/common` (optional, since non-AI callers of `CatalogModel.search` don't populate it). Mirror field added to Zod metadata schemas (`toolFindExploresArgs`, `toolFindFieldsArgs`).
- **XML rendering**: `findExplores.tsx` and `findFields.tsx` add `usageInVerifiedCharts={N}` next to the existing `usageInCharts={N}` attribute on every `<field>` element.

## Why not a denormalized `verified_chart_usage` column on `catalog_search`

We considered it. Trade-off table:

|                            | Denormalize column                                                | Enrich at query time (chosen)                          |
|----------------------------|-------------------------------------------------------------------|--------------------------------------------------------|
| Migration + backfill       | Required                                                          | None                                                   |
| Hooks on verify/unverify/chart-save | 3+ services touched, drift risk                          | Not needed                                             |
| Read cost per agent call   | Pure SELECT (no extra JOIN)                                       | One extra grouped query (memoized per agent run)       |
| Available to non-AI surfaces | Yes (Spotlight, etc.) — broader long-term utility               | No — strictly AI service-layer                         |

We went with enrichment because the read cost is bounded (verified-chart corpus is small in practice), there's zero drift risk, and the data path matches how `SearchModel` already enriches per-result verification info for `findContent` (Stage A). If broader UI demand materialises, promoting to a denormalized column becomes a focused follow-up PR.

## Regression analysis

- **Existing callers of `CatalogModel.search`**: unaffected. `verifiedChartUsage` is optional on `CatalogField` and only populated by the AI service-layer wrappers. Spotlight UI, Catalog API endpoints, and any other consumer see the same shape they got before.
- **Existing callers of `FindExploresFn` / `FindFieldFn`**: the new field is optional, so existing tests / mocks need no update. The XML rendering simply emits `usageInVerifiedCharts="0"` when verification data is absent.
- **Subagent in projects with zero verified content**: the prompt explicitly says "tiebreaker, not hard filter" — when `usageInVerifiedCharts` is `0` everywhere, the existing Step 3/4 logic (joined tables, raw `usageInCharts`, search rank) handles the decision as before.
- **Soft-deleted charts**: filtered out in `getVerifiedFieldUsage` via `whereNull(saved_queries.deleted_at)`.
- **Performance**: one additional grouped query per `AiAgent.findExplores` / `AiAgent.findFields` call (memoized per agent run). Verified-chart corpus is bounded (typically <100 items per project), so the JOIN and GROUP BY are cheap. Wrapped in a Sentry transaction for visibility.

## Tickets

Stage C is the final piece of:

- **PROD-7128** ("Include admin-verified content in in-product AI retrieval") — together with Stage A (#23208), admin-verified content is now visible to the agent at every retrieval surface: `findContent`, `getDashboardCharts`, `findExplores`, `findFields`. Recommend closing on merge of both PRs.
- **PROD-7130** ("Teach the in-product AI agent to reference verified content in its system prompt") — together with Stage A's parent-agent prompt update, the subagent's prompt now also treats verified content as canonical at the ambiguity-tiebreaker and field-shortlisting decision points. Recommend closing on merge of both PRs.

Stage B (embedding-based RAG of verified chart configs into the generation context, to let the agent copy verified patterns when building new charts) remains a potential future option, gated on whether telemetry from Stage A's `ai_agent.find_content_coverage` event suggests the tool-time signal isn't enough.

## Test plan

- [ ] Manual: in the seeded dev DB, verify a chart in two competing explores, ask a vague data question that could plausibly hit either explore, confirm the subagent picks the explore with verified usage.
- [ ] Manual: in a project with zero verified charts, confirm the subagent behaves identically to before (Step 3/4 falls through to existing tiebreakers).
- [ ] Manual: verify a chart with two metrics, ask for one of those metrics, confirm the resolved field shortlist preferentially includes the verified metric.
- [ ] Manual: confirm an agent with a custom instruction telling it to "always use `net_revenue`" still picks `net_revenue` even when `gross_revenue` has higher `usageInVerifiedCharts`.