### PR TITLE
feat(ai-agent): stream response by word with 20ms delay

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -737,8 +737,8 @@ export const streamAgentResponse = async ({
                 await cleanupMcpClients();
             },
             experimental_transform: smoothStream({
-                delayInMs: 40,
-                chunking: 'line',
+                delayInMs: 20,
+                chunking: 'word',
             }),
             onError: ({ error }) => {
                 console.error(error);


### PR DESCRIPTION
## Summary

Word-level chunking with a tighter cadence for the in-product AI agent's streaming response.

- `chunking: 'line'` → `'word'`
- `delayInMs: 40` → `20`

## Why

The line-by-line streaming introduced in #23122 chunks the response on `\n` and waits 40ms between flushes. For the agent's typical output — short prose blocks between tool calls — that often means the user stares at "Thinking…" until the entire block lands, then the whole block appears at once. Word chunking with a 20ms cadence reads as substantially more responsive without buffering more.

## Regression analysis

- **Wire load**: more frequent SSE flushes per response. The AI SDK's `smoothStream` transform already batches very small chunks, so the practical bytes-on-wire delta is small. Negligible cost on the backend.
- **UI rendering**: the frontend treats incoming text chunks as append-to-string, no per-chunk DOM thrash beyond what already happens.
- **Slack output**: Slack uses `updateSlackMessage` for streaming updates, which throttles independently. This change doesn't affect Slack's throttle cadence.
- **Reverts a recently-shipped change** (#23122 went the other direction). Reverting because the line cadence felt sluggish in practice; word cadence with halved delay strikes a better balance.

## Test plan

- [ ] Manual: ask the agent a question that produces a multi-sentence response. Confirm text streams in word-sized increments rather than landing in line-shaped chunks.
- [ ] Manual: confirm tool-call chips and reasoning rows still render in the right order around the streamed text.