### PR TITLE
fix(sum-distinct): update sum distinct to partition only on distinct_keys

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -2390,6 +2390,18 @@ export const EXPLORE_WITH_SUM_DISTINCT: Explore = {
                     tablesReferences: ['orders'],
                     hidden: false,
                 },
+                line_item_id: {
+                    type: DimensionType.STRING,
+                    name: 'line_item_id',
+                    label: 'Line Item ID',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.line_item_id',
+                    compiledSql: '"orders".line_item_id',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
             },
             metrics: {
                 total_revenue: {
@@ -2403,6 +2415,24 @@ export const EXPLORE_WITH_SUM_DISTINCT: Explore = {
                     compiledSql: 'SUM("orders".amount)',
                     compiledValueSql: '"orders".amount',
                     compiledDistinctKeys: ['"orders".line_item_id'],
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                // Multi-key distinct: dedupes by (order_id, payment_method)
+                total_payment_by_method_per_order: {
+                    type: MetricType.SUM_DISTINCT,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    name: 'total_payment_by_method_per_order',
+                    label: 'Total payment by method per order',
+                    sql: '${TABLE}.amount',
+                    compiledSql: 'SUM("orders".amount)',
+                    compiledValueSql: '"orders".amount',
+                    compiledDistinctKeys: [
+                        '"orders".order_id',
+                        '"orders".payment_method',
+                    ],
                     tablesReferences: ['orders'],
                     hidden: false,
                 },
@@ -2424,6 +2454,64 @@ export const METRIC_QUERY_SUM_DISTINCT_WITH_DIMS: CompiledMetricQuery = {
     compiledAdditionalMetrics: [],
     compiledCustomDimensions: [],
 };
+
+// Selected dimension matches the metric's distinct_key — exercises the INNER JOIN path
+// where the dedup CTE keeps one row per distinct-key value.
+export const METRIC_QUERY_SUM_DISTINCT_WITH_JOINABLE_DIM: CompiledMetricQuery =
+    {
+        exploreName: 'orders',
+        dimensions: ['orders_line_item_id'],
+        metrics: ['orders_total_revenue'],
+        filters: {},
+        sorts: [{ fieldId: 'orders_total_revenue', descending: true }],
+        limit: 10,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+// Multi-key distinct where both distinct_keys are selected as dimensions — reproduces
+// the case reported on feature/spk-450 where every output row was incorrectly the same.
+export const METRIC_QUERY_SUM_DISTINCT_MULTI_KEY_FULLY_JOINABLE: CompiledMetricQuery =
+    {
+        exploreName: 'orders',
+        dimensions: ['orders_order_id', 'orders_payment_method'],
+        metrics: ['orders_total_payment_by_method_per_order'],
+        filters: {},
+        sorts: [
+            {
+                fieldId: 'orders_total_payment_by_method_per_order',
+                descending: true,
+            },
+        ],
+        limit: 10,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+// Multi-key distinct where only one of two distinct_keys is selected — outer CTE must
+// aggregate across the unselected key, INNER JOIN on the selected one.
+export const METRIC_QUERY_SUM_DISTINCT_MULTI_KEY_PARTIAL_JOIN: CompiledMetricQuery =
+    {
+        exploreName: 'orders',
+        dimensions: ['orders_order_id'],
+        metrics: ['orders_total_payment_by_method_per_order'],
+        filters: {},
+        sorts: [
+            {
+                fieldId: 'orders_total_payment_by_method_per_order',
+                descending: true,
+            },
+        ],
+        limit: 10,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
 
 export const METRIC_QUERY_SUM_DISTINCT_NO_DIMS: CompiledMetricQuery = {
     exploreName: 'orders',

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -2200,7 +2200,7 @@ LIMIT 10`;
             );
         });
 
-        test('sum_distinct should include selected dimensions in PARTITION BY', () => {
+        test('sum_distinct should partition only on distinct keys regardless of selected dimensions (SPK-450)', () => {
             const result = buildQuery({
                 explore: EXPLORE_WITH_SUM_DISTINCT,
                 compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
@@ -2209,14 +2209,18 @@ LIMIT 10`;
                 timezone: QUERY_BUILDER_UTC_TIMEZONE,
             });
 
-            // The PARTITION BY should include both the distinct key and the selected dimensions
+            // PARTITION BY contains only the distinct key — selected dimensions are excluded so the
+            // dedup CTE collapses to a single scalar that's repeated across every output row.
             expect(result.query).toContain(
-                'PARTITION BY "orders".line_item_id, "orders".payment_method, "orders".status',
+                'PARTITION BY "orders".line_item_id ORDER BY',
             );
-            // Should still have the ROW_NUMBER window function
+            expect(result.query).not.toContain('"orders".payment_method,');
+            // Scalar dedup CTE is attached via CROSS JOIN, never INNER JOIN on dimensions.
+            expect(result.query).toContain(
+                'CROSS JOIN dd_orders_total_revenue',
+            );
+            expect(result.query).not.toContain('INNER JOIN dd_');
             expect(result.query).toContain('ROW_NUMBER() OVER');
-            // Should have the dd CTE
-            expect(result.query).toContain('dd_orders_total_revenue');
         });
 
         test('sum_distinct should work with no dimensions selected', () => {
@@ -2261,7 +2265,7 @@ LIMIT 10`;
             expect(result.query).not.toContain('COALESCE');
         });
 
-        test('average_distinct should include selected dimensions in PARTITION BY', () => {
+        test('average_distinct should partition only on distinct keys regardless of selected dimensions (SPK-450)', () => {
             const result = buildQuery({
                 explore: EXPLORE_WITH_AVERAGE_DISTINCT,
                 compiledMetricQuery: METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
@@ -2271,10 +2275,13 @@ LIMIT 10`;
             });
 
             expect(result.query).toContain(
-                'PARTITION BY "orders".line_item_id, "orders".payment_method',
+                'PARTITION BY "orders".line_item_id ORDER BY',
             );
-            expect(result.query).toContain('GROUP BY');
-            expect(result.query).toContain('dd_orders_avg_shipping_cost');
+            expect(result.query).not.toContain('"orders".payment_method,');
+            expect(result.query).toContain(
+                'CROSS JOIN dd_orders_avg_shipping_cost',
+            );
+            expect(result.query).not.toContain('INNER JOIN dd_');
         });
 
         test('type:number metric referencing cross-model sum_distinct should use CTE', () => {
@@ -2297,11 +2304,6 @@ LIMIT 10`;
             );
             // The inlined fallback SUM should NOT appear in the final SELECT
             // (it's OK inside the CTE, but not in the outer query)
-            const outerSelect =
-                result.query.split('FROM')[
-                    result.query.split('FROM').length - 1
-                ];
-            // Check the final SELECT doesn't use the raw inlined SQL
             expect(result.query).not.toMatch(
                 /SELECT[\s\S]*\(SUM\("orders"\.amount\)\) \* 1\.1[\s\S]*FROM(?![\s\S]*AS \()/,
             );

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -42,7 +42,6 @@ import {
     INTRINSIC_USER_ATTRIBUTES,
     METRIC_QUERY,
     METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS,
-    METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
     METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT,
     METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT_NO_DIMS,
     METRIC_QUERY_CROSS_TABLE,
@@ -64,7 +63,6 @@ import {
     METRIC_QUERY_NESTED_AGG_WITH_DIMS,
     METRIC_QUERY_SAME_MODEL_NUMBER_WITH_SUM_DISTINCT,
     METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
-    METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
     METRIC_QUERY_TWO_TABLES,
     METRIC_QUERY_WITH_CUSTOM_DIMENSION,
     METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE,
@@ -2200,29 +2198,6 @@ LIMIT 10`;
             );
         });
 
