### PR TITLE
fix(backend): stamp scheduler_name + savedSqlUuid in uploadGsheets log context

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -83,6 +83,28 @@ describe('setSchedulerJobLogContext', () => {
             setSchedulerJobLogContext({ jobId: 'job-1' }),
         ).not.toThrow();
     });
+
+    it('replaces (not merges) the scheduler sub-context on a second call', () => {
+        ExecutionContext.run(() => {
+            setSchedulerJobLogContext({
+                jobId: 'job-7',
+                schedulerUuid: 'sched-7',
+            });
+            setSchedulerJobLogContext({
+                jobId: 'job-7',
+                schedulerUuid: 'sched-7',
+                schedulerName: 'Weekly gsheets sync',
+                savedSqlUuid: 'sql-7',
+            });
+            const ctx = ExecutionContext.get<ExecutionContextInfo>();
+            expect(ctx.scheduler).toEqual({
+                job_id: 'job-7',
+                scheduler_uuid: 'sched-7',
+                scheduler_name: 'Weekly gsheets sync',
+                saved_sql_uuid: 'sql-7',
+            });
+        }, {} as ExecutionContextInfo);
+    });
 });
 
 describe('isPositiveThresholdAlert', () => {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2910,6 +2910,13 @@ export default class SchedulerTask {
                     schedulerUuid,
                 );
 
+            setSchedulerJobLogContext({
+                jobId,
+                schedulerUuid,
+                schedulerName: scheduler.name,
+                savedSqlUuid: scheduler.savedSqlUuid,
+            });
+
             const { format, savedChartUuid, dashboardUuid, thresholds } =
                 scheduler;
 


### PR DESCRIPTION
## Summary
- Follow-up to #23250. Every other ` + "`setSchedulerJobLogContext`" + ` call site that has a ` + "`schedulerUuid`" + ` also passes ` + "`schedulerName`" + ` (and ` + "`savedSqlUuid`" + ` when available), but ` + "`uploadGsheets`" + ` only stamped ` + "`{ jobId, schedulerUuid }`" + ` at entry because the ` + "`SchedulerAndTargets`" + ` row is fetched later in the function body.
- Result: every gsheets sync log line was carrying ` + "`scheduler_uuid`" + ` but never ` + "`scheduler_name`" + ` (and never ` + "`saved_sql_uuid`" + ` for SQL-runner-backed deliveries).
- Adds a second ` + "`setSchedulerJobLogContext`" + ` call immediately after the scheduler fetch with the full attribution set.

## Empirical evidence (pre-fix, GCP Cloud Logging, fleet-wide, 15-minute window)
| Query | Unique scheduler_uuid values |
|---|---|
| ` + "`scheduler_uuid != NULL AND scheduler_name != NULL`" + ` | **0** |
| ` + "`scheduler_uuid != NULL AND scheduler_name IS NULL`" + ` | 4 |
| ` + "`scheduler_name = \"\"`" + ` (empty string) | 0 |

The empty-string check confirms the field was missing entirely (not dropped by the helper's truthiness guard), pinpointing the only code path that omits it.

## Why a second call, not destructure at entry?
` + "`GsheetsNotificationPayload`" + ` doesn't carry the full ` + "`SchedulerAndTargets`" + ` row — ` + "`uploadGsheets`" + ` has to fetch it via ` + "`schedulerService.schedulerModel.getSchedulerAndTargets`" + `. The semantics of ` + "`setSchedulerJobLogContext`" + ` (second call replaces the scheduler sub-context, not merges) are already documented in the helper docstring. A new unit test pins that behaviour so future refactors keep the enrichment-after-fetch pattern working.

## Test plan
- [x] ` + "`pnpm --filter backend test -- SchedulerTask.test.ts`" + ` — 26/26 pass (including new ` + "`replaces (not merges) the scheduler sub-context on a second call`" + `)
- [x] ` + "`pnpm --filter backend typecheck`" + ` — clean
- [x] ` + "`pnpm --filter backend exec eslint`" + ` on changed files — clean
- [ ] Post-deploy: confirm in Cloud Logging that gsheets sync logs now carry ` + "`scheduler_name`" + ` (` + "`jsonPayload.scheduler_name != NULL AND jsonPayload.query_context = \"scheduledGsheetsSqlChart\"`" + `)

🤖 Generated with [Claude Code](https://claude.com/claude-code)