### PR TITLE
fix: copy group-level custom roles to preview projects

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -18,6 +18,7 @@ import { getTracker, MockClient, RawQuery, Tracker } from 'knex-mock-client';
 import { FunctionQueryMatcher } from 'knex-mock-client/types/mock-client';
 import isEqual from 'lodash/isEqual';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { ProjectGroupAccessTableName } from '../../database/entities/projectGroupAccess';
 import {
     CachedExploresTableName,
     CachedExploreTableName,
@@ -492,6 +493,61 @@ describe('ProjectModel', () => {
 
             // Only the space insert, no access grant
             expect(tracker.history.insert).toHaveLength(1);
+        });
+    });
+
+    describe('getProjectGroupAccesses', () => {
+        const groupUuid = 'group-uuid-1';
+        const customRoleUuid = 'custom-role-uuid-1';
+
+        test('returns custom role uuid in `role` when role_uuid is set', async () => {
+            tracker.on
+                .select(
+                    queryMatcher(ProjectGroupAccessTableName, [projectUuid]),
+                )
+                .response([
+                    {
+                        projectUuid,
+                        groupUuid,
+                        role: 'viewer',
+                        role_uuid: customRoleUuid,
+                    },
+                ]);
+
+            const result = await model.getProjectGroupAccesses(projectUuid);
+
+            expect(result).toEqual([
+                {
+                    projectUuid,
+                    groupUuid,
+                    role: customRoleUuid,
+                },
+            ]);
+        });
+
+        test('returns system role in `role` when role_uuid is null', async () => {
+            tracker.on
+                .select(
+                    queryMatcher(ProjectGroupAccessTableName, [projectUuid]),
+                )
+                .response([
+                    {
+                        projectUuid,
+                        groupUuid,
+                        role: 'editor',
+                        role_uuid: null,
+                    },
+                ]);
+
+            const result = await model.getProjectGroupAccesses(projectUuid);
+
+            expect(result).toEqual([
+                {
+                    projectUuid,
+                    groupUuid,
+                    role: 'editor',
+                },
+            ]);
         });
     });
 });

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2143,14 +2143,18 @@ export class ProjectModel {
         const projectGroupAccesses = await this.database(
             ProjectGroupAccessTableName,
         )
-            .select<ProjectGroupAccess[]>({
+            .select<(ProjectGroupAccess & { role_uuid: string | null })[]>({
                 projectUuid: 'project_uuid',
                 groupUuid: 'group_uuid',
                 role: 'role',
+                role_uuid: 'role_uuid',
             })
             .where('project_uuid', projectUuid);
 
-        return projectGroupAccesses;
+        return projectGroupAccesses.map(({ role_uuid, ...access }) => ({
+            ...access,
+            role: role_uuid ?? access.role,
+        }));
     }
 
     async getWarehouseCredentialsForProject(


### PR DESCRIPTION
Closes #23105

## Summary

Creating a preview project failed with "user doesn't have permissions to update project parameters" when the user's access to the parent project came through a group assigned to a custom role. The group landed in the preview as plain `Viewer` instead of the custom role, dropping the permissions the user needed to finish setup.

User-level custom role access already copies correctly — only group-level access was affected. Both self-hosted and cloud are impacted.

## Root cause

`ProjectModel.getProjectGroupAccesses()` only selected the base `role` column. For groups assigned to a custom role the DB stores `role: 'viewer'` (legacy fallback) plus `role_uuid: <custom_role_uuid>`; without reading `role_uuid` the custom role was silently dropped on read, so `copyUserAccessOnPreview()` wrote the group into the preview as Viewer.

```ts
.select<ProjectGroupAccess[]>({
    projectUuid: 'project_uuid',
    groupUuid: 'group_uuid',
    role: 'role',           // role_uuid not selected
})
```

The write side (`GroupsModel.addProjectAccess`) already handles the overload — if the value isn't a system role it stores it as `role_uuid` — so the read side just has to undo the same dance. The type `ProjectGroupAccess.role: ProjectMemberRole | string` documents the overload.

```
DB row                               Returned before          Returned after
  role:      'viewer'                  role: 'viewer'  ← bug    role: '<uuid>'
  role_uuid: '<custom-role-uuid>'

  role:      'editor'                  role: 'editor'           role: 'editor'
  role_uuid: NULL
```

## Fix

Select `role_uuid` alongside `role` and map `role` to the UUID when it is set, matching the convention `getProjectAccess()` uses for user-level access.

- `packages/backend/src/models/ProjectModel/ProjectModel.ts` — select `role_uuid`, map into `role` on the way out.
- `packages/backend/src/models/ProjectModel/ProjectModel.test.ts` — regression coverage for both branches.

## Test plan

- [x] `pnpm -F backend lint && pnpm -F backend typecheck`
- [x] `npx jest src/models/ProjectModel/ProjectModel.test.ts` — 19 pass (added *returns custom role uuid in `role` when role_uuid is set*, *returns system role in `role` when role_uuid is null*)
- [ ] Manual: assign a group to a custom role in the parent project, create a preview as a group member, confirm preview Project Access shows the custom role (not Viewer) and creation completes without the permissions error
- [ ] Manual: user-level custom role copy still works (regression check)

## Notes

Supersedes external contribution #23165 — same one-line root cause, adds regression tests. Credited via co-author trailer in the commit.