### PR TITLE
feat(backend): structured observability for scheduler & warehouse queries

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -61,6 +61,7 @@ import Logger from './logging/logger';
 import {
     expressWinstonMiddleware,
     expressWinstonPreResponseMiddleware,
+    requestExecutionContextMiddleware,
 } from './logging/winston';
 import { sessionAccountMiddleware } from './middlewares/accountMiddleware';
 import { jwtAuthMiddleware } from './middlewares/jwtAuthMiddleware';
@@ -616,6 +617,9 @@ export default class App {
         // We'll also be able to add the user to Sentry for embedded users.
         expressApp.use(jwtAuthMiddleware);
         expressApp.use(sessionAccountMiddleware);
+        // Must run after auth so req.user is populated. Stamps every downstream
+        // log line with organization_uuid + organization_name via ExecutionContext.
+        expressApp.use(requestExecutionContextMiddleware);
 
         expressApp.use((req, res, next) => {
             if (req.user) {

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -28,6 +28,17 @@ import Logger from '../../logging/logger';
 
 const RETRYABLE_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND'];
 
+/**
+ * Appends `?ref=<id>` (or `&ref=`) to the URL so support can paste the
+ * correlation ID into Cloud Logging and land on the failing job directly,
+ * instead of triangulating from project UUID + approximate timestamp.
+ */
+function appendCorrelationRef(url: string, correlationId?: string): string {
+    if (!correlationId) return url;
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}ref=${encodeURIComponent(correlationId)}`;
+}
+
 function isNodemailerSmtpError(
     error: unknown,
 ): error is SMTPConnection.SMTPError {
@@ -369,6 +380,7 @@ export default class EmailClient {
         schedulerUrl: string,
         errorMessage?: string,
         disabledSync: boolean = true,
+        correlationId?: string,
     ) {
         // Sync failure but not disabled - will be retried
         if (!this.canSendEmail()) {
@@ -383,6 +395,8 @@ export default class EmailClient {
             throw new Error('Email transporter not configured');
         }
 
+        const urlWithRef = appendCorrelationRef(schedulerUrl, correlationId);
+
         // Sync has been disabled
         if (disabledSync) {
             return this.sendEmail({
@@ -393,7 +407,7 @@ export default class EmailClient {
                     host: this.lightdashConfig.siteUrl,
                     subject: 'Google Sheets Sync disabled',
                     description: `There's an error with your Google Sheets "${schedulerName}" sync. We've disabled it to prevent further errors.`,
-                    schedulerUrl,
+                    schedulerUrl: urlWithRef,
                 },
                 text: `Your Google Sheets ${schedulerName} sync has been disabled due to an error`,
             });
@@ -411,7 +425,7 @@ export default class EmailClient {
                       )}</p><br /><br />`
                     : ''
             }
-            <p>Please check your <a href="${schedulerUrl}">Google Sheets sync settings</a> and verify your Google Sheets connection and permissions.</p>
+            <p>Please check your <a href="${urlWithRef}">Google Sheets sync settings</a> and verify your Google Sheets connection and permissions.</p>
         `;
 
         return this.sendEmail({
@@ -425,7 +439,7 @@ export default class EmailClient {
             },
             text: `Warning: Your Google Sheets sync "${schedulerName}" failed. ${
                 errorMessage ? `Error: ${errorMessage}.` : ''
-            } Please check your settings at ${schedulerUrl}`,
+            } Please check your settings at ${urlWithRef}`,
         });
     }
 
