### PR TITLE
feat: add http_server_requests_seconds prometheus metric (opt-in)

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -366,7 +366,11 @@ export default class App {
             middleware(expressApp),
         );
 
-        expressApp.use(this.prometheusMetrics.httpServerRequestMetricsMiddleware());
+        if (this.lightdashConfig.prometheus.extendedMetricsEnabled) {
+            expressApp.use(
+                this.prometheusMetrics.httpServerRequestMetricsMiddleware(),
+            );
+        }
 
         expressApp.use(
             express.json({ limit: this.lightdashConfig.maxPayloadSize }),

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -366,6 +366,8 @@ export default class App {
             middleware(expressApp),
         );
 
+        expressApp.use(this.prometheusMetrics.httpServerRequestMetricsMiddleware());
+
         expressApp.use(
             express.json({ limit: this.lightdashConfig.maxPayloadSize }),
         );

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -198,6 +198,7 @@ export default class NatsWorkerApp {
 
     private async initServer(worker: NatsWorker, natsClient: NatsClient) {
         const app = express();
+        app.use(this.prometheusMetrics.httpServerRequestMetricsMiddleware());
         const server = http.createServer(app);
 
         createTerminus(server, {

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -198,7 +198,11 @@ export default class NatsWorkerApp {
 
     private async initServer(worker: NatsWorker, natsClient: NatsClient) {
         const app = express();
-        app.use(this.prometheusMetrics.httpServerRequestMetricsMiddleware());
+        if (this.lightdashConfig.prometheus.extendedMetricsEnabled) {
+            app.use(
+                this.prometheusMetrics.httpServerRequestMetricsMiddleware(),
+            );
+        }
         const server = http.createServer(app);
 
         createTerminus(server, {

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -229,7 +229,11 @@ export default class SchedulerApp {
         workerHealth: SchedulerWorkerHealth,
     ) {
         const app = express();
-        app.use(this.prometheusMetrics.httpServerRequestMetricsMiddleware());
+        if (this.lightdashConfig.prometheus.extendedMetricsEnabled) {
+            app.use(
+                this.prometheusMetrics.httpServerRequestMetricsMiddleware(),
+            );
+        }
         const server = http.createServer(app);
 
         createTerminus(server, {

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -229,6 +229,7 @@ export default class SchedulerApp {
         workerHealth: SchedulerWorkerHealth,
     ) {
         const app = express();
+        app.use(this.prometheusMetrics.httpServerRequestMetricsMiddleware());
         const server = http.createServer(app);
 
         createTerminus(server, {

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -98,6 +98,7 @@ export const lightdashConfigMock: LightdashConfig = {
         path: '/metrics',
         eventMetricsEnabled: false,
         allQueryMetricsEnabled: false,
+        extendedMetricsEnabled: false,
     },
     chart: { versionHistory: { daysLimit: 0 } },
     dashboard: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1018,6 +1018,7 @@ export type LightdashConfig = {
         eventMetricsEnabled: boolean;
         eventMetricsConfigPath?: string;
         allQueryMetricsEnabled: boolean;
+        extendedMetricsEnabled: boolean;
     };
     database: {
         connectionUri: string | undefined;
@@ -1965,6 +1966,9 @@ export const parseConfig = (): LightdashConfig => {
             allQueryMetricsEnabled:
                 process.env.LIGHTDASH_PROMETHEUS_ALL_QUERY_METRICS_ENABLED ===
                 'true', // defaults to false, tracks execution duration & S3 upload for all queries (not just pre-aggregate)
+            extendedMetricsEnabled:
+                process.env.LIGHTDASH_PROMETHEUS_EXTENDED_METRICS_ENABLED ===
+                'true', // defaults to false
         },
         allowMultiOrgs: process.env.ALLOW_MULTIPLE_ORGS === 'true',
         maxPayloadSize: process.env.LIGHTDASH_MAX_PAYLOAD || '5mb',

--- a/packages/backend/src/prometheus/PrometheusMetrics.test.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.test.ts
@@ -1,0 +1,94 @@
+import express from 'express';
+import { getHttpUriLabel } from './PrometheusMetrics';
+
+type PartialRequest = Partial<express.Request>;
+
+const buildRequest = (overrides: PartialRequest): express.Request =>
+    overrides as express.Request;
+
+describe('getHttpUriLabel', () => {
+    describe('matched routes', () => {
+        it('returns the templated route path for a TSOA route with a path param', () => {
+            const req = buildRequest({
+                baseUrl: '/api/v1/projects',
+                path: '/3675b69e-8324-4110-bdca-059031aa8da3/spaces',
+                route: {
+                    path: '/:projectUuid/spaces',
+                } as express.Request['route'],
+            });
+            expect(getHttpUriLabel(req)).toBe(
+                '/api/v1/projects/:projectUuid/spaces',
+            );
+        });
+
+        it('collapses different param values into the same label', () => {
+            const route = {
+                path: '/:projectUuid',
+            } as express.Request['route'];
+            const a = getHttpUriLabel(
+                buildRequest({
+                    baseUrl: '/api/v1/projects',
+                    path: '/aaaa',
+                    route,
+                }),
+            );
+            const b = getHttpUriLabel(
+                buildRequest({
+                    baseUrl: '/api/v1/projects',
+                    path: '/bbbb',
+                    route,
+                }),
+            );
+            expect(a).toBe(b);
+            expect(a).toBe('/api/v1/projects/:projectUuid');
+        });
+
+        it('handles a root-mounted route ("/" path)', () => {
+            const req = buildRequest({
+                baseUrl: '/api/v1/health',
+                path: '/',
+                route: { path: '/' } as express.Request['route'],
+            });
+            expect(getHttpUriLabel(req)).toBe('/api/v1/health');
+        });
+
+        it('handles missing baseUrl', () => {
+            const req = buildRequest({
+                baseUrl: '',
+                path: '/livez',
+                route: { path: '/livez' } as express.Request['route'],
+            });
+            expect(getHttpUriLabel(req)).toBe('/livez');
+        });
+    });
+
+    describe('unmatched routes', () => {
+        it('buckets unmatched paths into "unmatched" to cap cardinality', () => {
+            const req = buildRequest({
+                path: '/api/v1/does-not-exist',
+            });
+            expect(getHttpUriLabel(req)).toBe('unmatched');
+        });
+
+        it('buckets attacker scan paths into "unmatched"', () => {
+            const paths = [
+                '/wp-admin',
+                '/.env',
+                '/api/v1/projects/',
+                '/api/v1/projects//spaces',
+            ];
+            for (const path of paths) {
+                expect(getHttpUriLabel(buildRequest({ path }))).toBe(
+                    'unmatched',
+                );
+            }
+        });
+
+        it('buckets static asset requests into "/assets/*"', () => {
+            const req = buildRequest({
+                path: '/assets/main-abc123.js',
+            });
+            expect(getHttpUriLabel(req)).toBe('/assets/*');
+        });
+    });
+});

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -142,8 +142,53 @@ export default class PrometheusMetrics {
 
     private overheadDurationHistogram: prometheus.Histogram | null = null;
 
+    private httpServerRequestsDurationSeconds: prometheus.Histogram<
+        'method' | 'uri' | 'status_code'
+    > | null = null;
+
     constructor(config: LightdashConfig['prometheus']) {
         this.config = config;
+    }
+
+    private static getHttpUriLabel(req: express.Request): string {
+        const route = req.route;
+        if (route?.path !== undefined) {
+            const base = req.baseUrl ?? '';
+            const pathPart = route.path === '/' ? '' : route.path;
+            const combined = `${base}${pathPart}`;
+            return combined.length > 0 ? combined : '/';
+        }
+        if (req.path?.startsWith('/assets/')) {
+            return '/assets/*';
+        }
+        return req.path && req.path.length > 0 ? req.path : '/';
+    }
+
+    /**
+     * Records request duration into `http_server_requests_seconds` (histogram: _bucket, _count, _sum).
+     * Safe to mount when Prometheus is disabled (no-op).
+     */
+    public httpServerRequestMetricsMiddleware(): express.RequestHandler {
+        return (req, res, next) => {
+            const histogram = this.httpServerRequestsDurationSeconds;
+            if (!histogram) {
+                next();
+                return;
+            }
+            const start = process.hrtime.bigint();
+            res.on('finish', () => {
+                const seconds = Number(process.hrtime.bigint() - start) / 1e9;
+                histogram.observe(
+                    {
+                        method: req.method,
+                        uri: PrometheusMetrics.getHttpUriLabel(req),
+                        status_code: String(res.statusCode),
+                    },
+                    seconds,
+                );
+            });
+            next();
+        };
     }
 
     public start() {
@@ -210,6 +255,14 @@ export default class PrometheusMetrics {
                     help: 'Lightdash overhead: total duration minus warehouse execution time',
                     labelNames: ['context'],
                     buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
+                    ...rest,
+                });
+
+                this.httpServerRequestsDurationSeconds = new prometheus.Histogram({
+                    name: 'http_server_requests_seconds',
+                    help: 'HTTP server request duration in seconds',
+                    labelNames: ['method', 'uri', 'status_code'],
+                    buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
                     ...rest,
                 });
 

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -56,6 +56,20 @@ export function getQueryContextLabel(
     return SCHEDULED_CONTEXTS.has(context) ? 'scheduled' : 'interactive';
 }
 
+export function getHttpUriLabel(req: express.Request): string {
+    const { route } = req;
+    if (route?.path !== undefined) {
+        const base = req.baseUrl ?? '';
+        const pathPart = route.path === '/' ? '' : route.path;
+        const combined = `${base}${pathPart}`;
+        return combined.length > 0 ? combined : '/';
+    }
+    if (req.path?.startsWith('/assets/')) {
+        return '/assets/*';
+    }
+    return 'unmatched';
+}
+
 export default class PrometheusMetrics {
     private readonly config: LightdashConfig['prometheus'];
 
@@ -150,20 +164,6 @@ export default class PrometheusMetrics {
         this.config = config;
     }
 
-    private static getHttpUriLabel(req: express.Request): string {
-        const route = req.route;
-        if (route?.path !== undefined) {
-            const base = req.baseUrl ?? '';
-            const pathPart = route.path === '/' ? '' : route.path;
-            const combined = `${base}${pathPart}`;
-            return combined.length > 0 ? combined : '/';
-        }
-        if (req.path?.startsWith('/assets/')) {
-            return '/assets/*';
-        }
-        return req.path && req.path.length > 0 ? req.path : '/';
-    }
-    
     public httpServerRequestMetricsMiddleware(): express.RequestHandler {
         return (req, res, next) => {
             const histogram = this.httpServerRequestsDurationSeconds;
@@ -177,7 +177,7 @@ export default class PrometheusMetrics {
                 histogram.observe(
                     {
                         method: req.method,
-                        uri: PrometheusMetrics.getHttpUriLabel(req),
+                        uri: getHttpUriLabel(req),
                         status_code: String(res.statusCode),
                     },
                     seconds,
@@ -260,7 +260,10 @@ export default class PrometheusMetrics {
                             name: 'http_server_requests_seconds',
                             help: 'HTTP server request duration in seconds',
                             labelNames: ['method', 'uri', 'status_code'],
-                            buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
+                            buckets: [
+                                0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
+                                2.5, 5, 10, 30, 60, 120,
+                            ],
                             ...rest,
                         });
                 }

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -163,11 +163,7 @@ export default class PrometheusMetrics {
         }
         return req.path && req.path.length > 0 ? req.path : '/';
     }
-
-    /**
-     * Records request duration into `http_server_requests_seconds` (histogram: _bucket, _count, _sum).
-     * Safe to mount when Prometheus is disabled (no-op).
-     */
+    
     public httpServerRequestMetricsMiddleware(): express.RequestHandler {
         return (req, res, next) => {
             const histogram = this.httpServerRequestsDurationSeconds;
@@ -258,13 +254,16 @@ export default class PrometheusMetrics {
                     ...rest,
                 });
 
-                this.httpServerRequestsDurationSeconds = new prometheus.Histogram({
-                    name: 'http_server_requests_seconds',
-                    help: 'HTTP server request duration in seconds',
-                    labelNames: ['method', 'uri', 'status_code'],
-                    buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
-                    ...rest,
-                });
+                if (this.config.extendedMetricsEnabled) {
+                    this.httpServerRequestsDurationSeconds =
+                        new prometheus.Histogram({
+                            name: 'http_server_requests_seconds',
+                            help: 'HTTP server request duration in seconds',
+                            labelNames: ['method', 'uri', 'status_code'],
+                            buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
+                            ...rest,
+                        });
+                }
 
                 // Initialize AI Agent response time histograms
                 this.aiAgentGenerateResponseDurationHistogram =


### PR DESCRIPTION
## Summary

Adds an opt-in `http_server_requests_seconds` histogram that times every HTTP request across the Express API, scheduler, and NATS worker. Labelled by `method`, templated `uri`, and `status_code`. Off by default; enable with `LIGHTDASH_PROMETHEUS_EXTENDED_METRICS_ENABLED=true`.

Fills a real gap: existing `lightdash_query_*` histograms only cover the data-query pipeline, and Sentry transactions are sampled — neither gives accurate p99 latency or error-rate signals usable for Grafana dashboards / alerting.

- Uses `res.on('finish')` so timing covers the full middleware chain regardless of where the middleware sits.
- Cardinality is bounded: matched routes use the templated path (e.g. `/api/v1/projects/:projectUuid/spaces`), unmatched paths (404s, scanner hits) collapse into a single `unmatched` sentinel, static files into `/assets/*`.
- Buckets cover sub-100ms latency (so dashboards have real p50/p95/p99 signal) up through 120s (for long-running query endpoints).
- Helper `getHttpUriLabel` is unit-tested across matched, unmatched, root, missing-baseUrl, asset, and scanner-path cases.

## Test plan

- [ ] CI: typecheck, lint, and unit tests pass
- [ ] With `LIGHTDASH_PROMETHEUS_EXTENDED_METRICS_ENABLED=false` (default), `/metrics` does NOT include `http_server_requests_seconds`
- [ ] With the flag enabled, hit a TSOA route with several different UUIDs and confirm they all collapse into the same `:projectUuid` series
- [ ] Hit some bogus paths (`/wp-admin`, `/.env`, random 404s) and confirm they all land under `uri="unmatched"` (no new series per request)
- [ ] Confirm bucket distribution shows requests across multiple sub-100ms buckets, not all stacked in the lowest bucket
- [ ] Same metric appears on the scheduler and NATS worker Prometheus ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)