### PR TITLE
fix(ai): skip errored prompt responses when rebuilding chat history

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3161,7 +3161,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
                 messages.push(...toolCallmessages);
 
-                if (message.response) {
+                if (message.response && !message.error_message) {
                     messages.push({
                         role: 'assistant',
                         content: message.response,


### PR DESCRIPTION
Relates to: https://lightdash.sentry.io/issues/7490530620

## Summary

Guard the AI agent chat-history rebuild against a poison-pill case where a previously-errored prompt re-injects a partial assistant response into the next stream.

## The bug

When a streaming response errors, two independent things happen on the same `ai_prompt` row:

- `streamText`'s `onError` writes `ai_prompt.error_message` (the user-facing message)
- `streamText`'s `onFinish` still fires at the end of the stream and writes `ai_prompt.response` with whatever text was streamed before the error

So an errored prompt can persist with **both** `response` and `error_message` populated.

Later, `getChatHistoryFromThreadMessages` in `AiAgentService.ts` rebuilds the conversation for the next stream of the same thread and unconditionally appends an `assistant` message for any prompt with a non-null `response` — including the errored one. If that errored prompt happens to be the last in the thread (e.g. user retries the same prompt, or the upstream client just hits `/stream` again), the rebuilt `messages` array ends with an `assistant` turn instead of a `user` turn, and Anthropic 400s with:

> AI_APICallError: This model does not support assistant message prefill. The conversation must end with a user message.

## The fix

Skip the `assistant` push when `error_message` is set, so an errored prompt contributes only its `user` message to the rebuild. One-line guard:

```ts
if (message.response && !message.error_message) {
    messages.push({ role: 'assistant', content: message.response });
}
```

## Regression analysis

- Successful prompts (response set, error_message null) → unchanged behaviour.
- Fresh / in-flight prompts (response null) → unchanged (the existing `if (message.response)` already gated this).
- Errored prompts that previously contributed a stale assistant message → now contribute only the user prompt, which is the correct shape for replay.
- No persisted-data migration: the guard is read-only on `error_message`.

The deeper question of whether `onFinish` should refrain from saving a partial response when `onError` has fired is left for a follow-up — this PR is the minimal defensiveness needed at the rebuild boundary.

## Test plan

- [ ] Backend typecheck passes (`pnpm -F backend typecheck`)
- [ ] Manually reproduce: create a thread with a prompt that errors mid-stream, retry the same thread, confirm Anthropic no longer rejects with the prefill error