### PR TITLE
fix(api-tests): drop stale plain PKCE assertion

### DIFF
--- a/packages/api-tests/tests/oauthLogin.test.ts
+++ b/packages/api-tests/tests/oauthLogin.test.ts
@@ -187,7 +187,6 @@ describe('OAuth API Integration Tests', () => {
             expect(body.grant_types_supported).toContain('authorization_code');
             expect(body.grant_types_supported).toContain('refresh_token');
             expect(body.code_challenge_methods_supported).toContain('S256');
-            expect(body.code_challenge_methods_supported).toContain('plain');
 
             // OAuth2 endpoints should not have the {status, results} wrapper
             expect(body).not.toHaveProperty('status');


### PR DESCRIPTION
## Summary

Companion fix for #23174. After dropping `'plain'` from `code_challenge_methods_supported` in the OAuth discovery doc, the API integration test that asserted `plain` was advertised is now stale and failing on `main`.

Simply remove the assertion — we have no reason to assert anything about `plain`, and S256 is already covered on the line above.

## Test plan

- [ ] Backend API Tests (Vitest) — `OAuth Discovery > Should return OAuth server metadata` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)