### PR TITLE
fix(spaces): include chain-inherited spaces under "Shared with me"

### DIFF
--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -18,7 +18,10 @@ type SpaceSelectorProps = {
     selectedSpaceUuid: string | null;
     spaces:
         | Array<
-              Pick<SpaceSummary, 'inheritsFromOrgOrProject' | 'access'> &
+              Pick<
+                  SpaceSummary,
+                  'inheritsFromOrgOrProject' | 'access' | 'userAccess'
+              > &
                   NestableItem
           >
         | undefined;
@@ -62,9 +65,7 @@ const SpaceSelector = ({
                 // tree as non-selectable placeholders so hierarchy is preserved
                 // and same-named children remain visually distinguishable.
                 return spaces.map((space) => {
-                    const isAccessible =
-                        space.inheritsFromOrgOrProject ||
-                        space.access.includes(user.data.userUuid);
+                    const isAccessible = space.userAccess;
                     if (isAccessible) return space;
                     return { ...space, restricted: true };
                 });


### PR DESCRIPTION
Closes: ZAP-404

## Summary

In the space selector tree, admins toggling the "Shared with me" filter saw spaces they actually had access to rendered as restricted (non-selectable) placeholders. The bug only affected spaces a user reached via parent inheritance — e.g. a private parent shared with a group, with a child that inherits permissions.

## Root cause

The "Shared with me" filter checked accessibility by looking at the leaf space in isolation:

```ts
const isAccessible =
    space.inheritsFromOrgOrProject ||
    space.access.includes(user.data.userUuid);
```

`space.access` only contains direct user grants on that one space (plus group-expansion on the leaf). It does not reflect access granted on an ancestor space and inherited downward. So a user who could view a child space purely because they were a member of a group shared on the grandparent would be missing from `space.access` and marked restricted.

```
Private root (shared with group G)
    └── Child (inherits)        <-- user in G has access via the chain
            └── Grandchild      <-- but space.access here is empty
```

## Fix

Switch the check to `space.userAccess` — the chain-aware resolved access that `ProjectService` already attaches to every `SpaceSummary` by walking the parent chain. It is `undefined` when the user only has admin-override access on a private space, so the admin-vs-member distinction the filter relies on is preserved.

- `packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx` — replace direct `access`-list lookup with `userAccess` truthiness; widen the `Pick<SpaceSummary, ...>` to include `userAccess`.

## Test plan

- [ ] `pnpm -F frontend typecheck && pnpm -F frontend lint`
- [ ] As an admin, share a private space with a group, add a child space that inherits, sign in as a group member, open the space selector, toggle "Shared with me" — the child is selectable, not restricted.
- [ ] As an admin on a private space the admin is not explicitly a member of, "Shared with me" still hides it (admin-override is not counted as shared).
- [ ] Regular (non-admin) user flow is unchanged — the filter is hidden for them.