### PR TITLE
feat(cli): support --combine-manifest on deploy

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -876,6 +876,10 @@ program
     )
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
     .option(
+        '--combine-manifest <path>',
+        'Path to an additional dbt manifest.json. Models present in this file but missing from the deploy manifest are merged in so the deploy includes the full project. The deploy-generated manifest always wins on conflicts.',
+    )
+    .option(
         '--start-of-week <number>',
         'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
         parseStartOfWeekArgument,


### PR DESCRIPTION
## Summary
- Adds the `--combine-manifest <path>` flag to the `deploy` command. It was already wired up on `preview` and `start-preview` but missing from `deploy`, even though all the underlying plumbing (`DbtCompileOptions.combineManifest`, the merge logic in `compile()` at [packages/cli/src/handlers/compile.ts:235](https://github.com/lightdash/lightdash/blob/main/packages/cli/src/handlers/compile.ts#L235)) already exists.
- Pure Commander option declaration — no behavior change for users who don't pass the flag.

## Test plan
- [ ] `lightdash deploy --help` shows the new option
- [ ] `lightdash deploy --combine-manifest /path/to/manifest.json …` merges models from the external manifest into the deploy, with the deploy-generated manifest winning on conflicts
- [ ] `lightdash deploy` (without the flag) behaves identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)