### PR TITLE
fix: include orphan tiles in tab-filtered dashboard renders (PROD-2505)

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -47,6 +47,7 @@ import {
     isSchedulerGsheetsOptions,
     isSchedulerImageOptions,
     isTableChartConfig,
+    isTileInSelectedTabs,
     isVizTableConfig,
     LightdashPage,
     MAX_SAFE_INTEGER,
@@ -761,10 +762,8 @@ export default class SchedulerTask {
                         const chartTiles = dashboard.tiles
                             .filter(isDashboardChartTileType)
                             .filter((tile) => tile.properties.savedChartUuid)
-                            .filter(
-                                (tile) =>
-                                    !selectedTabs ||
-                                    selectedTabs.includes(tile.tabUuid || ''),
+                            .filter((tile) =>
+                                isTileInSelectedTabs(tile, selectedTabs),
                             )
                             .map((tile) => ({
                                 tileUuid: tile.uuid,
@@ -4240,9 +4239,7 @@ export default class SchedulerTask {
                 const limit = pLimit(5);
 
                 const isInSelectedTab = (tile: { tabUuid?: string | null }) =>
-                    !selectedTabs ||
-                    !tile.tabUuid ||
-                    selectedTabs.includes(tile.tabUuid);
+                    isTileInSelectedTabs(tile, selectedTabs);
 
                 const chartTilePromises = dashboard.tiles
                     .filter(isDashboardChartTileType)

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -11,6 +11,7 @@ import {
     HealthState,
     isDashboardChartTileType,
     isDashboardSqlChartTile,
+    isTileInSelectedTabs,
     LightdashMode,
     LightdashPage,
     LightdashRequestMethodHeader,
@@ -399,12 +400,12 @@ export class UnfurlService extends BaseService {
 
                 validateSelectedTabs(selectedTabs, dashboard.tiles);
 
-                // Filter tiles based on selected tabs if they exist
-                const filteredTiles = selectedTabs
-                    ? dashboard.tiles.filter((tile) =>
-                          selectedTabs.includes(tile.tabUuid || ''),
-                      )
-                    : dashboard.tiles;
+                // Filter tiles based on selected tabs if they exist.
+                // Orphan tiles (tabUuid=null) are always included to match the
+                // frontend behaviour that renders them on the first tab.
+                const filteredTiles = dashboard.tiles.filter((tile) =>
+                    isTileInSelectedTabs(tile, selectedTabs),
+                );
 
                 return {
                     title: dashboard.name,
@@ -685,15 +686,15 @@ export class UnfurlService extends BaseService {
 
         validateSelectedTabs(selectedTabs, dashboard.tiles);
 
-        // Create a new URLSearchParams object for query filters
+        // Create a new URLSearchParams object for query filters.
+        // When selectedTabs is null we forward every tab UUID present on the
+        // dashboard (and `null` for orphan tiles) so the frontend's
+        // `schedulerTabsSelected.includes(tile.tabUuid)` filter keeps orphans
+        // in the aggregated screenshot. See PROD-2505.
         const selectedTabsParams = new URLSearchParams();
-        const selectedTabsList =
+        const selectedTabsList: (string | null)[] =
             selectedTabs ??
-            uniq(
-                dashboard.tiles
-                    .map((tile) => tile.tabUuid)
-                    .filter((tabUuid) => !!tabUuid),
-            );
+            uniq(dashboard.tiles.map((tile) => tile.tabUuid ?? null));
 
         if (selectedTabsList.length > 0)
             selectedTabsParams.set(

--- a/packages/common/src/utils/dashboard.test.ts
+++ b/packages/common/src/utils/dashboard.test.ts
@@ -1,6 +1,6 @@
 import { type DashboardTile } from '../types/dashboard';
 import { ParameterError } from '../types/errors';
-import { validateSelectedTabs } from './dashboard';
+import { isTileInSelectedTabs, validateSelectedTabs } from './dashboard';
 
 describe('validateSelectedTabs', () => {
     // Simple mock that focuses on just the tabUuid property
@@ -50,5 +50,36 @@ describe('validateSelectedTabs', () => {
         expect(() =>
             validateSelectedTabs(['any-tab'], tilesWithoutTabUuid),
         ).toThrow('None of the selected tabs exist in the dashboard');
+    });
+});
+
+describe('isTileInSelectedTabs', () => {
+    it('includes every tile when selectedTabs is null', () => {
+        expect(isTileInSelectedTabs({ tabUuid: 'tab1' }, null)).toBe(true);
+        expect(isTileInSelectedTabs({ tabUuid: null }, null)).toBe(true);
+        expect(isTileInSelectedTabs({ tabUuid: undefined }, null)).toBe(true);
+    });
+
+    it('includes orphan tiles regardless of selectedTabs (PROD-2505)', () => {
+        expect(isTileInSelectedTabs({ tabUuid: null }, ['tab1'])).toBe(true);
+        expect(isTileInSelectedTabs({ tabUuid: undefined }, ['tab1'])).toBe(
+            true,
+        );
+    });
+
+    it('includes a tile whose tab is in selectedTabs', () => {
+        expect(isTileInSelectedTabs({ tabUuid: 'tab1' }, ['tab1'])).toBe(true);
+        expect(
+            isTileInSelectedTabs({ tabUuid: 'tab2' }, ['tab1', 'tab2']),
+        ).toBe(true);
+    });
+
+    it('excludes a tile whose tab is not in selectedTabs', () => {
+        expect(isTileInSelectedTabs({ tabUuid: 'tab3' }, ['tab1'])).toBe(false);
+    });
+
+    it('excludes non-orphan tiles when selectedTabs is empty', () => {
+        expect(isTileInSelectedTabs({ tabUuid: 'tab1' }, [])).toBe(false);
+        expect(isTileInSelectedTabs({ tabUuid: null }, [])).toBe(true);
     });
 });

--- a/packages/common/src/utils/dashboard.ts
+++ b/packages/common/src/utils/dashboard.ts
@@ -20,6 +20,20 @@ export const convertChartSourceTypeToDashboardTileType = (
 };
 
 /**
+ * Whether a tile should be rendered for the given tab selection.
+ *
+ * Includes orphan (legacy) tiles — tiles whose `tabUuid` is null/undefined —
+ * regardless of `selectedTabs`, mirroring the frontend behaviour that surfaces
+ * legacy tiles on the first tab. When `selectedTabs` is null, no filtering is
+ * applied. See PROD-2505.
+ */
+export const isTileInSelectedTabs = (
+    tile: { tabUuid?: string | null },
+    selectedTabs: string[] | null,
+): boolean =>
+    !selectedTabs || !tile.tabUuid || selectedTabs.includes(tile.tabUuid);
+
+/**
  * Validates that selected tabs exist in the dashboard tiles.
  * If selectedTabs is provided and not empty, ensures at least one selected tab exists in dashboard tabs.
  * @param selectedTabs - Array of selected tab UUIDs or null


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-2505/issues-with-orphan-tiles-in-dashboards-with-tabs

<img width="655" height="956" alt="CleanShot 2026-05-19 at 09 49 31" src="https://github.com/user-attachments/assets/5c5e018f-c9dd-494c-b80a-94a75df3acfa" />

<img width="1456" height="688" alt="CleanShot 2026-05-19 at 09 49 27@2x" src="https://github.com/user-attachments/assets/5d1b9f2e-417d-4f8b-9f1c-81d665e4009a" />


### Description:

Introduces a shared `isTileInSelectedTabs` utility function in `packages/common/src/utils/dashboard.ts` that centralises the logic for determining whether a dashboard tile should be included based on the current tab selection.

The key behaviour change is that **orphan tiles** (tiles with a `null` or `undefined` `tabUuid`) are now **always included**, regardless of which tabs are selected. This mirrors the frontend behaviour that renders legacy/orphan tiles on the first tab. Previously, inconsistent filtering logic across `SchedulerTask.ts` and `UnfurlService.ts` meant orphan tiles could be incorrectly excluded from scheduled screenshots and unfurls when tab filtering was active.

Additionally, when `selectedTabs` is `null` (no tab filter applied), the full list of tab UUIDs forwarded in the URL now includes `null` entries for orphan tiles, ensuring the frontend's tab filter does not accidentally drop them during aggregated screenshot generation.

Unit tests covering all filtering cases — including orphan tile inclusion, tab matching, and empty `selectedTabs` — have been added for the new utility.