### PR TITLE
fix(spaces): show org and project admins in space access list

### DIFF
--- a/packages/api-tests/tests/serviceAccounts.test.ts
+++ b/packages/api-tests/tests/serviceAccounts.test.ts
@@ -672,6 +672,14 @@ describe('Service Account content attribution', () => {
         ]);
         const sa = bearerClient(token);
 
+        // Resolve the SA's dedicated user_uuid so we can match it against
+        // the space's access list.
+        const whoamiResp = await sa.get<Body<{ userUuid: string }>>(
+            `${apiUrl}/user`,
+        );
+        expect(whoamiResp.status).toBe(200);
+        const saUserUuid = whoamiResp.body.results.userUuid;
+
         const createResp = await sa.post<Body<{ uuid: string; name: string }>>(
             `${apiUrl}/projects/${projectUuid}/spaces`,
             {
@@ -685,18 +693,27 @@ describe('Service Account content attribution', () => {
         const detailResp = await admin.get<
             Body<{
                 uuid: string;
-                createdByUserUuid?: string;
-                userId?: number;
-                pinnedListUuid?: string | null;
-                access?: Array<{ userUuid: string }>;
+                access?: Array<{
+                    userUuid: string;
+                    hasDirectAccess: boolean;
+                }>;
             }>
         >(`${apiUrl}/projects/${projectUuid}/spaces/${spaceUuid}`);
         expect(detailResp.status).toBe(200);
-        // The seeded admin should NOT be the recorded creator anymore — the
-        // SA's own dedicated user row is.
         const access = detailResp.body.results.access ?? [];
-        const accessUuids = access.map((a) => a.userUuid);
-        expect(accessUuids).not.toContain(SEED_ORG_1_ADMIN.user_uuid);
+
+        // The SA is the sole direct-access entry — they are the creator.
+        // The seeded admin may surface as an auto-merged org admin
+        // (hasDirectAccess: false) but must not be a direct share.
+        const directEntries = access.filter((a) => a.hasDirectAccess);
+        expect(directEntries.map((a) => a.userUuid)).toEqual([saUserUuid]);
+
+        const adminEntry = access.find(
+            (a) => a.userUuid === SEED_ORG_1_ADMIN.user_uuid,
+        );
+        if (adminEntry !== undefined) {
+            expect(adminEntry.hasDirectAccess).toBe(false);
+        }
     });
 });
 

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -539,6 +539,83 @@ describe('SpacePermissionService', () => {
                 service.getAllSpaceAccessContext(spaceUuid),
             ).rejects.toThrow(NotFoundError);
         });
