### PR TITLE
fix: unblock data app iframe assets

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -321,6 +321,35 @@ export default class App {
     }
 
     private async initExpress(expressApp: Express) {
+        // Short-circuit CORS preflights for data-app iframe asset fetches.
+        //
+        // The data-app preview iframe uses `sandbox="allow-scripts allow-modals"`
+        // (no `allow-same-origin`), so subresource fetches originate from the
+        // opaque origin `null`. The global `cors()` middleware below ends those
+        // preflights with 204 but, because `null` doesn't match the configured
+        // allow-list, omits `Access-Control-Allow-Origin` — which blocks the
+        // subsequent asset GET and renders the iframe (and any scheduled
+        // screenshot of it) as a blank page. The appPreviewRouter has its own
+        // permissive CORS handler for these URLs, but it never runs because
+        // `cors()` short-circuits the preflight first. Handling OPTIONS here
+        // restores the intended behaviour without widening CORS for any other
+        // route. The matching GET handler remains auth-gated by `requireToken`.
+        if (this.lightdashConfig.appRuntime.s3) {
+            expressApp.options(
+                '/api/apps/:appUuid/versions/:version/assets/:filename',
+                (_req, res) => {
+                    res.setHeader('Access-Control-Allow-Origin', '*');
+                    res.setHeader(
+                        'Access-Control-Allow-Methods',
+                        'GET, OPTIONS',
+                    );
+                    res.setHeader('Access-Control-Allow-Headers', '*');
+                    res.setHeader('Access-Control-Max-Age', '86400');
+                    res.status(204).end();
+                },
+            );
+        }
+
         // Cross-Origin Resource Sharing policy (CORS)
         // WARNING: this middleware should be mounted before the helmet middleware
         // (ideally at the top of the middleware stack)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ --><!-- reference the related issue e.g. #150 -->

### Description:

## Problem

Scheduled deliveries for data apps render as blank pages on Lightdash Cloud (and any multi-host deployment with `LIGHTDASH_CORS_ENABLED=true`).

The data app preview iframe is loaded with `sandbox="allow-scripts allow-modals"` (no `allow-same-origin`), so its document origin is the opaque value `null`. Vite emits its
`<script type="module">` and `<link rel="stylesheet">` tags as `crossorigin`, which forces a CORS preflight on every asset fetch from origin `null`.

The `appPreviewRouter` already has a permissive CORS handler at `routers/appPreviewRouter.ts:294-314` intended to satisfy these preflights — but it never runs. In `App.ts`, the
global `cors()` middleware (`L349-356`) is mounted before the router and short-circuits the OPTIONS request: because `null` doesn't match `LIGHTDASH_CORS_ALLOWED_DOMAINS`, the
`cors` package ends the preflight with a 204 but omits `Access-Control-Allow-Origin`. The browser blocks the asset GET, the iframe stays empty, and the headless screenshot
captures a blank page.

Confirmed via the worker pod browser console (`analytics-lightdash-worker-8486bfb69d-5lp6p`):

Access to script at 'https://analytics.lightdash.app/api/apps/.../versions/1/assets/index-B59Pu9t3.js?token=...'
from origin 'null' has been blocked by CORS policy: Response to preflight request doesn't pass
access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.

And via curl against the live endpoint: preflight returns `204` with `Access-Control-Allow-Methods` and `Access-Control-Allow-Headers`, but no `Access-Control-Allow-Origin`.

Default self-hosted deployments aren't affected because `LIGHTDASH_CORS_ENABLED` is opt-in — the global `cors()` middleware never mounts and the router's own handler works as
intended.

## Solution

Mount a narrow `OPTIONS`\-only handler in `App.ts` _before_ the global `cors()` middleware, scoped to exactly `/api/apps/:appUuid/versions/:version/assets/:filename`. It returns
`204` with `Access-Control-Allow-Origin: *` and the same permissive `Allow-Methods`/`Allow-Headers` the router-level handler already returns, so preflights succeed before
`cors()` can intercept them.

Why this shape:

- **Surgical.** Only the preflight is short-circuited. The actual asset `GET` still flows through helmet, prometheus, JSON parsing, the appPreviewRouter, and — critically — the
`requireToken` auth middleware. No auth bypass.
- **No widening of CORS for any other route.** Other endpoints behave exactly as before.
- **No new security posture.** The router already intended `ACAO: *` for these URLs (`appPreviewRouter.ts:297`); this just makes that intent reachable. `credentials: false` is
preserved, no cookies are sent cross-origin, and an attacker can't read the asset without a valid preview token.
- **Gated on** **`appRuntime.s3`**, matching the existing appPreviewRouter mount condition, so deployments without data apps configured are untouched.

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->