### PR TITLE
feat(mcp): return structuredContent from run_sql

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -313,6 +313,7 @@ export class McpService extends BaseService {
     private async buildScopedResponse(
         context: McpProtocolContext,
         toolResult: string,
+        structuredContent?: Record<string, unknown>,
     ) {
         const metadata = await this.getActiveContextMetadata(context);
 
@@ -334,7 +335,9 @@ export class McpService extends BaseService {
             });
         }
 
-        return { content };
+        return structuredContent !== undefined
+            ? { content, structuredContent }
+            : { content };
     }
 
     static async streamToolResult<T extends { result: string }>(
@@ -1381,6 +1384,25 @@ export class McpService extends BaseService {
             {
                 description: toolRunSqlArgsSchema.description,
                 inputSchema: this.getMcpCompatibleSchema(toolRunSqlArgsSchema),
+                outputSchema: {
+                    rows: z
+                        .array(z.record(z.unknown()))
+                        .describe(
+                            'Result rows. Each row is an object keyed by column name. Values come from the warehouse as JSON-serializable primitives (numbers, strings, booleans, ISO date strings, or null).',
+                        ),
+                    columns: z
+                        .array(z.string())
+                        .describe(
+                            'Ordered list of column names matching the keys in each row of `rows`.',
+                        ),
+                    rowCount: z
+                        .number()
+                        .int()
+                        .nonnegative()
+                        .describe(
+                            'Total number of rows returned. May be less than the requested limit.',
+                        ),
+                },
                 annotations: {
                     readOnlyHint: true,
                     destructiveHint: false,
@@ -1426,6 +1448,7 @@ export class McpService extends BaseService {
                         return await this.buildScopedResponse(
                             ctx,
                             `Query returned 0 rows.${header ? ` ${header}` : ''}`,
+                            { rows: [], columns, rowCount: 0 },
                         );
                     }
 
@@ -1434,7 +1457,11 @@ export class McpService extends BaseService {
                         columns,
                     });
 
-                    return await this.buildScopedResponse(ctx, csv);
+                    return await this.buildScopedResponse(ctx, csv, {
+                        rows,
+                        columns,
+                        rowCount: rows.length,
+                    });
                 } catch (e) {
                     const errorMessage =
                         e instanceof Error ? e.message : String(e);

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
@@ -14,6 +14,25 @@ The query is executed directly against the warehouse, so use the SQL dialect app
 Parameters:
 - sql: The SQL query to execute. Must be a valid SELECT statement.
 - limit: Maximum number of rows to return (default 500, max 5000).
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: "<CSV string>" }] — header row + data rows, comma-separated. Provided for human/LLM display and as a fallback.
+- structuredContent: {
+    rows:     Array<Record<string, unknown>>,  // each row keyed by column name
+    columns:  string[],                        // column names in order
+    rowCount: number                           // total rows returned
+  }
+
+When writing code that consumes this tool (e.g. inside a live artifact), prefer structuredContent.rows over parsing the CSV. Example:
+
+  const result = await callMcpTool('run_sql', { sql, limit });
+  const rows    = result.structuredContent.rows;     // [{ status: 'completed', n: 94, total_amount: 2397 }, ...]
+  const columns = result.structuredContent.columns;  // ['status', 'n', 'total_amount']
+
+Notes:
+- Values in rows are JSON-serializable primitives: numbers, strings, booleans, ISO date strings, or null. They are NOT pre-stringified — there's no need for parseFloat / parseInt on numeric columns.
+- Empty results still return structuredContent with { rows: [], columns, rowCount: 0 } — distinct from a parse failure.
+- On error, the response has isError: true and content[0].text contains the error message; structuredContent is omitted.
 `;
 
 export const toolRunSqlArgsSchema = createToolSchema({


### PR DESCRIPTION
Closes #23274
Closes PROD-7802

## What changed

`run_sql` now returns `structuredContent: { rows, columns, rowCount }` alongside the existing CSV text payload, plus declares an `outputSchema`. The tool description documents the response shape with a worked example.

## Files touched

- `packages/backend/src/ee/services/McpService/McpService.ts` — added `outputSchema` to the `run_sql` registration, passed `structuredContent` through the response, extended `buildScopedResponse` to optionally carry structured content.
- `packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts` — added a "Response shape" section to the tool description with a copy-pasteable example.

## Back-compat

`content[0].text` still contains raw CSV — existing clients that parse the text directly keep working. `structuredContent` is purely additive. Empty results return `structuredContent: { rows: [], columns, rowCount: 0 }`, distinguishable from a parse failure.

## Verification

Reproduced the failure mode in a clean artifact against Jaffle shop — diagnostic panel captured the exact envelope `callMcpTool` returned and confirmed the parser fell through to `JSON.stringify(raw)` → empty array. Built a second artifact that reads `raw.structuredContent.rows` directly in two lines, with a verdict banner that flips green once the fix is live.

Typecheck passes on common and backend. Lint passes on common; backend lint hits a pre-existing custom-rule resolution issue unrelated to these changes (reproduces on untouched files).

## Follow-ups worth a separate ticket

- Audit other MCP tools that return row-shaped data via text-only (`list_verified_content`, `list_explores`, etc. — most return descriptive XML rather than data rows, so likely no action, but worth confirming).
- Tighter `outputSchema` per-warehouse if useful (today values are typed `z.unknown()` because warehouses return mixed types).
- Add `McpService.test.ts` covering `run_sql` response-shape end-to-end.