### PR TITLE
fix(ai): harden suggestion chip validation and tool gating

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -339,12 +339,19 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Query() threadUuid?: string,
         @Query() afterMessageUuid?: string,
+        @Query() enableSqlMode?: boolean,
     ): Promise<ApiAgentSuggestionsResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
         const results = await this.getAiAgentService().getAgentSuggestions(
             toSessionUser(req.account),
-            { projectUuid, agentUuid, threadUuid, afterMessageUuid },
+            {
+                projectUuid,
+                agentUuid,
+                threadUuid,
+                afterMessageUuid,
+                enableSqlMode,
+            },
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -42,6 +42,7 @@ import {
     filterExploreByTags,
     followUpToolsText,
     ForbiddenError,
+    getItemId,
     isExploreError,
     isSlackPrompt,
     isToolProposeChangeSuccessResult,
@@ -314,16 +315,54 @@ function extractLatestQueryExplore(
                     label: explore.label,
                     description: baseTable.description ?? null,
                     dimensions: Object.values(baseTable.dimensions).map(
-                        (d) => d.label,
+                        (d) => ({
+                            id: getItemId(d),
+                            label: d.label,
+                        }),
                     ),
-                    metrics: Object.values(baseTable.metrics).map(
-                        (m) => m.label,
-                    ),
+                    metrics: Object.values(baseTable.metrics).map((m) => ({
+                        id: getItemId(m),
+                        label: m.label,
+                    })),
                 };
             }
         }
     }
     return null;
+}
+
+function validateGeneratedSuggestion(
+    chip: AgentSuggestion,
+    catalog: SuggestionValidationCatalog,
+    availableExplores: Explore[],
+) {
+    const result = validateAgentSuggestion(chip, catalog);
+    if (!result.valid || chip.kind === 'navigate') {
+        return result;
+    }
+
+    const { explore: exploreName, dimensions } = chip.defaults;
+    if (!exploreName || dimensions.length === 0) {
+        return result;
+    }
+
+    const explore = availableExplores.find((e) => e.name === exploreName);
+    if (!explore) {
+        return result;
+    }
+
+    try {
+        validateSelectedFieldsExistence(explore, dimensions);
+        return result;
+    } catch (error) {
+        return {
+            valid: false as const,
+            reason:
+                error instanceof Error
+                    ? error.message
+                    : `unknown dimensions for explore "${exploreName}"`,
+        };
+    }
 }
 
 export class AiAgentService extends BaseService {
@@ -718,10 +757,16 @@ export class AiAgentService extends BaseService {
                 description: baseTable.description ?? null,
                 dimensions: Object.values(baseTable.dimensions)
                     .slice(0, 8)
-                    .map((d) => d.label),
+                    .map((d) => ({
+                        id: getItemId(d),
+                        label: d.label,
+                    })),
                 metrics: Object.values(baseTable.metrics)
                     .slice(0, 8)
-                    .map((m) => m.label),
+                    .map((m) => ({
+                        id: getItemId(m),
+                        label: m.label,
+                    })),
             };
         });
 
