### PR TITLE
feat: pivot-aware sort identity and column sort UI improvements

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -14,6 +14,7 @@ import {
     isPeriodOverPeriodAdditionalMetric,
     isTableCalculation,
     isTimeBasedDimension,
+    type SortField,
     type TableCalculation,
 } from '@lightdash/common';
 import { ActionIcon, Box, Group, Menu, Text } from '@mantine-8/core';
@@ -44,6 +45,7 @@ import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useCannotAuthorCustomSql } from '../../../hooks/user/useCannotAuthorCustomSql';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import { SortDirection } from '../../../utils/sortUtils';
 import { BetaBadge } from '../../common/BetaBadge';
 import MantineIcon from '../../common/MantineIcon';
 import { type HeaderProps, type TableColumn } from '../../common/Table/types';
@@ -106,6 +108,20 @@ const ContextMenu: FC<ContextMenuProps> = ({
     const isPopAdditionalMetric =
         isPeriodOverPeriodAdditionalMetric(additionalMetric);
 
+    const sortSelectedDirection = sort
+        ? sort.descending
+            ? SortDirection.DESC
+            : SortDirection.ASC
+        : undefined;
+    const onSortSelect = (direction: SortDirection) => {
+        if (!item) return;
+        const newSort: SortField = {
+            fieldId: getItemId(item),
+            descending: direction === SortDirection.DESC,
+        };
+        dispatch(explorerActions.setSortFields([newSort]));
+    };
+
     if (item && isField(item)) {
         const itemFieldId = getItemId(item);
         return (
@@ -160,7 +176,11 @@ const ContextMenu: FC<ContextMenuProps> = ({
 
                 {!isPopAdditionalMetric && (
                     <>
-                        <ColumnHeaderSortMenuOptions item={item} sort={sort} />
+                        <ColumnHeaderSortMenuOptions
+                            item={item}
+                            selectedDirection={sortSelectedDirection}
+                            onSelect={onSortSelect}
+                        />
                         <Menu.Divider />
                     </>
                 )}
@@ -278,7 +298,11 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     </>
                 )}
 
-                <ColumnHeaderSortMenuOptions item={item} sort={sort} />
+                <ColumnHeaderSortMenuOptions
+                    item={item}
+                    selectedDirection={sortSelectedDirection}
+                    onSelect={onSortSelect}
+                />
 
                 {!hideRemove && (
                     <>
@@ -334,7 +358,11 @@ const ContextMenu: FC<ContextMenuProps> = ({
 
                 <Menu.Divider />
 
-                <ColumnHeaderSortMenuOptions item={item} sort={sort} />
+                <ColumnHeaderSortMenuOptions
+                    item={item}
+                    selectedDirection={sortSelectedDirection}
+                    onSelect={onSortSelect}
+                />
 
                 <Menu.Divider />
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
@@ -1,81 +1,63 @@
 import {
-    getItemId,
     type CustomDimension,
     type Field,
-    type SortField,
     type TableCalculation,
 } from '@lightdash/common';
 import { Menu, Text } from '@mantine-8/core';
 import { IconCheck } from '@tabler/icons-react';
-import { useCallback, type FC } from 'react';
-import {
-    explorerActions,
-    useExplorerDispatch,
-} from '../../../features/explorer/store';
+import { type FC } from 'react';
 import {
     getSortDirectionOrder,
     getSortLabel,
-    SortDirection,
+    type SortDirection,
 } from '../../../utils/sortUtils';
 import MantineIcon from '../../common/MantineIcon';
 
 type Props = {
     item: Field | TableCalculation | CustomDimension;
-    sort: SortField | undefined;
+    selectedDirection: SortDirection | undefined;
+    onSelect: (direction: SortDirection) => void;
+    /** When provided and a direction is active, renders a "Remove sort" item. */
+    onRemove?: () => void;
 };
 
-const ColumnHeaderSortMenuOptions: FC<Props> = ({ item, sort }) => {
-    const itemFieldId = getItemId(item);
-    const hasSort = !!sort;
-    const selectedSortDirection = sort
-        ? sort.descending
-            ? SortDirection.DESC
-            : SortDirection.ASC
-        : undefined;
-
-    const dispatch = useExplorerDispatch();
-
-    const handleSortClick = useCallback(
-        (sortDirection: SortDirection) => {
-            if (hasSort && selectedSortDirection === sortDirection) {
-                // Remove sort - clicking on current direction removes it
-                dispatch(explorerActions.setSortFields([]));
-            } else {
-                // Replace ALL sorts with this single sort
-                const newSort: SortField = {
-                    fieldId: itemFieldId,
-                    descending: sortDirection === SortDirection.DESC,
-                };
-                dispatch(explorerActions.setSortFields([newSort]));
-            }
-        },
-        [dispatch, hasSort, itemFieldId, selectedSortDirection],
-    );
-
+const ColumnHeaderSortMenuOptions: FC<Props> = ({
+    item,
+    selectedDirection,
+    onSelect,
+    onRemove,
+}) => {
     return (
         <>
             <Menu.Label>Sorting</Menu.Label>
-            {item &&
-                getSortDirectionOrder(item).map((sortDirection) => (
+            {getSortDirectionOrder(item).map((direction) => {
+                const isActive = selectedDirection === direction;
+                return (
                     <Menu.Item
-                        key={sortDirection}
+                        key={direction}
                         leftSection={
-                            hasSort &&
-                            selectedSortDirection === sortDirection ? (
+                            isActive ? (
                                 <MantineIcon icon={IconCheck} />
                             ) : undefined
                         }
-                        disabled={
-                            hasSort && selectedSortDirection === sortDirection
-                        }
-                        onClick={() => handleSortClick(sortDirection)}
+                        disabled={isActive}
+                        onClick={() => onSelect(direction)}
                     >
                         Sort{' '}
                         <Text span fz="inherit" lh="inherit" fw="bold">
-                            {getSortLabel(item, sortDirection)}
+                            {getSortLabel(item, direction)}
                         </Text>
                     </Menu.Item>
-                ))}
+                );
+            })}
+            {onRemove && selectedDirection !== undefined && (
+                <>
+                    <Menu.Divider />
+                    <Menu.Item color="red" onClick={onRemove}>
+                        Remove sort
+                    </Menu.Item>
+                </>
+            )}
         </>
     );
 };

--- a/packages/frontend/src/components/SortButton/SortItem.tsx
+++ b/packages/frontend/src/components/SortButton/SortItem.tsx
@@ -2,7 +2,7 @@ import {
     type DraggableProvidedDraggableProps,
     type DraggableProvidedDragHandleProps,
 } from '@hello-pangea/dnd';
-import { isField, type SortField } from '@lightdash/common';
+import { formatItemValue, isField, type SortField } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -12,7 +12,8 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { IconGripVertical, IconMinus } from '@tabler/icons-react';
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
+import { useColumns } from '../../hooks/useColumns';
 import {
     getSortDirectionOrder,
     getSortLabel,
@@ -64,6 +65,26 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
 
         const selectedSortNullsFirst = getSortNullsFirstValue(sort);
 
+        const columns = useColumns();
+        const pivotLabel = useMemo(() => {
+            if (!sort.pivotValues?.length) return null;
+            return sort.pivotValues
+                .map((pv) => {
+                    const dimItem = columns.find((c) => c.id === pv.reference)
+                        ?.meta?.item;
+                    const dimLabel =
+                        dimItem && isField(dimItem)
+                            ? dimItem.label || dimItem.name
+                            : pv.reference;
+                    const valueLabel = dimItem
+                        ? (formatItemValue(dimItem, pv.value) ??
+                          String(pv.value))
+                        : String(pv.value);
+                    return `${dimLabel}=${valueLabel}`;
+                })
+                .join(', ');
+        }, [sort.pivotValues, columns]);
+
         if (!item) {
             return null;
         }
@@ -96,6 +117,12 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
                         {(isField(item) ? item.label : item.name) ||
                             sort.fieldId}
                     </Text>
+
+                    {pivotLabel && (
+                        <Text fz="xs" c="dimmed">
+                            @ {pivotLabel}
+                        </Text>
+                    )}
                 </Group>
 
                 <Group gap="xs">

--- a/packages/frontend/src/components/SortButton/Sorting.tsx
+++ b/packages/frontend/src/components/SortButton/Sorting.tsx
@@ -4,7 +4,13 @@ import {
     Droppable,
     type DropResult,
 } from '@hello-pangea/dnd';
-import { isField } from '@lightdash/common';
+import {
+    isField,
+    type CustomDimension,
+    type Field,
+    type SortField,
+    type TableCalculation,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Button,
@@ -21,9 +27,20 @@ import {
     useExplorerDispatch,
 } from '../../features/explorer/store';
 import { useColumns } from '../../hooks/useColumns';
+import {
+    matchesIdentity,
+    serializeIdentity,
+    type PivotSortIdentity,
+} from '../../utils/pivotSortIdentity';
 import MantineIcon from '../common/MantineIcon';
 import { DraggablePortalHandler } from '../VisualizationConfigs/TreemapConfig/DraggablePortalHandler';
 import SortItem from './SortItem';
+
+type IdentityWithItem = {
+    fieldId: string;
+    item: Field | TableCalculation | CustomDimension;
+    label: string;
+};
 
 const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
     const columns = useColumns();
@@ -31,25 +48,27 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
     const dispatch = useExplorerDispatch();
 
     const addSortField = useCallback(
-        (fieldId: string, options?: { descending: boolean }) => {
-            const existingSort = sorts.find((s) => s.fieldId === fieldId);
-            const newSort = {
-                fieldId,
+        (identity: PivotSortIdentity, options?: { descending: boolean }) => {
+            const existingSort = sorts.find((s) =>
+                matchesIdentity(s, identity),
+            );
+            const newSort: SortField = {
+                fieldId: identity.fieldId,
                 descending: options?.descending ?? false,
-                // Preserve nullsFirst if it exists
+                ...(identity.pivotValues?.length && {
+                    pivotValues: identity.pivotValues,
+                }),
                 ...(existingSort?.nullsFirst !== undefined && {
                     nullsFirst: existingSort.nullsFirst,
                 }),
             };
 
             if (existingSort) {
-                // Replace in place to preserve order
                 const newSorts = sorts.map((s) =>
-                    s.fieldId === fieldId ? newSort : s,
+                    matchesIdentity(s, identity) ? newSort : s,
                 );
                 dispatch(explorerActions.setSortFields(newSorts));
             } else {
-                // Add new sort at the end
                 dispatch(explorerActions.setSortFields([...sorts, newSort]));
             }
         },
@@ -57,8 +76,8 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
     );
 
     const removeSortField = useCallback(
-        (fieldId: string) => {
-            const newSorts = sorts.filter((s) => s.fieldId !== fieldId);
+        (identity: PivotSortIdentity) => {
+            const newSorts = sorts.filter((s) => !matchesIdentity(s, identity));
             dispatch(explorerActions.setSortFields(newSorts));
         },
         [dispatch, sorts],
@@ -75,9 +94,9 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
     );
 
     const setSortFieldNullsFirst = useCallback(
-        (fieldId: string, nullsFirst: boolean | undefined) => {
+        (identity: PivotSortIdentity, nullsFirst: boolean | undefined) => {
             const newSorts = sorts.map((s) =>
-                s.fieldId === fieldId ? { ...s, nullsFirst } : s,
+                matchesIdentity(s, identity) ? { ...s, nullsFirst } : s,
             );
             dispatch(explorerActions.setSortFields(newSorts));
         },
@@ -90,20 +109,32 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
         moveSortFields(result.source.index, result.destination.index);
     };
 
-    const availableColumnsToAddToSort = columns
-        .filter((c) => !sorts.some((s) => s.fieldId === c.id))
+    const addOptions = columns
         .map((c) => {
             const item = c.meta?.item;
-            return {
-                value: c.id || '',
-                label: item
-                    ? isField(item)
-                        ? item.label || item.name
-                        : item.name
-                    : c.id,
-            };
+            if (!item || !c.id) return null;
+            const label =
+                (isField(item) ? item.label || item.name : item.name) || c.id;
+            return { fieldId: c.id, item, label } as IdentityWithItem;
         })
-        .filter((c) => c.value !== '');
+        .filter((c): c is IdentityWithItem => c !== null)
+        .filter(
+            (opt) =>
+                !sorts.some((s) =>
+                    matchesIdentity(s, { fieldId: opt.fieldId }),
+                ),
+        )
+        .map((opt) => ({ value: opt.fieldId, label: opt.label }));
+
+    const resetAddState = () => setIsAddingSort(false);
+
+    const handleAdd = (value: string | null) => {
+        if (!value) return;
+        addSortField({ fieldId: value });
+        resetAddState();
+    };
+
+    const hasAddableSomething = addOptions.length > 0;
 
     return (
         <>
@@ -114,63 +145,77 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
                             ref={provided.innerRef}
                             {...provided.droppableProps}
                         >
-                            {sorts.map((sort, index) => (
-                                <Draggable
-                                    key={sort.fieldId}
-                                    isDragDisabled={!isEditMode}
-                                    draggableId={sort.fieldId}
-                                    index={index}
-                                >
-                                    {(
-                                        {
-                                            draggableProps,
-                                            dragHandleProps,
-                                            innerRef,
-                                        },
-                                        snapshot,
-                                    ) => (
-                                        <DraggablePortalHandler
-                                            snapshot={snapshot}
-                                        >
-                                            <SortItem
-                                                isEditMode={isEditMode}
-                                                ref={innerRef}
-                                                isFirstItem={index === 0}
-                                                isOnlyItem={sorts.length === 1}
-                                                isDragging={snapshot.isDragging}
-                                                draggableProps={draggableProps}
-                                                dragHandleProps={
-                                                    dragHandleProps
-                                                }
-                                                sort={sort}
-                                                column={columns.find(
-                                                    (c) =>
-                                                        c.id === sort.fieldId,
-                                                )}
-                                                onAddSortField={(options) => {
-                                                    addSortField(
-                                                        sort.fieldId,
-                                                        options,
-                                                    );
-                                                }}
-                                                onRemoveSortField={() => {
-                                                    removeSortField(
-                                                        sort.fieldId,
-                                                    );
-                                                }}
-                                                onSetSortFieldNullsFirst={(
-                                                    payload,
-                                                ) => {
-                                                    setSortFieldNullsFirst(
-                                                        sort.fieldId,
+                            {sorts.map((sort, index) => {
+                                const identity: PivotSortIdentity = {
+                                    fieldId: sort.fieldId,
+                                    pivotValues: sort.pivotValues,
+                                };
+                                const key = serializeIdentity(identity);
+                                return (
+                                    <Draggable
+                                        key={key}
+                                        isDragDisabled={!isEditMode}
+                                        draggableId={key}
+                                        index={index}
+                                    >
+                                        {(
+                                            {
+                                                draggableProps,
+                                                dragHandleProps,
+                                                innerRef,
+                                            },
+                                            snapshot,
+                                        ) => (
+                                            <DraggablePortalHandler
+                                                snapshot={snapshot}
+                                            >
+                                                <SortItem
+                                                    isEditMode={isEditMode}
+                                                    ref={innerRef}
+                                                    isFirstItem={index === 0}
+                                                    isOnlyItem={
+                                                        sorts.length === 1
+                                                    }
+                                                    isDragging={
+                                                        snapshot.isDragging
+                                                    }
+                                                    draggableProps={
+                                                        draggableProps
+                                                    }
+                                                    dragHandleProps={
+                                                        dragHandleProps
+                                                    }
+                                                    sort={sort}
+                                                    column={columns.find(
+                                                        (c) =>
+                                                            c.id ===
+                                                            sort.fieldId,
+                                                    )}
+                                                    onAddSortField={(opts) => {
+                                                        addSortField(
+                                                            identity,
+                                                            opts,
+                                                        );
+                                                    }}
+                                                    onRemoveSortField={() => {
+                                                        removeSortField(
+                                                            identity,
+                                                        );
+                                                    }}
+                                                    onSetSortFieldNullsFirst={(
                                                         payload,
-                                                    );
-                                                }}
-                                            />
-                                        </DraggablePortalHandler>
-                                    )}
-                                </Draggable>
-                            ))}
+                                                    ) => {
+                                                        setSortFieldNullsFirst(
+                                                            identity,
+                                                            payload,
+                                                        );
+                                                    }}
+                                                />
+                                            </DraggablePortalHandler>
+                                        )}
+                                    </Draggable>
+                                );
+                            })}
 
                             {provided.placeholder}
                         </div>
@@ -178,11 +223,7 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
                 </Droppable>
             </DragDropContext>
 
-            {/*
-                Add sort to multi-sort form
-                Mimics SortItem component
-            */}
-            {isEditMode && availableColumnsToAddToSort.length > 0 && (
+            {isEditMode && hasAddableSomething && (
                 <>
                     {!isAddingSort ? (
                         <Button
@@ -195,46 +236,32 @@ const Sorting = forwardRef<HTMLDivElement, Props>(({ sorts, isEditMode }) => {
                             Add sort
                         </Button>
                     ) : (
-                        <Group
-                            wrap="nowrap"
-                            justify="space-between"
-                            pl="xs"
-                            pr="xxs"
-                            py="two"
-                        >
-                            <Group gap="sm">
-                                {isEditMode && sorts.length > 0 && (
-                                    <MantineIcon
-                                        color="ldGray.5"
-                                        opacity={0.9}
-                                        icon={IconGripVertical}
-                                        style={{ cursor: 'grab' }}
-                                    />
-                                )}
-                                <Text fz="xs">then by</Text>
-                                <Select
-                                    placeholder="Add sort field"
-                                    size="xs"
-                                    data={availableColumnsToAddToSort.map(
-                                        (c) => ({
-                                            value: c.value,
-                                            label: c.label || '',
-                                        }),
-                                    )}
-                                    onChange={(value: string | null) => {
-                                        if (value) {
-                                            addSortField(value);
-                                            setIsAddingSort(false);
-                                        }
-                                    }}
+                        <Group wrap="nowrap" gap="sm" pl="xs" py="two">
+                            {sorts.length > 0 && (
+                                <MantineIcon
+                                    color="ldGray.5"
+                                    opacity={0.9}
+                                    icon={IconGripVertical}
+                                    style={{ cursor: 'grab' }}
                                 />
-                            </Group>
+                            )}
+                            <Text fz="xs">then by</Text>
+                            <Select
+                                placeholder="Column"
+                                size="xs"
+                                searchable
+                                data={addOptions}
+                                value={null}
+                                onChange={handleAdd}
+                                flex={1}
+                                comboboxProps={{ withinPortal: false }}
+                            />
                             <Tooltip label="Cancel">
                                 <ActionIcon
                                     size="xs"
                                     variant="subtle"
                                     color="ldGray.6"
-                                    onClick={() => setIsAddingSort(false)}
+                                    onClick={resetAddState}
                                 >
                                     <MantineIcon icon={IconMinus} />
                                 </ActionIcon>

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -22,11 +22,11 @@ import {
     type ResultValue,
     type SortField,
 } from '@lightdash/common';
+import { Menu } from '@mantine-8/core';
 import {
     Box,
     Button,
     Group,
-    Menu,
     Text,
     useMantineColorScheme,
     type BoxProps,
@@ -64,6 +64,10 @@ import {
     getColorFromRange,
     transformColorsForDarkMode,
 } from '../../../utils/colorUtils';
+import {
+    getMetricLabelHeaderRowIndex,
+    getPivotColumnIdentities,
+} from '../../../utils/pivotColumnIdentity';
 import { getSortIcon } from '../../../utils/sortUtils';
 import { getConditionalRuleLabelFromItem } from '../Filters/FilterInputs/utils';
 import Table from '../LightTable';
@@ -164,8 +168,7 @@ type PivotTableProps = BoxProps & // TODO: remove this
         onColumnWidthChange?: (fieldId: string, width: number) => void;
         parameters?: ParametersValuesMap;
         sortBy?: SortField[];
-        // Header click handler. Consumer renders Menu.Item children inside
-        // the Mantine Menu. Absent → headers are non-interactive.
+        /** Renders inside a Mantine Menu opened by clicking sortable headers. */
         renderSortMenu?: (target: PivotSortMenuTarget) => React.ReactNode;
     };
 
@@ -263,56 +266,14 @@ const PivotTable: FC<PivotTableProps> = ({
         [data],
     );
 
-    // -1 when metricsAsRows is true. Clicks and sort indicators belong on
-    // this row; dim rows above are ambiguous with more than one value column.
-    const metricLabelHeaderRowIndex = useMemo(() => {
-        for (let i = data.headerValueTypes.length - 1; i >= 0; i -= 1) {
-            if (data.headerValueTypes[i].type === FieldType.METRIC) {
-                return i;
-            }
-        }
-        return -1;
-    }, [data.headerValueTypes]);
-
-    const metricRefByDataColIndex = useMemo(() => {
-        const dataColumnCount = data.dataColumnCount ?? 0;
-        const result: (string | undefined)[] = Array.from(
-            { length: dataColumnCount },
-            () => undefined,
-        );
-        if (metricLabelHeaderRowIndex < 0) return result;
-        const labelRow = data.headerValues[metricLabelHeaderRowIndex];
-        if (!labelRow) return result;
-        const limit = Math.min(labelRow.length, dataColumnCount);
-        for (let colIdx = 0; colIdx < limit; colIdx += 1) {
-            const cell = labelRow[colIdx];
-            if (cell.type === 'label') {
-                result[colIdx] = cell.fieldId;
-            }
-        }
-        return result;
-    }, [data.headerValues, data.dataColumnCount, metricLabelHeaderRowIndex]);
-
-    // Each header-row cell maps 1:1 with a data column (merged cells carry
-    // the owner's payload with colSpan=0) — index directly, never by colSpan
-    // cursor or merged slots get double-counted.
-    const pivotValuesByDataColIndex = useMemo(() => {
-        const dataColumnCount = data.dataColumnCount ?? 0;
-        const cumulative: Array<Record<string, unknown>> = Array.from(
-            { length: dataColumnCount },
-            () => ({}),
-        );
-        for (const headerRow of data.headerValues) {
-            const limit = Math.min(headerRow.length, dataColumnCount);
-            for (let colIdx = 0; colIdx < limit; colIdx += 1) {
-                const cell = headerRow[colIdx];
-                if (cell.type === 'value') {
-                    cumulative[colIdx][cell.fieldId] = cell.value?.raw;
-                }
-            }
-        }
-        return cumulative;
-    }, [data.headerValues, data.dataColumnCount]);
+    const metricLabelHeaderRowIndex = useMemo(
+        () => getMetricLabelHeaderRowIndex(data),
+        [data],
+    );
+    const pivotColumnIdentities = useMemo(
+        () => getPivotColumnIdentities(data),
+        [data],
+    );
 
     // Data-column index → matching sort entry. Built once so header render is O(1).
     const sortMatchByDataColIndex = useMemo(() => {
@@ -327,17 +288,20 @@ const PivotTable: FC<PivotTableProps> = ({
                 // — distinguishes per-metric sorts under the same pin.
                 for (
                     let colIdx = 0;
-                    colIdx < pivotValuesByDataColIndex.length;
+                    colIdx < pivotColumnIdentities.length;
                     colIdx += 1
                 ) {
-                    const info = pivotValuesByDataColIndex[colIdx];
-                    const allMatch = pivots.every(
-                        (pv) =>
-                            pv.reference in info &&
-                            info[pv.reference] === pv.value,
-                    );
+                    const identity = pivotColumnIdentities[colIdx];
+                    const allMatch = pivots.every((pv) => {
+                        const found = identity.pivotValues.find(
+                            (p) => p.reference === pv.reference,
+                        );
+                        return (
+                            found !== undefined && found.rawValue === pv.value
+                        );
+                    });
                     if (!allMatch) continue;
-                    const colMetric = metricRefByDataColIndex[colIdx];
+                    const colMetric = identity.metricFieldId;
                     const metricMatches =
                         colMetric === undefined || colMetric === sort.fieldId;
                     if (metricMatches && !result.has(colIdx)) {
@@ -356,7 +320,7 @@ const PivotTable: FC<PivotTableProps> = ({
             if (!isValueColumnSort) continue;
 
             if (metricLabelHeaderRowIndex < 0) {
-                if (pivotValuesByDataColIndex.length > 0 && !result.has(0)) {
+                if (pivotColumnIdentities.length > 0 && !result.has(0)) {
                     result.set(0, sort);
                 }
                 continue;
@@ -364,11 +328,12 @@ const PivotTable: FC<PivotTableProps> = ({
 
             for (
                 let colIdx = 0;
-                colIdx < metricRefByDataColIndex.length;
+                colIdx < pivotColumnIdentities.length;
                 colIdx += 1
             ) {
                 if (
-                    metricRefByDataColIndex[colIdx] === sort.fieldId &&
+                    pivotColumnIdentities[colIdx].metricFieldId ===
+                        sort.fieldId &&
                     !result.has(colIdx)
                 ) {
                     result.set(colIdx, sort);
@@ -377,13 +342,7 @@ const PivotTable: FC<PivotTableProps> = ({
             }
         }
         return result;
-    }, [
-        getField,
-        sortBy,
-        pivotValuesByDataColIndex,
-        metricRefByDataColIndex,
-        metricLabelHeaderRowIndex,
-    ]);
+    }, [getField, sortBy, pivotColumnIdentities, metricLabelHeaderRowIndex]);
 
     const hasColumnTotals = data.pivotConfig.columnTotals;
 
@@ -1091,6 +1050,28 @@ const PivotTable: FC<PivotTableProps> = ({
                                           )
                                         : undefined;
 
+                                const titleInnerContent =
+                                    titleField?.fieldId ? (
+                                        titleSortIcon ? (
+                                            <Group
+                                                display="inline-flex"
+                                                spacing={4}
+                                                noWrap
+                                                align="center"
+                                            >
+                                                {getFieldLabel(
+                                                    titleField.fieldId,
+                                                )}
+                                                <MantineIcon
+                                                    icon={titleSortIcon}
+                                                    size={14}
+                                                />
+                                            </Group>
+                                        ) : (
+                                            getFieldLabel(titleField.fieldId)
+                                        )
+                                    ) : undefined;
+
                                 const titleWidthKey = titleField?.fieldId;
                                 const titleWidth = titleWidthKey
                                     ? columnProperties[titleWidthKey]?.width
@@ -1180,28 +1161,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                         role="button"
                                                         tabIndex={0}
                                                     >
-                                                        {titleSortIcon ? (
-                                                            <Group
-                                                                display="inline-flex"
-                                                                spacing={4}
-                                                                noWrap
-                                                                align="center"
-                                                            >
-                                                                {getFieldLabel(
-                                                                    titleField.fieldId,
-                                                                )}
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        titleSortIcon
-                                                                    }
-                                                                    size={14}
-                                                                />
-                                                            </Group>
-                                                        ) : (
-                                                            getFieldLabel(
-                                                                titleField.fieldId,
-                                                            )
-                                                        )}
+                                                        {titleInnerContent}
                                                     </Box>
                                                 </Menu.Target>
                                                 <Menu.Dropdown>
@@ -1210,9 +1170,9 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     )}
                                                 </Menu.Dropdown>
                                             </Menu>
-                                        ) : titleField?.fieldId ? (
-                                            getFieldLabel(titleField?.fieldId)
-                                        ) : undefined}
+                                        ) : (
+                                            titleInnerContent
+                                        )}
                                         {canResizeTitle && (
                                             <div
                                                 className={
@@ -1279,8 +1239,10 @@ const PivotTable: FC<PivotTableProps> = ({
                             const isMetricLabelRow =
                                 metricLabelHeaderRowIndex >= 0 &&
                                 headerRowIndex === metricLabelHeaderRowIndex;
+                            const columnIdentity =
+                                pivotColumnIdentities[headerColIndex];
                             const columnMetricRef =
-                                metricRefByDataColIndex[headerColIndex];
+                                columnIdentity?.metricFieldId;
                             const isClickableHeader =
                                 isMetricLabelRow &&
                                 isLabel &&
@@ -1331,19 +1293,18 @@ const PivotTable: FC<PivotTableProps> = ({
                             );
 
                             const pivotMenuTarget: PivotSortMenuTarget | null =
-                                columnMetricRef
+                                columnMetricRef && columnIdentity
                                     ? {
                                           kind: 'pivotColumn',
                                           dataColIndex: headerColIndex,
                                           metricReference: columnMetricRef,
-                                          pivotValues: Object.entries(
-                                              pivotValuesByDataColIndex[
-                                                  headerColIndex
-                                              ] ?? {},
-                                          ).map(([reference, value]) => ({
-                                              reference,
-                                              value,
-                                          })),
+                                          pivotValues:
+                                              columnIdentity.pivotValues.map(
+                                                  (p) => ({
+                                                      reference: p.reference,
+                                                      value: p.rawValue,
+                                                  }),
+                                              ),
                                       }
                                     : null;
 
@@ -1365,7 +1326,6 @@ const PivotTable: FC<PivotTableProps> = ({
                                     maw={effectiveWidth}
                                 >
                                     {isClickableHeader && pivotMenuTarget ? (
-                                        // BaseCell drops onClick — bind via Menu.Target instead.
                                         <Menu
                                             shadow="md"
                                             position="bottom-start"

--- a/packages/frontend/src/utils/pivotColumnIdentity.ts
+++ b/packages/frontend/src/utils/pivotColumnIdentity.ts
@@ -1,0 +1,58 @@
+import { FieldType, type PivotData } from '@lightdash/common';
+
+export type PivotPin = {
+    reference: string;
+    rawValue: unknown;
+    formatted: string;
+};
+
+export type PivotColumnIdentity = {
+    /** undefined when metricsAsRows: true. */
+    metricFieldId: string | undefined;
+    pivotValues: PivotPin[];
+};
+
+/** -1 when metricsAsRows: true. */
+export const getMetricLabelHeaderRowIndex = (data: PivotData): number => {
+    for (let i = data.headerValueTypes.length - 1; i >= 0; i -= 1) {
+        if (data.headerValueTypes[i].type === FieldType.METRIC) return i;
+    }
+    return -1;
+};
+
+// Each header-row cell maps 1:1 with a data column (merged cells carry the
+// owner's payload with colSpan=0) — index directly, never by colSpan cursor.
+export const getPivotColumnIdentities = (
+    data: PivotData,
+): PivotColumnIdentity[] => {
+    const dataColumnCount = data.dataColumnCount ?? 0;
+    const metricLabelRowIndex = getMetricLabelHeaderRowIndex(data);
+    const identities: PivotColumnIdentity[] = Array.from(
+        { length: dataColumnCount },
+        () => ({ metricFieldId: undefined, pivotValues: [] }),
+    );
+
+    for (let rowIdx = 0; rowIdx < data.headerValues.length; rowIdx += 1) {
+        const headerRow = data.headerValues[rowIdx];
+        const limit = Math.min(headerRow.length, dataColumnCount);
+        for (let colIdx = 0; colIdx < limit; colIdx += 1) {
+            const cell = headerRow[colIdx];
+            if (cell.type === 'value') {
+                const raw = cell.value?.raw;
+                identities[colIdx].pivotValues.push({
+                    reference: cell.fieldId,
+                    rawValue: raw,
+                    formatted:
+                        cell.value?.formatted ??
+                        (raw === undefined || raw === null ? '' : String(raw)),
+                });
+            } else if (
+                cell.type === 'label' &&
+                rowIdx === metricLabelRowIndex
+            ) {
+                identities[colIdx].metricFieldId = cell.fieldId;
+            }
+        }
+    }
+    return identities;
+};

--- a/packages/frontend/src/utils/pivotSortIdentity.test.ts
+++ b/packages/frontend/src/utils/pivotSortIdentity.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePivotValues, pivotValuesEqual } from './pivotSortIdentity';
+
+describe('normalizePivotValues', () => {
+    it('preserves strings as-is', () => {
+        expect(
+            normalizePivotValues([{ reference: 'status', value: 'completed' }]),
+        ).toEqual([{ reference: 'status', value: 'completed' }]);
+    });
+
+    it('preserves numbers as-is', () => {
+        expect(
+            normalizePivotValues([{ reference: 'segment_id', value: 42 }]),
+        ).toEqual([{ reference: 'segment_id', value: 42 }]);
+    });
+
+    it('preserves null as-is', () => {
+        expect(
+            normalizePivotValues([{ reference: 'channel', value: null }]),
+        ).toEqual([{ reference: 'channel', value: null }]);
+    });
+
+    it('preserves native booleans (does not stringify)', () => {
+        // Regression: BigQuery rejects BOOL = STRING. Booleans must reach the
+        // backend as native booleans so the SQL emits TRUE/FALSE, not 'true'/'false'.
+        expect(
+            normalizePivotValues([
+                { reference: 'is_completed', value: false },
+                { reference: 'is_active', value: true },
+            ]),
+        ).toEqual([
+            { reference: 'is_completed', value: false },
+            { reference: 'is_active', value: true },
+        ]);
+    });
+
+    it('falls back to String() for non-primitive types (Date, object)', () => {
+        const date = new Date('2024-01-01T00:00:00Z');
+        const [result] = normalizePivotValues([
+            { reference: 'order_date', value: date },
+        ]);
+        expect(typeof result.value).toBe('string');
+        expect(result.value).toBe(String(date));
+    });
+});
+
+describe('pivotValuesEqual', () => {
+    it('treats undefined and empty array as equal', () => {
+        expect(pivotValuesEqual(undefined, [])).toBe(true);
+        expect(pivotValuesEqual([], undefined)).toBe(true);
+    });
+
+    it('matches on same reference/value pairs regardless of order', () => {
+        expect(
+            pivotValuesEqual(
+                [
+                    { reference: 'a', value: 1 },
+                    { reference: 'b', value: 'x' },
+                ],
+                [
+                    { reference: 'b', value: 'x' },
+                    { reference: 'a', value: 1 },
+                ],
+            ),
+        ).toBe(true);
+    });
+
+    it('returns false when values differ', () => {
+        expect(
+            pivotValuesEqual(
+                [{ reference: 'a', value: 1 }],
+                [{ reference: 'a', value: 2 }],
+            ),
+        ).toBe(false);
+    });
+
+    it('returns false when sizes differ', () => {
+        expect(
+            pivotValuesEqual(
+                [{ reference: 'a', value: 1 }],
+                [
+                    { reference: 'a', value: 1 },
+                    { reference: 'b', value: 2 },
+                ],
+            ),
+        ).toBe(false);
+    });
+});

--- a/packages/frontend/src/utils/pivotSortIdentity.ts
+++ b/packages/frontend/src/utils/pivotSortIdentity.ts
@@ -1,0 +1,53 @@
+import { type SortField } from '@lightdash/common';
+
+export type PivotSortIdentity = {
+    fieldId: string;
+    pivotValues?: SortField['pivotValues'];
+};
+
+// Narrow `unknown` warehouse values to `SortField['pivotValues']` element type.
+// Booleans round-trip natively so downstream SQL emits TRUE/FALSE instead of
+// quoted 'true'/'false' (which BigQuery rejects against BOOL columns).
+export const normalizePivotValues = (
+    pin: { reference: string; value: unknown }[],
+): NonNullable<SortField['pivotValues']> =>
+    pin.map((pv) => ({
+        reference: pv.reference,
+        value:
+            pv.value === null ||
+            typeof pv.value === 'number' ||
+            typeof pv.value === 'string' ||
+            typeof pv.value === 'boolean'
+                ? (pv.value as string | number | boolean | null)
+                : String(pv.value),
+    }));
+
+export const pivotValuesEqual = (
+    a: SortField['pivotValues'],
+    b: SortField['pivotValues'],
+): boolean => {
+    const left = a ?? [];
+    const right = b ?? [];
+    if (left.length !== right.length) return false;
+    const lookup = new Map(left.map((p) => [p.reference, p.value]));
+    return right.every(
+        (p) => lookup.has(p.reference) && lookup.get(p.reference) === p.value,
+    );
+};
+
+/** Same fieldId + same pin (both unpinned counts as equal). */
+export const matchesIdentity = (
+    candidate: SortField,
+    target: PivotSortIdentity,
+): boolean =>
+    candidate.fieldId === target.fieldId &&
+    pivotValuesEqual(candidate.pivotValues, target.pivotValues);
+
+/** Stable string key for React lists / Draggable IDs. */
+export const serializeIdentity = (identity: PivotSortIdentity): string => {
+    if (!identity.pivotValues?.length) return identity.fieldId;
+    const pinKey = identity.pivotValues
+        .map((pv) => `${pv.reference}=${String(pv.value)}`)
+        .join('|');
+    return `${identity.fieldId}::${pinKey}`;
+};


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Adds pivot-aware sorting support to the pivot table, enabling sorts to be scoped to a specific combination of pivot dimension values (a "pivot column identity") rather than just a field ID.

A new `PivotSortIdentity` type is introduced, combining a `fieldId` with optional `pivotValues`, along with utilities (`matchesIdentity`, `serializeIdentity`, `normalizePivotValues`, `pivotValuesEqual`) for comparing and keying these identities. The sort panel (`Sorting.tsx`, `SortItem.tsx`) now uses these identities throughout — add, remove, reorder, and nulls-first operations all correctly distinguish between sorts on the same metric pinned to different pivot columns.

A new `pivotColumnIdentity.ts` module extracts the per-data-column metadata (metric field ID + pivot dimension pins with raw and formatted values) from `PivotData`, replacing the two separate `metricRefByDataColIndex` and `pivotValuesByDataColIndex` maps that previously lived inline in `PivotTable`. The sort indicator matching logic in `PivotTable` is updated to use these structured identities, fixing cases where a sort on one pivot column could incorrectly highlight another.

`ColumnHeaderSortMenuOptions` is refactored to be a controlled component — it now receives `selectedDirection` and `onSelect` as props instead of dispatching to the store directly, and gains an optional `onRemove` prop that renders a "Remove sort" item when a direction is active. The sort direction logic is lifted into `ColumnHeaderContextMenu`.

`SortItem` displays a formatted pivot label (e.g. `Status=Completed, Region=West`) beneath the field name when the sort is pinned to specific pivot values.

Boolean pivot values are preserved as native booleans through normalization so that downstream SQL emits `TRUE`/`FALSE` rather than quoted strings, which would be rejected by BigQuery against `BOOL` columns. Unit tests cover `normalizePivotValues` and `pivotValuesEqual`.