### PR TITLE
feat(ai): repair invalid tool-call inputs before they poison the conversation

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1,12 +1,16 @@
 import { AgentToolOutput, assertUnreachable, Explore } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
+    generateObject,
     generateText,
+    jsonSchema,
+    NoSuchToolError,
     smoothStream,
     stepCountIs,
     streamText,
     StreamTextResult,
     type Output,
+    type ToolCallRepairFunction,
     type ToolSet,
 } from 'ai';
 import Logger from '../../../../logging/logger';
@@ -87,6 +91,40 @@ export const defaultAgentOptions = {
     stopWhen: stepCountIs(STEP_CAP),
     maxRetries: 6, // Increased for Bedrock rate limits
 };
+
+export const buildRepairToolCall =
+    (args: AiAgentArgs): ToolCallRepairFunction<ToolSet> =>
+    async ({ toolCall, inputSchema, error }) => {
+        if (NoSuchToolError.isInstance(error)) {
+            return null;
+        }
+        try {
+            const schema = await inputSchema({
+                toolName: toolCall.toolName,
+            });
+            const { object: repaired } = await generateObject({
+                model: args.model,
+                providerOptions: args.providerOptions,
+                schema: jsonSchema(schema),
+                prompt: [
+                    `The previous tool call to "${toolCall.toolName}" produced invalid arguments.`,
+                    `Original (invalid) arguments:`,
+                    toolCall.input,
+                    `Validation error: ${error.message}`,
+                    `Return a corrected JSON object matching the tool's input schema.`,
+                ].join('\n'),
+            });
+            return {
+                ...toolCall,
+                input: JSON.stringify(repaired),
+            };
+        } catch (repairError) {
+            Sentry.captureException(repairError, {
+                tags: { errorType: 'AiAgentRepairToolCall' },
+            });
+            return null;
+        }
+    };
 
 const getAgentTools = (
     args: AiAgentArgs,
@@ -327,6 +365,7 @@ export const generateAgentResponse = async ({
             model: args.model,
             tools,
             messages,
+            experimental_repairToolCall: buildRepairToolCall(args),
             experimental_context: new AgentContext(availableExplores),
             onStepFinish: async (step) => {
                 for (const toolCall of step.toolCalls) {
@@ -524,6 +563,7 @@ export const streamAgentResponse = async ({
             model: args.model,
             tools,
             messages,
+            experimental_repairToolCall: buildRepairToolCall(args),
             experimental_context: new AgentContext(availableExplores),
             onChunk: (event) => {
                 // Track time to first chunk (any type) - only once

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1,9 +1,7 @@
 import { AgentToolOutput, assertUnreachable, Explore } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
-    generateObject,
     generateText,
-    jsonSchema,
     NoSuchToolError,
     smoothStream,
     stepCountIs,
@@ -94,29 +92,55 @@ export const defaultAgentOptions = {
 
 export const buildRepairToolCall =
     (args: AiAgentArgs): ToolCallRepairFunction<ToolSet> =>
-    async ({ toolCall, inputSchema, error }) => {
+    async ({ toolCall, tools, error, messages, system }) => {
         if (NoSuchToolError.isInstance(error)) {
             return null;
         }
         try {
-            const schema = await inputSchema({
-                toolName: toolCall.toolName,
-            });
-            const { object: repaired } = await generateObject({
+            const reaskResult = await generateText({
                 model: args.model,
                 providerOptions: args.providerOptions,
-                schema: jsonSchema(schema),
-                prompt: [
-                    `The previous tool call to "${toolCall.toolName}" produced invalid arguments.`,
-                    `Original (invalid) arguments:`,
-                    toolCall.input,
-                    `Validation error: ${error.message}`,
-                    `Return a corrected JSON object matching the tool's input schema.`,
-                ].join('\n'),
+                system,
+                tools,
+                messages: [
+                    ...messages,
+                    {
+                        role: 'assistant',
+                        content: [
+                            {
+                                type: 'tool-call',
+                                toolCallId: toolCall.toolCallId,
+                                toolName: toolCall.toolName,
+                                input: toolCall.input,
+                            },
+                        ],
+                    },
+                    {
+                        role: 'tool',
+                        content: [
+                            {
+                                type: 'tool-result',
+                                toolCallId: toolCall.toolCallId,
+                                toolName: toolCall.toolName,
+                                output: {
+                                    type: 'error-text',
+                                    value: error.message,
+                                },
+                            },
+                        ],
+                    },
+                ],
             });
+
+            const repaired = reaskResult.toolCalls.find(
+                (tc) => tc.toolName === toolCall.toolName,
+            );
+            if (!repaired) {
+                return null;
+            }
             return {
                 ...toolCall,
-                input: JSON.stringify(repaired),
+                input: JSON.stringify(repaired.input),
             };
         } catch (repairError) {
             Sentry.captureException(repairError, {


### PR DESCRIPTION
Related to: https://lightdash.sentry.io/issues/7490528088/?alert_rule_id=15833412&alert_type=issue&environment=cloud_beta&project=5959292&referrer=slack

## Summary

When the model emits syntactically broken JSON for a tool call (e.g. an omitted value like `{"query": ,`), the AI SDK throws `AI_InvalidToolInputError`. The assistant turn carrying the malformed `tool_use` block stays in the conversation, and the next round to Anthropic gets a hard 400:

```
AI_APICallError: messages.N.content.M.tool_use.input: Input should be an object
```

…which then cascades into further failure modes for the same thread.

This PR plugs `experimental_repairToolCall` into both the streaming and non-streaming agent paths so the AI SDK gets one chance to fix the arguments before the bad turn hits the wire.

## How it works

```ts
experimental_repairToolCall: buildRepairToolCall(args),
```

The repair helper:

1. Short-circuits on `NoSuchToolError` (not repairable — the model called a tool that doesn't exist).
2. On `InvalidToolInputError`, asks the configured model to re-emit valid arguments against the tool's input schema via `generateObject` (matching the pattern used by other generators in `packages/backend/src/ee/services/ai/agents/`).
3. Returns the corrected `LanguageModelV3ToolCall` with a re-stringified `input`, which the SDK then retries the tool call with.
4. If the repair itself errors, captures to Sentry under `errorType: 'AiAgentRepairToolCall'` and returns `null` so the original error propagates unchanged.

## Regression analysis

- Well-formed tool calls → repair function is never invoked; zero behaviour change.
- Calls to non-existent tools → still surface the original `NoSuchToolError` (we return `null` for that case).
- Calls with malformed input → one extra `generateObject` round against the same model + provider options the agent already uses; on success the tool runs as if the model had emitted valid JSON to begin with, on failure the original error stands.
- Cost/latency: a single extra model call per malformed tool call. Repair is rare in steady state, and the alternative (a poisoned conversation that 400s on every subsequent stream) is strictly worse.

## Test plan

- [ ] Backend typecheck passes (`pnpm -F backend typecheck`)
- [ ] Backend lint passes (`pnpm -F backend lint`)
- [ ] Manually trigger an invalid tool call (e.g. ask the agent something that historically produced malformed JSON for `searchFieldValues`) and confirm the repair round happens and the thread completes