-        test('sum_distinct should partition only on distinct keys regardless of selected dimensions (SPK-450)', () => {
-            const result = buildQuery({
-                explore: EXPLORE_WITH_SUM_DISTINCT,
-                compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
-                warehouseSqlBuilder: warehouseClientMock,
-                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                timezone: QUERY_BUILDER_UTC_TIMEZONE,
-            });
-
-            // PARTITION BY contains only the distinct key — selected dimensions are excluded so the
-            // dedup CTE collapses to a single scalar that's repeated across every output row.
-            expect(result.query).toContain(
-                'PARTITION BY "orders".line_item_id ORDER BY',
-            );
-            expect(result.query).not.toContain('"orders".payment_method,');
-            // Scalar dedup CTE is attached via CROSS JOIN, never INNER JOIN on dimensions.
-            expect(result.query).toContain(
-                'CROSS JOIN dd_orders_total_revenue',
-            );
-            expect(result.query).not.toContain('INNER JOIN dd_');
-            expect(result.query).toContain('ROW_NUMBER() OVER');
-        });
-
         test('sum_distinct should work with no dimensions selected', () => {
             const result = buildQuery({
                 explore: EXPLORE_WITH_SUM_DISTINCT,
@@ -2263,25 +2238,6 @@ LIMIT 10`;
             );
             // Neither distinct metric type should use COALESCE
             expect(result.query).not.toContain('COALESCE');
-        });
-
-        test('average_distinct should partition only on distinct keys regardless of selected dimensions (SPK-450)', () => {
-            const result = buildQuery({
-                explore: EXPLORE_WITH_AVERAGE_DISTINCT,
-                compiledMetricQuery: METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
-                warehouseSqlBuilder: warehouseClientMock,
-                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                timezone: QUERY_BUILDER_UTC_TIMEZONE,
-            });
-
-            expect(result.query).toContain(
-                'PARTITION BY "orders".line_item_id ORDER BY',
-            );
-            expect(result.query).not.toContain('"orders".payment_method,');
-            expect(result.query).toContain(
-                'CROSS JOIN dd_orders_avg_shipping_cost',
-            );
-            expect(result.query).not.toContain('INNER JOIN dd_');
         });
 
         test('type:number metric referencing cross-model sum_distinct should use CTE', () => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2674,24 +2674,21 @@ export class MetricQueryBuilder {
 
     /**
      * Builds CTE(s) for distinct metrics (sum_distinct, average_distinct) using ROW_NUMBER deduplication.
-     * Follows the same pattern as PoP CTEs: separate CTE per metric, joined on dimensions.
+     * The dedup CTE collapses to a single scalar per metric (grain = distinct_keys), and is attached
+     * to every output row via CROSS JOIN. Selected dimensions are intentionally excluded from the
+     * PARTITION BY and GROUP BY so the same globally-deduplicated value is repeated across rows —
+     * see SPK-450.
      */
     private buildDistinctMetricCtes({
-        dimensionSelects,
-        dimensionGroupBy,
         dimensionFilters,
         sqlFrom,
         joinsSql,
         dimensionJoins,
-        baseCteName,
     }: {
-        dimensionSelects: Record<string, string>;
-        dimensionGroupBy: string | undefined;
         dimensionFilters: string | undefined;
         sqlFrom: string;
         joinsSql: string | undefined;
         dimensionJoins: string[];
-        baseCteName: string;
     }): {
         ctes: string[];
         ddJoins: string[];
@@ -2710,30 +2707,9 @@ export class MetricQueryBuilder {
             },
         );
 
-        const dimensionAlias = Object.keys(dimensionSelects).map(
-            (alias) => `${fieldQuoteChar}${alias}${fieldQuoteChar}`,
-        );
-
-        // Recompute GROUP BY for the outer CTE using dimension count
-        const ddGroupBy =
-            dimensionAlias.length > 0
-                ? `GROUP BY ${dimensionAlias.map((_, i) => i + 1).join(',')}`
-                : undefined;
-
         const ctes: string[] = [];
         const ddJoins: string[] = [];
         const ddMetricSelects: string[] = [];
-
-        // Extract raw SQL expressions from dimension selects (strip " AS alias" suffix)
-        const dimensionExprs = Object.entries(dimensionSelects).map(
-            ([id, selectStr]) => {
-                const suffix = ` AS ${fieldQuoteChar}${id}${fieldQuoteChar}`;
-                const idx = selectStr.lastIndexOf(suffix);
-                return idx > -1
-                    ? selectStr.substring(0, idx).trim()
-                    : selectStr.trim();
-            },
-        );
 
         for (const metricId of ddMetricIds) {
             const metric = this.getMetricFromId(metricId);
@@ -2743,18 +2719,12 @@ export class MetricQueryBuilder {
             ) {
                 const ddCteName = `dd_${snakeCaseName(metricId)}`;
 
-                // Include selected dimensions in PARTITION BY so each
-                // (distinct_key, dimension) combination gets its own rn=1
-                const partitionExprs = [
-                    ...metric.compiledDistinctKeys,
-                    ...dimensionExprs,
-                ];
-
-                // Inner subquery: raw data + ROW_NUMBER
+                // Inner subquery: pick one row per distinct-key combination.
+                // dimensionJoins + dimensionFilters are still applied so query-level
+                // filters narrow the dedup population, but no dimensions are projected.
                 const innerSelects = [
-                    ...Object.values(dimensionSelects),
                     `  ${metric.compiledValueSql} AS __dd_val`,
-                    `  ROW_NUMBER() OVER (PARTITION BY ${partitionExprs.join(', ')} ORDER BY ${metric.compiledValueSql}) AS __dd_rn`,
+                    `  ROW_NUMBER() OVER (PARTITION BY ${metric.compiledDistinctKeys.join(', ')} ORDER BY ${metric.compiledValueSql}) AS __dd_rn`,
                 ];
 
                 const innerSubquery = MetricQueryBuilder.assembleSqlParts([
@@ -2765,7 +2735,7 @@ export class MetricQueryBuilder {
                     dimensionFilters,
                 ]);
 
-                // Outer CTE: aggregate with CASE WHEN on ROW_NUMBER
+                // Outer CTE: aggregate the deduped rows into a single scalar (no GROUP BY)
                 let outerAgg: string;
                 if (metric.type === MetricType.AVERAGE_DISTINCT) {
                     const floatType = warehouseSqlBuilder.getFloatingType();
@@ -2773,29 +2743,12 @@ export class MetricQueryBuilder {
                 } else {
                     outerAgg = `SUM(CASE WHEN __dd_rn = 1 THEN __dd_val ELSE NULL END)`;
                 }
-                const outerSelects = [
-                    ...dimensionAlias,
-                    `  ${outerAgg} AS ${fieldQuoteChar}${metricId}${fieldQuoteChar}`,
-                ];
 
-                const cteSql = `${ddCteName} AS (\nSELECT\n${outerSelects.join(',\n')}\nFROM (\n${innerSubquery}\n) __dd_sub\n${ddGroupBy ?? ''}\n)`;
+                const cteSql = `${ddCteName} AS (\nSELECT\n  ${outerAgg} AS ${fieldQuoteChar}${metricId}${fieldQuoteChar}\nFROM (\n${innerSubquery}\n) __dd_sub\n)`;
                 ctes.push(cteSql);
 
-                // Build JOIN clause (same NULL-safe pattern as PoP)
-                if (dimensionAlias.length === 0) {
-                    ddJoins.push(`CROSS JOIN ${ddCteName}`);
-                } else {
-                    ddJoins.push(
-                        `INNER JOIN ${ddCteName} ON ${dimensionAlias
-                            .map(
-                                (alias) =>
-                                    `( ${baseCteName}.${alias} = ${ddCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${ddCteName}.${alias} IS NULL ) )`,
-                            )
-                            .join(' AND ')}`,
-                    );
-                }
+                ddJoins.push(`CROSS JOIN ${ddCteName}`);
 
-                // Metric select for final query
                 ddMetricSelects.push(
                     `  ${ddCteName}.${fieldQuoteChar}${metricId}${fieldQuoteChar} AS ${fieldQuoteChar}${metricId}${fieldQuoteChar}`,
                 );
@@ -4142,13 +4095,10 @@ export class MetricQueryBuilder {
                 ddJoins,
                 ddMetricSelects,
             } = this.buildDistinctMetricCtes({
-                dimensionSelects: dimensionsSQL.selects,
-                dimensionGroupBy: dimensionsSQL.groupBySQL,
                 dimensionFilters: dimensionsSQL.filtersSQL,
                 sqlFrom,
                 joinsSql: joins.joinSQL,
                 dimensionJoins: dimensionsSQL.joins,
-                baseCteName: ddBaseCteName,
             });
             ctes.push(...ddCtes);
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2674,21 +2674,30 @@ export class MetricQueryBuilder {
 
     /**
      * Builds CTE(s) for distinct metrics (sum_distinct, average_distinct) using ROW_NUMBER deduplication.
-     * The dedup CTE collapses to a single scalar per metric (grain = distinct_keys), and is attached
-     * to every output row via CROSS JOIN. Selected dimensions are intentionally excluded from the
-     * PARTITION BY and GROUP BY so the same globally-deduplicated value is repeated across rows —
-     * see SPK-450.
+     *
+     * Semantics (SPK-450):
+     *   1. Inner subquery picks one row per distinct_keys combination (PARTITION BY distinct_keys).
+     *   2. Outer CTE aggregates up to the grain of (distinct_keys ∩ selected dimensions).
+     *   3. JOIN to dd_base on the overlapping keys (INNER JOIN), or CROSS JOIN when there is no
+     *      overlap so a single scalar is repeated across every output row.
+     *
+     * Selected dimensions that are NOT part of distinct_keys never affect the dedup or the
+     * partitioning — they ride along on dd_base and receive the same value across all of their rows.
      */
     private buildDistinctMetricCtes({
+        dimensionSelects,
         dimensionFilters,
         sqlFrom,
         joinsSql,
         dimensionJoins,
+        baseCteName,
     }: {
+        dimensionSelects: Record<string, string>;
         dimensionFilters: string | undefined;
         sqlFrom: string;
         joinsSql: string | undefined;
         dimensionJoins: string[];
+        baseCteName: string;
     }): {
         ctes: string[];
         ddJoins: string[];
@@ -2707,6 +2716,26 @@ export class MetricQueryBuilder {
             },
         );
 
+        // Build a map: normalized dimension SQL expression -> dimension id.
+        // Used to detect which distinct_keys overlap with the selected dimensions.
+        const normalizeSql = (sql: string): string => {
+            let s = sql.trim();
+            while (s.startsWith('(') && s.endsWith(')')) {
+                s = s.slice(1, -1).trim();
+            }
+            return s;
+        };
+        const dimensionSqlToId = new Map<string, string>();
+        for (const [id, selectStr] of Object.entries(dimensionSelects)) {
+            const suffix = ` AS ${fieldQuoteChar}${id}${fieldQuoteChar}`;
+            const idx = selectStr.lastIndexOf(suffix);
+            const sqlExpr =
+                idx > -1
+                    ? selectStr.substring(0, idx).trim()
+                    : selectStr.trim();
+            dimensionSqlToId.set(normalizeSql(sqlExpr), id);
+        }
+
         const ctes: string[] = [];
         const ddJoins: string[] = [];
         const ddMetricSelects: string[] = [];
@@ -2719,10 +2748,30 @@ export class MetricQueryBuilder {
             ) {
                 const ddCteName = `dd_${snakeCaseName(metricId)}`;
 
-                // Inner subquery: pick one row per distinct-key combination.
-                // dimensionJoins + dimensionFilters are still applied so query-level
-                // filters narrow the dedup population, but no dimensions are projected.
+                // For each distinct_key, find the matching selected dimension (if any).
+                // Joinable keys = distinct_keys that the user is also grouping by, and so
+                // need to flow through to the output as join columns.
+                const joinableKeys: Array<{
+                    keySql: string;
+                    dimId: string;
+                }> = [];
+                for (const keySql of metric.compiledDistinctKeys) {
+                    const matchedDimId = dimensionSqlToId.get(
+                        normalizeSql(keySql),
+                    );
+                    if (matchedDimId) {
+                        joinableKeys.push({ keySql, dimId: matchedDimId });
+                    }
+                }
+
+                // Inner subquery: project joinable keys (so the outer can group by them)
+                // plus the row-numbered metric value.
+                const innerKeySelects = joinableKeys.map(
+                    ({ keySql, dimId }) =>
+                        `  ${keySql} AS ${fieldQuoteChar}${dimId}${fieldQuoteChar}`,
+                );
                 const innerSelects = [
+                    ...innerKeySelects,
                     `  ${metric.compiledValueSql} AS __dd_val`,
                     `  ROW_NUMBER() OVER (PARTITION BY ${metric.compiledDistinctKeys.join(', ')} ORDER BY ${metric.compiledValueSql}) AS __dd_rn`,
                 ];
@@ -2735,7 +2784,6 @@ export class MetricQueryBuilder {
                     dimensionFilters,
                 ]);
 
-                // Outer CTE: aggregate the deduped rows into a single scalar (no GROUP BY)
                 let outerAgg: string;
                 if (metric.type === MetricType.AVERAGE_DISTINCT) {
                     const floatType = warehouseSqlBuilder.getFloatingType();
@@ -2744,10 +2792,39 @@ export class MetricQueryBuilder {
                     outerAgg = `SUM(CASE WHEN __dd_rn = 1 THEN __dd_val ELSE NULL END)`;
                 }
 
-                const cteSql = `${ddCteName} AS (\nSELECT\n  ${outerAgg} AS ${fieldQuoteChar}${metricId}${fieldQuoteChar}\nFROM (\n${innerSubquery}\n) __dd_sub\n)`;
+                // Outer CTE: group by the joinable keys (or no group by for a scalar).
+                const outerKeyAliases = joinableKeys.map(
+                    ({ dimId }) => `${fieldQuoteChar}${dimId}${fieldQuoteChar}`,
+                );
+                const outerSelects = [
+                    ...outerKeyAliases.map((alias) => `  ${alias}`),
+                    `  ${outerAgg} AS ${fieldQuoteChar}${metricId}${fieldQuoteChar}`,
+                ];
+                const outerGroupBy =
+                    joinableKeys.length > 0
+                        ? `GROUP BY ${joinableKeys.map((_, i) => i + 1).join(', ')}`
+                        : undefined;
+
+                const cteParts = [
+                    `SELECT\n${outerSelects.join(',\n')}`,
+                    `FROM (\n${innerSubquery}\n) __dd_sub`,
+                    outerGroupBy,
+                ];
+                const cteSql = `${ddCteName} AS (\n${MetricQueryBuilder.assembleSqlParts(cteParts)}\n)`;
                 ctes.push(cteSql);
 
-                ddJoins.push(`CROSS JOIN ${ddCteName}`);
+                if (joinableKeys.length === 0) {
+                    ddJoins.push(`CROSS JOIN ${ddCteName}`);
+                } else {
+                    ddJoins.push(
+                        `INNER JOIN ${ddCteName} ON ${outerKeyAliases
+                            .map(
+                                (alias) =>
+                                    `( ${baseCteName}.${alias} = ${ddCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${ddCteName}.${alias} IS NULL ) )`,
+                            )
+                            .join(' AND ')}`,
+                    );
+                }
 
                 ddMetricSelects.push(
                     `  ${ddCteName}.${fieldQuoteChar}${metricId}${fieldQuoteChar} AS ${fieldQuoteChar}${metricId}${fieldQuoteChar}`,
@@ -4095,10 +4172,12 @@ export class MetricQueryBuilder {
                 ddJoins,
                 ddMetricSelects,
             } = this.buildDistinctMetricCtes({
+                dimensionSelects: dimensionsSQL.selects,
                 dimensionFilters: dimensionsSQL.filtersSQL,
                 sqlFrom,
                 joinsSql: joins.joinSQL,
                 dimensionJoins: dimensionsSQL.joins,
+                baseCteName: ddBaseCteName,
             });
             ctes.push(...ddCtes);
 

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
@@ -1,6 +1,182 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a sum-distinct query with dimensions 1`] = `
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a multi-key sum-distinct query with a partially overlapping selection 1`] = `
+"WITH
+  dd_orders_total_payment_by_method_per_order AS (
+    SELECT
+      "orders_order_id",
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "orders_total_payment_by_method_per_order"
+    FROM
+      (
+        SELECT
+          "orders".order_id AS "orders_order_id",
+          "orders".amount AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "orders".order_id,
+              "orders".payment_method
+            ORDER BY
+              "orders".amount
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."orders" AS "orders"
+      ) __dd_sub
+    GROUP BY
+      1
+  ),
+  dd_base AS (
+    SELECT
+      "orders".order_id AS "orders_order_id"
+    FROM
+      "db"."schema"."orders" AS "orders"
+    GROUP BY
+      1
+  )
+SELECT
+  dd_base.*,
+  dd_orders_total_payment_by_method_per_order."orders_total_payment_by_method_per_order" AS "orders_total_payment_by_method_per_order"
+FROM
+  dd_base
+  INNER JOIN dd_orders_total_payment_by_method_per_order ON (
+    dd_base."orders_order_id" = dd_orders_total_payment_by_method_per_order."orders_order_id"
+    OR (
+      dd_base."orders_order_id" IS NULL
+      AND dd_orders_total_payment_by_method_per_order."orders_order_id" IS NULL
+    )
+  )
+ORDER BY
+  "orders_total_payment_by_method_per_order" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a multi-key sum-distinct query with all distinct keys selected 1`] = `
+"WITH
+  dd_orders_total_payment_by_method_per_order AS (
+    SELECT
+      "orders_order_id",
+      "orders_payment_method",
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "orders_total_payment_by_method_per_order"
+    FROM
+      (
+        SELECT
+          "orders".order_id AS "orders_order_id",
+          "orders".payment_method AS "orders_payment_method",
+          "orders".amount AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "orders".order_id,
+              "orders".payment_method
+            ORDER BY
+              "orders".amount
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."orders" AS "orders"
+      ) __dd_sub
+    GROUP BY
+      1,
+      2
+  ),
+  dd_base AS (
+    SELECT
+      "orders".order_id AS "orders_order_id",
+      "orders".payment_method AS "orders_payment_method"
+    FROM
+      "db"."schema"."orders" AS "orders"
+    GROUP BY
+      1,
+      2
+  )
+SELECT
+  dd_base.*,
+  dd_orders_total_payment_by_method_per_order."orders_total_payment_by_method_per_order" AS "orders_total_payment_by_method_per_order"
+FROM
+  dd_base
+  INNER JOIN dd_orders_total_payment_by_method_per_order ON (
+    dd_base."orders_order_id" = dd_orders_total_payment_by_method_per_order."orders_order_id"
+    OR (
+      dd_base."orders_order_id" IS NULL
+      AND dd_orders_total_payment_by_method_per_order."orders_order_id" IS NULL
+    )
+  )
+  AND (
+    dd_base."orders_payment_method" = dd_orders_total_payment_by_method_per_order."orders_payment_method"
+    OR (
+      dd_base."orders_payment_method" IS NULL
+      AND dd_orders_total_payment_by_method_per_order."orders_payment_method" IS NULL
+    )
+  )
+ORDER BY
+  "orders_total_payment_by_method_per_order" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a sum-distinct query where the selected dimension is the distinct key 1`] = `
+"WITH
+  dd_orders_total_revenue AS (
+    SELECT
+      "orders_line_item_id",
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "orders_total_revenue"
+    FROM
+      (
+        SELECT
+          "orders".line_item_id AS "orders_line_item_id",
+          "orders".amount AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "orders".line_item_id
+            ORDER BY
+              "orders".amount
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."orders" AS "orders"
+      ) __dd_sub
+    GROUP BY
+      1
+  ),
+  dd_base AS (
+    SELECT
+      "orders".line_item_id AS "orders_line_item_id"
+    FROM
+      "db"."schema"."orders" AS "orders"
+    GROUP BY
+      1
+  )
+SELECT
+  dd_base.*,
+  dd_orders_total_revenue."orders_total_revenue" AS "orders_total_revenue"
+FROM
+  dd_base
+  INNER JOIN dd_orders_total_revenue ON (
+    dd_base."orders_line_item_id" = dd_orders_total_revenue."orders_line_item_id"
+    OR (
+      dd_base."orders_line_item_id" IS NULL
+      AND dd_orders_total_revenue."orders_line_item_id" IS NULL
+    )
+  )
+ORDER BY
+  "orders_total_revenue" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a sum-distinct query with dimensions not in distinct_keys 1`] = `
 "WITH
   dd_orders_total_revenue AS (
     SELECT
@@ -80,7 +256,7 @@ LIMIT
   10"
 `;
 
-exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for an average-distinct query with dimensions 1`] = `
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for an average-distinct query with dimensions not in distinct_keys 1`] = `
 "WITH
   dd_orders_avg_shipping_cost AS (
     SELECT

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
@@ -4,8 +4,6 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a su
 "WITH
   dd_orders_total_revenue AS (
     SELECT
-      "orders_payment_method",
-      "orders_status",
       SUM(
         CASE
           WHEN __dd_rn = 1 THEN __dd_val
@@ -15,23 +13,16 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a su
     FROM
       (
         SELECT
-          "orders".payment_method AS "orders_payment_method",
-          "orders".status AS "orders_status",
           "orders".amount AS __dd_val,
           ROW_NUMBER() OVER (
             PARTITION BY
-              "orders".line_item_id,
-              "orders".payment_method,
-              "orders".status
+              "orders".line_item_id
             ORDER BY
               "orders".amount
           ) AS __dd_rn
         FROM
           "db"."schema"."orders" AS "orders"
       ) __dd_sub
-    GROUP BY
-      1,
-      2
   ),
   dd_base AS (
     SELECT
@@ -48,20 +39,7 @@ SELECT
   dd_orders_total_revenue."orders_total_revenue" AS "orders_total_revenue"
 FROM
   dd_base
-  INNER JOIN dd_orders_total_revenue ON (
-    dd_base."orders_payment_method" = dd_orders_total_revenue."orders_payment_method"
-    OR (
-      dd_base."orders_payment_method" IS NULL
-      AND dd_orders_total_revenue."orders_payment_method" IS NULL
-    )
-  )
-  AND (
-    dd_base."orders_status" = dd_orders_total_revenue."orders_status"
-    OR (
-      dd_base."orders_status" IS NULL
-      AND dd_orders_total_revenue."orders_status" IS NULL
-    )
-  )
+  CROSS JOIN dd_orders_total_revenue
 ORDER BY
   "orders_total_revenue" DESC
 LIMIT
@@ -106,7 +84,6 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for an a
 "WITH
   dd_orders_avg_shipping_cost AS (
     SELECT
-      "orders_payment_method",
       CAST(
         SUM(
           CASE
@@ -127,20 +104,16 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for an a
     FROM
       (
         SELECT
-          "orders".payment_method AS "orders_payment_method",
           "orders".shipping_cost AS __dd_val,
           ROW_NUMBER() OVER (
             PARTITION BY
-              "orders".line_item_id,
-              "orders".payment_method
+              "orders".line_item_id
             ORDER BY
               "orders".shipping_cost
           ) AS __dd_rn
         FROM
           "db"."schema"."orders" AS "orders"
       ) __dd_sub
-    GROUP BY
-      1
   ),
   dd_base AS (
     SELECT
@@ -155,13 +128,7 @@ SELECT
   dd_orders_avg_shipping_cost."orders_avg_shipping_cost" AS "orders_avg_shipping_cost"
 FROM
   dd_base
-  INNER JOIN dd_orders_avg_shipping_cost ON (
-    dd_base."orders_payment_method" = dd_orders_avg_shipping_cost."orders_payment_method"
-    OR (
-      dd_base."orders_payment_method" IS NULL
-      AND dd_orders_avg_shipping_cost."orders_payment_method" IS NULL
-    )
-  )
+  CROSS JOIN dd_orders_avg_shipping_cost
 ORDER BY
   "orders_avg_shipping_cost" DESC
 LIMIT

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
@@ -3,15 +3,19 @@ import {
     EXPLORE_WITH_SUM_DISTINCT,
     METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS,
     METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
+    METRIC_QUERY_SUM_DISTINCT_MULTI_KEY_FULLY_JOINABLE,
+    METRIC_QUERY_SUM_DISTINCT_MULTI_KEY_PARTIAL_JOIN,
     METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
     METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
+    METRIC_QUERY_SUM_DISTINCT_WITH_JOINABLE_DIM,
 } from '../MetricQueryBuilder.mock';
 import { buildQuery } from './helpers';
 
 describe('MetricQueryBuilder snapshot: distinct queries', () => {
-    // Covers sum_distinct with selected dimensions, where the deduplication CTE must partition
-    // by both the distinct key and every selected grouping dimension before rejoining the results.
-    test('matches snapshot for a sum-distinct query with dimensions', () => {
+    // Selected dimensions are orthogonal to the distinct key, so the dedup CTE collapses to a
+    // scalar and is CROSS JOINed onto dd_base. Every output row sees the same global total
+    // (SPK-450 Wise case).
+    test('matches snapshot for a sum-distinct query with dimensions not in distinct_keys', () => {
         expect(
             buildQuery({
                 explore: EXPLORE_WITH_SUM_DISTINCT,
@@ -20,8 +24,44 @@ describe('MetricQueryBuilder snapshot: distinct queries', () => {
         ).toMatchSnapshot();
     });
 
-    // Covers the no-dimension sum_distinct path, where the deduped aggregate should avoid
-    // dimension joins entirely and collapse back to a single-row aggregation shape.
+    // The selected dimension is the metric's distinct key, so the dedup CTE keeps one row per
+    // distinct-key value and is INNER JOINed back onto dd_base.
+    test('matches snapshot for a sum-distinct query where the selected dimension is the distinct key', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT,
+                compiledMetricQuery:
+                    METRIC_QUERY_SUM_DISTINCT_WITH_JOINABLE_DIM,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Multi-key distinct where every distinct key is also a selected dimension — one output row
+    // per (order_id, payment_method), INNER JOIN on both keys. Regression test for the case where
+    // a global CROSS JOIN scalar incorrectly produced the same value on every row.
+    test('matches snapshot for a multi-key sum-distinct query with all distinct keys selected', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT,
+                compiledMetricQuery:
+                    METRIC_QUERY_SUM_DISTINCT_MULTI_KEY_FULLY_JOINABLE,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Multi-key distinct where only one of two distinct keys is selected — the dedup CTE
+    // aggregates over the unselected key, then INNER JOINs on the one selected key.
+    test('matches snapshot for a multi-key sum-distinct query with a partially overlapping selection', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT,
+                compiledMetricQuery:
+                    METRIC_QUERY_SUM_DISTINCT_MULTI_KEY_PARTIAL_JOIN,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // No-dimension path: the dedup CTE collapses to a single-row aggregation with no join.
     test('matches snapshot for a sum-distinct query without dimensions', () => {
         expect(
             buildQuery({
@@ -42,9 +82,9 @@ describe('MetricQueryBuilder snapshot: distinct queries', () => {
         ).toMatchSnapshot();
     });
 
-    // Covers average_distinct with grouping dimensions, where the distinct CTE must partition
-    // by the selected dimensions and then regroup the deduplicated rows into the final result set.
-    test('matches snapshot for an average-distinct query with dimensions', () => {
+    // average_distinct with a selected dimension that is not in distinct_keys — same global value
+    // attached to every dimension row via CROSS JOIN.
+    test('matches snapshot for an average-distinct query with dimensions not in distinct_keys', () => {
         expect(
             buildQuery({
                 explore: EXPLORE_WITH_AVERAGE_DISTINCT,

--- a/packages/e2e/cypress/e2e/api/sumDistinctWithFanout.cy.ts
+++ b/packages/e2e/cypress/e2e/api/sumDistinctWithFanout.cy.ts
@@ -120,7 +120,97 @@ describe('SQL fanout deduplication', () => {
         });
     });
 
-    it('sum_distinct should return the same global deduplicated total on every dimension row (SPK-450)', () => {
+    it('sum_distinct should INNER JOIN on distinct_keys when the user selects them as dimensions (SPK-450)', () => {
+        // Multi-key sum_distinct: distinct_keys = [order_id, payment_method].
+        // Selecting both keys as dimensions should produce one (correct) value per
+        // (order_id, payment_method), via INNER JOIN on the dedup CTE.
+        const groundTruthQuery = {
+            exploreName: 'payments',
+            dimensions: ['payments_order_id', 'payments_payment_method'],
+            metrics: ['payments_total_revenue'],
+            filters: {},
+            sorts: [
+                { fieldId: 'payments_order_id', descending: false },
+                { fieldId: 'payments_payment_method', descending: false },
+            ],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+            metricOverrides: {},
+        };
+
+        const dedupedQuery = {
+            exploreName: 'customer_order_payments',
+            dimensions: [
+                'customer_order_payments_order_id',
+                'customer_order_payments_payment_method',
+            ],
+            metrics: [
+                'customer_order_payments_total_payment_by_method_per_order',
+            ],
+            filters: {},
+            sorts: [
+                {
+                    fieldId: 'customer_order_payments_order_id',
+                    descending: false,
+                },
+                {
+                    fieldId: 'customer_order_payments_payment_method',
+                    descending: false,
+                },
+            ],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+            metricOverrides: {},
+        };
+
+        runMetricQuery(projectUuid, groundTruthQuery).then(
+            (groundTruthRows) => {
+                expect(groundTruthRows.length).to.be.greaterThan(1);
+
+                const expected: Record<string, number> = {};
+                groundTruthRows.forEach((row) => {
+                    const key = `${String(row.payments_order_id)}|${String(
+                        row.payments_payment_method,
+                    )}`;
+                    expected[key] = Number(row.payments_total_revenue);
+                });
+
+                runMetricQuery(projectUuid, dedupedQuery).then(
+                    (dedupedRows) => {
+                        expect(dedupedRows.length).to.eq(
+                            groundTruthRows.length,
+                        );
+
+                        // Distinct values across rows confirms it's NOT a global scalar CROSS JOIN.
+                        const distinctValues = new Set(
+                            dedupedRows.map((r) =>
+                                Number(
+                                    r.customer_order_payments_total_payment_by_method_per_order,
+                                ),
+                            ),
+                        );
+                        expect(distinctValues.size).to.be.greaterThan(1);
+
+                        dedupedRows.forEach((row) => {
+                            const key = `${String(
+                                row.customer_order_payments_order_id,
+                            )}|${String(
+                                row.customer_order_payments_payment_method,
+                            )}`;
+                            const deduped = Number(
+                                row.customer_order_payments_total_payment_by_method_per_order,
+                            );
+                            expect(deduped, `key=${key}`).to.eq(expected[key]);
+                        });
+                    },
+                );
+            },
+        );
+    });
+
+    it('sum_distinct should return the same global deduplicated total when the selected dimension is not a distinct_key (SPK-450)', () => {
         // Ground truth: direct SUM on payments table without grouping (no fan-out)
         const paymentsTotalQuery = {
             exploreName: 'payments',

--- a/packages/e2e/cypress/e2e/api/sumDistinctWithFanout.cy.ts
+++ b/packages/e2e/cypress/e2e/api/sumDistinctWithFanout.cy.ts
@@ -120,27 +120,23 @@ describe('SQL fanout deduplication', () => {
         });
     });
 
-    it('sum_distinct grouped by dimension should return correct per-group values', () => {
-        // Query 1: Ground truth — direct SUM on payments table grouped by payment_method (no fan-out)
-        const paymentsQuery = {
+    it('sum_distinct should return the same global deduplicated total on every dimension row (SPK-450)', () => {
+        // Ground truth: direct SUM on payments table without grouping (no fan-out)
+        const paymentsTotalQuery = {
             exploreName: 'payments',
-            dimensions: ['payments_payment_method'],
+            dimensions: [],
             metrics: ['payments_total_revenue'],
             filters: {},
-            sorts: [
-                {
-                    fieldId: 'payments_payment_method',
-                    descending: false,
-                },
-            ],
+            sorts: [],
             limit: 500,
             tableCalculations: [],
             additionalMetrics: [],
             metricOverrides: {},
         };
 
-        // Query 2: sum_distinct on the wide table grouped by payment_method
-        // Before the fix, PARTITION BY excluded payment_method, zeroing out all but one row per payment_id
+        // sum_distinct on the wide (fanned-out) table grouped by a non-distinct-key dimension.
+        // Selected dimensions must NOT participate in the dedup PARTITION BY — every row should
+        // show the same global total, since payment_method isn't part of distinct_keys.
         const wideTableQuery = {
             exploreName: 'customer_order_payments',
             dimensions: ['customer_order_payments_payment_method'],
@@ -158,19 +154,14 @@ describe('SQL fanout deduplication', () => {
             metricOverrides: {},
         };
 
-        runMetricQuery(projectUuid, paymentsQuery).then((paymentsRows) => {
-            expect(paymentsRows.length).to.be.greaterThan(1);
-
-            // Build lookup: payment_method → total_revenue
-            const expectedByMethod: Record<string, number> = {};
-            paymentsRows.forEach((row) => {
-                const method = String(row.payments_payment_method);
-                expectedByMethod[method] = Number(row.payments_total_revenue);
-            });
+        runMetricQuery(projectUuid, paymentsTotalQuery).then((totalRows) => {
+            expect(totalRows).to.have.length(1);
+            const expectedTotal = Number(totalRows[0].payments_total_revenue);
+            expect(expectedTotal).to.be.greaterThan(0);
 
             runMetricQuery(projectUuid, wideTableQuery).then(
                 (wideTableRows) => {
-                    expect(wideTableRows.length).to.eq(paymentsRows.length);
+                    expect(wideTableRows.length).to.be.greaterThan(1);
 
                     wideTableRows.forEach((row) => {
                         const method = String(
@@ -179,10 +170,9 @@ describe('SQL fanout deduplication', () => {
                         const deduped = Number(
                             row.customer_order_payments_total_payment_amount_deduped,
                         );
-                        const expected = expectedByMethod[method];
 
                         expect(deduped, `payment_method=${method}`).to.eq(
-                            expected,
+                            expectedTotal,
                         );
                     });
                 },


### PR DESCRIPTION
closes:  [SPK-450](https://linear.app/lightdash/issue/SPK-450/remove-extra-dimensions-from-sum-distinct-partitioning)

Fixes sum_distinct and average_distinct so they return the correct deduplicated total when a user selects a dimension that's unrelated to the metric's distinct_keys.                                                                                                                                                    
                                                                                                                                                                    
Before this PR, selecting a dimension that wasn't part of distinct_keys caused the metric to dedupe per dimension group instead of globally. So the "total" shown was actually a per-group sum, hiding the real deduplicated value.
                                                                                                                                                                                   
The metric now always deduplicates at the distinct_keys grain. Three cases at the join:                                                                            
  - None of the selected dims are distinct_keys → one global value, repeated on every row.                                                                               
  - Some of the selected dims are distinct_keys → group by those overlapping dims, join on them.
  - All selected dims are distinct_keys → one value per group, joined on every key.                                                                                 
                                                                                                                                                                    
Tests                                                                                                                                                             
  - New snapshot tests cover the multi-key cases (one distinct_key selected, both selected, neither selected).                                                      
  - Cypress e2e (sumDistinctWithFanout.cy.ts) updated for the new behaviour.
  - Removed duplicate inline assertions that the snapshots already cover.                                                                                           
                              
Note this PR reverses the SPK-334 behaviour of partitioning by the selected dimensions, which produced per-group sums and obscured the global deduplicated total when the selected dimension was orthogonal to the distinct_keys grain.