@@ -816,7 +861,11 @@ export class AiAgentService extends BaseService {
             }
 
             const validated = resolved.filter((chip) => {
-                const result = validateAgentSuggestion(chip, validationCatalog);
+                const result = validateGeneratedSuggestion(
+                    chip,
+                    validationCatalog,
+                    availableExplores,
+                );
                 if (!result.valid) {
                     dropped.push(`${chip.label} (${result.reason})`);
                     return false;

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -69,6 +69,7 @@ import {
     UpdateWebAppResponse,
     validateAgentSuggestion,
     WarehouseQueryError,
+    type AgentSuggestionTool,
     type AiPromptContextInput,
     type SessionUser,
     type SuggestionValidationCatalog,
@@ -335,14 +336,23 @@ function validateGeneratedSuggestion(
     chip: AgentSuggestion,
     catalog: SuggestionValidationCatalog,
     availableExplores: Explore[],
+    enabledTools: AgentSuggestionTool[],
 ) {
     const result = validateAgentSuggestion(chip, catalog);
     if (!result.valid || chip.kind === 'navigate') {
         return result;
     }
 
-    const { explore: exploreName, dimensions } = chip.defaults;
-    if (!exploreName || dimensions.length === 0) {
+    if (!enabledTools.includes(chip.tool)) {
+        return {
+            valid: false as const,
+            reason: `disabled tool "${chip.tool}"`,
+        };
+    }
+
+    const { explore: exploreName, dimensions, metrics } = chip.defaults;
+    const selectedFields = [...dimensions, ...metrics];
+    if (!exploreName || selectedFields.length === 0) {
         return result;
     }
 
@@ -352,7 +362,7 @@ function validateGeneratedSuggestion(
     }
 
     try {
-        validateSelectedFieldsExistence(explore, dimensions);
+        validateSelectedFieldsExistence(explore, selectedFields);
         return result;
     } catch (error) {
         return {
@@ -721,11 +731,13 @@ export class AiAgentService extends BaseService {
             agentUuid,
             threadUuid,
             afterMessageUuid,
+            enableSqlMode = false,
         }: {
             projectUuid: string;
             agentUuid: string;
             threadUuid?: string;
             afterMessageUuid?: string;
+            enableSqlMode?: boolean;
         },
     ): Promise<{ chips: AgentSuggestion[] }> {
         const { organizationUuid } = user;
@@ -742,6 +754,35 @@ export class AiAgentService extends BaseService {
         }
 
         const agent = await this.getAgent(user, agentUuid, projectUuid);
+
+        const auditedAbility = this.createAuditedAbility(user);
+        const canRunSql =
+            enableSqlMode &&
+            auditedAbility.can(
+                'manage',
+                subject('SqlRunner', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            );
+        const canManageAgent = auditedAbility.can(
+            'manage',
+            subject('AiAgent', {
+                organizationUuid,
+                projectUuid,
+                metadata: {
+                    agentUuid,
+                    agentName: agent.name,
+                },
+            }),
+        );
+        const enabledTools = AGENT_SUGGESTION_TOOLS.filter((tool) => {
+            if (tool === 'runSql') return canRunSql;
+            if (tool === 'proposeChange') {
+                return agent.enableSelfImprovement && canManageAgent;
+            }
+            return true;
+        });
 
         const availableExplores = await this.getAvailableExplores(
             user,
@@ -818,7 +859,7 @@ export class AiAgentService extends BaseService {
                 {
                     agentName: agent.name,
                     agentInstruction: agent.instruction,
-                    enabledTools: AGENT_SUGGESTION_TOOLS,
+                    enabledTools,
                     explores,
                     verifiedQuestions,
                     verifiedContentTags: agent.tags ?? [],
@@ -865,6 +906,7 @@ export class AiAgentService extends BaseService {
                     chip,
                     validationCatalog,
                     availableExplores,
+                    enabledTools,
                 );
                 if (!result.valid) {
                     dropped.push(`${chip.label} (${result.reason})`);

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
@@ -11,7 +11,7 @@ const EMPTY_STATE_PROMPT = `You write 3-6 starter "chips" that appear above an e
 
 There are TWO chip kinds:
 
-1. PROMPT chips (kind="prompt") — a complete data question the agent can act on by running a query, building a chart, or finding existing content. When clicked, the label is sent verbatim as the user's next message. Use a real tool from: ${AGENT_SUGGESTION_TOOLS.join(', ')}. Reference only real explore and dimension/metric labels from the catalogue.
+1. PROMPT chips (kind="prompt") — a complete data question the agent can act on by running a query, building a chart, or finding existing content. When clicked, the label is sent verbatim as the user's next message. Use a real tool from: ${AGENT_SUGGESTION_TOOLS.join(', ')}. Reference only real explore and dimension/metric labels from the catalogue. In defaults.dimensions, use field IDs from the catalogue, not labels.
 
 2. NAVIGATE chips (kind="navigate") — open one of the user's own recent threads. ONLY emit these when <recentUserConversations> contains a thread the user might want to resume. Set recentConversationIndex to the array index (0 = most recent). The server resolves the URL. Label should make it clear the chip resumes a conversation, e.g. "Continue your funnel conversion analysis" or "Resume the visit analytics dashboard build". Don't write more than ONE navigate chip per response — keep the rest as fresh PROMPT chips.
 
@@ -47,7 +47,7 @@ Two modes:
 
 1. ANSWER mode — when <thread.latestAssistantTurn.askedClarifyingQuestion> is true, the chips ARE the user's likely answers to the agent's question. Pull options from the choices the agent presented in its reply. 5-40 chars typically.
 
-2. CONTINUE mode — natural next prompts (drill-in, refinement, comparison, follow-up). Use ONLY field labels visible in <thread.latestAssistantTurn.latestQueryExplore> (preferred — these are the fields the agent JUST used), or in <thread.latestAssistantTurn.text>, or in <explores>. Never invent terms — if a concept doesn't appear in the data, do not propose it.
+2. CONTINUE mode — natural next prompts (drill-in, refinement, comparison, follow-up). Use ONLY field labels visible in <thread.latestAssistantTurn.latestQueryExplore> (preferred — these are the fields the agent JUST used), or in <thread.latestAssistantTurn.text>, or in <explores>. Never invent terms — if a concept doesn't appear in the data, do not propose it. In defaults.dimensions, use field IDs from the catalogue, not labels.
 
 PREFERRED CONTEXT:
 - When <thread.latestAssistantTurn.latestQueryExplore> is present, lean on its dimensions and metrics first. These are the fields the agent just touched — the user is almost certainly thinking in that explore's frame.
@@ -105,6 +105,11 @@ export type VerifiedContentItem = {
     description: string | null;
 };
 
+type SuggestionFieldContext = {
+    id: string;
+    label: string;
+};
+
 export type SuggestionPromptContext = {
     agentName: string;
     agentInstruction: string | null;
@@ -113,8 +118,8 @@ export type SuggestionPromptContext = {
         name: string;
         label: string;
         description: string | null;
-        dimensions: string[];
-        metrics: string[];
+        dimensions: SuggestionFieldContext[];
+        metrics: SuggestionFieldContext[];
     }>;
     verifiedQuestions: string[];
     verifiedContentTags: string[];
@@ -136,8 +141,8 @@ export type SuggestionPromptContext = {
                 name: string;
                 label: string;
                 description: string | null;
-                dimensions: string[];
-                metrics: string[];
+                dimensions: SuggestionFieldContext[];
+                metrics: SuggestionFieldContext[];
             } | null;
         };
     };

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
@@ -11,7 +11,7 @@ const EMPTY_STATE_PROMPT = `You write 3-6 starter "chips" that appear above an e
 
 There are TWO chip kinds:
 
-1. PROMPT chips (kind="prompt") — a complete data question the agent can act on by running a query, building a chart, or finding existing content. When clicked, the label is sent verbatim as the user's next message. Use a real tool from: ${AGENT_SUGGESTION_TOOLS.join(', ')}. Reference only real explore and dimension/metric labels from the catalogue. In defaults.dimensions, use field IDs from the catalogue, not labels.
+1. PROMPT chips (kind="prompt") — a complete data question the agent can act on by running a query, building a chart, or finding existing content. When clicked, the label is sent verbatim as the user's next message. Use only tools listed in <enabledTools>. Reference only real explore and dimension/metric labels from the catalogue. In defaults.dimensions and defaults.metrics, use field IDs from the catalogue, not labels.
 
 2. NAVIGATE chips (kind="navigate") — open one of the user's own recent threads. ONLY emit these when <recentUserConversations> contains a thread the user might want to resume. Set recentConversationIndex to the array index (0 = most recent). The server resolves the URL. Label should make it clear the chip resumes a conversation, e.g. "Continue your funnel conversion analysis" or "Resume the visit analytics dashboard build". Don't write more than ONE navigate chip per response — keep the rest as fresh PROMPT chips.
 
@@ -32,7 +32,7 @@ How to use the context (PROMPT chips):
 
 Tool guide (PROMPT chips):
 - \`runQuery\`: factual data questions answerable from the semantic layer.
-- \`runSql\`: rare; only when the question can't be expressed in the semantic layer.
+- \`runSql\`: rare; only when present in <enabledTools> and the question can't be expressed in the semantic layer.
 - \`generateDashboard\`: multi-chart overview ("Build me an executive summary").
 - \`findContent\`: "Is there already a chart for monthly revenue?" — locates existing saved content.
 - \`proposeChange\`: implicit metric/dimension definition change.
@@ -47,7 +47,7 @@ Two modes:
 
 1. ANSWER mode — when <thread.latestAssistantTurn.askedClarifyingQuestion> is true, the chips ARE the user's likely answers to the agent's question. Pull options from the choices the agent presented in its reply. 5-40 chars typically.
 
-2. CONTINUE mode — natural next prompts (drill-in, refinement, comparison, follow-up). Use ONLY field labels visible in <thread.latestAssistantTurn.latestQueryExplore> (preferred — these are the fields the agent JUST used), or in <thread.latestAssistantTurn.text>, or in <explores>. Never invent terms — if a concept doesn't appear in the data, do not propose it. In defaults.dimensions, use field IDs from the catalogue, not labels.
+2. CONTINUE mode — natural next prompts (drill-in, refinement, comparison, follow-up). Use ONLY field labels visible in <thread.latestAssistantTurn.latestQueryExplore> (preferred — these are the fields the agent JUST used), or in <thread.latestAssistantTurn.text>, or in <explores>. Never invent terms — if a concept doesn't appear in the data, do not propose it. In defaults.dimensions and defaults.metrics, use field IDs from the catalogue, not labels.
 
 PREFERRED CONTEXT:
 - When <thread.latestAssistantTurn.latestQueryExplore> is present, lean on its dimensions and metrics first. These are the fields the agent just touched — the user is almost certainly thinking in that explore's frame.
@@ -57,14 +57,14 @@ HARD RULES:
 - Never reference a field name, segment, tier, or metric that does not appear in <thread.latestAssistantTurn.latestQueryExplore>, <explores>, <thread.latestAssistantTurn.text>, or <verifiedContent>. This is the #1 failure mode.
 - If <thread.latestAssistantTurn.refused> is true (the agent just said it couldn't do something): do NOT repeat the refused line. Pivot — propose a different explore, a related verified question, or an adjacent angle the data actually supports.
 - 3 chips is ideal. 5 is the maximum.
-- Verified questions, verified content, and content tags reflect the user's curated workflow — prefer them when they fit the next-step slot. A chip that points at a verified chart ("Open the {name}") via \`findContent\` is often stronger than a new query.
+- Verified questions, verified content, and content tags reflect the user's curated workflow — prefer them when they fit the next-step slot. A chip that points at a verified chart ("Find the {name} chart") via \`findContent\` is often stronger than a new query.
 - No trailing punctuation on labels. Imperative or interrogative tense.
 
-For each chip, set defaults.explore, defaults.dimensions, defaults.timeframe based on what the chip implies. Use nulls / empty arrays when not applicable. Set tool to the best-fit value: ${AGENT_SUGGESTION_TOOLS.join(', ')}.
+For each chip, set defaults.explore, defaults.dimensions, defaults.metrics, defaults.timeframe based on what the chip implies. Use nulls / empty arrays when not applicable. Set tool to the best-fit enabled tool from <enabledTools>.
 
 Tool guide:
 - \`runQuery\`: drill-ins, breakdowns, refinements of the data
-- \`runSql\`: rare; only when semantic layer can't express what's being asked
+- \`runSql\`: rare; only when present in <enabledTools> and semantic layer can't express what's being asked
 - \`generateDashboard\`: "build me an overview" or multi-chart
 - \`findContent\`: "is there already a saved chart for this", or to surface a verified chart
 - \`proposeChange\`: when the user is implicitly asking for a metric/dimension definition change`;
@@ -74,19 +74,34 @@ export const SUGGESTION_FALLBACK_CHIPS: AgentSuggestion[] = [
         kind: 'prompt',
         label: 'Show me what data is available',
         tool: 'findContent',
-        defaults: { explore: null, dimensions: [], timeframe: null },
+        defaults: {
+            explore: null,
+            dimensions: [],
+            metrics: [],
+            timeframe: null,
+        },
     },
     {
         kind: 'prompt',
         label: 'Summarise activity from the last 30 days',
         tool: 'runQuery',
-        defaults: { explore: null, dimensions: [], timeframe: 'last 30 days' },
+        defaults: {
+            explore: null,
+            dimensions: [],
+            metrics: [],
+            timeframe: 'last 30 days',
+        },
     },
     {
         kind: 'prompt',
         label: 'Build a quick overview dashboard',
         tool: 'generateDashboard',
-        defaults: { explore: null, dimensions: [], timeframe: null },
+        defaults: {
+            explore: null,
+            dimensions: [],
+            metrics: [],
+            timeframe: null,
+        },
     },
 ];
 

--- a/packages/common/src/ee/AiAgent/schemas/agentSuggestions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/agentSuggestions.ts
@@ -29,6 +29,11 @@ const promptChipModelSchema = z.object({
                 .describe(
                     'Field IDs the chip implies. Empty array when the chip does not pin dimensions.',
                 ),
+            metrics: z
+                .array(z.string())
+                .describe(
+                    'Metric field IDs the chip implies. Empty array when the chip does not pin metrics.',
+                ),
             timeframe: z
                 .string()
                 .nullable()

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -69,6 +69,7 @@ export type AgentSuggestionPromptChip = {
     defaults: {
         explore: string | null;
         dimensions: string[];
+        metrics: string[];
         timeframe: string | null;
     };
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -284,6 +284,8 @@ export const AgentChatInput = ({
                     properties: {
                         projectId: projectUuid,
                         agentId: agentUuid,
+                        threadId: threadUuid,
+                        afterMessageId: latestAssistantMessageUuid,
                         chipLabel: chip.label,
                         chipKind: chip.kind,
                         chipTool:
@@ -328,7 +330,16 @@ export const AgentChatInput = ({
             setValueState('');
             trackClick();
         },
-        [editor, projectUuid, agentUuid, track, emptyStateMode, navigate],
+        [
+            editor,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            latestAssistantMessageUuid,
+            track,
+            emptyStateMode,
+            navigate,
+        ],
     );
 
     const handleImpression = useCallback(

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -203,6 +203,7 @@ export const AgentChatInput = ({
     const suggestionsQuery = useAgentSuggestions({
         projectUuid,
         agentUuid,
+        enableSqlMode: sqlMode,
         threadUuid: postResponseMode ? threadUuid : undefined,
         afterMessageUuid: postResponseMode
             ? latestAssistantMessageUuid

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -390,6 +390,7 @@ export const AgentChatInput = ({
             <AgentSuggestionChips
                 chips={chips}
                 isLoading={suggestionsQuery.isLoading}
+                loadingVariant={postResponseMode ? 'follow-up' : 'skeleton'}
                 onChipClick={handleChipClick}
                 onImpression={handleImpression}
             />

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -25,6 +25,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { ModelSelector } from '../../../../../components/common/ModelSelector/ModelSelector';
+import useUser from '../../../../../hooks/user/useUser';
 import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -118,6 +119,7 @@ export const AgentChatInput = ({
     defaultValue,
     onValueChange,
 }: AgentChatInputProps) => {
+    const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
     const navigate = useNavigate();
     const onSubmitRef = useRef(onSubmit);
@@ -278,10 +280,12 @@ export const AgentChatInput = ({
     const handleChipClick = useCallback(
         (chip: AgentSuggestion, index: number) => {
             const trackClick = () => {
-                if (!projectUuid || !agentUuid) return;
+                const organizationId = user.data?.organizationUuid;
+                if (!organizationId || !projectUuid || !agentUuid) return;
                 track({
                     name: EventName.AI_AGENT_SUGGESTION_CLICK,
                     properties: {
+                        organizationId,
                         projectId: projectUuid,
                         agentId: agentUuid,
                         threadId: threadUuid,
@@ -336,6 +340,7 @@ export const AgentChatInput = ({
             agentUuid,
             threadUuid,
             latestAssistantMessageUuid,
+            user.data?.organizationUuid,
             track,
             emptyStateMode,
             navigate,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
@@ -100,6 +100,57 @@
     border-radius: 6px;
 }
 
+.followUpLoader {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 0 var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    min-height: 30px;
+    animation: chipFadeIn 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.loaderText {
+    font-weight: 500;
+
+    @mixin light {
+        color: var(--mantine-color-ldGray-6);
+    }
+
+    @mixin dark {
+        color: var(--mantine-color-ldDark-2);
+    }
+}
+
+.loaderDots {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding-top: 1px;
+
+    span {
+        width: 3px;
+        height: 3px;
+        border-radius: 999px;
+        animation: loaderDotPulse 950ms ease-in-out infinite;
+
+        @mixin light {
+            background-color: var(--mantine-color-ldGray-5);
+        }
+
+        @mixin dark {
+            background-color: var(--mantine-color-ldDark-2);
+        }
+    }
+
+    span:nth-child(2) {
+        animation-delay: 120ms;
+    }
+
+    span:nth-child(3) {
+        animation-delay: 240ms;
+    }
+}
+
 .fadeIn {
     animation: chipFadeIn 320ms cubic-bezier(0.22, 1, 0.36, 1) both;
     animation-delay: calc(var(--chip-idx, 0) * 40ms);
@@ -116,6 +167,19 @@
     }
 }
 
+@keyframes loaderDotPulse {
+    0%,
+    70%,
+    100% {
+        opacity: 0.35;
+        transform: translateY(0);
+    }
+    35% {
+        opacity: 1;
+        transform: translateY(-1px);
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .chip {
         transition-duration: 0ms;
@@ -124,6 +188,14 @@
     .fadeIn {
         animation: chipFadeInReduced 120ms ease-out both;
         animation-delay: 0ms;
+    }
+
+    .followUpLoader {
+        animation: none;
+    }
+
+    .loaderDots span {
+        animation: none;
     }
 
     @keyframes chipFadeInReduced {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
@@ -1,5 +1,5 @@
 import type { AgentSuggestion } from '@lightdash/common';
-import { Box, Button, Skeleton } from '@mantine-8/core';
+import { Box, Button, Skeleton, Text } from '@mantine-8/core';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import { useEffect, useRef } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -8,6 +8,7 @@ import styles from './AgentSuggestionChips.module.css';
 type Props = {
     chips: AgentSuggestion[];
     isLoading: boolean;
+    loadingVariant?: 'skeleton' | 'follow-up';
     onChipClick: (chip: AgentSuggestion, index: number) => void;
     onImpression?: (chipCount: number) => void;
 };
@@ -27,6 +28,7 @@ const renderLeftIcon = (chip: AgentSuggestion) => {
 export const AgentSuggestionChips = ({
     chips,
     isLoading,
+    loadingVariant = 'skeleton',
     onChipClick,
     onImpression,
 }: Props) => {
@@ -42,6 +44,25 @@ export const AgentSuggestionChips = ({
     }, [chips, isLoading, onImpression]);
 
     if (isLoading) {
+        if (loadingVariant === 'follow-up') {
+            return (
+                <Box className={styles.followUpLoader}>
+                    <Text
+                        component="span"
+                        size="xs"
+                        className={styles.loaderText}
+                    >
+                        Finding good follow-ups
+                    </Text>
+                    <Box className={styles.loaderDots} aria-hidden>
+                        <span />
+                        <span />
+                        <span />
+                    </Box>
+                </Box>
+            );
+        }
+
         return (
             <Box className={styles.row}>
                 {Array.from({ length: SKELETON_COUNT }).map((_, idx) => (

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAgentSuggestions.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAgentSuggestions.ts
@@ -7,10 +7,12 @@ const AGENT_SUGGESTIONS_KEY = 'agentSuggestions';
 const getAgentSuggestions = (
     projectUuid: string,
     agentUuid: string,
+    enableSqlMode: boolean,
     threadUuid?: string,
     afterMessageUuid?: string,
 ) => {
     const search = new URLSearchParams();
+    if (enableSqlMode) search.set('enableSqlMode', 'true');
     if (threadUuid) search.set('threadUuid', threadUuid);
     if (afterMessageUuid) search.set('afterMessageUuid', afterMessageUuid);
     const qs = search.toString();
@@ -27,12 +29,14 @@ const getAgentSuggestions = (
 export const useAgentSuggestions = ({
     projectUuid,
     agentUuid,
+    enableSqlMode,
     threadUuid,
     afterMessageUuid,
     enabled,
 }: {
     projectUuid: string | undefined;
     agentUuid: string | undefined;
+    enableSqlMode: boolean;
     threadUuid?: string;
     afterMessageUuid?: string;
     enabled: boolean;
@@ -42,6 +46,7 @@ export const useAgentSuggestions = ({
             AGENT_SUGGESTIONS_KEY,
             projectUuid,
             agentUuid,
+            enableSqlMode,
             threadUuid ?? null,
             afterMessageUuid ?? null,
         ],
@@ -49,6 +54,7 @@ export const useAgentSuggestions = ({
             getAgentSuggestions(
                 projectUuid!,
                 agentUuid!,
+                enableSqlMode,
                 threadUuid,
                 afterMessageUuid,
             ),

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -483,6 +483,8 @@ type AiAgentSuggestionClickEvent = {
     properties: {
         projectId: string;
         agentId: string;
+        threadId?: string;
+        afterMessageId?: string;
         chipLabel: string;
         chipKind: 'prompt' | 'navigate';
         chipTool?: string;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -481,6 +481,7 @@ type AiAgentSuggestionImpressionEvent = {
 type AiAgentSuggestionClickEvent = {
     name: EventName.AI_AGENT_SUGGESTION_CLICK;
     properties: {
+        organizationId: string;
         projectId: string;
         agentId: string;
         threadId?: string;


### PR DESCRIPTION
## Summary
- Reuse existing AI-agent field validation for suggestion defaults
- Include metrics in suggestion defaults and validation
- Gate runSql/proposeChange suggestions by actual user capability
- Include organizationId in chip click analytics
- Replace post-response chip skeletons with a quieter follow-up loader

## Linear
Closes ZAP-410: https://linear.app/lightdash/issue/ZAP-410/ship-data-aware-ai-agent-suggestion-chips

## Stack
Depends on: #23267

Note: the stream-based post-response PR (#23265) was closed in favor of the reliable endpoint-driven flow.

## Verification
- pnpm common-typecheck
- pnpm backend-typecheck
- pnpm frontend-typecheck
- pnpm frontend run focused lint on touched chip/input files