### PR TITLE
feat: add organization trial warning banner

### DIFF
--- a/packages/backend/src/routers/organizationRouter.ts
+++ b/packages/backend/src/routers/organizationRouter.ts
@@ -13,6 +13,26 @@ import {
 
 export const organizationRouter: Router = express.Router();
 
+organizationRouter.get(
+    '/access',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const results = await req.services
+                .getOrganizationAccessService()
+                .getOrganizationAccess(req.account);
+
+            res.json({
+                status: 'ok',
+                results,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
+
 organizationRouter.post(
     '/projects/precompiled',
     allowApiKeyAuthentication,

--- a/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.test.ts
+++ b/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.test.ts
@@ -1,0 +1,54 @@
+import {
+    FeatureFlags,
+    OrganizationAccessStatus,
+    type Account,
+} from '@lightdash/common';
+import { type FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
+import { OrganizationAccessService } from './OrganizationAccessService';
+
+const account = {
+    organization: {
+        organizationUuid: 'org-uuid',
+        name: 'Acme',
+    },
+    user: {
+        id: 'user-uuid',
+    },
+    authentication: {
+        type: 'session',
+    },
+} as Account;
+
+const buildService = (enabledFlags: Set<string>) => {
+    const featureFlagService = {
+        get: jest.fn(async ({ featureFlagId }: { featureFlagId: string }) => ({
+            id: featureFlagId,
+            enabled: enabledFlags.has(featureFlagId),
+        })),
+    } as unknown as FeatureFlagService;
+
+    return new OrganizationAccessService({
+        featureFlagService,
+        cacheTtlMs: 0,
+    });
+};
+
+describe('OrganizationAccessService', () => {
+    it('returns active when no trial flags are enabled', async () => {
+        const service = buildService(new Set());
+
+        await expect(service.getOrganizationAccess(account)).resolves.toEqual({
+            status: OrganizationAccessStatus.ACTIVE,
+        });
+    });
+
+    it('returns trial warning when the warning flag is enabled', async () => {
+        const service = buildService(
+            new Set([FeatureFlags.OrganizationTrialWarning]),
+        );
+
+        const access = await service.getOrganizationAccess(account);
+
+        expect(access.status).toBe(OrganizationAccessStatus.TRIAL_WARNING);
+    });
+});

--- a/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.ts
+++ b/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.ts
@@ -1,0 +1,86 @@
+import {
+    FeatureFlags,
+    OrganizationAccessStatus,
+    type Account,
+    type OrganizationAccess,
+} from '@lightdash/common';
+import { BaseService } from '../BaseService';
+import { type FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
+
+const DEFAULT_CACHE_TTL_MS = 60 * 1000;
+
+type OrganizationAccessServiceArguments = {
+    featureFlagService: FeatureFlagService;
+    cacheTtlMs?: number;
+};
+
+type CacheEntry = {
+    access: OrganizationAccess;
+    expiresAt: number;
+};
+
+export class OrganizationAccessService extends BaseService {
+    private readonly featureFlagService: FeatureFlagService;
+
+    private readonly cacheTtlMs: number;
+
+    private readonly cache = new Map<string, CacheEntry>();
+
+    constructor(args: OrganizationAccessServiceArguments) {
+        super();
+        this.featureFlagService = args.featureFlagService;
+        this.cacheTtlMs = args.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    }
+
+    async getOrganizationAccess(
+        account?: Account,
+    ): Promise<OrganizationAccess> {
+        const organizationUuid = account?.organization.organizationUuid;
+        if (!organizationUuid) {
+            return { status: OrganizationAccessStatus.ACTIVE };
+        }
+
+        const cached = this.cache.get(organizationUuid);
+        if (cached && cached.expiresAt > Date.now()) {
+            return cached.access;
+        }
+
+        const access = await this.resolveOrganizationAccess(account);
+        this.cache.set(organizationUuid, {
+            access,
+            expiresAt: Date.now() + this.cacheTtlMs,
+        });
+        return access;
+    }
+
+    clearCache(organizationUuid?: string) {
+        if (organizationUuid) {
+            this.cache.delete(organizationUuid);
+            return;
+        }
+        this.cache.clear();
+    }
+
+    private async resolveOrganizationAccess(
+        account: Account,
+    ): Promise<OrganizationAccess> {
+        const user = {
+            userUuid: account.user.id,
+            organizationUuid: account.organization.organizationUuid,
+            organizationName: account.organization.name,
+        };
+
+        const isWarning = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.OrganizationTrialWarning,
+        });
+
+        if (isWarning.enabled) {
+            return {
+                status: OrganizationAccessStatus.TRIAL_WARNING,
+            };
+        }
+
+        return { status: OrganizationAccessStatus.ACTIVE };
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -35,6 +35,7 @@ import { LightdashAnalyticsService } from './LightdashAnalyticsService/Lightdash
 import { MetricsExplorerService } from './MetricsExplorerService/MetricsExplorerService';
 import { NotificationsService } from './NotificationsService/NotificationsService';
 import { OAuthService } from './OAuthService/OAuthService';
+import { OrganizationAccessService } from './OrganizationAccessService/OrganizationAccessService';
 import { OrganizationService } from './OrganizationService/OrganizationService';
 import { OrganizationSsoService } from './OrganizationSsoService/OrganizationSsoService';
 import { PermissionsService } from './PermissionsService/PermissionsService';
@@ -88,6 +89,7 @@ interface ServiceManifest {
 
     organizationService: OrganizationService;
     organizationSsoService: OrganizationSsoService;
+    organizationAccessService: OrganizationAccessService;
     preAggregateMaterializationService: PreAggregateMaterializationService;
     persistentDownloadFileService: PersistentDownloadFileService;
     personalAccessTokenService: PersonalAccessTokenService;
@@ -527,6 +529,16 @@ export class ServiceRepository
                         this.models.getOrganizationAllowedEmailDomainsModel(),
                     groupsModel: this.models.getGroupsModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
+                }),
+        );
+    }
+
+    public getOrganizationAccessService(): OrganizationAccessService {
+        return this.getService(
+            'organizationAccessService',
+            () =>
+                new OrganizationAccessService({
+                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -132,6 +132,7 @@ export * from './types/notifications';
 export * from './types/oauth';
 export * from './types/openIdIdentity';
 export * from './types/organization';
+export * from './types/organizationAccess';
 export * from './types/organizationMemberProfile';
 export * from './types/organizationSso';
 export * from './types/organizationWarehouseCredentials';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -140,6 +140,7 @@ import {
     type OrganizationProject,
     type UpdateAllowedEmailDomains,
 } from './organization';
+import { type OrganizationAccess } from './organizationAccess';
 import {
     type ApiOrganizationMemberProfiles,
     type OrganizationMemberProfile,
@@ -882,6 +883,7 @@ type ApiResults =
     | ApiRefreshResults
     | ApiCreatePreviewResults
     | ApiHealthResults
+    | OrganizationAccess
     | Organization
     | LightdashUser
     | LoginOptions

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -193,6 +193,12 @@ export enum FeatureFlags {
      * Enable AI thread context compaction for streamed web-app conversations.
      */
     AiContextCompaction = 'ai-context-compaction',
+
+    /**
+     * Show a persistent trial warning banner for an organization on shared
+     * instances. This does not block product access.
+     */
+    OrganizationTrialWarning = 'organization-trial-warning',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/organizationAccess.ts
+++ b/packages/common/src/types/organizationAccess.ts
@@ -1,0 +1,17 @@
+export enum OrganizationAccessStatus {
+    ACTIVE = 'active',
+    TRIAL_WARNING = 'trial_warning',
+}
+
+export type OrganizationAccess =
+    | {
+          status: OrganizationAccessStatus.ACTIVE;
+      }
+    | {
+          status: OrganizationAccessStatus.TRIAL_WARNING;
+      };
+
+export type ApiOrganizationAccessResponse = {
+    status: 'ok';
+    results: OrganizationAccess;
+};

--- a/packages/frontend/src/components/NavBar/TrialWarningBanner.module.css
+++ b/packages/frontend/src/components/NavBar/TrialWarningBanner.module.css
@@ -1,0 +1,3 @@
+.banner {
+    z-index: var(--mantine-z-index-app);
+}

--- a/packages/frontend/src/components/NavBar/TrialWarningBanner.tsx
+++ b/packages/frontend/src/components/NavBar/TrialWarningBanner.tsx
@@ -1,0 +1,33 @@
+import {
+    OrganizationAccessStatus,
+    type OrganizationAccess,
+} from '@lightdash/common';
+import { Center, Text } from '@mantine-8/core';
+import { BANNER_HEIGHT } from '../common/Page/constants';
+import classes from './TrialWarningBanner.module.css';
+
+type Props = {
+    access: OrganizationAccess;
+};
+
+export const TrialWarningBanner = ({ access }: Props) => {
+    if (access.status !== OrganizationAccessStatus.TRIAL_WARNING) {
+        return null;
+    }
+
+    return (
+        <Center
+            pos="fixed"
+            top={0}
+            w="100%"
+            h={BANNER_HEIGHT}
+            px="md"
+            bg="yellow.7"
+            className={classes.banner}
+        >
+            <Text c="gray.9" size="sm" fw={700} truncate>
+                Your Lightdash trial has expired. Contact sales@lightdash.com
+            </Text>
+        </Center>
+    );
+};

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -1,9 +1,10 @@
-import { ProjectType } from '@lightdash/common';
+import { OrganizationAccessStatus, ProjectType } from '@lightdash/common';
 import { Box } from '@mantine-8/core';
 import { clsx } from '@mantine/core';
 import { memo } from 'react';
 import { useParams } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import { useOrganizationAccess } from '../../hooks/organization/useOrganizationAccess';
 import { useActiveProjectUuid } from '../../hooks/useActiveProject';
 import { useProject } from '../../hooks/useProject';
 import { useImpersonation } from '../../hooks/user/useImpersonation';
@@ -15,6 +16,7 @@ import { ImpersonationBanner } from './ImpersonationBanner';
 import classes from './index.module.css';
 import { MainNavBarContent } from './MainNavBarContent';
 import { PreviewBanner } from './PreviewBanner';
+import { TrialWarningBanner } from './TrialWarningBanner';
 
 enum NavBarMode {
     DEFAULT = 'default',
@@ -69,12 +71,19 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
 
     const isCurrentProjectPreview = project?.type === ProjectType.PREVIEW;
     const { isImpersonating } = useImpersonation();
+    const { data: organizationAccess } = useOrganizationAccess();
 
     const { navBarMode } = useNavBarMode();
 
-    const hasBanner = isImpersonating || isCurrentProjectPreview;
+    const showTrialWarning =
+        !isImpersonating &&
+        !isCurrentProjectPreview &&
+        organizationAccess?.status === OrganizationAccessStatus.TRIAL_WARNING;
 
-    // Calculate placeholder height: navbar + banner (if preview or impersonating)
+    const hasBanner =
+        isImpersonating || isCurrentProjectPreview || showTrialWarning;
+
+    // Calculate placeholder height: navbar + banner.
     const headerContainerHeight =
         NAVBAR_HEIGHT + (hasBanner ? BANNER_HEIGHT : 0);
 
@@ -91,9 +100,11 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
             >
                 {isImpersonating ? (
                     <ImpersonationBanner />
+                ) : isCurrentProjectPreview ? (
+                    <PreviewBanner expiresAt={project?.expiresAt ?? null} />
                 ) : (
-                    isCurrentProjectPreview && (
-                        <PreviewBanner expiresAt={project?.expiresAt ?? null} />
+                    organizationAccess && (
+                        <TrialWarningBanner access={organizationAccess} />
                     )
                 )}
                 <Box

--- a/packages/frontend/src/hooks/organization/useOrganizationAccess.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationAccess.ts
@@ -1,0 +1,20 @@
+import { type ApiError, type OrganizationAccess } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+
+const getOrganizationAccess = async (): Promise<OrganizationAccess> => {
+    return lightdashApi<OrganizationAccess>({
+        url: '/org/access',
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useOrganizationAccess = (enabled: boolean = true) =>
+    useQuery<OrganizationAccess, ApiError>({
+        queryKey: ['organization-access'],
+        queryFn: getOrganizationAccess,
+        enabled,
+        retry: false,
+        refetchOnMount: false,
+    });


### PR DESCRIPTION
## Summary
- add an org trial warning feature flag and org-access API response
- show a short persistent navbar trial banner with tooltip copy and contact-sales CTA
- keep the service disabled outside configured Lightdash Cloud instances so self-hosted installs are inert

## Notes
- this PR is banner-only and does not block product usage
- query blocking is split into the stacked follow-up PR

## Validation
- pnpm -F common build
- pnpm -F backend test -- OrganizationAccessService.test.ts
- pnpm -F common typecheck
- pnpm -F backend linter src/routers/apiV1Router.ts src/services/OrganizationAccessService/OrganizationAccessService.ts src/services/OrganizationAccessService/OrganizationAccessService.test.ts src/services/ServiceRepository.ts
- pnpm -F frontend linter src/components/NavBar/TrialWarningBanner.tsx src/components/NavBar/index.tsx src/hooks/organization/useOrganizationAccess.ts
- pnpm -F frontend typecheck