### PR TITLE
fix: scope dashboard editor sessionStorage keys to dashboardUuid

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -6,6 +6,7 @@ import { Box, Menu, useMantineColorScheme } from '@mantine-8/core';
 import { IconCopy } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import React, { useCallback, useMemo, useState, type FC } from 'react';
+import { useParams } from 'react-router';
 import rehypeExternalLinks from 'rehype-external-links';
 import { v4 as uuid4 } from 'uuid';
 import { DashboardTileComments } from '../../features/comments';
@@ -45,7 +46,7 @@ const MarkdownTile: FC<Props> = (props) => {
     const setHaveTilesChanged = useDashboardContext(
         (c) => c.setHaveTilesChanged,
     );
-    const unsavedDashboardTiles = getUnsavedDashboardTiles();
+    const { dashboardUuid } = useParams<{ dashboardUuid: string }>();
 
     const dashboardComments = useMemo(
         () =>
@@ -66,8 +67,11 @@ const MarkdownTile: FC<Props> = (props) => {
             uuid: uuid4(),
         };
 
+        const unsavedDashboardTiles = dashboardUuid
+            ? getUnsavedDashboardTiles(dashboardUuid)
+            : [];
         const existingTiles =
-            unsavedDashboardTiles?.length > 0
+            unsavedDashboardTiles.length > 0
                 ? unsavedDashboardTiles
                 : dashboardTiles;
 
@@ -77,7 +81,8 @@ const MarkdownTile: FC<Props> = (props) => {
         setHaveTilesChanged(true);
     }, [
         props.tile,
-        unsavedDashboardTiles,
+        dashboardUuid,
+        getUnsavedDashboardTiles,
         dashboardTiles,
         setDashboardTiles,
         setHaveTilesChanged,

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -4,6 +4,7 @@ import {
     type CreateChartInDashboard,
     type CreateDashboardChartTile,
     type CreateSavedChartVersion,
+    type DashboardTile,
 } from '@lightdash/common';
 import {
     Button,
@@ -97,7 +98,6 @@ export const SaveToDashboard: FC<Props> = ({
         setUnsavedDashboardTiles,
         getDashboardActiveTabUuid,
     } = useDashboardStorage();
-    const unsavedDashboardTiles = getUnsavedDashboardTiles();
     const form = useForm<FormValues>({
         initialValues: {
             ...defaults,
@@ -105,13 +105,12 @@ export const SaveToDashboard: FC<Props> = ({
         validate: zodResolver(validationSchema),
     });
 
-    const activeTabUuid = getDashboardActiveTabUuid();
-
     const handleSaveChartInDashboard = useCallback(
         async (values: SaveToDashboardFormValues) => {
             if (!dashboardUuid || !projectUuid) {
                 return;
             }
+            const activeTabUuid = getDashboardActiveTabUuid(dashboardUuid);
             const newChartInDashboard: CreateChartInDashboard = {
                 ...savedData,
                 name: values.name,
@@ -130,13 +129,18 @@ export const SaveToDashboard: FC<Props> = ({
                 },
                 ...getDefaultChartTileSize(savedData.chartConfig?.type),
             };
+            const unsavedDashboardTiles =
+                getUnsavedDashboardTiles(dashboardUuid);
             const existingTiles =
-                unsavedDashboardTiles?.length > 0
+                unsavedDashboardTiles.length > 0
                     ? unsavedDashboardTiles
                     : selectedDashboard?.tiles;
 
             setUnsavedDashboardTiles(
-                appendNewTilesToBottom(existingTiles || [], [newTile]),
+                dashboardUuid,
+                appendNewTilesToBottom<
+                    DashboardTile | CreateDashboardChartTile
+                >(existingTiles || [], [newTile]),
             );
             void navigate(
                 activeTabUuid
@@ -151,13 +155,13 @@ export const SaveToDashboard: FC<Props> = ({
             savedData,
             dashboardUuid,
             createChart,
+            getDashboardActiveTabUuid,
+            getUnsavedDashboardTiles,
             setUnsavedDashboardTiles,
-            unsavedDashboardTiles,
             navigate,
             projectUuid,
             showToastSuccess,
             dashboardName,
-            activeTabUuid,
             selectedDashboard?.tiles,
         ],
     );

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -9,6 +9,7 @@ import {
     type CreateDashboardChartTile,
     type CreateSavedChartVersion,
     type DashboardChartTile,
+    type DashboardTile,
     type DashboardVersionedFields,
     type SavedChart,
 } from '@lightdash/common';
@@ -347,7 +348,9 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                     dashboardUuid: originatingDashboard.dashboardUuid,
                 };
                 savedQuery = await createChart(newChartInDashboard);
-                const activeTabUuid = getDashboardActiveTabUuid();
+                const activeTabUuid = getDashboardActiveTabUuid(
+                    originatingDashboard.dashboardUuid,
+                );
                 const newTile: CreateDashboardChartTile = {
                     uuid: uuid4(),
                     type: DashboardTileTypes.SAVED_CHART,
@@ -359,13 +362,18 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                     },
                     ...getDefaultChartTileSize(savedData.chartConfig?.type),
                 };
-                const unsavedTiles = getUnsavedDashboardTiles();
+                const unsavedTiles = getUnsavedDashboardTiles(
+                    originatingDashboard.dashboardUuid,
+                );
                 const existingTiles =
                     unsavedTiles?.length > 0
                         ? unsavedTiles
                         : originatingDashboardData?.tiles;
                 setUnsavedDashboardTiles(
-                    appendNewTilesToBottom(existingTiles ?? [], [newTile]),
+                    originatingDashboard.dashboardUuid,
+                    appendNewTilesToBottom<
+                        DashboardTile | CreateDashboardChartTile
+                    >(existingTiles ?? [], [newTile]),
                 );
                 void navigate(
                     activeTabUuid

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.test.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.test.ts
@@ -1,0 +1,165 @@
+import {
+    DashboardTileTypes,
+    type DashboardChartTile,
+    type DashboardFilters,
+} from '@lightdash/common';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import useDashboardStorage from './useDashboardStorage';
+
+const DASHBOARD_A_UUID = '01636314-fc83-4284-9b95-179de80ad22c';
+const DASHBOARD_B_UUID = '429907e3-2c54-449d-99bc-7f577d98287b';
+
+const makeTile = (uuid: string): DashboardChartTile => ({
+    uuid,
+    type: DashboardTileTypes.SAVED_CHART,
+    x: 0,
+    y: 0,
+    w: 24,
+    h: 9,
+    tabUuid: undefined,
+    properties: {
+        title: '',
+        hideTitle: false,
+        savedChartUuid: 'chart-from-a',
+        belongsToDashboard: true,
+        chartName: 'A inline chart',
+    },
+});
+
+const emptyFilters: DashboardFilters = {
+    dimensions: [],
+    metrics: [],
+    tableCalculations: [],
+};
+
+describe('useDashboardStorage', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    afterEach(() => {
+        sessionStorage.clear();
+    });
+
+    it('isolates tiles by dashboardUuid so navigating to a different dashboard does not pick up another dashboards stored tiles', () => {
+        const { result } = renderHook(() => useDashboardStorage());
+        const aTile = makeTile('tile-from-a');
+
+        act(() => {
+            result.current.storeDashboard(
+                [aTile],
+                emptyFilters,
+                true,
+                false,
+                DASHBOARD_A_UUID,
+                'Dashboard A',
+            );
+        });
+
+        expect(
+            result.current.getUnsavedDashboardTiles(DASHBOARD_A_UUID),
+        ).toEqual([aTile]);
+        expect(
+            result.current.getUnsavedDashboardTiles(DASHBOARD_B_UUID),
+        ).toEqual([]);
+    });
+
+    it('writes namespaced sessionStorage keys (no flat unsavedDashboardTiles key)', () => {
+        const { result } = renderHook(() => useDashboardStorage());
+
+        act(() => {
+            result.current.storeDashboard(
+                [makeTile('tile-x')],
+                emptyFilters,
+                true,
+                false,
+                DASHBOARD_A_UUID,
+                'Dashboard A',
+            );
+        });
+
+        expect(sessionStorage.getItem('unsavedDashboardTiles')).toBeNull();
+        expect(
+            sessionStorage.getItem(`unsavedDashboardTiles:${DASHBOARD_A_UUID}`),
+        ).not.toBeNull();
+    });
+
+    it('clearDashboardStorage only removes the namespaced keys belonging to the source dashboard', () => {
+        const { result } = renderHook(() => useDashboardStorage());
+
+        act(() => {
+            result.current.storeDashboard(
+                [makeTile('tile-from-a')],
+                emptyFilters,
+                true,
+                false,
+                DASHBOARD_A_UUID,
+                'Dashboard A',
+            );
+            result.current.setUnsavedDashboardTiles(DASHBOARD_B_UUID, [
+                makeTile('tile-from-b'),
+            ]);
+        });
+
+        act(() => {
+            result.current.clearDashboardStorage();
+        });
+
+        expect(
+            result.current.getUnsavedDashboardTiles(DASHBOARD_A_UUID),
+        ).toEqual([]);
+        expect(
+            result.current.getUnsavedDashboardTiles(DASHBOARD_B_UUID),
+        ).toEqual([makeTile('tile-from-b')]);
+    });
+
+    it('storeDashboard is a no-op when dashboardUuid is missing', () => {
+        const { result } = renderHook(() => useDashboardStorage());
+
+        act(() => {
+            result.current.storeDashboard(
+                [makeTile('tile-x')],
+                emptyFilters,
+                true,
+                false,
+                undefined,
+                'No dashboard',
+            );
+        });
+
+        expect(sessionStorage.length).toBe(0);
+    });
+
+    it('getDashboardActiveTabUuid returns each dashboards own active tab', () => {
+        const { result } = renderHook(() => useDashboardStorage());
+
+        act(() => {
+            result.current.storeDashboard(
+                [makeTile('tile-a')],
+                emptyFilters,
+                true,
+                false,
+                DASHBOARD_A_UUID,
+                'A',
+                'tab-of-a',
+            );
+            result.current.storeDashboard(
+                [makeTile('tile-b')],
+                emptyFilters,
+                true,
+                false,
+                DASHBOARD_B_UUID,
+                'B',
+                'tab-of-b',
+            );
+        });
+
+        expect(result.current.getDashboardActiveTabUuid(DASHBOARD_A_UUID)).toBe(
+            'tab-of-a',
+        );
+        expect(result.current.getDashboardActiveTabUuid(DASHBOARD_B_UUID)).toBe(
+            'tab-of-b',
+        );
+    });
+});

--- a/packages/frontend/src/hooks/dashboard/useDashboardStorage.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardStorage.ts
@@ -6,6 +6,16 @@ import {
 } from '@lightdash/common';
 import { useCallback, useEffect, useState } from 'react';
 
+const tilesKey = (dashboardUuid: string) =>
+    `unsavedDashboardTiles:${dashboardUuid}`;
+const tabsKey = (dashboardUuid: string) => `dashboardTabs:${dashboardUuid}`;
+const filtersKey = (dashboardUuid: string) =>
+    `unsavedDashboardFilters:${dashboardUuid}`;
+const activeTabKey = (dashboardUuid: string) =>
+    `activeTabUuid:${dashboardUuid}`;
+const hasChangesKey = (dashboardUuid: string) =>
+    `hasDashboardChanges:${dashboardUuid}`;
+
 const getIsEditingDashboardChart = () => {
     return (
         !!sessionStorage.getItem('fromDashboard') ||
@@ -36,10 +46,13 @@ const useDashboardStorage = () => {
     }, []);
 
     const getEditingDashboardInfo = useCallback(() => {
+        const dashboardUuid = sessionStorage.getItem('dashboardUuid');
         return {
             name: sessionStorage.getItem('fromDashboard'),
-            dashboardUuid: sessionStorage.getItem('dashboardUuid'),
-            activeTabUuid: sessionStorage.getItem('activeTabUuid'),
+            dashboardUuid,
+            activeTabUuid: dashboardUuid
+                ? sessionStorage.getItem(activeTabKey(dashboardUuid))
+                : null,
         };
     }, []);
 
@@ -57,22 +70,32 @@ const useDashboardStorage = () => {
     );
 
     const getHasDashboardChanges = useCallback(() => {
-        return JSON.parse(
-            sessionStorage.getItem('getHasDashboardChanges') ?? 'false',
-        );
+        const dashboardUuid = sessionStorage.getItem('dashboardUuid');
+        if (!dashboardUuid) return false;
+        try {
+            return JSON.parse(
+                sessionStorage.getItem(hasChangesKey(dashboardUuid)) ?? 'false',
+            );
+        } catch {
+            return false;
+        }
     }, []);
 
-    const getDashboardActiveTabUuid = useCallback(() => {
-        return sessionStorage.getItem('activeTabUuid');
+    const getDashboardActiveTabUuid = useCallback((dashboardUuid: string) => {
+        return sessionStorage.getItem(activeTabKey(dashboardUuid));
     }, []);
 
     const clearDashboardStorage = useCallback(() => {
+        const dashboardUuid = sessionStorage.getItem('dashboardUuid');
         sessionStorage.removeItem('fromDashboard');
         sessionStorage.removeItem('dashboardUuid');
-        sessionStorage.removeItem('unsavedDashboardTiles');
-        sessionStorage.removeItem('unsavedDashboardFilters');
-        sessionStorage.removeItem('hasDashboardChanges');
-        sessionStorage.removeItem('activeTabUuid');
+        if (dashboardUuid) {
+            sessionStorage.removeItem(tilesKey(dashboardUuid));
+            sessionStorage.removeItem(tabsKey(dashboardUuid));
+            sessionStorage.removeItem(filtersKey(dashboardUuid));
+            sessionStorage.removeItem(activeTabKey(dashboardUuid));
+            sessionStorage.removeItem(hasChangesKey(dashboardUuid));
+        }
         // Trigger storage event to update NavBar
         window.dispatchEvent(new Event('storage'));
     }, []);
@@ -83,20 +106,21 @@ const useDashboardStorage = () => {
             dashboardFilters: DashboardFilters,
             haveTilesChanged: boolean,
             haveFiltersChanged: boolean,
-            dashboardUuid?: string,
-            dashboardName?: string,
+            dashboardUuid: string | undefined,
+            dashboardName: string | undefined,
             activeTabUuid?: string,
             dashboardTabs?: DashboardTab[],
         ) => {
+            if (!dashboardUuid) return;
             sessionStorage.setItem('fromDashboard', dashboardName ?? '');
-            sessionStorage.setItem('dashboardUuid', dashboardUuid ?? '');
+            sessionStorage.setItem('dashboardUuid', dashboardUuid);
             sessionStorage.setItem(
-                'unsavedDashboardTiles',
+                tilesKey(dashboardUuid),
                 JSON.stringify(dashboardTiles ?? []),
             );
             if (dashboardTabs && dashboardTabs.length > 0) {
                 sessionStorage.setItem(
-                    'dashboardTabs',
+                    tabsKey(dashboardUuid),
                     JSON.stringify(dashboardTabs),
                 );
             }
@@ -105,16 +129,19 @@ const useDashboardStorage = () => {
                 dashboardFilters.metrics.length > 0
             ) {
                 sessionStorage.setItem(
-                    'unsavedDashboardFilters',
+                    filtersKey(dashboardUuid),
                     JSON.stringify(dashboardFilters),
                 );
             }
             sessionStorage.setItem(
-                'hasDashboardChanges',
+                hasChangesKey(dashboardUuid),
                 JSON.stringify(haveTilesChanged || haveFiltersChanged),
             );
             if (activeTabUuid) {
-                sessionStorage.setItem('activeTabUuid', activeTabUuid);
+                sessionStorage.setItem(
+                    activeTabKey(dashboardUuid),
+                    activeTabUuid,
+                );
             }
             // Trigger storage event to update NavBar
             window.dispatchEvent(new Event('storage'));
@@ -122,18 +149,28 @@ const useDashboardStorage = () => {
         [],
     );
 
-    const getUnsavedDashboardTiles = useCallback(() => {
-        return JSON.parse(
-            sessionStorage.getItem('unsavedDashboardTiles') ?? '[]',
-        );
-    }, []);
+    const getUnsavedDashboardTiles = useCallback(
+        (dashboardUuid: string): DashboardTile[] => {
+            try {
+                return JSON.parse(
+                    sessionStorage.getItem(tilesKey(dashboardUuid)) ?? '[]',
+                );
+            } catch {
+                return [];
+            }
+        },
+        [],
+    );
 
     const setUnsavedDashboardTiles = useCallback(
         (
-            unsavedDashboardTiles: DashboardTile[] | CreateDashboardChartTile[],
+            dashboardUuid: string,
+            unsavedDashboardTiles: Array<
+                DashboardTile | CreateDashboardChartTile
+            >,
         ) => {
             sessionStorage.setItem(
-                'unsavedDashboardTiles',
+                tilesKey(dashboardUuid),
                 JSON.stringify(unsavedDashboardTiles),
             );
         },

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -256,14 +256,15 @@ const Dashboard: FC = () => {
     useEffect(() => {
         if (isDashboardLoading) return;
         if (dashboardTiles === undefined) return;
+        if (!dashboardUuid) return;
 
         clearIsEditingDashboardChart();
 
-        const unsavedDashboardTilesRaw = sessionStorage.getItem(
-            'unsavedDashboardTiles',
-        );
+        const tilesStorageKey = `unsavedDashboardTiles:${dashboardUuid}`;
+        const unsavedDashboardTilesRaw =
+            sessionStorage.getItem(tilesStorageKey);
         if (unsavedDashboardTilesRaw) {
-            sessionStorage.removeItem('unsavedDashboardTiles');
+            sessionStorage.removeItem(tilesStorageKey);
 
             try {
                 const unsavedDashboardTiles = JSON.parse(
@@ -284,9 +285,10 @@ const Dashboard: FC = () => {
             }
         }
 
-        const unsavedDashboardTabsRaw = sessionStorage.getItem('dashboardTabs');
+        const tabsStorageKey = `dashboardTabs:${dashboardUuid}`;
+        const unsavedDashboardTabsRaw = sessionStorage.getItem(tabsStorageKey);
 
-        sessionStorage.removeItem('dashboardTabs');
+        sessionStorage.removeItem(tabsStorageKey);
 
         if (unsavedDashboardTabsRaw) {
             try {
@@ -308,6 +310,7 @@ const Dashboard: FC = () => {
     }, [
         isDashboardLoading,
         dashboardTiles,
+        dashboardUuid,
         activeTab,
         setHaveTilesChanged,
         setDashboardTiles,
@@ -626,7 +629,7 @@ const Dashboard: FC = () => {
                 `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
             ) &&
             // Allow user to add a new table
-            !sessionStorage.getItem('unsavedDashboardTiles')
+            !sessionStorage.getItem(`unsavedDashboardTiles:${dashboardUuid}`)
         ) {
             return true; //blocks navigation
         }

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -1016,11 +1016,16 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 
         // Temp filters
         const tempFilterSearchParam = searchParams.get('tempFilters');
-        const unsavedDashboardFiltersRaw = sessionStorage.getItem(
-            'unsavedDashboardFilters',
-        );
+        const filtersStorageKey = dashboardUuid
+            ? `unsavedDashboardFilters:${dashboardUuid}`
+            : null;
+        const unsavedDashboardFiltersRaw = filtersStorageKey
+            ? sessionStorage.getItem(filtersStorageKey)
+            : null;
 
-        sessionStorage.removeItem('unsavedDashboardFilters');
+        if (filtersStorageKey) {
+            sessionStorage.removeItem(filtersStorageKey);
+        }
         if (unsavedDashboardFiltersRaw) {
             try {
                 const unsavedDashboardFilters = JSON.parse(


### PR DESCRIPTION
## Problem

The frontend hands off dashboard editor state — pending tile changes, tabs, filters, and the active tab — across page navigations using `sessionStorage`. The keys used (`unsavedDashboardTiles`, `dashboardTabs`, `unsavedDashboardFilters`, `activeTabUuid`, `hasDashboardChanges`) were flat per-origin strings, but the data they hold is per-dashboard.

If a user is on Dashboard A and clicks "Edit chart" on an inline tile (or "Add tile → Chart from scratch"), A's tiles/tabs/filters are written to those keys to be picked up again when they return. If the user then navigates to a different dashboard B in the same tab before saving, B's mount effect reads the same flat keys and rehydrates A's state under B's UUID. Saving from there sends a `PATCH /api/v2/projects/{P}/dashboards/{B}` whose body contains A's tile UUIDs verbatim, and the server writes them.

## What this changes

- Per-dashboard payloads are now keyed as `{key}:{dashboardUuid}`: `unsavedDashboardTiles`, `dashboardTabs`, `unsavedDashboardFilters`, `activeTabUuid`, `hasDashboardChanges`.
- The flat `fromDashboard` and `dashboardUuid` keys remain — they're singletons describing "the dashboard the user is currently editing a chart for" and back the chart editor's "Back to X" UI.
- `Dashboard.tsx` and `DashboardProvider.tsx` now read using the dashboard UUID from the URL, so another dashboard's stored state is invisible at mount.
- `SaveToDashboard` / `SaveToSpaceOrDashboard` pass the target dashboard's UUID when reading/writing the storage.
- Side fix: `getHasDashboardChanges` was reading from key `'getHasDashboardChanges'` instead of `'hasDashboardChanges'`. The chart editor's beforeunload warning ("You have unsaved changes to your dashboard!") was effectively disabled. Typo corrected, key now namespaced.

## Reproduction (pre-patch on `main`, fixed by this PR)

### Pre-requisites
- Two dashboards: **A** (the source) and **B** (the target) — can be in the same project or different spaces.
- A must contain at least one **inline chart** (`belongsToDashboard: true`) so the "Edit chart" menu item is enabled. The seed Jaffle shop dashboards work.
- A user signed in with view access on A and edit access on B.

### Steps to reproduce the bug (without this patch)
1. Open Dashboard **A** in **view mode**. Confirm the URL is `/projects/{P}/dashboards/{A_uuid}/view`.
2. Hover an inline tile on A. Click the kebab → **"Edit chart"**. (This menu item is disabled in edit mode — the trigger needs view mode.) You will be navigated to `/projects/{P}/saved/{chartUuid}/edit?fromDashboard={A_uuid}`.
3. Open DevTools → Application → Session Storage → the Lightdash origin. Confirm the following flat keys are present and populated with A's data:
   - `unsavedDashboardTiles` — JSON array of A's tiles (each with a `uuid` field)
   - `dashboardTabs` — JSON array of A's tabs (each with a `uuid` field)
   - `dashboardUuid` — A's UUID
   - `fromDashboard` — A's name
4. **Do not save the chart edit.** In the same browser tab, navigate to Dashboard **B** (e.g., via the sidebar or the dashboards index).
5. Observe Dashboard B's page rendering:
   - **Bug present**: B's frame renders A's tiles. The editor shows an "unsaved changes" indicator. B's actual tile content is gone from the live view.
   - **Bug fixed**: B's own tiles render normally.
6. Click **Save** on Dashboard B. Inspect the network request — it's `PATCH /api/v2/projects/{P}/dashboards/{B_uuid}` with a JSON body containing a `tiles` array whose `uuid` values are A's tile UUIDs (and tabs likewise).
7. Reload Dashboard B. The corruption is now persistent — B's saved content has been replaced by A's tiles. Version history shows the bad save as the current version.

### DB confirmation (post-bad-save, byte-identity check)
```sql
SELECT dt.dashboard_tile_uuid
FROM dashboard_tiles dt
JOIN dashboard_versions dv ON dv.dashboard_version_id = dt.dashboard_version_id
JOIN dashboards d ON d.dashboard_id = dv.dashboard_id
WHERE d.dashboard_uuid IN ('{A_uuid}', '{B_uuid}')
  AND dv.dashboard_version_id IN (
    SELECT MAX(dashboard_version_id) FROM dashboard_versions
    WHERE dashboard_id IN (
      SELECT dashboard_id FROM dashboards WHERE dashboard_uuid IN ('{A_uuid}', '{B_uuid}')
    )
    GROUP BY dashboard_id
  );
```
The intersection of the two result sets should be non-empty — A's tile UUIDs appear in B's latest version. With this patch, the intersection is empty.

### After the patch
- Step 3's keys are now suffixed: e.g. `unsavedDashboardTiles:{A_uuid}` instead of `unsavedDashboardTiles`.
- Step 5 renders B's own tiles even when A's `unsavedDashboardTiles:{A_uuid}` is still in storage, because B's mount effect reads `unsavedDashboardTiles:{B_uuid}` (which is absent).
- Step 6's PATCH body contains B's own tile UUIDs.
- Returning to Dashboard A still rehydrates A's unsaved edits — the chart-edit-from-A handoff path is preserved.

## Test plan

- [x] `pnpm -F frontend exec vitest run src/hooks/dashboard/useDashboardStorage.test.ts` — 5 new tests pass with the change, fail without it (verified by stash/restore).
- [x] `pnpm -F frontend typecheck` clean.
- [x] Manual: reproduced the original behaviour locally per the steps above, confirmed it no longer occurs after this change.
- [ ] Manual: chart-edit-from-dashboard flow still works (open inline chart, edit, save → return to source dashboard with edits applied).
- [ ] Manual: "Add tile → Chart from scratch" still creates a chart and adds it to the source dashboard.
- [ ] Manual: "Save chart → Save to dashboard" appends to the chosen target dashboard's tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)