### PR TITLE
feat(cli): support spark dbt adapter in deploy command

### DIFF
--- a/packages/backend/src/dbt/DbtMetadataApiClient.ts
+++ b/packages/backend/src/dbt/DbtMetadataApiClient.ts
@@ -21,6 +21,7 @@ const quoteChars: Record<SupportedDbtAdapter, string> = {
     trino: `"`,
     clickhouse: `"`,
     athena: `"`,
+    spark: '`',
 };
 
 const PAGE_SIZE = 500;

--- a/packages/backend/src/formulaDialectMapper.ts
+++ b/packages/backend/src/formulaDialectMapper.ts
@@ -31,6 +31,7 @@ export const mapAdapterToFormulaDialect = (
         case SupportedDbtAdapter.DUCKDB:
             return 'duckdb';
         case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
             return 'databricks';
         case SupportedDbtAdapter.CLICKHOUSE:
             return 'clickhouse';

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -204,9 +204,10 @@ export function getIntervalSyntax(
             // BigQuery always uses DATE_ADD/DATE_SUB
             intervalExpression = `DATE_${operation}(DATE(${columnWithInterval}), INTERVAL ${value} ${granularity})`;
             break;
-        case SupportedDbtAdapter.DATABRICKS: {
-            // Databricks uses interval arithmetic with quoted values
-            // Databricks doesn't support QUARTER interval, convert to months
+        case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK: {
+            // Databricks/Spark uses interval arithmetic with quoted values
+            // Doesn't support QUARTER interval, convert to months
             const [dbValue, dbGranularity] = normalizeIntervalGranularity(
                 value,
                 granularity,

--- a/packages/cli/src/dbt/profile.ts
+++ b/packages/cli/src/dbt/profile.ts
@@ -15,6 +15,7 @@ import { convertDuckdbSchema } from './targets/duckdb';
 import { convertPostgresSchema } from './targets/postgres';
 import { convertRedshiftSchema } from './targets/redshift';
 import { convertSnowflakeSchema } from './targets/snowflake';
+import { convertSparkSchema } from './targets/spark';
 import { convertTrinoSchema } from './targets/trino';
 import { renderProfilesYml } from './templating';
 import { LoadProfileArgs, Profiles, Target } from './types';
@@ -77,6 +78,8 @@ export const warehouseCredentialsFromDbtTarget = async (
             return convertAthenaSchema(target);
         case 'duckdb':
             return convertDuckdbSchema(target);
+        case 'spark':
+            return convertSparkSchema();
         default:
             throw new ParseError(
                 `Sorry! Lightdash doesn't yet support ${target.type} dbt targets`,

--- a/packages/cli/src/dbt/targets/spark.ts
+++ b/packages/cli/src/dbt/targets/spark.ts
@@ -1,0 +1,9 @@
+import { ParseError } from '@lightdash/common';
+
+export const convertSparkSchema = (): never => {
+    throw new ParseError(
+        `Spark dbt projects don't provide warehouse credentials directly. ` +
+            `Use --no-warehouse-credentials flag, then configure your ` +
+            `query engine (e.g., Athena) in the Lightdash UI.`,
+    );
+};

--- a/packages/cli/src/handlers/dbt/getWarehouseClient.ts
+++ b/packages/cli/src/handlers/dbt/getWarehouseClient.ts
@@ -173,6 +173,16 @@ function getMockCredentials(
                 httpPath: '',
                 personalAccessToken: '',
             };
+        case SupportedDbtAdapter.SPARK:
+            // Spark uses same SQL dialect as Databricks
+            return {
+                type: WarehouseTypes.DATABRICKS,
+                catalog: '',
+                database: '',
+                serverHostName: '',
+                httpPath: '',
+                personalAccessToken: '',
+            };
         case SupportedDbtAdapter.TRINO:
             return {
                 type: WarehouseTypes.TRINO,

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -21,6 +21,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getConfig, setProject } from '../config';
 import { getDbtContext } from '../dbt/context';
+import { loadDbtTarget } from '../dbt/profile';
 import GlobalState from '../globalState';
 import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
 import { CliProjectType, detectProjectType } from '../lightdash/projectType';
@@ -586,6 +587,43 @@ export const deployHandler = async (originalOptions: DeployHandlerOptions) => {
     options.warehouseCredentials = projectTypeConfig.warehouseCredentials;
     options.skipDbtCompile = projectTypeConfig.skipDbtCompile;
     options.skipWarehouseCatalog = projectTypeConfig.skipWarehouseCatalog;
+
+    // Auto-detect Spark adapter and skip warehouse credentials
+    // Spark session-based projects have no warehouse server to connect to;
+    // users configure their actual query engine (e.g., Athena) in the UI.
+    if (
+        projectTypeConfig.type === CliProjectType.Dbt &&
+        options.warehouseCredentials !== false
+    ) {
+        try {
+            const context = await getDbtContext({
+                projectDir: path.resolve(options.projectDir),
+                targetPath: options.targetPath,
+            });
+            const { target } = await loadDbtTarget({
+                profilesDir: path.resolve(options.profilesDir),
+                profileName: options.profile || context.profileName,
+                targetName: options.target,
+            });
+            if (target.type === 'spark') {
+                options.warehouseCredentials = false;
+                options.skipWarehouseCatalog = true;
+                GlobalState.debug(
+                    '> Spark adapter detected, skipping warehouse credentials',
+                );
+                console.error(
+                    styles.warning(
+                        `Spark adapter detected. Project will be created without warehouse credentials.\nConfigure your query engine (e.g., Athena) in the Lightdash UI.`,
+                    ),
+                );
+            }
+        } catch (e) {
+            // If we can't read the profile, let the normal flow handle it
+            GlobalState.debug(
+                `> Could not detect adapter type: ${getErrorMessage(e)}`,
+            );
+        }
+    }
 
     // Resolve organization credentials early before doing any heavy work
     if (options.organizationCredentials) {

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -96,6 +96,7 @@ const convertTimezone = (
         case SupportedDbtAdapter.DUCKDB:
             return timestampSql;
         case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
             return timestampSql;
         // Athena uses Trino SQL, timestamps return in server timezone
         case SupportedDbtAdapter.TRINO:

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -39,6 +39,7 @@ export enum SupportedDbtAdapter {
     TRINO = 'trino',
     CLICKHOUSE = 'clickhouse',
     ATHENA = 'athena',
+    SPARK = 'spark',
 }
 
 export type DbtNodeConfig = {
@@ -316,6 +317,7 @@ export const normaliseModelDatabase = (
         case SupportedDbtAdapter.CLICKHOUSE:
             return { ...model, database: '' }; // Clickhouse doesn't have a database field
         case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
             return { ...model, database: model.database || 'DEFAULT' };
         default:
             return assertUnreachable(

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -123,6 +123,11 @@ export const dateTruncTimezoneConversions: Record<
             `from_utc_timestamp(to_utc_timestamp(${sql}, current_timezone()), '${tz}')`,
         toUTC: (sql, tz) => `to_utc_timestamp(${sql}, '${tz}')`,
     },
+    [SupportedDbtAdapter.SPARK]: {
+        toProjectTz: (sql, tz) =>
+            `from_utc_timestamp(to_utc_timestamp(${sql}, current_timezone()), '${tz}')`,
+        toUTC: (sql, tz) => `to_utc_timestamp(${sql}, '${tz}')`,
+    },
     // Trino returns `timestamp with time zone` values as strings like
     // "2024-01-14 00:00:00.000 America/New_York", which dayjs/moment can't
     // parse — so `toUTC` casts the UTC-shifted result back to a naive
@@ -184,6 +189,10 @@ export const dateExtractsTimezoneConversions: Record<
             `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
     },
     [SupportedDbtAdapter.DATABRICKS]: {
+        toExtractInputTz: (sql, tz) =>
+            `from_utc_timestamp(to_utc_timestamp(${sql}, current_timezone()), '${tz}')`,
+    },
+    [SupportedDbtAdapter.SPARK]: {
         toExtractInputTz: (sql, tz) =>
             `from_utc_timestamp(to_utc_timestamp(${sql}, current_timezone()), '${tz}')`,
     },

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -669,6 +669,7 @@ const warehouseConfigs: Record<SupportedDbtAdapter, WarehouseConfig> = {
     [SupportedDbtAdapter.POSTGRES]: postgresConfig,
     [SupportedDbtAdapter.DUCKDB]: postgresConfig,
     [SupportedDbtAdapter.DATABRICKS]: databricksConfig,
+    [SupportedDbtAdapter.SPARK]: databricksConfig, // Spark uses same SQL dialect as Databricks
     [SupportedDbtAdapter.TRINO]: trinoConfig,
     [SupportedDbtAdapter.ATHENA]: trinoConfig, // Athena uses Trino SQL dialect
     [SupportedDbtAdapter.CLICKHOUSE]: clickhouseConfig,

--- a/packages/common/src/utils/warehouse.ts
+++ b/packages/common/src/utils/warehouse.ts
@@ -48,6 +48,7 @@ export const getAggregatedField = (
     switch (adapterType) {
         case SupportedDbtAdapter.BIGQUERY:
         case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
         case SupportedDbtAdapter.SNOWFLAKE:
         case SupportedDbtAdapter.REDSHIFT:
         case SupportedDbtAdapter.TRINO:

--- a/packages/warehouses/src/warehouseSqlBuilderFromType.ts
+++ b/packages/warehouses/src/warehouseSqlBuilderFromType.ts
@@ -44,6 +44,8 @@ export const warehouseSqlBuilderFromType = (
             return new TrinoSqlBuilder(...args);
         case SupportedDbtAdapter.ATHENA:
             return new AthenaSqlBuilder(...args);
+        case SupportedDbtAdapter.SPARK:
+            return new DatabricksSqlBuilder(...args);
         default:
             const never: never = adapterType;
             throw new Error(`Unsupported adapter type: ${adapterType}`);


### PR DESCRIPTION
## Summary

Rebases and lands @jessicabowden's #21592 (community contribution from Norm.ai), which adds `SupportedDbtAdapter.SPARK` so the CLI and compiler can handle dbt projects using the `spark` adapter.

- Adds `SPARK` to `SupportedDbtAdapter` enum, mapped to Databricks SQL behavior
- Auto-detects Spark adapter in `deploy --create` and skips warehouse credentials (Spark `session`-based projects have no warehouse server to connect to)
- Users configure their actual query engine (e.g., Athena) in the Lightdash UI after project creation

## What's different from #21592

The original PR was opened against main from March 31. In the intervening commits, three new exhaustive `SupportedDbtAdapter` sites were added on main that the original diff doesn't cover. This PR carries Jessica's original commit unchanged (preserving her authorship) and adds a single follow-up commit that covers the three new sites:

- `dateTruncTimezoneConversions` in `packages/common/src/utils/timeFrames.ts`
- `dateExtractsTimezoneConversions` in `packages/common/src/utils/timeFrames.ts`
- `mapAdapterToFormulaDialect` in `packages/backend/src/formulaDialectMapper.ts`

All follow the established "SPARK == DATABRICKS for SQL behavior" pattern.

## Test plan

- [x] `pnpm -F common typecheck` (validates all exhaustive Record/switch coverage)
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F cli typecheck`
- [x] `pnpm -F warehouses typecheck`
- [x] `pnpm -F common test` (2039 tests pass)
- [x] `pnpm -F backend test` for `DbtMetadataApiClient`, `MetricQueryBuilder`, `formulaDialectMapper`, `timeFrames` (188 tests pass)
- [x] Regression: non-spark `lightdash deploy --create` works against a local Postgres dbt project (no behavior change, no errors)
- [x] Spark auto-detect: `lightdash deploy --create` against a synthetic `type: spark, method: session` profile shows the warning and creates the project without warehouse credentials
- [ ] **For customer testing (not reproducible locally):** full deploy → Athena connection → query workflow end-to-end, including date/time filters (week/quarter granularity) which exercise the SPARK→Databricks dialect mapping in `MetricQueryBuilder` and the new timezone conversions

Closes #21592.