+
+        test('returns admins extracted from project and org access, org wins over project on dedup', async () => {
+            const spaceUuid = 'private-space';
+
+            mockPermissionModel.getInheritanceChains.mockResolvedValue({
+                [spaceUuid]: {
+                    chain: [
+                        {
+                            spaceUuid,
+                            spaceName: 'Private',
+                            inheritParentPermissions: false,
+                        },
+                    ],
+                    inheritsFromOrgOrProject: false,
+                },
+            });
+            mockPermissionModel.getDirectSpaceAccess.mockResolvedValue({});
+            mockPermissionModel.getProjectSpaceAccess.mockResolvedValue({
+                [spaceUuid]: [
+                    {
+                        userUuid: 'project-admin',
+                        spaceUuid,
+                        role: 'admin' as ProjectMemberRole,
+                        from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
+                    },
+                    {
+                        userUuid: 'dual-admin',
+                        spaceUuid,
+                        role: 'admin' as ProjectMemberRole,
+                        from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
+                    },
+                    {
+                        userUuid: 'editor-user',
+                        spaceUuid,
+                        role: 'editor' as ProjectMemberRole,
+                        from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
+                    },
+                ],
+            });
+            mockPermissionModel.getOrganizationSpaceAccess.mockResolvedValue({
+                [spaceUuid]: [
+                    {
+                        userUuid: 'org-admin',
+                        spaceUuid,
+                        role: 'admin' as OrganizationMemberRole,
+                    },
+                    {
+                        userUuid: 'dual-admin',
+                        spaceUuid,
+                        role: 'admin' as OrganizationMemberRole,
+                    },
+                    {
+                        userUuid: 'org-member',
+                        spaceUuid,
+                        role: 'member' as OrganizationMemberRole,
+                    },
+                ],
+            });
+            mockPermissionModel.getSpaceInfo.mockResolvedValue({
+                [spaceUuid]: { projectUuid, organizationUuid },
+            });
+
+            const result = await service.getAllSpaceAccessContext(spaceUuid);
+
+            // dual-admin is in both lists; org source wins
+            expect(result.admins).toEqual(
+                expect.arrayContaining([
+                    { userUuid: 'org-admin', source: 'organization' },
+                    { userUuid: 'dual-admin', source: 'organization' },
+                    { userUuid: 'project-admin', source: 'project' },
+                ]),
+            );
+            expect(result.admins).toHaveLength(3);
+            expect(
+                result.admins.find((a) => a.userUuid === 'dual-admin')?.source,
+            ).toBe('organization');
+        });
     });
 
     describe('getInheritedPermissionsToCopy', () => {

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -2,6 +2,8 @@ import { subject } from '@casl/ability';
 import {
     getHighestSpaceRole,
     NotFoundError,
+    OrganizationMemberRole,
+    ProjectMemberRole,
     resolveSpaceAccess,
     type AbilityAction,
     type OrganizationSpaceAccess,
@@ -15,11 +17,19 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { SpacePermissionModel } from '../../models/SpacePermissionModel';
 import { BaseService } from '../BaseService';
 
+export type SpaceAdmin = {
+    userUuid: string;
+    source: 'organization' | 'project';
+};
+
 export type SpaceAccessContextForCasl = {
     organizationUuid: string;
     projectUuid: string;
     inheritsFromOrgOrProject: boolean;
     access: SpaceAccess[];
+    // Admins reach the space via CASL even when `resolveSpaceAccess` omits
+    // them (private spaces with no direct entry). Surfaced for audit display.
+    admins: SpaceAdmin[];
 };
 
 export class SpacePermissionService extends BaseService {
@@ -238,11 +248,30 @@ export class SpacePermissionService extends BaseService {
                 organizationAccess: orgAccess,
             });
 
+            // Build the admin map project-first, then overwrite with org —
+            // org source wins on dedup.
+            const adminSource = new Map<string, SpaceAdmin['source']>();
+            for (const a of projectAccess) {
+                if (a.role === ProjectMemberRole.ADMIN) {
+                    adminSource.set(a.userUuid, 'project');
+                }
+            }
+            for (const a of orgAccess) {
+                if (a.role === OrganizationMemberRole.ADMIN) {
+                    adminSource.set(a.userUuid, 'organization');
+                }
+            }
+            const admins: SpaceAdmin[] = Array.from(
+                adminSource,
+                ([userUuid, source]) => ({ userUuid, source }),
+            );
+
             result[spaceUuid] = {
                 organizationUuid: space.organizationUuid,
                 projectUuid: space.projectUuid,
                 inheritsFromOrgOrProject,
                 access,
+                admins,
             };
         }
         return result;

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -954,6 +954,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
             projectUuid: 'project-uuid',
             inheritsFromOrgOrProject: true,
             access: [],
+            admins: [],
         });
         mockSpacePermissionService.getGroupAccess.mockResolvedValue([]);
         mockSpacePermissionService.getUserMetadataByUuids.mockResolvedValue({});
@@ -1230,5 +1231,158 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
         expect(
             mockSpaceModel.updateWithCopiedPermissions,
         ).not.toHaveBeenCalled();
