### PR TITLE
feat: add `PivotColumnSort` feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -147,6 +147,16 @@ export enum FeatureFlags {
      * if the flag is later turned off.
      */
     LockDashboardFilters = 'lock-dashboard-filters',
+
+    /**
+     * Enable the new pivot-column-sort UI: per-pivot-column sort menu on
+     * pivot table headers, sort-direction indicators, and the pinned
+     * pivot-column entries in the Sort popover. Backend support
+     * (per-metric anchor CTE, pivot_values persistence) is always on;
+     * this flag only gates the UI/UX so we can validate with design
+     * partners before announcing GA.
+     */
+    PivotColumnSort = 'pivot-column-sort',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
Closes:

### Description:
Adds a new `PivotColumnSort` feature flag (`'pivot-column-sort'`) that gates the pivot column sort UI/UX. This includes the per-pivot-column sort menu on pivot table headers, sort-direction indicators, and the pinned pivot-column entries in the Sort popover. The backend support (per-metric anchor CTE and `pivot_values` persistence) remains always enabled — this flag exists solely to control the frontend experience so it can be validated with design partners before a GA announcement.