@@ -434,6 +448,7 @@ export default class EmailClient {
         schedulerName: string,
         schedulerUrl: string,
         errorMessage: string,
+        correlationId?: string,
     ) {
         if (!this.canSendEmail()) {
             Logger.error(
@@ -446,6 +461,8 @@ export default class EmailClient {
             throw new Error('Email transporter not configured');
         }
 
+        const urlWithRef = appendCorrelationRef(schedulerUrl, correlationId);
+
         const message = `
             <p>Your scheduled delivery <strong>"${schedulerName}"</strong> failed to send.</p>
             <br />
@@ -454,7 +471,7 @@ export default class EmailClient {
             <p><strong>Error:</strong> ${sanitizeHtml(errorMessage)}</p>
             <br />
             <br />
-            <p>Please check your <a href="${schedulerUrl}">scheduled delivery settings</a> and try again.</p>
+            <p>Please check your <a href="${urlWithRef}">scheduled delivery settings</a> and try again.</p>
         `;
 
         return this.sendEmail({
@@ -466,7 +483,7 @@ export default class EmailClient {
                 title: 'Scheduled delivery failure',
                 message,
             },
-            text: `Warning: Your scheduled delivery "${schedulerName}" failed to send. Error: ${errorMessage}. Please check your settings at ${schedulerUrl}`,
+            text: `Warning: Your scheduled delivery "${schedulerName}" failed to send. Error: ${errorMessage}. Please check your settings at ${urlWithRef}`,
         });
     }
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -875,7 +875,16 @@ export class EmbedService extends BaseService {
         explore: Explore;
         queryTags: Omit<
             Required<RunQueryTags>,
-            'user_uuid' | 'chart_uuid' | 'dashboard_uuid'
+            | 'user_uuid'
+            | 'chart_uuid'
+            | 'dashboard_uuid'
+            // Scheduler-attribution tags only apply to scheduler-driven jobs,
+            // never to embed/JWT queries, so they're excluded from the
+            // required-shape enforced here.
+            | 'saved_sql_uuid'
+            | 'scheduler_uuid'
+            | 'scheduler_name'
+            | 'job_id'
         > & {
             embed: 'true';
             external_id: string;

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -62,6 +62,14 @@ export type ExecutionContextInfo = {
         priority: number;
         attempts: number;
     };
+    organization_uuid?: string;
+    organization_name?: string;
+    scheduler?: {
+        scheduler_uuid?: string;
+        scheduler_name?: string;
+        saved_sql_uuid?: string;
+        job_id?: string;
+    };
 };
 
 const addExecutionContent = winston.format(
@@ -73,6 +81,31 @@ const addExecutionContent = winston.format(
               }
             : info,
 );
+
+export const getSchedulerContext = ():
+    | NonNullable<ExecutionContextInfo['scheduler']>
+    | undefined => {
+    if (!ExecutionContext.exists()) return undefined;
+    return ExecutionContext.get<ExecutionContextInfo>().scheduler;
+};
+
+export const getOrganizationContext = (): Pick<
+    ExecutionContextInfo,
+    'organization_uuid' | 'organization_name'
+> => {
+    if (!ExecutionContext.exists()) return {};
+    const ctx = ExecutionContext.get<ExecutionContextInfo>();
+    return {
+        organization_uuid: ctx.organization_uuid,
+        organization_name: ctx.organization_name,
+    };
+};
+
+const ALIAS_RESPONSE_TIME_AS_DURATION = winston.format((info) => {
+    if (typeof info.responseTime === 'number' && info.duration_ms === undefined)
+        return { ...info, duration_ms: info.responseTime };
+    return info;
+});
 
 const printMessage = (
     info: winston.Logform.TransformableInfo & ExecutionContextInfo & SentryInfo,
@@ -94,6 +127,7 @@ const formatters = {
     plain: winston.format.combine(
         addSentryTraceId(),
         addExecutionContent(),
+        ALIAS_RESPONSE_TIME_AS_DURATION(),
         winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
         winston.format.uncolorize(),
         winston.format.printf(printMessage),
@@ -101,6 +135,7 @@ const formatters = {
     pretty: winston.format.combine(
         addSentryTraceId(),
         addExecutionContent(),
+        ALIAS_RESPONSE_TIME_AS_DURATION(),
         winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
         winston.format.colorize({ all: true }),
         winston.format.printf(printMessage),
@@ -108,6 +143,7 @@ const formatters = {
     json: winston.format.combine(
         addSentryTraceId(),
         addExecutionContent(),
+        ALIAS_RESPONSE_TIME_AS_DURATION(),
         winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
         winston.format.json(),
     ),
@@ -284,4 +320,31 @@ export const expressWinstonPreResponseMiddleware: express.RequestHandler = (
         });
     }
     next();
+};
+
+// Stamps every log emitted while processing this request with the requesting
+// user's organization context, by attaching it to the AsyncLocalStorage-backed
+// ExecutionContext that `addExecutionContent` already merges into log payloads.
+// Place this AFTER session/auth middlewares so req.user is populated.
+export const requestExecutionContextMiddleware: express.RequestHandler = (
+    req,
+    _res,
+    next,
+) => {
+    const organizationUuid = req.user?.organizationUuid;
+    const organizationName = req.user?.organizationName;
+    if (!organizationUuid && !organizationName) {
+        next();
+        return;
+    }
+    const context: ExecutionContextInfo = {
+        organization_uuid: organizationUuid,
+        organization_name: organizationName,
+    };
+    if (ExecutionContext.exists()) {
+        ExecutionContext.update(context as unknown as Record<string, unknown>);
+        next();
+        return;
+    }
+    ExecutionContext.run(() => next(), context);
 };

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -325,14 +325,19 @@ export const expressWinstonPreResponseMiddleware: express.RequestHandler = (
 // Stamps every log emitted while processing this request with the requesting
 // user's organization context, by attaching it to the AsyncLocalStorage-backed
 // ExecutionContext that `addExecutionContent` already merges into log payloads.
-// Place this AFTER session/auth middlewares so req.user is populated.
+// Place this AFTER session/auth middlewares so req.user and req.account are
+// populated. req.user is set for session-authenticated requests; embed/JWT
+// requests populate req.account only, so we fall back to it.
 export const requestExecutionContextMiddleware: express.RequestHandler = (
     req,
     _res,
     next,
 ) => {
-    const organizationUuid = req.user?.organizationUuid;
-    const organizationName = req.user?.organizationName;
+    const organizationUuid =
+        req.user?.organizationUuid ??
+        req.account?.organization?.organizationUuid;
+    const organizationName =
+        req.user?.organizationName ?? req.account?.organization?.name;
     if (!organizationUuid && !organizationName) {
         next();
         return;

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -3,6 +3,8 @@ import {
     NotEnoughResults,
     ThresholdOperator,
 } from '@lightdash/common';
+import ExecutionContext from 'node-execution-context';
+import type { ExecutionContextInfo } from '../logging/winston';
 import SchedulerTask, {
     buildSchedulerLogContext,
     setSchedulerJobLogContext,
@@ -78,6 +80,30 @@ describe('setSchedulerJobLogContext', () => {
         const update = jest.fn();
         setSchedulerJobLogContext({}, update);
         expect(update).not.toHaveBeenCalled();
+    });
+
+    it('writes through the default ExecutionContext updater', () => {
+        const initial: ExecutionContextInfo = {};
+        ExecutionContext.run(() => {
+            setSchedulerJobLogContext({
+                jobId: 'job-42',
+                schedulerUuid: 'sched-42',
+                schedulerName: 'Weekly sync',
+            });
+            const ctx = ExecutionContext.get<ExecutionContextInfo>();
+            expect(ctx.scheduler).toEqual({
+                job_id: 'job-42',
+                scheduler_uuid: 'sched-42',
+                scheduler_name: 'Weekly sync',
+            });
+        }, initial);
+    });
+
+    it('is a no-op when called outside an ExecutionContext', () => {
+        expect(ExecutionContext.exists()).toBe(false);
+        expect(() =>
+            setSchedulerJobLogContext({ jobId: 'job-1' }),
+        ).not.toThrow();
     });
 });
 

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -54,28 +54,6 @@ describe('buildSchedulerLogContext', () => {
 });
 
 describe('setSchedulerJobLogContext', () => {
-    it('invokes the injected updater with the built sub-context', () => {
-        const update = jest.fn();
-        setSchedulerJobLogContext(
-            {
-                jobId: 'job-1',
-                schedulerUuid: 'sched-1',
-                schedulerName: 'My sync',
-                savedSqlUuid: 'sql-1',
-            },
-            update,
-        );
-        expect(update).toHaveBeenCalledTimes(1);
-        expect(update).toHaveBeenCalledWith({
-            scheduler: {
-                job_id: 'job-1',
-                scheduler_uuid: 'sched-1',
-                scheduler_name: 'My sync',
-                saved_sql_uuid: 'sql-1',
-            },
-        });
-    });
-
     it('skips the updater entirely when no attribution fields are set', () => {
         const update = jest.fn();
         setSchedulerJobLogContext({}, update);

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -3,7 +3,10 @@ import {
     NotEnoughResults,
     ThresholdOperator,
 } from '@lightdash/common';
-import SchedulerTask from './SchedulerTask';
+import SchedulerTask, {
+    buildSchedulerLogContext,
+    setSchedulerJobLogContext,
+} from './SchedulerTask';
 import {
     resultsWithOneRow,
     resultsWithTwoDecreasingRows,
@@ -11,6 +14,72 @@ import {
     thresholdIncreasedByMock,
     thresholdLessThanMock,
 } from './SchedulerTask.mock';
+
+describe('buildSchedulerLogContext', () => {
+    it('returns null when no attribution fields are set', () => {
+        expect(buildSchedulerLogContext({})).toBeNull();
+    });
+
+    it('returns null when only nullish values are passed', () => {
+        expect(
+            buildSchedulerLogContext({
+                jobId: undefined,
+                savedSqlUuid: null,
+            }),
+        ).toBeNull();
+    });
+
+    it('includes only populated fields', () => {
+        expect(
+            buildSchedulerLogContext({
+                jobId: 'job-1',
+                schedulerUuid: 'sched-1',
+            }),
+        ).toEqual({
+            job_id: 'job-1',
+            scheduler_uuid: 'sched-1',
+        });
+    });
+
+    it('omits a null savedSqlUuid', () => {
+        expect(
+            buildSchedulerLogContext({
+                jobId: 'job-1',
+                savedSqlUuid: null,
+            }),
+        ).toEqual({ job_id: 'job-1' });
+    });
+});
+
+describe('setSchedulerJobLogContext', () => {
+    it('invokes the injected updater with the built sub-context', () => {
+        const update = jest.fn();
+        setSchedulerJobLogContext(
+            {
+                jobId: 'job-1',
+                schedulerUuid: 'sched-1',
+                schedulerName: 'My sync',
+                savedSqlUuid: 'sql-1',
+            },
+            update,
+        );
+        expect(update).toHaveBeenCalledTimes(1);
+        expect(update).toHaveBeenCalledWith({
+            scheduler: {
+                job_id: 'job-1',
+                scheduler_uuid: 'sched-1',
+                scheduler_name: 'My sync',
+                saved_sql_uuid: 'sql-1',
+            },
+        });
+    });
+
+    it('skips the updater entirely when no attribution fields are set', () => {
+        const update = jest.fn();
+        setSchedulerJobLogContext({}, update);
+        expect(update).not.toHaveBeenCalled();
+    });
+});
 
 describe('isPositiveThresholdAlert', () => {
     it('should return false if there are no results or no thresholds', () => {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -196,35 +196,67 @@ export type SchedulerTaskArguments = {
 };
 
 /**
- * Stamps the current job's AsyncLocalStorage-backed ExecutionContext with
- * scheduler/sync attribution so every downstream log line and warehouse
- * `queryTags` row carries the originating scheduler_uuid, scheduler_name,
- * saved_sql_uuid, and job_id.
+ * Builds the scheduler sub-context from a partial set of attribution fields.
+ * Pure function — used directly in tests; the default updater calls it.
  *
- * Called once per scheduler task entry point. Replaces any prior scheduler
- * sub-context. Organization context (organization_uuid, organization_name)
- * is set centrally by SchedulerTaskTracer before the task runs.
- *
- * SchedulerWorkerEventEmitter has already opened a context per job, so we
- * only need to `update()` — there is nothing to do outside a worker job.
+ * Returns `null` when no fields are populated so callers can short-circuit
+ * the ExecutionContext write.
  */
-function setSchedulerJobLogContext(args: {
+export function buildSchedulerLogContext(args: {
     jobId?: string;
     schedulerUuid?: string;
     schedulerName?: string;
     savedSqlUuid?: string | null;
-}) {
-    if (!ExecutionContext.exists()) return;
+}): NonNullable<ExecutionContextInfo['scheduler']> | null {
     const schedulerCtx: NonNullable<ExecutionContextInfo['scheduler']> = {};
     if (args.schedulerUuid) schedulerCtx.scheduler_uuid = args.schedulerUuid;
     if (args.schedulerName) schedulerCtx.scheduler_name = args.schedulerName;
     if (args.savedSqlUuid) schedulerCtx.saved_sql_uuid = args.savedSqlUuid;
     if (args.jobId) schedulerCtx.job_id = args.jobId;
-    if (Object.keys(schedulerCtx).length === 0) return;
-    ExecutionContext.update({ scheduler: schedulerCtx } as unknown as Record<
-        string,
-        unknown
-    >);
+    return Object.keys(schedulerCtx).length === 0 ? null : schedulerCtx;
+}
+
+/**
+ * Strategy used to write scheduler attribution into the surrounding log
+ * context. Injected so tests can supply a spy; the default writes through
+ * the AsyncLocalStorage-backed `ExecutionContext`.
+ */
+export type SchedulerLogContextUpdater = (
+    update: Pick<ExecutionContextInfo, 'scheduler'>,
+) => void;
+
+const defaultSchedulerLogContextUpdater: SchedulerLogContextUpdater = (
+    update,
+) => {
+    if (!ExecutionContext.exists()) return;
+    ExecutionContext.update(update as unknown as Record<string, unknown>);
+};
+
+/**
+ * Stamps the current job's log context with scheduler/sync attribution so
+ * every downstream log line and warehouse `queryTags` row carries the
+ * originating scheduler_uuid, scheduler_name, saved_sql_uuid, and job_id.
+ *
+ * Called once per scheduler task entry point. Replaces any prior scheduler
+ * sub-context. Organization context (organization_uuid, organization_name)
+ * is set centrally by SchedulerTaskTracer before the task runs.
+ *
+ * The context updater is injected (default: writes through ExecutionContext)
+ * so unit tests can verify the built sub-context without setting up
+ * AsyncLocalStorage.
+ */
+export function setSchedulerJobLogContext(
+    args: {
+        jobId?: string;
+        schedulerUuid?: string;
+        schedulerName?: string;
+        savedSqlUuid?: string | null;
+    },
+    update: SchedulerLogContextUpdater = defaultSchedulerLogContextUpdater,
+) {
+    const scheduler = buildSchedulerLogContext(args);
+    if (!scheduler) return;
+    update({ scheduler });
 }
 
 export default class SchedulerTask {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -199,7 +199,11 @@ export type SchedulerTaskArguments = {
  * Stamps the current job's AsyncLocalStorage-backed ExecutionContext with
  * scheduler/sync attribution so every downstream log line and warehouse
  * `queryTags` row carries the originating scheduler_uuid, scheduler_name,
- * saved_sql_uuid, job_id, and organization context.
+ * saved_sql_uuid, and job_id.
+ *
+ * Called once per scheduler task entry point. Replaces any prior scheduler
+ * sub-context. Organization context (organization_uuid, organization_name)
+ * is set centrally by SchedulerTaskTracer before the task runs.
  *
  * SchedulerWorkerEventEmitter has already opened a context per job, so we
  * only need to `update()` — there is nothing to do outside a worker job.
@@ -209,23 +213,18 @@ function setSchedulerJobLogContext(args: {
     schedulerUuid?: string;
     schedulerName?: string;
     savedSqlUuid?: string | null;
-    organizationUuid?: string;
-    organizationName?: string;
 }) {
     if (!ExecutionContext.exists()) return;
-    const updates: Partial<ExecutionContextInfo> = {};
-    if (args.organizationUuid)
-        updates.organization_uuid = args.organizationUuid;
-    if (args.organizationName)
-        updates.organization_name = args.organizationName;
     const schedulerCtx: NonNullable<ExecutionContextInfo['scheduler']> = {};
     if (args.schedulerUuid) schedulerCtx.scheduler_uuid = args.schedulerUuid;
     if (args.schedulerName) schedulerCtx.scheduler_name = args.schedulerName;
     if (args.savedSqlUuid) schedulerCtx.saved_sql_uuid = args.savedSqlUuid;
     if (args.jobId) schedulerCtx.job_id = args.jobId;
-    if (Object.keys(schedulerCtx).length > 0) updates.scheduler = schedulerCtx;
-    if (Object.keys(updates).length === 0) return;
-    ExecutionContext.update(updates as unknown as Record<string, unknown>);
+    if (Object.keys(schedulerCtx).length === 0) return;
+    ExecutionContext.update({ scheduler: schedulerCtx } as unknown as Record<
+        string,
+        unknown
+    >);
 }
 
 export default class SchedulerTask {
@@ -1057,7 +1056,6 @@ export default class SchedulerTask {
             schedulerUuid,
             schedulerName: scheduler.name,
             savedSqlUuid: scheduler.savedSqlUuid,
-            organizationUuid: notification.organizationUuid,
         });
         this.analytics.track({
             event: 'scheduler_notification_job.started',
@@ -1434,7 +1432,6 @@ export default class SchedulerTask {
             schedulerUuid,
             schedulerName: scheduler.name,
             savedSqlUuid: scheduler.savedSqlUuid,
-            organizationUuid: notification.organizationUuid,
         });
         this.analytics.track({
             event: 'scheduler_notification_job.started',
@@ -1880,6 +1877,7 @@ export default class SchedulerTask {
         scheduledTime: Date,
         payload: MaterializePreAggregatePayload,
     ) {
+        setSchedulerJobLogContext({ jobId });
         const baseLog: Pick<SchedulerLog, 'task' | 'jobId' | 'scheduledTime'> =
             {
                 task: SCHEDULER_TASKS.MATERIALIZE_PRE_AGGREGATE,
@@ -2213,6 +2211,7 @@ export default class SchedulerTask {
         scheduledTime: Date,
         payload: UploadMetricGsheetPayload,
     ) {
+        setSchedulerJobLogContext({ jobId });
         const baseLog: Pick<SchedulerLog, 'task' | 'jobId' | 'scheduledTime'> =
             {
                 task: SCHEDULER_TASKS.UPLOAD_GSHEET_FROM_QUERY,
@@ -2410,7 +2409,6 @@ export default class SchedulerTask {
             schedulerUuid,
             schedulerName: scheduler.name,
             savedSqlUuid: scheduler.savedSqlUuid,
-            organizationUuid: notification.organizationUuid,
         });
 
         this.analytics.track({
@@ -2848,7 +2846,6 @@ export default class SchedulerTask {
         setSchedulerJobLogContext({
             jobId,
             schedulerUuid,
-            organizationUuid: notification.organizationUuid,
         });
 
         this.analytics.track({
@@ -4144,7 +4141,6 @@ export default class SchedulerTask {
     ) {
         setSchedulerJobLogContext({
             jobId,
-            organizationUuid: payload.organizationUuid,
         });
         await this.logWrapper(
             {
@@ -4751,7 +4747,6 @@ export default class SchedulerTask {
             schedulerUuid,
             schedulerName: scheduler.name,
             savedSqlUuid: scheduler.savedSqlUuid,
-            organizationUuid: notification.organizationUuid,
         });
 
         this.analytics.track({
@@ -4984,7 +4979,6 @@ export default class SchedulerTask {
             schedulerUuid,
             schedulerName: scheduler.name,
             savedSqlUuid: scheduler.savedSqlUuid,
-            organizationUuid: notification.organizationUuid,
         });
 
         this.analytics.track({
@@ -5207,7 +5201,6 @@ export default class SchedulerTask {
             schedulerUuid,
             schedulerName: scheduler.name,
             savedSqlUuid: scheduler.savedSqlUuid,
-            organizationUuid: notification.organizationUuid,
         });
 
         this.analytics.track({
@@ -5428,7 +5421,6 @@ export default class SchedulerTask {
             schedulerUuid,
             schedulerName: scheduler.name,
             savedSqlUuid: scheduler.savedSqlUuid,
-            organizationUuid: notification.organizationUuid,
         });
         this.analytics.track({
             event: 'scheduler_notification_job.started',
@@ -5660,7 +5652,6 @@ export default class SchedulerTask {
             schedulerUuid,
             schedulerName: scheduler.name,
             savedSqlUuid: scheduler.savedSqlUuid,
-            organizationUuid: notification.organizationUuid,
         });
 
         this.analytics.track({

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -112,6 +112,7 @@ import archiver from 'archiver';
 import fsSync from 'fs';
 import fs from 'fs/promises';
 import { nanoid } from 'nanoid';
+import ExecutionContext from 'node-execution-context';
 import pLimit from 'p-limit';
 import slackifyMarkdown from 'slackify-markdown';
 import { Readable } from 'stream';
@@ -139,6 +140,7 @@ import { LightdashConfig } from '../config/parseConfig';
 import type { PreAggregateModel } from '../ee/models/PreAggregateModel';
 import type { PreAggregateMaterializationService } from '../ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService';
 import Logger from '../logging/logger';
+import type { ExecutionContextInfo } from '../logging/winston';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
 import { SCHEDULER_POLLING_OPTIONS } from '../services/AsyncQueryService/types';
 import type { CatalogService } from '../services/CatalogService/CatalogService';
@@ -192,6 +194,39 @@ export type SchedulerTaskArguments = {
     preAggregateModel: PreAggregateModel;
     preAggregateMaterializationService: PreAggregateMaterializationService;
 };
+
+/**
+ * Stamps the current job's AsyncLocalStorage-backed ExecutionContext with
+ * scheduler/sync attribution so every downstream log line and warehouse
+ * `queryTags` row carries the originating scheduler_uuid, scheduler_name,
+ * saved_sql_uuid, job_id, and organization context.
+ *
+ * SchedulerWorkerEventEmitter has already opened a context per job, so we
+ * only need to `update()` — there is nothing to do outside a worker job.
+ */
+function setSchedulerJobLogContext(args: {
+    jobId?: string;
+    schedulerUuid?: string;
+    schedulerName?: string;
+    savedSqlUuid?: string | null;
+    organizationUuid?: string;
+    organizationName?: string;
+}) {
+    if (!ExecutionContext.exists()) return;
+    const updates: Partial<ExecutionContextInfo> = {};
+    if (args.organizationUuid)
+        updates.organization_uuid = args.organizationUuid;
+    if (args.organizationName)
+        updates.organization_name = args.organizationName;
+    const schedulerCtx: NonNullable<ExecutionContextInfo['scheduler']> = {};
+    if (args.schedulerUuid) schedulerCtx.scheduler_uuid = args.schedulerUuid;
+    if (args.schedulerName) schedulerCtx.scheduler_name = args.schedulerName;
+    if (args.savedSqlUuid) schedulerCtx.saved_sql_uuid = args.savedSqlUuid;
+    if (args.jobId) schedulerCtx.job_id = args.jobId;
+    if (Object.keys(schedulerCtx).length > 0) updates.scheduler = schedulerCtx;
+    if (Object.keys(updates).length === 0) return;
+    ExecutionContext.update(updates as unknown as Record<string, unknown>);
+}
 
 export default class SchedulerTask {
     protected readonly lightdashConfig: LightdashConfig;
@@ -1017,6 +1052,13 @@ export default class SchedulerTask {
             scheduledTime,
             scheduler,
         } = notification;
+        setSchedulerJobLogContext({
+            jobId,
+            schedulerUuid,
+            schedulerName: scheduler.name,
+            savedSqlUuid: scheduler.savedSqlUuid,
+            organizationUuid: notification.organizationUuid,
+        });
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
@@ -1387,6 +1429,13 @@ export default class SchedulerTask {
             scheduledTime,
             scheduler,
         } = notification;
+        setSchedulerJobLogContext({
+            jobId,
+            schedulerUuid,
+            schedulerName: scheduler.name,
+            savedSqlUuid: scheduler.savedSqlUuid,
+            organizationUuid: notification.organizationUuid,
+        });
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
@@ -2356,6 +2405,14 @@ export default class SchedulerTask {
             scheduler,
         } = notification;
 
+        setSchedulerJobLogContext({
+            jobId,
+            schedulerUuid,
+            schedulerName: scheduler.name,
+            savedSqlUuid: scheduler.savedSqlUuid,
+            organizationUuid: notification.organizationUuid,
+        });
+
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
@@ -2787,6 +2844,12 @@ export default class SchedulerTask {
         notification: GsheetsNotificationPayload,
     ) {
         const { schedulerUuid, scheduledTime } = notification;
+
+        setSchedulerJobLogContext({
+            jobId,
+            schedulerUuid,
+            organizationUuid: notification.organizationUuid,
+        });
 
         this.analytics.track({
             event: 'scheduler_notification_job.started',
@@ -3306,6 +3369,7 @@ export default class SchedulerTask {
                         deliveryUrl,
                         getErrorMessage(e),
                         shouldDisableSync,
+                        jobId,
                     );
                 }
             } catch (emailError) {
@@ -3872,6 +3936,7 @@ export default class SchedulerTask {
                         scheduler.name,
                         schedulerUrl,
                         translatedSlackError?.error ?? getErrorMessage(e),
+                        jobId,
                     );
                 }
             } catch (emailError) {
@@ -4077,6 +4142,10 @@ export default class SchedulerTask {
         scheduledTime: Date,
         payload: ExportCsvDashboardPayload,
     ) {
+        setSchedulerJobLogContext({
+            jobId,
+            organizationUuid: payload.organizationUuid,
+        });
         await this.logWrapper(
             {
                 task: SCHEDULER_TASKS.EXPORT_CSV_DASHBOARD,
@@ -4677,6 +4746,14 @@ export default class SchedulerTask {
 
         const results: DeliveryResult[] = [];
 
+        setSchedulerJobLogContext({
+            jobId,
+            schedulerUuid,
+            schedulerName: scheduler.name,
+            savedSqlUuid: scheduler.savedSqlUuid,
+            organizationUuid: notification.organizationUuid,
+        });
+
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
@@ -4902,6 +4979,14 @@ export default class SchedulerTask {
 
         const results: DeliveryResult[] = [];
 
+        setSchedulerJobLogContext({
+            jobId,
+            schedulerUuid,
+            schedulerName: scheduler.name,
+            savedSqlUuid: scheduler.savedSqlUuid,
+            organizationUuid: notification.organizationUuid,
+        });
+
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
@@ -5117,6 +5202,14 @@ export default class SchedulerTask {
 
         const results: DeliveryResult[] = [];
 
+        setSchedulerJobLogContext({
+            jobId,
+            schedulerUuid,
+            schedulerName: scheduler.name,
+            savedSqlUuid: scheduler.savedSqlUuid,
+            organizationUuid: notification.organizationUuid,
+        });
+
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
@@ -5330,6 +5423,13 @@ export default class SchedulerTask {
             scheduledTime,
             scheduler,
         } = notification;
+        setSchedulerJobLogContext({
+            jobId,
+            schedulerUuid,
+            schedulerName: scheduler.name,
+            savedSqlUuid: scheduler.savedSqlUuid,
+            organizationUuid: notification.organizationUuid,
+        });
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
@@ -5554,6 +5654,14 @@ export default class SchedulerTask {
             notification;
 
         const results: DeliveryResult[] = [];
+
+        setSchedulerJobLogContext({
+            jobId,
+            schedulerUuid,
+            schedulerName: scheduler.name,
+            savedSqlUuid: scheduler.savedSqlUuid,
+            organizationUuid: notification.organizationUuid,
+        });
 
         this.analytics.track({
             event: 'scheduler_notification_job.started',

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -317,6 +317,12 @@ export const traceTask = <T extends SchedulerTaskName>(
                                     priority: job.priority,
                                     attempts: job.attempts,
                                 },
+                                ...(organizationUuid && {
+                                    organization_uuid: organizationUuid,
+                                }),
+                                ...(organizationName && {
+                                    organization_name: organizationName,
+                                }),
                             };
                             await ExecutionContext.run(
                                 () => task(payload, helpers),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -6079,8 +6079,6 @@ export class AsyncQueryService extends ProjectService {
                 queryTags: {
                     ...this.getUserQueryTags(account),
                     ...AsyncQueryService.getSchedulerQueryTags(),
-                    ...AsyncQueryService.getSchedulerQueryTags(),
-                    ...AsyncQueryService.getSchedulerQueryTags(),
                     organization_uuid: savedChart.organizationUuid,
                     project_uuid: projectUuid,
                     explore_name: explore.name,
@@ -6147,8 +6145,6 @@ export class AsyncQueryService extends ProjectService {
                 context: QueryExecutionContext.CALCULATE_TOTAL,
                 queryTags: {
                     ...this.getUserQueryTags(account),
-                    ...AsyncQueryService.getSchedulerQueryTags(),
-                    ...AsyncQueryService.getSchedulerQueryTags(),
                     ...AsyncQueryService.getSchedulerQueryTags(),
                     organization_uuid: account.organization.organizationUuid,
                     project_uuid: projectUuid,
@@ -6237,7 +6233,6 @@ export class AsyncQueryService extends ProjectService {
             context: QueryExecutionContext.CALCULATE_SUBTOTAL,
             queryTags: {
                 ...this.getUserQueryTags(account),
-                ...AsyncQueryService.getSchedulerQueryTags(),
                 ...AsyncQueryService.getSchedulerQueryTags(),
                 organization_uuid: account.organization.organizationUuid,
                 project_uuid: projectUuid,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -124,6 +124,7 @@ import { createLocalParquetUploadStream } from '../../clients/ResultsFileStorage
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { getDuckdbRuntimeConfig } from '../../ee/services/AsyncQueryService/getDuckdbRuntimeConfig';
 import { measureTime } from '../../logging/measureTime';
+import { getSchedulerContext } from '../../logging/winston';
 import { DownloadAuditModel } from '../../models/DownloadAuditModel';
 import { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import type { SavedSqlModel } from '../../models/SavedSqlModel';
@@ -2403,7 +2404,12 @@ export class AsyncQueryService extends ProjectService {
                     warehouseType: warehouseCredentialsType,
                     errorName: e instanceof Error ? e.name : undefined,
                     errorCode: (e as { code?: string })?.code,
-                    queryContext: queryTags.query_context,
+                    // Surface every queryTag (chart_uuid, dashboard_uuid,
+                    // saved_sql_uuid, scheduler_uuid, scheduler_name, job_id,
+                    // explore_name, query_context, …) onto the error log so a
+                    // single Cloud Logging filter maps a warehouse failure
+                    // back to the originating chart / scheduled sync.
+                    ...queryTags,
                 },
             );
 
@@ -2712,6 +2718,23 @@ export class AsyncQueryService extends ProjectService {
         }
     }
 
+    /**
+     * Reads scheduler/job context from the request-scoped ExecutionContext
+     * (populated by SchedulerTask handlers when a scheduled job is running)
+     * so warehouse queries can be tagged back to the originating sync/delivery.
+     * Returns an empty object outside scheduler execution.
+     */
+    private static getSchedulerQueryTags(): Partial<RunQueryTags> {
+        const ctx = getSchedulerContext();
+        if (!ctx) return {};
+        const tags: Partial<RunQueryTags> = {};
+        if (ctx.scheduler_uuid) tags.scheduler_uuid = ctx.scheduler_uuid;
+        if (ctx.scheduler_name) tags.scheduler_name = ctx.scheduler_name;
+        if (ctx.saved_sql_uuid) tags.saved_sql_uuid = ctx.saved_sql_uuid;
+        if (ctx.job_id) tags.job_id = ctx.job_id;
+        return tags;
+    }
+
     private static buildQueryTags(query: QueryHistory): RunQueryTags {
         let actorTags: Record<string, string>;
         if (query.createdByActorType === 'jwt') {
@@ -2743,6 +2766,7 @@ export class AsyncQueryService extends ProjectService {
 
         return {
             ...actorTags,
+            ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: query.organizationUuid,
             project_uuid: query.projectUuid ?? undefined,
             explore_name: query.metricQuery.exploreName,
@@ -3637,6 +3661,7 @@ export class AsyncQueryService extends ProjectService {
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
+            ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: organizationUuid,
             project_uuid: projectUuid,
             explore_name: metricQuery.exploreName,
@@ -3823,6 +3848,7 @@ export class AsyncQueryService extends ProjectService {
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
+            ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: organizationUuid,
             project_uuid: projectUuid,
             explore_name: explore.name,
@@ -4034,6 +4060,7 @@ export class AsyncQueryService extends ProjectService {
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
+            ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: savedChartOrganizationUuid,
             project_uuid: projectUuid,
             chart_uuid: chartUuid,
@@ -4353,6 +4380,7 @@ export class AsyncQueryService extends ProjectService {
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
+            ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: organizationUuid,
             project_uuid: projectUuid,
             chart_uuid: chartUuid,
@@ -4717,6 +4745,7 @@ export class AsyncQueryService extends ProjectService {
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
+            ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: organizationUuid,
             project_uuid: projectUuid,
             explore_name: exploreName,
@@ -4932,6 +4961,7 @@ export class AsyncQueryService extends ProjectService {
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
+            ...AsyncQueryService.getSchedulerQueryTags(),
             organization_uuid: organizationUuid,
             project_uuid: projectUuid,
             query_context: context,
@@ -4980,25 +5010,58 @@ export class AsyncQueryService extends ProjectService {
             );
         }
 
-        await warehouseConnection.warehouseClient.streamQuery(
-            applyLimitToSqlQuery({ sqlQuery: columnDiscoverySql, limit: 1 }),
-            (chunk) => {
-                // Only handle the first call
-                if (columns.length === 0 && chunk.fields) {
-                    Object.keys(chunk.fields).forEach((key) => {
-                        columns.push({
-                            name: key,
-                            type: chunk.fields[key].type,
+        const limitedColumnDiscoverySql = applyLimitToSqlQuery({
+            sqlQuery: columnDiscoverySql,
+            limit: 1,
+        });
+        this.logger.info('column_discovery.started', {
+            event: 'column_discovery.started',
+            projectUuid,
+            sqlBytes: Buffer.byteLength(limitedColumnDiscoverySql, 'utf8'),
+            ...queryTags,
+        });
+        try {
+            await warehouseConnection.warehouseClient.streamQuery(
+                limitedColumnDiscoverySql,
+                (chunk) => {
+                    // Only handle the first call
+                    if (columns.length === 0 && chunk.fields) {
+                        Object.keys(chunk.fields).forEach((key) => {
+                            columns.push({
+                                name: key,
+                                type: chunk.fields[key].type,
+                            });
                         });
-                    });
-                }
-            },
-            {
-                tags: queryTags,
-            },
-        );
+                    }
+                },
+                {
+                    tags: queryTags,
+                },
+            );
+        } catch (e) {
+            const durationMs = performance.now() - sectionStartColumnDiscovery;
+            this.logger.error('column_discovery.failed', {
+                event: 'column_discovery.failed',
+                projectUuid,
+                durationMs,
+                sqlBytes: Buffer.byteLength(limitedColumnDiscoverySql, 'utf8'),
+                errorName: e instanceof Error ? e.name : undefined,
+                errorCode: (e as { code?: string })?.code,
+                errorMessage: getErrorMessage(e),
+                ...queryTags,
+            });
+            throw e;
+        }
         const durationColumnDiscovery =
             performance.now() - sectionStartColumnDiscovery;
+        this.logger.info('column_discovery.completed', {
+            event: 'column_discovery.completed',
+            projectUuid,
+            durationMs: durationColumnDiscovery,
+            sqlBytes: Buffer.byteLength(limitedColumnDiscoverySql, 'utf8'),
+            columnCount: columns.length,
+            ...queryTags,
+        });
 
         // 4. Query Building
         const sectionStartQueryBuilding = performance.now();
@@ -5147,14 +5210,15 @@ export class AsyncQueryService extends ProjectService {
                 2,
             )}`,
             {
+                event: 'prepare_sql_chart_async_query_args.completed',
+                projectUuid,
                 totalTimeMs: totalTime,
-                sections: {
-                    warehouseMs: durationWarehouse.toFixed(2),
-                    userAttributesMs: durationUserAttributes.toFixed(2),
-                    columnDiscoveryMs: durationColumnDiscovery.toFixed(2),
-                    queryBuildingMs: durationQueryBuilding.toFixed(2),
-                    sqlGenerationMs: durationSqlGeneration.toFixed(2),
-                },
+                warehouseMs: durationWarehouse,
+                userAttributesMs: durationUserAttributes,
+                columnDiscoveryMs: durationColumnDiscovery,
+                queryBuildingMs: durationQueryBuilding,
+                sqlGenerationMs: durationSqlGeneration,
+                ...queryTags,
             },
         );
 
@@ -6014,6 +6078,9 @@ export class AsyncQueryService extends ProjectService {
                 context: QueryExecutionContext.CALCULATE_TOTAL,
                 queryTags: {
                     ...this.getUserQueryTags(account),
+                    ...AsyncQueryService.getSchedulerQueryTags(),
+                    ...AsyncQueryService.getSchedulerQueryTags(),
+                    ...AsyncQueryService.getSchedulerQueryTags(),
                     organization_uuid: savedChart.organizationUuid,
                     project_uuid: projectUuid,
                     explore_name: explore.name,
@@ -6080,6 +6147,9 @@ export class AsyncQueryService extends ProjectService {
                 context: QueryExecutionContext.CALCULATE_TOTAL,
                 queryTags: {
                     ...this.getUserQueryTags(account),
+                    ...AsyncQueryService.getSchedulerQueryTags(),
+                    ...AsyncQueryService.getSchedulerQueryTags(),
+                    ...AsyncQueryService.getSchedulerQueryTags(),
                     organization_uuid: account.organization.organizationUuid,
                     project_uuid: projectUuid,
                     explore_name: data.explore,
@@ -6167,6 +6237,8 @@ export class AsyncQueryService extends ProjectService {
             context: QueryExecutionContext.CALCULATE_SUBTOTAL,
             queryTags: {
                 ...this.getUserQueryTags(account),
+                ...AsyncQueryService.getSchedulerQueryTags(),
+                ...AsyncQueryService.getSchedulerQueryTags(),
                 organization_uuid: account.organization.organizationUuid,
                 project_uuid: projectUuid,
                 explore_name: data.explore,

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -12,6 +12,10 @@ export type RunQueryTags = {
     organization_uuid?: string;
     chart_uuid?: string;
     dashboard_uuid?: string;
+    saved_sql_uuid?: string;
+    scheduler_uuid?: string;
+    scheduler_name?: string;
+    job_id?: string;
     explore_name?: string;
     query_context: QueryExecutionContext;
 };


### PR DESCRIPTION
## Summary

Promotes scheduler/warehouse debugging signals from unstructured log text to filterable structured fields so future investigations land in one Cloud Logging query instead of cross-referencing message strings.

### What changes

1. **Tag warehouse errors with scheduler context.** `RunQueryTags` now carries `scheduler_uuid`, `scheduler_name`, `saved_sql_uuid`, and `job_id` alongside the existing `chart_uuid` / `dashboard_uuid` / `query_context`. `AsyncQueryService` reads scheduler context from a request-scoped `ExecutionContext` and spreads it onto every `queryTags` assembly, and the warehouse-error catch block now spreads the full `queryTags` so a single log line maps a generic warehouse error (e.g. ``\"Connection terminated unexpectedly\"``) back to the originating sync.

2. **Log the column-discovery phase as distinct events.** The synchronous LIMIT-1 column-discovery query in ``prepareSqlChartAsyncQueryArgs`` was silent before. It now emits ``column_discovery.started`` / ``.completed`` / ``.failed`` with ``durationMs`` / ``sqlBytes`` / ``columnCount`` plus the queryTags. The existing ``performance.now()`` timers (``warehouseMs``, ``userAttributesMs``, ``columnDiscoveryMs``, ``queryBuildingMs``, ``sqlGenerationMs``) are emitted as numeric structured fields instead of stringified-and-nested under ``sections``.

3. **Emit ``duration_ms`` as a top-level structured field on every HTTP access log.** A new winston format aliases ``express-winston``'s ``responseTime`` to ``duration_ms``, so latency dashboards and alerting can use ``jsonPayload.duration_ms > 60000`` instead of regexing the message text for ``\"… 600612 ms\"``.

4. **Correlation ID in failure emails.** ``sendGoogleSheetsErrorNotificationEmail`` and ``sendScheduledDeliveryFailureEmail`` now take a ``correlationId`` parameter and append ``?ref=<jobId>`` to the existing deep-link. Support can paste one ID into Cloud Logging and land on the failing job instead of triangulating from project UUID + approximate timestamp.

5. **Stamp every backend log with ``organization_uuid`` + ``organization_name``.** Extends the existing AsyncLocalStorage-backed ``ExecutionContext`` so a new express middleware (HTTP) and ``setSchedulerJobLogContext()`` (scheduler tasks) attach org context once, and every downstream ``Logger.info`` / ``Logger.error`` call automatically inherits it. Multi-tenant log filtering becomes ``jsonPayload.organization_name=\"acme-co\"`` instead of grepping UUIDs across pods.

**Note:** the spec mentioned ``organization_slug`` but no such field exists in this codebase — substituted ``organization_name`` (the closest human-readable equivalent).

### Why now

Motivated by a recent investigation where a generic warehouse error in the logs took significant time to map back to a specific scheduled sync, because the log line had project UUID + endpoint but no scheduler attribution. Each of these five changes shrinks that loop:

| Before | After |
|---|---|
| ``error: Connection terminated unexpectedly`` (with ``project_uuid`` only) | ``error: Connection terminated unexpectedly`` + ``scheduler_uuid``, ``scheduler_name``, ``saved_sql_uuid``, ``job_id``, ``organization_name`` |
| Column-discovery LIMIT-1 query: silent | ``column_discovery.completed durationMs:7.97 columnCount:2 …`` |
| ``POST … 200 - 600612 ms`` (regex the message) | ``{\"duration_ms\":600612, …}`` |
| Failure email links to ``/scheduler/settings`` | Failure email links to ``/scheduler/settings?ref=<jobId>`` |
| Filter pods by grepping ``172a2270-…`` in message text | Filter by ``organization_name=\"acme-co\"`` structured field |

### Sample log lines (verified live)

HTTP access log:
```json
{\"duration_ms\":79,\"level\":\"http\",\"message\":\"POST /api/v2/projects/…/query/metric-query 200 - 79 ms\",\"organization_name\":\"Acme Co\",\"organization_uuid\":\"…\"}
```

Deep inside ``AsyncQueryService`` (no HTTP middleware involvement — proves the ``ExecutionContext`` propagation works):
```json
{\"level\":\"info\",\"message\":\"Query … completed: source=warehouse …\",\"organization_name\":\"Acme Co\",\"organization_uuid\":\"…\",\"serviceName\":\"AsyncQueryService\"}
```

Column-discovery event:
```json
{\"event\":\"column_discovery.completed\",\"durationMs\":7.97,\"columnCount\":2,\"project_uuid\":\"…\",\"query_context\":\"sqlRunner\",\"organization_name\":\"Acme Co\",…}
```

## Test plan

- [x] ``pnpm -F backend typecheck`` passes
- [x] ``pnpm -F backend lint`` passes
- [x] ``pnpm -F common build`` passes
- [x] Smoke test: triggered metric query — confirmed ``duration_ms`` + ``organization_uuid`` + ``organization_name`` on HTTP and service logs
- [x] Smoke test: triggered SQL runner query — confirmed ``column_discovery.started`` / ``completed`` events with the new structured fields
- [x] No API/scheduler crash-loop after restart
- [ ] Trigger an actual scheduler failure to verify ``?ref=`` appears in the email link (code reviewed; requires a forced delivery failure to exercise live)

## Out of scope

- ``organization_slug`` (does not exist in this codebase)
- Scheduler-context tagging for non-scheduler entry points (embed/JWT queries explicitly exclude these tags via ``Omit<>`` in ``EmbedService``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)