### PR TITLE
feat(filters): allow locking dashboard filters when no tabs exist

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -981,6 +981,7 @@ export class EmbedService extends BaseService {
         // for the right tab. Tiles created before tabs may have null/undefined.
         const tile = dashboard.tiles.find((t) => t.uuid === tileUuid);
         const tileTabUuid = tile?.tabUuid ?? undefined;
+        const hasTabs = (dashboard.tabs?.length ?? 0) > 0;
 
         let effectiveFilters: DashboardFilters = dashboard.filters;
 
@@ -993,6 +994,7 @@ export class EmbedService extends BaseService {
                     dashboard.filters,
                     dashboardFilters,
                     tileTabUuid,
+                    hasTabs,
                 );
 
             if (droppedCount > 0) {
@@ -1002,14 +1004,14 @@ export class EmbedService extends BaseService {
             }
 
             const lockedDimensions = dashboard.filters.dimensions.filter(
-                (rule) => isFilterLockedOnTab(rule, tileTabUuid),
+                (rule) => isFilterLockedOnTab(rule, tileTabUuid, hasTabs),
             );
             const lockedMetrics = dashboard.filters.metrics.filter((rule) =>
-                isFilterLockedOnTab(rule, tileTabUuid),
+                isFilterLockedOnTab(rule, tileTabUuid, hasTabs),
             );
             const lockedTableCalculations =
                 dashboard.filters.tableCalculations.filter((rule) =>
-                    isFilterLockedOnTab(rule, tileTabUuid),
+                    isFilterLockedOnTab(rule, tileTabUuid, hasTabs),
                 );
 
             effectiveFilters = {

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -1263,6 +1263,7 @@ describe('stripOverridesForLockedFiltersOnTab', () => {
             saved,
             overrides,
             TAB_A,
+            true,
         );
         expect(result.filters.dimensions).toEqual([]);
         expect(result.droppedCount).toBe(1);
@@ -1287,6 +1288,7 @@ describe('stripOverridesForLockedFiltersOnTab', () => {
             saved,
             overrides,
             TAB_B,
+            true,
         );
         expect(result.filters.dimensions).toHaveLength(1);
         expect(result.droppedCount).toBe(0);
@@ -1311,6 +1313,7 @@ describe('stripOverridesForLockedFiltersOnTab', () => {
             saved,
             overrides,
             TAB_A,
+            true,
         );
         expect(result.filters.dimensions).toHaveLength(1);
         expect(result.droppedCount).toBe(0);
@@ -1335,6 +1338,7 @@ describe('stripOverridesForLockedFiltersOnTab', () => {
             saved,
             overrides,
             TAB_A,
+            true,
         );
         expect(result.filters.metrics).toHaveLength(1);
         expect(result.droppedCount).toBe(0);
@@ -1359,12 +1363,13 @@ describe('stripOverridesForLockedFiltersOnTab', () => {
             saved,
             overrides,
             TAB_A,
+            true,
         );
         expect(result.filters.dimensions).toHaveLength(1);
         expect(result.droppedCount).toBe(0);
     });
 
-    test('undefined tabUuid means nothing is stripped', () => {
+    test('tabbed dashboard with undefined tabUuid strips nothing (transient pre-selection state)', () => {
         const saved = {
             dimensions: [
                 makeRule('s-1', 'orders_status', 'orders', {
@@ -1383,6 +1388,7 @@ describe('stripOverridesForLockedFiltersOnTab', () => {
             saved,
             overrides,
             undefined,
+            true,
         );
         expect(result.filters.dimensions).toHaveLength(1);
         expect(result.droppedCount).toBe(0);
@@ -1403,8 +1409,18 @@ describe('stripOverridesForLockedFiltersOnTab', () => {
             metrics: [],
             tableCalculations: [],
         };
-        const a = stripOverridesForLockedFiltersOnTab(saved, overrides, TAB_A);
-        const b = stripOverridesForLockedFiltersOnTab(saved, overrides, TAB_B);
+        const a = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            TAB_A,
+            true,
+        );
+        const b = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            TAB_B,
+            true,
+        );
         expect(a.droppedCount).toBe(1);
         expect(b.droppedCount).toBe(1);
     });
@@ -1428,6 +1444,86 @@ describe('stripOverridesForLockedFiltersOnTab', () => {
             saved,
             overrides,
             TAB_A,
+            true,
+        );
+        expect(result.filters.dimensions).toHaveLength(1);
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('tab-less dashboard: any non-empty lockedTabUuids strips overrides', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: ['dashboard-uuid-as-sentinel'],
+                }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [
+                makeRule('o-1', 'orders_status', 'orders', {
+                    values: ['returned'],
+                }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            undefined,
+            false,
+        );
+        expect(result.filters.dimensions).toEqual([]);
+        expect(result.droppedCount).toBe(1);
+    });
+
+    test('tab-less dashboard: empty lockedTabUuids still does not strip', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: [],
+                }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'orders_status', 'orders')],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            undefined,
+            false,
+        );
+        expect(result.filters.dimensions).toHaveLength(1);
+        expect(result.droppedCount).toBe(0);
+    });
+
+    test('tab-less dashboard: non-target field is not affected by lock', () => {
+        const saved = {
+            dimensions: [
+                makeRule('s-1', 'orders_status', 'orders', {
+                    lockedTabUuids: ['dashboard-uuid-as-sentinel'],
+                }),
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const overrides = {
+            dimensions: [makeRule('o-1', 'orders_amount', 'orders')],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = stripOverridesForLockedFiltersOnTab(
+            saved,
+            overrides,
+            undefined,
+            false,
         );
         expect(result.filters.dimensions).toHaveLength(1);
         expect(result.droppedCount).toBe(0);

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -908,11 +908,15 @@ export const getDashboardFiltersForTile = (
     ]),
 });
 
+// When a dashboard has no tabs, the lock toggle stores the dashboard uuid as
+// a sentinel in lockedTabUuids — so any non-empty list means "locked".
 export const isFilterLockedOnTab = (
     rule: Pick<DashboardFilterRule, 'lockedTabUuids'>,
     tabUuid: string | undefined,
+    hasTabs: boolean,
 ): boolean => {
     if (!rule.lockedTabUuids || rule.lockedTabUuids.length === 0) return false;
+    if (!hasTabs) return true;
     if (!tabUuid) return false;
     return rule.lockedTabUuids.includes(tabUuid);
 };
@@ -920,10 +924,11 @@ export const isFilterLockedOnTab = (
 const buildLockedTargetKeysForTab = (
     rules: DashboardFilterRule[],
     tabUuid: string | undefined,
+    hasTabs: boolean,
 ): Set<string> => {
     const keys = new Set<string>();
     rules.forEach((rule) => {
-        if (isFilterLockedOnTab(rule, tabUuid)) {
+        if (isFilterLockedOnTab(rule, tabUuid, hasTabs)) {
             keys.add(`${rule.target.tableName}::${rule.target.fieldId}`);
         }
     });
@@ -956,25 +961,27 @@ export type StripOverridesForLockedFiltersResult = {
 
 /**
  * Drop override rules that target a field whose saved filter is locked on the
- * given tab. When `tabUuid` is undefined nothing is stripped — lock state only
- * applies when we know which tab is being evaluated.
+ * given tab. For tab-less dashboards (`hasTabs=false`) any non-empty
+ * `lockedTabUuids` is treated as a dashboard-wide lock. For tabbed dashboards
+ * `tabUuid` is required to decide; when undefined nothing is stripped.
  */
 export const stripOverridesForLockedFiltersOnTab = (
     saved: DashboardFilters,
     overrides: DashboardFilters,
     tabUuid: string | undefined,
+    hasTabs: boolean,
 ): StripOverridesForLockedFiltersResult => {
     const dimensions = dropRulesTargetingLockedFields(
         overrides.dimensions,
-        buildLockedTargetKeysForTab(saved.dimensions, tabUuid),
+        buildLockedTargetKeysForTab(saved.dimensions, tabUuid, hasTabs),
     );
     const metrics = dropRulesTargetingLockedFields(
         overrides.metrics,
-        buildLockedTargetKeysForTab(saved.metrics, tabUuid),
+        buildLockedTargetKeysForTab(saved.metrics, tabUuid, hasTabs),
     );
     const tableCalculations = dropRulesTargetingLockedFields(
         overrides.tableCalculations,
-        buildLockedTargetKeysForTab(saved.tableCalculations, tabUuid),
+        buildLockedTargetKeysForTab(saved.tableCalculations, tabUuid, hasTabs),
     );
     return {
         filters: {

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -78,6 +78,7 @@ const Filter: FC<Props> = ({
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const activeTab = useDashboardContext((c) => c.activeTab);
     const activeTabUuid = activeTab?.uuid;
+    const hasTabs = (dashboardTabs?.length ?? 0) > 0;
     const allFilterableFields = useDashboardContext(
         (c) => c.allFilterableFields,
     );
@@ -86,22 +87,26 @@ const Filter: FC<Props> = ({
     );
     const isLockFilterEnabled =
         lockDashboardFiltersFlag?.enabled ?? import.meta.env.DEV;
-    const isLockedOnActiveTab = isFilterLockedOnTab(filterRule, activeTabUuid);
+    const isLocked = isFilterLockedOnTab(filterRule, activeTabUuid, hasTabs);
     const { track } = useTracking();
     const handleLockToggle = useCallback(
         (e: MouseEvent) => {
             e.stopPropagation();
-            if (!activeTabUuid) return;
+            // On tab-less dashboards we store the dashboard uuid as a sentinel
+            // in lockedTabUuids so the same shape can express "locked
+            // everywhere on this dashboard" without a schema change.
+            const lockKey = hasTabs ? activeTabUuid : dashboard?.uuid;
+            if (!lockKey) return;
             const existing = filterRule.lockedTabUuids ?? [];
-            const nextTabUuids = isLockedOnActiveTab
-                ? existing.filter((uuid) => uuid !== activeTabUuid)
-                : [...existing, activeTabUuid];
+            const nextTabUuids = isLocked
+                ? existing.filter((uuid) => uuid !== lockKey)
+                : [...existing, lockKey];
             track({
                 name: EventName.DASHBOARD_FILTER_LOCK_TOGGLED,
                 properties: {
-                    action: isLockedOnActiveTab ? 'unlock' : 'lock',
+                    action: isLocked ? 'unlock' : 'lock',
                     dashboardUuid: dashboard?.uuid,
-                    tabUuid: activeTabUuid,
+                    tabUuid: hasTabs ? activeTabUuid : undefined,
                     fieldId: filterRule.target.fieldId,
                     tableName: filterRule.target.tableName,
                 },
@@ -115,8 +120,9 @@ const Filter: FC<Props> = ({
         [
             activeTabUuid,
             dashboard?.uuid,
+            hasTabs,
             filterRule,
-            isLockedOnActiveTab,
+            isLocked,
             onUpdate,
             track,
         ],
@@ -240,7 +246,7 @@ const Filter: FC<Props> = ({
     const hasUnsetRequiredFilter =
         filterRule.required && !hasFilterValueSet(filterRule);
 
-    const isReadOnlyLocked = isLockedOnActiveTab && !isEditMode && !isTemporary;
+    const isReadOnlyLocked = isLocked && !isEditMode && !isTemporary;
 
     const handleClose = useCallback(() => {
         if (isPopoverOpen) onPopoverClose();
@@ -339,10 +345,12 @@ const Filter: FC<Props> = ({
                                         {isLockFilterEnabled &&
                                             isEditMode &&
                                             !isTemporary &&
-                                            activeTabUuid && (
+                                            (hasTabs
+                                                ? activeTabUuid
+                                                : !!dashboard?.uuid) && (
                                                 <span
                                                     className={
-                                                        isLockedOnActiveTab
+                                                        isLocked
                                                             ? classes.lockSlotActive
                                                             : classes.lockSlot
                                                     }
@@ -350,9 +358,13 @@ const Filter: FC<Props> = ({
                                                     <Tooltip
                                                         fz="xs"
                                                         label={
-                                                            isLockedOnActiveTab
-                                                                ? 'Unlock filter on this tab'
-                                                                : 'Lock filter on this tab'
+                                                            isLocked
+                                                                ? hasTabs
+                                                                    ? 'Unlock filter on this tab'
+                                                                    : 'Unlock filter'
+                                                                : hasTabs
+                                                                  ? 'Lock filter on this tab'
+                                                                  : 'Lock filter'
                                                         }
                                                         withinPortal
                                                     >
@@ -365,15 +377,19 @@ const Filter: FC<Props> = ({
                                                             radius="xl"
                                                             variant="subtle"
                                                             aria-label={
-                                                                isLockedOnActiveTab
-                                                                    ? 'Unlock filter on this tab'
-                                                                    : 'Lock filter on this tab'
+                                                                isLocked
+                                                                    ? hasTabs
+                                                                        ? 'Unlock filter on this tab'
+                                                                        : 'Unlock filter'
+                                                                    : hasTabs
+                                                                      ? 'Lock filter on this tab'
+                                                                      : 'Lock filter'
                                                             }
                                                         >
                                                             <MantineIcon
                                                                 size="sm"
                                                                 icon={
-                                                                    isLockedOnActiveTab
+                                                                    isLocked
                                                                         ? IconLock
                                                                         : IconLockOpen
                                                                 }
@@ -382,12 +398,16 @@ const Filter: FC<Props> = ({
                                                     </Tooltip>
                                                 </span>
                                             )}
-                                        {!isEditMode && isLockedOnActiveTab && (
+                                        {!isEditMode && isLocked && (
                                             <span
                                                 className={
                                                     classes.lockSlotActive
                                                 }
-                                                aria-label="Filter is locked on this tab"
+                                                aria-label={
+                                                    hasTabs
+                                                        ? 'Filter is locked on this tab'
+                                                        : 'Filter is locked'
+                                                }
                                             >
                                                 <MantineIcon
                                                     size="sm"

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -743,6 +743,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                         filterableFieldsByTileUuid,
                     ),
                 );
+                const hasTabs = (currentDashboard.tabs?.length ?? 0) > 0;
                 const sdkStripResult = stripOverridesForLockedFiltersOnTab(
                     currentDashboard.filters,
                     {
@@ -751,6 +752,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                         tableCalculations: [],
                     },
                     activeTab?.uuid,
+                    hasTabs,
                 );
                 droppedLockedOverrides += sdkStripResult.droppedCount;
                 // SDK filters replace embedded dashboard filters, but
@@ -761,7 +763,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 // server-side.
                 const lockedSavedDimensions =
                     currentDashboard.filters.dimensions.filter((rule) =>
-                        isFilterLockedOnTab(rule, activeTab?.uuid),
+                        isFilterLockedOnTab(rule, activeTab?.uuid, hasTabs),
                     );
                 updatedDashboardFilters.dimensions = [
                     ...lockedSavedDimensions,
@@ -770,12 +772,13 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             }
 
             // Apply overrides from URL — but never override filters locked on
-            // the currently active tab.
+            // the currently active tab (or dashboard-wide if there are no tabs).
             if (hasSavedFiltersOverrides(overrides)) {
                 const urlStripResult = stripOverridesForLockedFiltersOnTab(
                     currentDashboard.filters,
                     overrides,
                     activeTab?.uuid,
+                    (currentDashboard.tabs?.length ?? 0) > 0,
                 );
                 overrides = urlStripResult.filters;
                 droppedLockedOverrides += urlStripResult.droppedCount;
@@ -862,21 +865,29 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             dashboard.filters,
             dashboardTemporaryFilters,
             activeTab?.uuid,
+            (dashboard.tabs?.length ?? 0) > 0,
         );
-    }, [dashboard?.filters, dashboardTemporaryFilters, activeTab]);
+    }, [
+        dashboard?.filters,
+        dashboard?.tabs,
+        dashboardTemporaryFilters,
+        activeTab,
+    ]);
 
     useEffect(() => {
         if (lockedTemporaryDroppedCount === 0) return;
         if (hasNotifiedLockedOverrideRef.current) return;
         hasNotifiedLockedOverrideRef.current = true;
+        const hasTabs = (dashboard?.tabs?.length ?? 0) > 0;
+        const scopeSuffix = hasTabs ? ' on this tab' : '';
         showToastInfo({
             title: 'Locked dashboard filter',
             subtitle:
                 lockedTemporaryDroppedCount === 1
-                    ? 'A temporary filter was ignored because the dashboard editor locked it on this tab.'
-                    : `${lockedTemporaryDroppedCount} temporary filters were ignored because the dashboard editor locked them on this tab.`,
+                    ? `A temporary filter was ignored because the dashboard editor locked it${scopeSuffix}.`
+                    : `${lockedTemporaryDroppedCount} temporary filters were ignored because the dashboard editor locked them${scopeSuffix}.`,
         });
-    }, [lockedTemporaryDroppedCount, showToastInfo]);
+    }, [lockedTemporaryDroppedCount, showToastInfo, dashboard?.tabs]);
 
     // Updates url with temp and overridden filters and deep compare to avoid unnecessary re-renders for dashboardTemporaryFilters
     // Only sync URL in regular dashboards or 'direct' embed mode (not 'sdk' mode)
@@ -947,6 +958,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                     dashboard.filters,
                     overridesForSavedDashboardFilters,
                     activeTab?.uuid,
+                    (dashboard.tabs?.length ?? 0) > 0,
                 );
 
             if (!hasSavedFiltersOverrides(safeOverrides)) {
@@ -976,7 +988,12 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 return updated;
             });
         }
-    }, [dashboard?.filters, overridesForSavedDashboardFilters, activeTab]);
+    }, [
+        dashboard?.filters,
+        dashboard?.tabs,
+        overridesForSavedDashboardFilters,
+        activeTab,
+    ]);
 
     // Gets filters and dateZoom from URL and storage after redirect
     useMount(() => {


### PR DESCRIPTION
## Summary

Follow-up to #23106 (per-tab dashboard filter locking). The per-tab refactor keyed every lock off `activeTabUuid`, which meant that on dashboards with **no tabs** the lock toggle never rendered and the strip helpers silently no-oped — so the entire feature was unavailable for tab-less dashboards.

This PR extends the existing shape so the lock works in both cases, without a schema or type change.

- `isFilterLockedOnTab` and `stripOverridesForLockedFiltersOnTab` take a new `hasTabs` arg. When `hasTabs=false`, any non-empty `lockedTabUuids` is treated as a dashboard-wide lock.
- The lock toggle now renders on tab-less dashboards and writes the **dashboard uuid** into `lockedTabUuids` as a sentinel. Tabbed dashboards keep per-tab semantics unchanged.
- Tooltip / aria-label / toast subtitle drop the "on this tab" suffix when there are no tabs.
- All call sites (`DashboardProvider`, `EmbedService`) pass `hasTabs`.

## Test plan

- [x] `pnpm -F common typecheck` / `pnpm -F frontend typecheck` / `pnpm -F backend typecheck` — all clean
- [x] `pnpm -F common test` — 2032 passed (3 new `stripOverridesForLockedFiltersOnTab` cases for the no-tabs path; existing per-tab cases updated to pass `hasTabs=true`)
- [x] `pnpm exec jest EmbedService` — 11 passed
- [x] Lint clean on all 5 modified files
- [ ] **Tabbed dashboard regression check:** lock toggle still scoped to the active tab; switching tabs shows/hides the lock indicator as before
- [ ] **Tab-less dashboard (e.g. seed "Filter Tests Dashboard"):**
  - [ ] In edit mode, the lock icon appears on a filter chip with tooltip "Lock filter"
  - [ ] Toggling persists to `lockedTabUuids` containing the dashboard uuid
  - [ ] In view mode, the read-only lock badge renders
  - [ ] URL filter overrides for that field are stripped and a toast notification shows
  - [ ] SDK / temporary filter overrides for that field are also stripped
- [ ] **Embed (server-side):** locked saved filters survive when an embed consumer sends overrides on a tab-less dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)