### PR TITLE
fix(cli): skip table-groups call when config key absent

### DIFF
--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -141,10 +141,13 @@ const replaceProjectTableGroups = async (
     projectUuid: string,
     lightdashProjectConfig: LightdashProjectConfig,
 ) => {
+    if (!lightdashProjectConfig.table_groups) {
+        return;
+    }
     await lightdashApi<null>({
         method: 'PUT',
         url: `/api/v1/projects/${projectUuid}/table-groups`,
-        body: JSON.stringify(lightdashProjectConfig.table_groups ?? {}),
+        body: JSON.stringify(lightdashProjectConfig.table_groups),
     });
 };
 


### PR DESCRIPTION
Closes: PROD-7782 (follow-up to #23228)

## Summary

CLI 0.2975+ calls `PUT /api/v1/projects/{uuid}/table-groups` on every `lightdash deploy` and `lightdash preview`, even when `table_groups` is absent from `lightdash.config.yml`. Users whose Lightdash instance predates #23228 hit a 404 on every deploy and see a stack of red warnings in the logs, despite never using the feature.

## Root cause

#23228 wired the CLI to always send the parsed `table_groups` block, defaulting to `{}` when the key was absent. The intent was to let users clear server-side groups by removing the key from config — but the side effect is an unconditional call to a new endpoint that many production API servers don't yet expose.

```ts
// packages/cli/src/handlers/deploy.ts (before)
body: JSON.stringify(lightdashProjectConfig.table_groups ?? {}),
```

The call is wrapped in `try/catch` so the deploy doesn't abort, but the warning is logged every time and obscures real failures. Table groups are a niche feature — the blast radius here is ~99% of users paying the cost for ~1% of users' feature.

## Fix

Gate the API call on `table_groups` being present in the parsed config. This matches the existing pattern for `replaceProjectDefaults` immediately above it (`deploy.ts:130`), which already short-circuits when its key is absent.

- `packages/cli/src/handlers/deploy.ts` — early-return from `replaceProjectTableGroups` when `lightdashProjectConfig.table_groups` is `undefined`.

**Contract change:** removing `table_groups:` from the config no longer clears server-side groups on next deploy. Users who want to clear them must now set `table_groups: {}` explicitly. This is an acceptable tradeoff — clearing all groups is rare, and the explicit `{}` is honest about intent.

## Behaviour

```
                       Before                      After
table_groups: absent → PUT /table-groups {}        (no call)
table_groups: {…}    → PUT /table-groups {…}       PUT /table-groups {…}
table_groups: {}     → PUT /table-groups {}        PUT /table-groups {}
```

## Test plan

- [x] `pnpm -F cli typecheck && pnpm -F cli lint`
- [ ] Manual: `lightdash deploy` against an instance without the `/table-groups` endpoint, with no `table_groups` in config — no warning logged, no API call made
- [ ] Manual: `lightdash deploy` with `table_groups:` set — labels still applied
- [ ] Manual: `lightdash deploy` with `table_groups: {}` — groups still cleared