### PR TITLE
feat(ai): show table detail for warehouse tool calls

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -66,8 +66,6 @@ const TOOLS_WITHOUT_PREVIEW = new Set<string>([
     'improveContext',
     'proposeChange',
     'runSavedChart',
-    'listWarehouseTables',
-    'describeWarehouseTable',
 ]);
 
 const getMcpDisplayName = (toolName: string) => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
@@ -28,8 +28,6 @@ const TOOLS_WITHOUT_DESCRIPTION = new Set<ToolName>([
     'improveContext',
     'proposeChange',
     'runSavedChart',
-    'listWarehouseTables',
-    'describeWarehouseTable',
 ]);
 
 // Tools whose description renders something tall (e.g. a code block) and can't

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/DescribeWarehouseTableToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/DescribeWarehouseTableToolCallDescription.tsx
@@ -1,0 +1,20 @@
+import { rem, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+import { ToolCallChip } from '../ToolCallChip';
+
+type DescribeWarehouseTableToolCallDescriptionProps = {
+    table: string;
+    schema: string | null;
+};
+
+export const DescribeWarehouseTableToolCallDescription: FC<
+    DescribeWarehouseTableToolCallDescriptionProps
+> = ({ table, schema }) => {
+    const qualified = schema ? `${schema}.${table}` : table;
+    return (
+        <Text c="dimmed" size="xs">
+            Inspected schema of{' '}
+            <ToolCallChip mx={rem(2)}>{qualified}</ToolCallChip>
+        </Text>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ListWarehouseTablesToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ListWarehouseTablesToolCallDescription.tsx
@@ -1,0 +1,41 @@
+import { rem, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+import { ToolCallChip } from '../ToolCallChip';
+
+type ListWarehouseTablesToolCallDescriptionProps = {
+    schema: string | null;
+    search: string | null;
+};
+
+export const ListWarehouseTablesToolCallDescription: FC<
+    ListWarehouseTablesToolCallDescriptionProps
+> = ({ schema, search }) => {
+    if (!schema && !search) {
+        return (
+            <Text c="dimmed" size="xs">
+                Listed warehouse tables
+            </Text>
+        );
+    }
+    return (
+        <Text c="dimmed" size="xs">
+            Listed warehouse tables{' '}
+            {schema ? (
+                <Text span>
+                    <Text c="dimmed" size="xs" span>
+                        in schema:
+                    </Text>
+                    <ToolCallChip mx={rem(2)}>{schema}</ToolCallChip>
+                </Text>
+            ) : null}
+            {search ? (
+                <Text span>
+                    <Text c="dimmed" size="xs" span>
+                        matching:
+                    </Text>
+                    <ToolCallChip mx={rem(2)}>"{search}"</ToolCallChip>
+                </Text>
+            ) : null}
+        </Text>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -6,6 +6,7 @@ import type {
 import {
     assertUnreachable,
     type ToolDashboardArgs,
+    type ToolDescribeWarehouseTableArgs,
     type ToolFindChartsArgs,
     type ToolFindContentArgs,
     type ToolFindDashboardsArgs,
@@ -14,6 +15,7 @@ import {
     type ToolFindExploresArgsV3,
     type ToolFindFieldsArgs,
     type ToolGetDashboardChartsArgs,
+    type ToolListWarehouseTablesArgs,
     type ToolName,
     type ToolRunQueryArgs,
     type ToolRunSqlArgs,
@@ -25,9 +27,11 @@ import { AiChartGenerationToolCallDescription } from './AiChartGenerationToolCal
 import { ContentSearchToolCallDescription } from './ContentSearchToolCallDescription';
 import { DashboardChartsToolCallDescription } from './DashboardChartsToolCallDescription';
 import { DashboardToolCallDescription } from './DashboardToolCallDescription';
+import { DescribeWarehouseTableToolCallDescription } from './DescribeWarehouseTableToolCallDescription';
 import { ExploreToolCallDescription } from './ExploreToolCallDescription';
 import { FieldSearchToolCallDescription } from './FieldSearchToolCallDescription';
 import { FieldValuesSearchToolCallDescription } from './FieldValuesSearchToolCallDescription';
+import { ListWarehouseTablesToolCallDescription } from './ListWarehouseTablesToolCallDescription';
 import { QueryResultToolCallDescription } from './QueryResultToolCallDescription';
 import { SqlRunToolCallDescription } from './SqlRunToolCallDescription';
 
@@ -156,9 +160,25 @@ export const ToolCallDescription: FC<{
                     limit={sqlToolArgs.limit}
                 />
             );
-        case 'discoverFields':
         case 'listWarehouseTables':
+            const listWarehouseTablesArgs =
+                toolCall.toolArgs as ToolListWarehouseTablesArgs;
+            return (
+                <ListWarehouseTablesToolCallDescription
+                    schema={listWarehouseTablesArgs.schema ?? null}
+                    search={listWarehouseTablesArgs.search ?? null}
+                />
+            );
         case 'describeWarehouseTable':
+            const describeWarehouseTableArgs =
+                toolCall.toolArgs as ToolDescribeWarehouseTableArgs;
+            return (
+                <DescribeWarehouseTableToolCallDescription
+                    table={describeWarehouseTableArgs.table}
+                    schema={describeWarehouseTableArgs.schema ?? null}
+                />
+            );
+        case 'discoverFields':
         case 'improveContext':
         case 'proposeChange':
         case 'runSavedChart':

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.ts
@@ -1,5 +1,6 @@
 import type {
     ToolDashboardArgs,
+    ToolDescribeWarehouseTableArgs,
     ToolFindChartsArgs,
     ToolFindContentArgs,
     ToolFindDashboardsArgs,
@@ -8,6 +9,7 @@ import type {
     ToolFindExploresArgsV3,
     ToolFindFieldsArgs,
     ToolGetDashboardChartsArgs,
+    ToolListWarehouseTablesArgs,
     ToolName,
     ToolRunQueryArgs,
     ToolSearchFieldValuesArgs,
@@ -83,10 +85,17 @@ export const getToolCallChipLabel = (
             const args = toolArgs as ToolGetDashboardChartsArgs;
             return args.dashboardName ?? args.dashboardUuid ?? null;
         }
+        case 'describeWarehouseTable': {
+            const args = toolArgs as ToolDescribeWarehouseTableArgs;
+            if (!args.table) return null;
+            return args.schema ? `${args.schema}.${args.table}` : args.table;
+        }
+        case 'listWarehouseTables': {
+            const args = toolArgs as ToolListWarehouseTablesArgs;
+            return args.schema ?? args.search ?? null;
+        }
         case 'runSql':
         case 'runSavedChart':
-        case 'listWarehouseTables':
-        case 'describeWarehouseTable':
         case 'improveContext':
         case 'proposeChange':
             return null;


### PR DESCRIPTION
Closes [PROD-7568](https://linear.app/lightdash/issue/PROD-7568/show-more-detail-for-warehouse-table-tool-calls).

## Summary

`Listing warehouse tables` and `Describing warehouse table` tool-call rows previously showed only the verb — no preview chip, no expand affordance, no detail. This PR surfaces the tables being inspected.

- `describeWarehouseTable` — chip + expanded description show `schema.table` (e.g. `jaffle.raw_orders`), or just `table` when schema was omitted.
- `listWarehouseTables` — chip + description show the schema filter and/or `"search"` term applied; falls back to a plain "Listed warehouse tables" when no filters were used.
- Both rows are now clickable (removed from `TOOLS_WITHOUT_DESCRIPTION`) and show inline previews in the live activity card (removed from `TOOLS_WITHOUT_PREVIEW`).

These tools only appear in AI agent threads when SQL Runner mode is enabled (`ai-agent-run-sql` flag on, user is developer+ or has SQL Runner via custom role). On web it's per-prompt; on Slack it's gated by the requester's perms.

## Affected vs not

- **Users with SQL Runner enabled (web + Slack OAuth):** see the new chips/descriptions wherever the agent calls list/describe warehouse tools. No behavior change beyond UI surface.
- **Users without SQL Runner:** unaffected — these tools aren't in the agent's toolset for them.
- **Existing tool-call rows for other tools:** untouched. The two sets they were removed from (`TOOLS_WITHOUT_DESCRIPTION`, `TOOLS_WITHOUT_PREVIEW`) still contain `improveContext`, `proposeChange`, `runSavedChart`, plus `runSql` in the live-card preview set.

Frontend-only change. No backend / schema / scope changes.

## Test plan

- [ ] In an AI agent thread (SQL Runner enabled), ask something that triggers `listWarehouseTables` (e.g. "what tables are in the warehouse?") — confirm the row shows the schema/search chip and expands to the full description.
- [ ] Ask something that triggers `describeWarehouseTable` (e.g. "what columns does raw_orders have?") — confirm the chip shows `schema.table` and the row expands.
- [ ] Verify the live activity card shows the chip preview while the tool is running.
- [ ] Trigger several `describeWarehouseTable` calls in a row — confirm grouped chips appear (up to 3) with the `+N` overflow indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)