### PR TITLE
feat: add source field picker to custom metric modal with hover preview support

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -2,6 +2,7 @@ import {
     canApplyFormattingToCustomMetric,
     CustomFormatType,
     friendlyName,
+    getCustomMetricType,
     getFilterableDimensionsFromItemsMap,
     getItemId,
     getMetrics,
@@ -19,7 +20,9 @@ import {
 import {
     Accordion,
     Button,
+    Group,
     NumberInput,
+    Select,
     Stack,
     Text,
     TextInput,
@@ -38,6 +41,8 @@ import {
 } from '../../../features/explorer/store';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useExplore } from '../../../hooks/useExplore';
+import Callout from '../../common/Callout';
+import FieldIcon from '../../common/Filters/FieldIcon';
 import FiltersProvider from '../../common/Filters/FiltersProvider';
 import MantineModal from '../../common/MantineModal';
 import { FormatForm } from '../FormatForm';
@@ -81,6 +86,75 @@ export const CustomMetricModal = memo(() => {
         dimensionToCheck =
             exploreData?.tables[item.table]?.dimensions[item.baseDimensionName];
     }
+
+    const originalBaseDimensionName = useMemo(() => {
+        if (isEditing && isAdditionalMetric(item) && item.baseDimensionName) {
+            return item.baseDimensionName;
+        }
+        if (!isEditing && isDimension(item)) {
+            return item.name;
+        }
+        return null;
+    }, [isEditing, item]);
+
+    const [selectedBaseDimensionName, setSelectedBaseDimensionName] = useState<
+        string | null
+    >(originalBaseDimensionName);
+
+    useEffect(() => {
+        setSelectedBaseDimensionName(originalBaseDimensionName);
+    }, [originalBaseDimensionName]);
+
+    const baseDimensionOptions = useMemo(() => {
+        if (!exploreData || !item || !customMetricType) return [];
+        const table = exploreData.tables[item.table];
+        if (!table) return [];
+        return Object.values(table.dimensions)
+            .filter((dim) => !dim.hidden)
+            .filter((dim) =>
+                getCustomMetricType(dim.type).includes(customMetricType),
+            )
+            .map((dim) => ({
+                value: dim.name,
+                label: dim.label || dim.name,
+                dim,
+            }));
+    }, [exploreData, item, customMetricType]);
+
+    const baseDimensionByName = useMemo(() => {
+        const map: Record<string, Dimension> = {};
+        baseDimensionOptions.forEach(({ value, dim }) => {
+            map[value] = dim;
+        });
+        return map;
+    }, [baseDimensionOptions]);
+
+    const selectedBaseDimension = useMemo(() => {
+        if (!selectedBaseDimensionName) return null;
+        return baseDimensionByName[selectedBaseDimensionName] ?? null;
+    }, [baseDimensionByName, selectedBaseDimensionName]);
+
+    const showBaseDimensionPicker =
+        isDimension(item) ||
+        (isEditing && isAdditionalMetric(item) && !!item.baseDimensionName);
+
+    const baseDimensionChanged =
+        isEditing &&
+        !!originalBaseDimensionName &&
+        !!selectedBaseDimensionName &&
+        originalBaseDimensionName !== selectedBaseDimensionName;
+
+    const renderBaseDimensionOption: React.ComponentProps<
+        typeof Select
+    >['renderOption'] = ({ option }) => {
+        const dim = baseDimensionByName[option.value];
+        return (
+            <Group gap="xs" wrap="nowrap">
+                {dim ? <FieldIcon item={dim} size="sm" /> : null}
+                <Text size="sm">{option.label}</Text>
+            </Group>
+        );
+    };
 
     const canApplyFormatting = useMemo(
         () =>
@@ -223,8 +297,25 @@ export const CustomMetricModal = memo(() => {
         ({ customMetricLabel, percentile, format }) => {
             if (!item || !customMetricType) return;
 
+            // When the user picked a different source field on edit, swap
+            // sql + table on the item handed to prepareCustomMetricData so the
+            // resulting metric aggregates the new column. The metric's internal
+            // `name` stays stable because prepareCustomMetricData derives it
+            // from item.baseDimensionName, which we leave untouched here.
+            const effectiveItem =
+                isEditing &&
+                isAdditionalMetric(item) &&
+                baseDimensionChanged &&
+                selectedBaseDimension
+                    ? {
+                          ...item,
+                          sql: selectedBaseDimension.sql,
+                          table: selectedBaseDimension.table,
+                      }
+                    : item;
+
             const data = prepareCustomMetricData({
-                item,
+                item: effectiveItem,
                 type: customMetricType,
                 customMetricLabel,
                 customMetricFiltersWithIds,
@@ -235,14 +326,28 @@ export const CustomMetricModal = memo(() => {
             });
 
             if (isEditing && isAdditionalMetric(item)) {
+                const updatedBaseDimensionName =
+                    baseDimensionChanged && selectedBaseDimension
+                        ? { baseDimensionName: selectedBaseDimension.name }
+                        : {};
                 dispatch(
                     explorerActions.editAdditionalMetric({
-                        additionalMetric: { ...item, ...data },
+                        additionalMetric: {
+                            ...item,
+                            ...data,
+                            ...updatedBaseDimensionName,
+                        },
                         previousAdditionalMetricName: getItemId(item),
                     }),
                 );
                 showToastSuccess({
-                    title: 'Custom metric edited successfully',
+                    title:
+                        baseDimensionChanged && selectedBaseDimension
+                            ? `Custom metric rebuilt on ${
+                                  selectedBaseDimension.label ||
+                                  selectedBaseDimension.name
+                              }`
+                            : 'Custom metric edited successfully',
                 });
             } else if (isDimension(item) && form.values.customMetricLabel) {
                 dispatch(
@@ -328,6 +433,52 @@ export const CustomMetricModal = memo(() => {
                         placeholder="Enter custom metric label"
                         {...form.getInputProps('customMetricLabel')}
                     />
+                    {showBaseDimensionPicker && customMetricType && (
+                        <Stack gap="xs">
+                            <Select
+                                label="Source field"
+                                description={
+                                    isEditing
+                                        ? `The field this metric aggregates over. Pick a different one to rebuild it without recreating it.`
+                                        : 'The field this metric aggregates over.'
+                                }
+                                data={baseDimensionOptions.map(
+                                    ({ value, label }) => ({ value, label }),
+                                )}
+                                value={selectedBaseDimensionName}
+                                onChange={setSelectedBaseDimensionName}
+                                readOnly={!isEditing}
+                                searchable={isEditing}
+                                allowDeselect={false}
+                                renderOption={renderBaseDimensionOption}
+                                leftSection={
+                                    selectedBaseDimension ? (
+                                        <FieldIcon
+                                            item={selectedBaseDimension}
+                                            size="sm"
+                                        />
+                                    ) : null
+                                }
+                                nothingFoundMessage="No compatible fields on this table"
+                                comboboxProps={{ withinPortal: true }}
+                            />
+                            {baseDimensionChanged && selectedBaseDimension ? (
+                                <Callout
+                                    variant="info"
+                                    title="Source field will change"
+                                >
+                                    This metric will be rebuilt to aggregate{' '}
+                                    <Text span fw={600}>
+                                        {selectedBaseDimension.label ||
+                                            selectedBaseDimension.name}
+                                    </Text>
+                                    . Filters and format options are preserved,
+                                    and the metric ID stays the same so saved
+                                    charts and dashboards keep working.
+                                </Callout>
+                            ) : null}
+                        </Stack>
+                    )}
                     {customMetricType && (
                         <TextInput
                             label="Type"

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -3,6 +3,7 @@ import {
     isDateFilterRule,
     isWithValueFilter,
     type CompiledMetric,
+    type Dimension,
 } from '@lightdash/common';
 import {
     Anchor,
@@ -28,6 +29,7 @@ import {
     useExplorerDispatch,
 } from '../../../../features/explorer/store';
 import { rehypeRemoveHeaderLinks } from '../../../../utils/markdownUtils';
+import FieldIcon from '../../../common/Filters/FieldIcon';
 import { filterOperatorLabel } from '../../../common/Filters/FilterInputs/constants';
 import MantineIcon from '../../../common/MantineIcon';
 import classes from './ItemDetailPreview.module.css';
@@ -82,6 +84,7 @@ export const ItemDetailPreview: FC<{
         compiledSql: string;
         name: string;
         filters?: CompiledMetric['filters'];
+        baseDimension?: Dimension;
     };
 }> = ({ description, onViewDescription, metricInfo }) => {
     /**
@@ -118,6 +121,29 @@ export const ItemDetailPreview: FC<{
                             {friendlyName(metricInfo.type)}
                         </Badge>
                     </Group>
+                    {metricInfo.baseDimension && (
+                        <>
+                            <Divider color="ldGray.2" />
+                            <Stack gap={4}>
+                                <Text fz="xs" fw={500} c="ldDark.7">
+                                    Source field
+                                </Text>
+                                <Group gap="xs" wrap="nowrap">
+                                    <FieldIcon
+                                        item={metricInfo.baseDimension}
+                                        size="sm"
+                                    />
+                                    <Text fz="xs" c="ldGray.7">
+                                        {metricInfo.baseDimension.tableLabel}
+                                    </Text>
+                                    <Text fz="xs" fw={500} c="ldDark.7">
+                                        {metricInfo.baseDimension.label ||
+                                            metricInfo.baseDimension.name}
+                                    </Text>
+                                </Group>
+                            </Stack>
+                        </>
+                    )}
                 </>
             )}
             {description && (

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -7,8 +7,10 @@ import {
     isField,
     isFilterableField,
     isTimeInterval,
+    MetricType,
     timeFrameConfigs,
     type AdditionalMetric,
+    type Dimension,
     type FilterableField,
     type Item,
 } from '@lightdash/common';
@@ -37,6 +39,7 @@ import {
     useExplorerSelector,
     type ExplorerStoreState,
 } from '../../../../../features/explorer/store';
+import { useExplore } from '../../../../../hooks/useExplore';
 import { useAddFilter } from '../../../../../hooks/useFilters';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -67,6 +70,30 @@ const NavItemIcon = ({
 };
 
 NavItemIcon.displayName = 'NavItemIcon';
+
+/**
+ * Mirrors `getDefaultMetricSql` from the warehouse package so we can show the
+ * aggregated form of a custom metric in the hover preview without pulling in
+ * a warehouse client on the frontend.
+ */
+const renderAggregatedSql = (sql: string, type: MetricType): string => {
+    switch (type) {
+        case MetricType.AVERAGE:
+            return `AVG(${sql})`;
+        case MetricType.COUNT:
+            return `COUNT(${sql})`;
+        case MetricType.COUNT_DISTINCT:
+            return `COUNT(DISTINCT ${sql})`;
+        case MetricType.MAX:
+            return `MAX(${sql})`;
+        case MetricType.MIN:
+            return `MIN(${sql})`;
+        case MetricType.SUM:
+            return `SUM(${sql})`;
+        default:
+            return sql;
+    }
+};
 
 type Props = {
     node: Node;
@@ -121,6 +148,9 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
     );
     const isSelected = useExplorerSelector(selectIsActive, (a, b) => a === b);
 
+    const exploreTableName = useTableTree((context) => context.tableName);
+    const { data: exploreData } = useExplore(exploreTableName);
+
     const metricInfo = useMemo(() => {
         if (isCompiledMetric(item)) {
             return {
@@ -132,10 +162,35 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                 name: item.name,
             };
         }
+        if (isAdditionalMetric(item)) {
+            const baseDimensionCandidate =
+                item.baseDimensionName && exploreData
+                    ? exploreData.tables[item.table]?.dimensions[
+                          item.baseDimensionName
+                      ]
+                    : undefined;
+            const baseDimension: Dimension | undefined =
+                baseDimensionCandidate && isDimension(baseDimensionCandidate)
+                    ? baseDimensionCandidate
+                    : undefined;
+            const baseSql = item.sql ?? '';
+            return {
+                type: item.type,
+                sql: baseSql,
+                compiledSql: renderAggregatedSql(baseSql, item.type),
+                filters: item.filters,
+                table: item.table,
+                name: item.name,
+                baseDimension,
+            };
+        }
         return undefined;
-    }, [item]);
+    }, [item, exploreData]);
 
-    const description = isField(item) ? item.description : undefined;
+    const description =
+        isField(item) || isAdditionalMetric(item)
+            ? item.description
+            : undefined;
 
     const isMissing =
         (isAdditionalMetric(item) &&
@@ -147,7 +202,10 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
 
     const isHoverCardDisabled = useMemo(() => {
         // Show metric info if either metric info or description is present
-        if (isCompiledMetric(item) && (!!metricInfo || !!description)) {
+        if (
+            (isCompiledMetric(item) || isAdditionalMetric(item)) &&
+            (!!metricInfo || !!description)
+        ) {
             return false;
         }
         // Show description if it's not missing
@@ -312,7 +370,19 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                         disabled={isHoverCardDisabled}
                         position="right"
                         radius="md"
-                        offset={70}
+                        /**
+                         * Regular fields show a filter ActionIcon on hover that
+                         * eats ~28px of the row, narrowing the HoverCard target.
+                         * Custom metrics and custom dimensions never render that
+                         * icon, so their target is wider and the popover ends up
+                         * further right at the same offset. Shave ~28px off to
+                         * align both.
+                         */
+                        offset={
+                            isAdditionalMetric(item) || isCustomDimension(item)
+                                ? 36
+                                : 70
+                        }
                     >
                         <HoverCard.Target>
                             <Highlight


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7755/i-want-to-be-able-to-see-change-the-field-used-to-create-my-custom

<img width="799" height="298" alt="CleanShot 2026-05-19 at 08 57 52" src="https://github.com/user-attachments/assets/12cb4658-3405-4860-90bf-9631ed7e3a98" />

### Description:

Adds a **Source field** picker to the Custom Metric modal that lets users change which dimension a custom metric aggregates over when editing, without having to delete and recreate the metric.

- When editing a custom metric, a searchable "Source field" dropdown appears showing all dimensions on the same table that are compatible with the metric's aggregation type. Each option renders with its field icon for easy identification.
- Selecting a different field swaps the underlying SQL and table reference on save while preserving the metric's ID, name, filters, and format options — so saved charts and dashboards continue to work without any changes.
- An info callout is shown when a different source field is selected, explaining what will change.
- When creating a new custom metric from a dimension, the source field is shown as read-only to make it clear which field is being aggregated.
- The hover preview card for custom metrics now shows a "Source field" section displaying the dimension's icon, table label, and field label.
- Custom metric hover cards also now correctly display the aggregated SQL (e.g. `SUM(${table.column})`) and the metric's description.
- Fixed the HoverCard horizontal offset for custom metrics and custom dimensions, which don't render the filter action icon that regular fields do, so the popover now aligns consistently.