### PR TITLE
fix: flag dashboard filters referencing deleted explores as TableDoesNotExist

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -322,6 +322,180 @@ describe('validation', () => {
         );
     });
 
+    it('Should flag dashboard filter referencing a deleted explore as TableDoesNotExist', async () => {
+        (
+            projectModel.findExploresFromCache as jest.Mock
+        ).mockImplementationOnce(async () => [explore]);
+        (
+            dashboardModel.findDashboardsForValidation as jest.Mock
+        ).mockImplementationOnce(async () => [
+            {
+                ...dashboardForValidation,
+                filters: {
+                    dimensions: [
+                        {
+                            id: 'filter-uuid',
+                            target: {
+                                fieldId: 'deleted_model_status',
+                                tableName: 'deleted_model',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: [],
+                        },
+                    ],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.DASHBOARDS]),
+        );
+
+        // Must match the exact wording parsed by
+        // ValidationModel.parseDashboardFilterError so the bell-icon UI
+        // categorises this as TableDoesNotExist (and offers a rename/delete).
+        expect(errors.map((error) => error.error)).toContain(
+            "Table 'deleted_model' no longer exists",
+        );
+        // The generic "field no longer exists" should NOT also appear for
+        // this target — we want a single, specific error.
+        expect(errors.map((error) => error.error)).not.toContain(
+            "Filter error: the field 'deleted_model_status' on table 'deleted_model' no longer exists",
+        );
+    });
+
+    it('Should flag dashboard tile target referencing a deleted explore as TableDoesNotExist', async () => {
+        (
+            projectModel.findExploresFromCache as jest.Mock
+        ).mockImplementationOnce(async () => [explore]);
+        (
+            dashboardModel.findDashboardsForValidation as jest.Mock
+        ).mockImplementationOnce(async () => [
+            {
+                ...dashboardForValidation,
+                filters: {
+                    dimensions: [
+                        {
+                            id: 'filter-uuid',
+                            target: {
+                                fieldId: 'table_dimension',
+                                tableName: 'table',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: [],
+                            tileTargets: {
+                                'tile-uuid': {
+                                    fieldId: 'deleted_model_status',
+                                    tableName: 'deleted_model',
+                                },
+                            },
+                        },
+                    ],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.DASHBOARDS]),
+        );
+
+        expect(errors.map((error) => error.error)).toContain(
+            "Table 'deleted_model' no longer exists",
+        );
+    });
+
+    it('Should NOT flag dashboard filter on a valid joined table', async () => {
+        // exploreWithJoin contains both `table` and `another_table` in its
+        // .tables map — a filter on `table_dimension` via `tableName: 'table'`
+        // must stay error-free even though `table` is not the baseTable.
+        (
+            projectModel.findExploresFromCache as jest.Mock
+        ).mockImplementationOnce(async () => [exploreWithJoin]);
+        (
+            dashboardModel.findDashboardsForValidation as jest.Mock
+        ).mockImplementationOnce(async () => [
+            {
+                ...dashboardForValidation,
+                filters: {
+                    dimensions: [
+                        {
+                            id: 'filter-uuid',
+                            target: {
+                                fieldId: 'table_dimension',
+                                tableName: 'table',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: [],
+                        },
+                    ],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.DASHBOARDS]),
+        );
+
+        expect(
+            errors.filter((e) =>
+                e.error?.startsWith("Table 'table' no longer exists"),
+            ),
+        ).toEqual([]);
+    });
+
+    it('Should still emit FieldDoesNotExist when the table is valid but the field is renamed', async () => {
+        (
+            projectModel.findExploresFromCache as jest.Mock
+        ).mockImplementationOnce(async () => [explore]);
+        (
+            dashboardModel.findDashboardsForValidation as jest.Mock
+        ).mockImplementationOnce(async () => [
+            {
+                ...dashboardForValidation,
+                filters: {
+                    dimensions: [
+                        {
+                            id: 'filter-uuid',
+                            target: {
+                                fieldId: 'table_renamed_field',
+                                tableName: 'table',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: [],
+                        },
+                    ],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.DASHBOARDS]),
+        );
+
+        expect(errors.map((error) => error.error)).toContain(
+            "Filter error: the field 'table_renamed_field' on table 'table' no longer exists",
+        );
+        expect(errors.map((error) => error.error)).not.toContain(
+            "Table 'table' no longer exists",
+        );
+    });
+
     it('Should validate dashboard tile targets with table name mismatch', async () => {
         (
             dashboardModel.findDashboardsForValidation as jest.Mock

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -139,6 +139,27 @@ export class ValidationService extends BaseService {
         return existingFields;
     }
 
+    private static buildExistingTableNames(
+        compiledExplores: (Explore | ExploreError)[],
+    ): Set<string> {
+        // Includes baseTable for every explore (even those that failed to
+        // compile, so a broken-but-present model is not falsely reported
+        // as deleted) plus every joined table from non-error explores —
+        // dashboard filter targets can reference joined tables too.
+        const tableNames = new Set<string>();
+        compiledExplores.forEach((explore) => {
+            if (explore.baseTable) {
+                tableNames.add(explore.baseTable);
+            }
+            if (!isExploreError(explore) && explore.tables) {
+                Object.keys(explore.tables).forEach((name) =>
+                    tableNames.add(name),
+                );
+            }
+        });
+        return tableNames;
+    }
+
     lightdashConfig: LightdashConfig;
 
     analytics: LightdashAnalytics;
@@ -597,6 +618,7 @@ export class ValidationService extends BaseService {
     private async validateDashboards(
         projectUuid: string,
         existingFields: CompiledField[],
+        existingTableNames: Set<string>,
         brokenCharts: Pick<CreateChartValidation, 'chartUuid' | 'name'>[],
         dashboardUuid?: string,
     ): Promise<CreateDashboardValidation[]> {
@@ -666,6 +688,27 @@ export class ValidationService extends BaseService {
                         return undefined;
                     };
 
+                    // Without this check a deleted dbt model's dimensions
+                    // stay silently in the filter dropdown — the existing
+                    // fieldId check only catches renamed/removed fields
+                    // within an existing table. The parser in
+                    // ValidationModel.parseDashboardFilterError keys off the
+                    // exact "Table 'X' no longer exists" wording.
+                    const checkTableExists = (
+                        fieldId: string,
+                        tableName: string | undefined,
+                    ): CreateDashboardValidation | undefined => {
+                        if (tableName && !existingTableNames.has(tableName)) {
+                            return {
+                                ...commonValidation,
+                                errorType: ValidationErrorType.Filter,
+                                error: `Table '${tableName}' no longer exists`,
+                                fieldName: fieldId,
+                            };
+                        }
+                        return undefined;
+                    };
+
                     const dashboardFilterRules = [
                         ...filters.dimensions,
                         ...filters.metrics,
@@ -694,6 +737,14 @@ export class ValidationService extends BaseService {
                             );
                             if (consistencyError) {
                                 return [...acc, consistencyError];
+                            }
+
+                            const tableMissingError = checkTableExists(
+                                fieldId,
+                                tableName,
+                            );
+                            if (tableMissingError) {
+                                return [...acc, tableMissingError];
                             }
 
                             return containsFieldId({
@@ -743,6 +794,14 @@ export class ValidationService extends BaseService {
                                     );
                                 if (consistencyError) {
                                     return [...acc, consistencyError];
+                                }
+
+                                const tableMissingError = checkTableExists(
+                                    fieldId,
+                                    tableName,
+                                );
+                                if (tableMissingError) {
+                                    return [...acc, tableMissingError];
                                 }
 
                                 return containsFieldId({
@@ -983,12 +1042,17 @@ export class ValidationService extends BaseService {
                 error.errorType !== ValidationErrorType.ChartConfiguration,
         );
 
+        const existingTableNames = explores
+            ? ValidationService.buildExistingTableNames(explores)
+            : new Set<string>();
+
         const dashboardErrors =
             !hasValidationTargets ||
             validationTargets.has(ValidationTarget.DASHBOARDS)
                 ? await this.validateDashboards(
                       projectUuid,
                       existingFields,
+                      existingTableNames,
                       blockingChartErrors,
                   )
                 : [];
@@ -1529,6 +1593,8 @@ export class ValidationService extends BaseService {
         // Get existing fields for validation
         const existingFields =
             ValidationService.buildExistingFields(compiledExplores);
+        const existingTableNames =
+            ValidationService.buildExistingTableNames(compiledExplores);
 
         // Get existing chart validation errors from database
         const validations = await this.validationModel.get(projectUuid);
@@ -1553,6 +1619,7 @@ export class ValidationService extends BaseService {
         const validationErrors = await this.validateDashboards(
             projectUuid,
             existingFields,
+            existingTableNames,
             blockingChartErrors,
             dashboardUuid,
         );


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-5931/deleted-dbt-model-persists-in-dashboard-filter-dropdowns](https://linear.app/lightdash/issue/PROD-5931/deleted-dbt-model-persists-in-dashboard-filter-dropdowns)<!-- reference the related issue e.g. #150 -->

### Description:

Dashboard filters that reference a deleted dbt model (explore) were previously silently ignored during validation — the existing field-level check only caught renamed or removed fields within a table that still existed. This meant deleted models could linger in the filter dropdown without any warning.

This adds a table-existence check to dashboard filter validation. A new `buildExistingTableNames` helper collects all known table names from compiled explores (including joined tables and broken-but-present models). During dashboard validation, both top-level filter targets and per-tile `tileTargets` are checked against this set before the field-level check runs. If the table is missing, a `"Table 'X' no longer exists"` error is emitted — matching the exact wording that `ValidationModel.parseDashboardFilterError` uses to categorise the error as `TableDoesNotExist` in the UI, enabling the rename/delete action in the bell-icon notification.

When the table exists but the field has been renamed or removed, the existing `FieldDoesNotExist` error is still emitted as before.