### PR TITLE
fix: support viewing data apps on mobile

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -39,6 +39,7 @@ import { useAiAgentButtonVisibility } from './ee/features/aiCopilot/hooks/useAiA
 import { useActiveProjectUuid } from './hooks/useActiveProject';
 import useLogoutMutation from './hooks/user/useUserLogoutMutation';
 import { getMantineThemeOverride } from './mantineTheme';
+import AppPreviewTest from './pages/AppPreviewTest';
 import AuthPopupResult, {
     SuccessAuthPopupResult,
 } from './pages/AuthPopupResult';
@@ -204,6 +205,8 @@ const routesNotSupportedInMobile = [
     '/projects/:projectUuid/tables/:tableId',
     '/projects/:projectUuid/tables',
     '/projects/:projectUuid/user-activity',
+    '/projects/:projectUuid/apps/:appUuid',
+    '/projects/:projectUuid/apps/generate',
 ];
 
 const FALLBACK_ROUTE: RouteObject = {
@@ -340,6 +343,14 @@ const APP_ROUTES: RouteObject[] = [
                                 <MobileSpaces />
                             </TrackPage>
                         ),
+                    },
+                    {
+                        path: '/projects/:projectUuid/apps/:appUuid/preview',
+                        element: <AppPreviewTest />,
+                    },
+                    {
+                        path: '/projects/:projectUuid/apps/:appUuid/versions/:version/preview',
+                        element: <AppPreviewTest />,
                     },
                 ],
             },

--- a/packages/frontend/src/pages/MobileSpace.tsx
+++ b/packages/frontend/src/pages/MobileSpace.tsx
@@ -1,4 +1,6 @@
 import {
+    ContentType,
+    contentToResourceViewItem,
     ResourceViewItemType,
     spaceToResourceViewItem,
     wrapResourceView,
@@ -17,6 +19,7 @@ import ResourceView from '../components/common/ResourceView';
 import { ResourceSortDirection } from '../components/common/ResourceView/types';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
+import { useInfiniteContent } from '../hooks/useContent';
 import { useSpace, useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
 
@@ -31,6 +34,15 @@ const MobileSpace: FC = () => {
         error,
     } = useSpace(projectUuid, spaceUuid);
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true);
+    const { data: appsContent } = useInfiniteContent(
+        {
+            projectUuids: projectUuid ? [projectUuid] : [],
+            spaceUuids: spaceUuid ? [spaceUuid] : [],
+            contentTypes: [ContentType.DATA_APP],
+            pageSize: 100,
+        },
+        { enabled: !!projectUuid && !!spaceUuid },
+    );
     const { user } = useApp();
     const [search, setSearch] = useState<string>('');
     const visibleItems = useMemo(() => {
@@ -39,6 +51,10 @@ const MobileSpace: FC = () => {
         );
         const dashboardsInSpace = space?.dashboards || [];
         const chartsInSpace = space?.queries || [];
+        const appsInSpace =
+            appsContent?.pages.flatMap((page) =>
+                page.data.map(contentToResourceViewItem),
+            ) ?? [];
         const allItems = [
             ...wrapResourceView(
                 childSpaces.map(spaceToResourceViewItem),
@@ -49,6 +65,7 @@ const MobileSpace: FC = () => {
                 ResourceViewItemType.DASHBOARD,
             ),
             ...wrapResourceView(chartsInSpace, ResourceViewItemType.CHART),
+            ...appsInSpace,
         ];
         if (search && search !== '') {
             const matchingItems: ResourceViewItem[] = [];
@@ -62,7 +79,7 @@ const MobileSpace: FC = () => {
             return matchingItems;
         }
         return allItems;
-    }, [space, spaces, spaceUuid, search]);
+    }, [space, spaces, spaceUuid, appsContent, search]);
 
     if (user.data?.ability?.cannot('view', 'SavedChart')) {
         return <ForbiddenPanel />;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-447/i-cant-view-my-data-apps-on-mobile

### Description:
Mobile used a separate route tree without any data-app routes, so tapping a data-app card hit the catch-all and bounced back to /projects. Mobile spaces also rendered only charts/dashboards/sub-spaces, so apps were invisible unless pinned to home.

Add mobile routes for the data-app preview pages (the build/generate flows stay in `routesNotSupportedInMobile`) and include data apps in the MobileSpace listing via the v2 content API.

Before:

https://github.com/user-attachments/assets/8c78f7bc-993c-48a9-9143-da18288cb825



After:


https://github.com/user-attachments/assets/2d599bf1-db83-4cd4-b6cc-c7fc6e6bc5de