+    });
+
+    test('getSpace surfaces org/project admins missing from resolver output', async () => {
+        // Restricted space: resolver returns one direct user, no admins
+        mockSpacePermissionService.getAllSpaceAccessContext.mockResolvedValue({
+            organizationUuid: 'org-uuid',
+            projectUuid: 'project-uuid',
+            inheritsFromOrgOrProject: false,
+            access: [
+                {
+                    userUuid: 'direct-user',
+                    role: SpaceMemberRole.EDITOR,
+                    hasDirectAccess: true,
+                    projectRole: undefined,
+                    inheritedRole: undefined,
+                    inheritedFrom: undefined,
+                },
+            ],
+            // CASL-only admins that resolveSpaceAccess intentionally drops
+            admins: [
+                { userUuid: 'org-admin', source: 'organization' },
+                { userUuid: 'project-admin', source: 'project' },
+            ],
+        });
+        mockSpacePermissionService.getUserMetadataByUuids.mockResolvedValue({
+            'direct-user': {
+                firstName: 'Direct',
+                lastName: 'User',
+                email: 'direct@example.com',
+            },
+            'org-admin': {
+                firstName: 'Org',
+                lastName: 'Admin',
+                email: 'orgadmin@example.com',
+            },
+            'project-admin': {
+                firstName: 'Project',
+                lastName: 'Admin',
+                email: 'projectadmin@example.com',
+            },
+        });
+
+        const result = await service.getSpace(
+            'project-uuid',
+            mockUser as unknown as SessionUser,
+            'space-uuid',
+        );
+
+        expect(result.access).toHaveLength(3);
+        expect(result.access).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    userUuid: 'direct-user',
+                    hasDirectAccess: true,
+                }),
+                expect.objectContaining({
+                    userUuid: 'org-admin',
+                    role: SpaceMemberRole.ADMIN,
+                    hasDirectAccess: false,
+                    inheritedFrom: 'organization',
+                    firstName: 'Org',
+                    email: 'orgadmin@example.com',
+                }),
+                expect.objectContaining({
+                    userUuid: 'project-admin',
+                    role: SpaceMemberRole.ADMIN,
+                    hasDirectAccess: false,
+                    inheritedFrom: 'project',
+                    firstName: 'Project',
+                }),
+            ]),
+        );
+    });
+
+    test('getSpace keeps direct role when admin user also has a direct entry', async () => {
+        mockSpacePermissionService.getAllSpaceAccessContext.mockResolvedValue({
+            organizationUuid: 'org-uuid',
+            projectUuid: 'project-uuid',
+            inheritsFromOrgOrProject: false,
+            access: [
+                {
+                    userUuid: 'org-admin',
+                    role: SpaceMemberRole.EDITOR,
+                    hasDirectAccess: true,
+                    projectRole: undefined,
+                    inheritedRole: undefined,
+                    inheritedFrom: undefined,
+                },
+            ],
+            admins: [{ userUuid: 'org-admin', source: 'organization' }],
+        });
+        mockSpacePermissionService.getUserMetadataByUuids.mockResolvedValue({
+            'org-admin': {
+                firstName: 'Org',
+                lastName: 'Admin',
+                email: 'orgadmin@example.com',
+            },
+        });
+
+        const result = await service.getSpace(
+            'project-uuid',
+            mockUser as unknown as SessionUser,
+            'space-uuid',
+        );
+
+        expect(result.access).toHaveLength(1);
+        expect(result.access[0]).toEqual(
+            expect.objectContaining({
+                userUuid: 'org-admin',
+                role: SpaceMemberRole.EDITOR,
+                hasDirectAccess: true,
+            }),
+        );
+    });
+
+    test('getSpace does not duplicate admins already present in resolver output', async () => {
+        mockSpacePermissionService.getAllSpaceAccessContext.mockResolvedValue({
+            organizationUuid: 'org-uuid',
+            projectUuid: 'project-uuid',
+            inheritsFromOrgOrProject: true,
+            access: [
+                {
+                    userUuid: 'org-admin',
+                    role: SpaceMemberRole.ADMIN,
+                    hasDirectAccess: false,
+                    projectRole: ProjectMemberRole.ADMIN,
+                    inheritedRole: OrganizationMemberRole.ADMIN,
+                    inheritedFrom: 'organization',
+                },
+            ],
+            admins: [{ userUuid: 'org-admin', source: 'organization' }],
+        });
+        mockSpacePermissionService.getUserMetadataByUuids.mockResolvedValue({
+            'org-admin': {
+                firstName: 'Org',
+                lastName: 'Admin',
+                email: 'orgadmin@example.com',
+            },
+        });
+
+        const result = await service.getSpace(
+            'project-uuid',
+            mockUser as unknown as SessionUser,
+            'space-uuid',
+        );
+
+        expect(result.access).toHaveLength(1);
+        expect(result.access[0]).toEqual(
+            expect.objectContaining({
+                userUuid: 'org-admin',
+                role: SpaceMemberRole.ADMIN,
+            }),
+        );
     });
 });

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -6,7 +6,9 @@ import {
     ForbiddenError,
     getHighestSpaceRole,
     NotFoundError,
+    OrganizationMemberRole,
     ParameterError,
+    ProjectMemberRole,
     SessionUser,
     Space,
     SpaceDeleteImpact,
@@ -157,12 +159,32 @@ export class SpaceService
             hasAccess: accessibleUuids.has(b.uuid),
         }));
 
+        // `resolveSpaceAccess` drops admins from restricted spaces; re-add
+        // them for audit display. A user already in `ctx.access` keeps the
+        // role they were granted directly — admin powers come via CASL.
+        const existingAccessUuids = new Set(ctx.access.map((a) => a.userUuid));
+        const adminAccess: SpaceAccess[] = ctx.admins
+            .filter((admin) => !existingAccessUuids.has(admin.userUuid))
+            .map((admin) => ({
+                userUuid: admin.userUuid,
+                role: SpaceMemberRole.ADMIN,
+                hasDirectAccess: false,
+                projectRole: ProjectMemberRole.ADMIN,
+                inheritedRole:
+                    admin.source === 'organization'
+                        ? OrganizationMemberRole.ADMIN
+                        : ProjectMemberRole.ADMIN,
+                inheritedFrom: admin.source,
+            }));
+
+        const allAccess: SpaceAccess[] = [...ctx.access, ...adminAccess];
+
         const userInfoMap =
             await this.spacePermissionService.getUserMetadataByUuids(
-                ctx.access.map((a) => a.userUuid),
+                allAccess.map((a) => a.userUuid),
             );
 
-        const access: SpaceShare[] = ctx.access.map((a) => ({
+        const access: SpaceShare[] = allAccess.map((a) => ({
             ...a,
             firstName: userInfoMap[a.userUuid]?.firstName ?? '',
             lastName: userInfoMap[a.userUuid]?.lastName ?? '',


### PR DESCRIPTION
Closes: ZAP-404

## Summary

The space access list (powering the share modal and audit view) under-reported who could reach a restricted space: org admins and project admins were silently missing unless they also had a direct space grant. On private spaces with only one explicit member, the API returned just that member, even though every org/project admin still had full access via CASL.

## Root cause

`getAllSpaceAccessContext` calls `resolveSpaceAccess`, which intentionally drops org/project admins from restricted spaces because their access comes from CASL, not from a stored space ACL row. `SpaceService.getSpace` then mapped only `ctx.access` into `SpaceShare[]`, so the audit view inherited the same blind spot.

```ts
// SpaceService.ts — before
const access: SpaceShare[] = ctx.access.map((a) => ({ ... }));
```

The admins were never absent from the system — they were absent from the *display* of the system. The resolver was correct for permission checks but wrong as a source of truth for "who has access."

## Fix

`SpacePermissionService` now computes an `admins: SpaceAdmin[]` list alongside `access`, gathered from the same project/org access rows it already loads (no extra DB calls). `SpaceService.getSpace` merges those admins into the returned access list as synthetic `ADMIN` entries, skipping any user who already appears in `ctx.access` so direct roles are preserved.

- `SpacePermissionService.ts` - add `SpaceAdmin` type and `admins` field; org source wins over project on dedup.
- `SpaceService.ts` - splice admins into the access list with `inheritedFrom` set to `organization` or `project`; keep direct entries untouched.
- Tests cover three cases: admins surfaced when missing, direct role preserved when an admin also has a direct entry, and no duplication when the resolver already returned the admin.

## How the access list is built

```
getSpace(spaceUuid)
   |
   v
+-----------------------------+      +------------------------------+
| ctx.access                  |      | ctx.admins                   |
| (resolveSpaceAccess output) |      | (org/project admin rows)     |
|                             |      |                              |
| - direct grants             |      | - org-admin    -> organization|
| - inherited non-admin roles |      | - project-admin -> project    |
+-----------------------------+      +------------------------------+
              \\                            /
               \\   skip admins already    /
                \\  present in ctx.access /
                 v                       v
            +-------------------------------+
            | merged SpaceShare[]           |
            | (returned to share modal)     |
            +-------------------------------+
```

Dedup order inside `ctx.admins`: project first, then org overwrites - so a user who is both an org admin and a project admin reports `inheritedFrom: 'organization'`.

## Test plan

- [x] \`pnpm -F backend typecheck && pnpm -F backend lint\`
- [x] \`npx jest SpacePermissionService SpaceService\` - new regressions pass:
  - \`returns admins extracted from project and org access, org wins over project on dedup\`
  - \`getSpace surfaces org/project admins missing from resolver output\`
  - \`getSpace keeps direct role when admin user also has a direct entry\`
  - \`getSpace does not duplicate admins already present in resolver output\`
- [ ] Manual: open a private space's share modal as an org admin - confirm all org and project admins appear with the correct \`inheritedFrom\` label
- [ ] Manual: confirm a user with a direct \`EDITOR\` grant who is also an org admin still shows as \`EDITOR\` (direct role wins)