### PR TITLE
feat(embed): render SQL chart tiles in embedded dashboards

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -41,6 +41,11 @@ interface Props extends Pick<
 > {
     tile: DashboardSqlChartTile;
     minimal?: boolean;
+    /**
+     * Render via the embed-only API surface (JWT-authorized via dashboard
+     * tile membership) instead of the registered chart endpoints.
+     */
+    isEmbed?: boolean;
 }
 
 /**
@@ -69,7 +74,7 @@ const DashboardOptions = memo(
     ),
 );
 
-const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
+const SqlChartTile: FC<Props> = ({ tile, isEditMode, isEmbed, ...rest }) => {
     const { user } = useApp();
     const { projectUuid, dashboardUuid } = useParams<{
         projectUuid: string;
@@ -119,11 +124,12 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
         projectUuid,
         savedSqlUuid,
         context,
-        dashboardUuid,
+        dashboardUuid: dashboardUuid ?? '',
         tileUuid: tile.uuid,
         dashboardFilters,
         dashboardSorts: [],
         parameters,
+        isEmbed,
     });
 
     // Charts in Dashboard shouldn't have animation

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -120,17 +120,29 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, isEmbed, ...rest }) => {
             isFetching: isChartResultsFetching,
         },
         getDownloadQueryUuid,
-    } = useSavedSqlChartResults({
-        projectUuid,
-        savedSqlUuid,
-        context,
-        dashboardUuid: dashboardUuid ?? '',
-        tileUuid: tile.uuid,
-        dashboardFilters,
-        dashboardSorts: [],
-        parameters,
-        isEmbed,
-    });
+    } = useSavedSqlChartResults(
+        isEmbed
+            ? {
+                  projectUuid,
+                  savedSqlUuid,
+                  context,
+                  tileUuid: tile.uuid,
+                  dashboardFilters,
+                  dashboardSorts: [],
+                  parameters,
+                  isEmbed: true,
+              }
+            : {
+                  projectUuid,
+                  savedSqlUuid,
+                  context,
+                  dashboardUuid: dashboardUuid!,
+                  tileUuid: tile.uuid,
+                  dashboardFilters,
+                  dashboardSorts: [],
+                  parameters,
+              },
+    );
 
     // Charts in Dashboard shouldn't have animation
     const specWithoutAnimation = useMemo(() => {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -118,6 +118,7 @@ const EmbedDashboardGrid: FC<{
                                 isEditMode={false}
                                 onDelete={() => {}}
                                 onEdit={() => {}}
+                                isEmbed
                             />
                         ) : tile.type === DashboardTileTypes.HEADING ? (
                             <EmbedHeadingTile

--- a/packages/frontend/src/features/queryRunner/executeQuery.ts
+++ b/packages/frontend/src/features/queryRunner/executeQuery.ts
@@ -154,3 +154,29 @@ export const executeDashboardSqlChartPivotQuery = async (
 
     return getPivotQueryResults(projectUuid, executeQueryResponse.queryUuid);
 };
+
+// Embed-only path: hits the /embed/* endpoint, which authorizes via the
+// dashboard JWT instead of the registered chart access used by the v2
+// dashboard-sql-chart endpoint.
+export const executeEmbedDashboardSqlChartPivotQuery = async (
+    projectUuid: string,
+    payload: {
+        tileUuid: string;
+    } & Pick<
+        ExecuteAsyncDashboardSqlChartRequestParams,
+        | 'dashboardFilters'
+        | 'dashboardSorts'
+        | 'invalidateCache'
+        | 'parameters'
+        | 'limit'
+    >,
+) => {
+    const executeQueryResponse =
+        await lightdashApi<ApiExecuteAsyncSqlQueryResults>({
+            url: `/embed/${projectUuid}/query/dashboard-sql-chart`,
+            method: 'POST',
+            body: JSON.stringify(payload),
+        });
+
+    return getPivotQueryResults(projectUuid, executeQueryResponse.queryUuid);
+};

--- a/packages/frontend/src/features/queryRunner/sqlRunnerPivotQueries.ts
+++ b/packages/frontend/src/features/queryRunner/sqlRunnerPivotQueries.ts
@@ -16,6 +16,7 @@ import {
 import { getVizIndexTypeFromSqlRunnerFieldType } from './BaseResultsRunner';
 import {
     executeDashboardSqlChartPivotQuery,
+    executeEmbedDashboardSqlChartPivotQuery,
     executeSqlChartPivotQuery,
     executeSqlPivotQuery,
 } from './executeQuery';
@@ -204,6 +205,49 @@ export const getDashboardSqlChartPivotChartData = async ({
         limit,
         parameters,
     });
+
+    const columns: VizColumn[] = Object.keys(pivotResults.columns).map(
+        (field) => ({
+            reference: field,
+        }),
+    );
+
+    return {
+        ...pivotResults,
+        columns,
+    };
+};
+
+export const getEmbedDashboardSqlChartPivotChartData = async ({
+    projectUuid,
+    tileUuid,
+    limit,
+    dashboardFilters,
+    dashboardSorts,
+    parameters,
+    invalidateCache,
+}: {
+    projectUuid: string;
+    tileUuid: string;
+    limit?: number;
+    dashboardFilters: DashboardFilters;
+    dashboardSorts: SortField[];
+    parameters?: ParametersValuesMap;
+    invalidateCache?: boolean;
+}): Promise<
+    PivotChartData & { queryUuid: string; originalColumns: ResultColumns }
+> => {
+    const pivotResults = await executeEmbedDashboardSqlChartPivotQuery(
+        projectUuid,
+        {
+            tileUuid,
+            dashboardFilters,
+            dashboardSorts,
+            limit,
+            parameters,
+            invalidateCache,
+        },
+    );
 
     const columns: VizColumn[] = Object.keys(pivotResults.columns).map(
         (field) => ({

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -259,6 +259,7 @@ export const useSavedSqlChartResults = (
                             dashboardFilters: args.dashboardFilters,
                             dashboardSorts: args.dashboardSorts,
                             limit: limit ?? MAX_SAFE_INTEGER,
+                            parameters,
                         });
                 } else if (isRegisteredDashboardArgs(args) && savedSqlUuid) {
                     queryForDownload = await getDashboardSqlChartPivotChartData(
@@ -271,6 +272,7 @@ export const useSavedSqlChartResults = (
                             savedSqlUuid,
                             context: args.context as QueryExecutionContext,
                             limit: limit ?? MAX_SAFE_INTEGER,
+                            parameters,
                         },
                     );
                 } else {
@@ -292,6 +294,7 @@ export const useSavedSqlChartResults = (
             context,
             projectUuid,
             savedSqlUuid,
+            parameters,
         ],
     );
 

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -20,10 +20,14 @@ import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColo
 import { useQueryRetryConfig } from '../../../hooks/useQueryRetry';
 import {
     getDashboardSqlChartPivotChartData,
+    getEmbedDashboardSqlChartPivotChartData,
     getSqlChartPivotChartData,
 } from '../../queryRunner/sqlRunnerPivotQueries';
 import { SqlChartResultsRunner } from '../runners/SqlRunnerResultsRunnerFrontend';
-import { fetchSavedSqlChart } from './useSavedSqlCharts';
+import {
+    fetchEmbedDashboardSqlChartTile,
+    fetchSavedSqlChart,
+} from './useSavedSqlCharts';
 
 type SavedSqlChartArgs = {
     savedSqlUuid?: string;
@@ -39,6 +43,10 @@ type SavedSqlChartDashboardArgs = SavedSqlChartArgs & {
     dashboardFilters: DashboardFilters;
     dashboardSorts: SortField[];
     parameters?: ParametersValuesMap;
+    // When true, the chart and its results are fetched via the /embed/*
+    // routes, which authorize JWT users via dashboard membership instead
+    // of requiring a registered account.
+    isEmbed?: boolean;
 };
 
 type UseSavedSqlChartResultsArguments =
@@ -70,17 +78,38 @@ export const useSavedSqlChartResults = (
         dashboardUuid: isDashboardArgs(args) ? args.dashboardUuid : undefined,
     });
 
-    // Step 1: Get the chart
+    const isEmbedDashboard = isDashboardArgs(args) && args.isEmbed === true;
+
+    // Step 1: Get the chart. Embed dashboards must use the embed-only
+    // endpoint, which authorizes via dashboard tile membership; the
+    // registered endpoint requires a session user and 403s for JWT users.
     const chartQuery = useQuery<SqlChart, Partial<ApiError>>(
-        ['savedSqlChart', savedSqlUuid ?? slug],
-        async () =>
-            fetchSavedSqlChart({
+        [
+            'savedSqlChart',
+            savedSqlUuid ?? slug,
+            isEmbedDashboard ? 'embed' : 'registered',
+            isEmbedDashboard && isDashboardArgs(args)
+                ? args.tileUuid
+                : undefined,
+        ],
+        async () => {
+            if (isEmbedDashboard && isDashboardArgs(args)) {
+                return fetchEmbedDashboardSqlChartTile({
+                    projectUuid: projectUuid!,
+                    tileUuid: args.tileUuid,
+                });
+            }
+            return fetchSavedSqlChart({
                 projectUuid: projectUuid!,
                 uuid: savedSqlUuid,
                 slug,
-            }),
+            });
+        },
         {
-            enabled: (!!savedSqlUuid || !!slug) && !!projectUuid,
+            enabled:
+                (isEmbedDashboard
+                    ? isDashboardArgs(args) && !!args.tileUuid
+                    : !!savedSqlUuid || !!slug) && !!projectUuid,
             ...retryConfig,
         },
     );
@@ -96,24 +125,40 @@ export const useSavedSqlChartResults = (
                 // Safe to assume these are defined because of the enabled flag
                 const chart = chartQuery.data!;
 
-                let { originalColumns, ...pivotChartData } =
-                    isDashboardArgs(args) && savedSqlUuid
-                        ? await getDashboardSqlChartPivotChartData({
+                let { originalColumns, ...pivotChartData } = isDashboardArgs(
+                    args,
+                )
+                    ? args.isEmbed
+                        ? await getEmbedDashboardSqlChartPivotChartData({
                               projectUuid: projectUuid!,
-                              dashboardUuid: args.dashboardUuid,
                               tileUuid: args.tileUuid,
                               dashboardFilters: args.dashboardFilters,
                               dashboardSorts: args.dashboardSorts,
-                              savedSqlUuid,
-                              context: args.context as QueryExecutionContext,
                               parameters,
                           })
-                        : await getSqlChartPivotChartData({
-                              projectUuid: projectUuid!,
-                              savedSqlUuid: chart.savedSqlUuid,
-                              context: context as QueryExecutionContext,
-                              parameters,
-                          });
+                        : savedSqlUuid
+                          ? await getDashboardSqlChartPivotChartData({
+                                projectUuid: projectUuid!,
+                                dashboardUuid: args.dashboardUuid,
+                                tileUuid: args.tileUuid,
+                                dashboardFilters: args.dashboardFilters,
+                                dashboardSorts: args.dashboardSorts,
+                                savedSqlUuid,
+                                context: args.context as QueryExecutionContext,
+                                parameters,
+                            })
+                          : await getSqlChartPivotChartData({
+                                projectUuid: projectUuid!,
+                                savedSqlUuid: chart.savedSqlUuid,
+                                context: context as QueryExecutionContext,
+                                parameters,
+                            })
+                    : await getSqlChartPivotChartData({
+                          projectUuid: projectUuid!,
+                          savedSqlUuid: chart.savedSqlUuid,
+                          context: context as QueryExecutionContext,
+                          parameters,
+                      });
 
                 const vizConfig = isVizTableConfig(chart.config)
                     ? chart.config.columns
@@ -172,7 +217,7 @@ export const useSavedSqlChartResults = (
             enabled:
                 !!chartQuery.data &&
                 !!projectUuid &&
-                (!!savedSqlUuid || !!slug),
+                (isEmbedDashboard || !!savedSqlUuid || !!slug),
             ...retryConfig,
         },
     );
@@ -190,24 +235,38 @@ export const useSavedSqlChartResults = (
             // 1. limit is null (meaning "all results" - should ignore existing query limits)
             // 2. limit is different from current query
             if (limit === null || limit !== chartQuery.data.limit) {
-                const queryForDownload =
-                    isDashboardArgs(args) && savedSqlUuid
-                        ? await getDashboardSqlChartPivotChartData({
+                const queryForDownload = isDashboardArgs(args)
+                    ? args.isEmbed
+                        ? await getEmbedDashboardSqlChartPivotChartData({
                               projectUuid: projectUuid!,
-                              dashboardUuid: args.dashboardUuid,
                               tileUuid: args.tileUuid,
                               dashboardFilters: args.dashboardFilters,
                               dashboardSorts: args.dashboardSorts,
-                              savedSqlUuid,
-                              context: args.context as QueryExecutionContext,
                               limit: limit ?? MAX_SAFE_INTEGER,
                           })
-                        : await getSqlChartPivotChartData({
-                              projectUuid: projectUuid!,
-                              savedSqlUuid: chartQuery.data.savedSqlUuid,
-                              context: context as QueryExecutionContext,
-                              limit: limit ?? MAX_SAFE_INTEGER,
-                          });
+                        : savedSqlUuid
+                          ? await getDashboardSqlChartPivotChartData({
+                                projectUuid: projectUuid!,
+                                dashboardUuid: args.dashboardUuid,
+                                tileUuid: args.tileUuid,
+                                dashboardFilters: args.dashboardFilters,
+                                dashboardSorts: args.dashboardSorts,
+                                savedSqlUuid,
+                                context: args.context as QueryExecutionContext,
+                                limit: limit ?? MAX_SAFE_INTEGER,
+                            })
+                          : await getSqlChartPivotChartData({
+                                projectUuid: projectUuid!,
+                                savedSqlUuid: chartQuery.data.savedSqlUuid,
+                                context: context as QueryExecutionContext,
+                                limit: limit ?? MAX_SAFE_INTEGER,
+                            })
+                    : await getSqlChartPivotChartData({
+                          projectUuid: projectUuid!,
+                          savedSqlUuid: chartQuery.data.savedSqlUuid,
+                          context: context as QueryExecutionContext,
+                          limit: limit ?? MAX_SAFE_INTEGER,
+                      });
                 queryUuidToDownload = queryForDownload.queryUuid;
             }
             return queryUuidToDownload;

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -29,7 +29,7 @@ import {
     fetchSavedSqlChart,
 } from './useSavedSqlCharts';
 
-type SavedSqlChartArgs = {
+type SavedSqlChartBaseArgs = {
     savedSqlUuid?: string;
     slug?: string;
     projectUuid?: string;
@@ -37,25 +37,43 @@ type SavedSqlChartArgs = {
     parameters?: ParametersValuesMap;
 };
 
-type SavedSqlChartDashboardArgs = SavedSqlChartArgs & {
-    dashboardUuid: string;
+type SavedSqlChartDashboardCommonArgs = SavedSqlChartBaseArgs & {
     tileUuid: string;
     dashboardFilters: DashboardFilters;
     dashboardSorts: SortField[];
-    parameters?: ParametersValuesMap;
-    // When true, the chart and its results are fetched via the /embed/*
-    // routes, which authorize JWT users via dashboard membership instead
-    // of requiring a registered account.
-    isEmbed?: boolean;
 };
 
+type SavedSqlChartRegisteredDashboardArgs = SavedSqlChartDashboardCommonArgs & {
+    dashboardUuid: string;
+    isEmbed?: false;
+};
+
+// Embed callers don't pass dashboardUuid — the JWT carries it server-side.
+type SavedSqlChartEmbedDashboardArgs = SavedSqlChartDashboardCommonArgs & {
+    isEmbed: true;
+};
+
+type SavedSqlChartDashboardArgs =
+    | SavedSqlChartRegisteredDashboardArgs
+    | SavedSqlChartEmbedDashboardArgs;
+
 type UseSavedSqlChartResultsArguments =
-    | SavedSqlChartArgs
+    | SavedSqlChartBaseArgs
     | SavedSqlChartDashboardArgs;
 
 const isDashboardArgs = (
     args: UseSavedSqlChartResultsArguments,
-): args is SavedSqlChartDashboardArgs => 'dashboardUuid' in args;
+): args is SavedSqlChartDashboardArgs => 'tileUuid' in args;
+
+const isEmbedDashboardArgs = (
+    args: UseSavedSqlChartResultsArguments,
+): args is SavedSqlChartEmbedDashboardArgs =>
+    isDashboardArgs(args) && args.isEmbed === true;
+
+const isRegisteredDashboardArgs = (
+    args: UseSavedSqlChartResultsArguments,
+): args is SavedSqlChartRegisteredDashboardArgs =>
+    isDashboardArgs(args) && !args.isEmbed;
 
 type UseSavedSqlChartResults = {
     queryUuid: string;
@@ -75,10 +93,13 @@ export const useSavedSqlChartResults = (
 
     const { savedSqlUuid, slug, projectUuid, context, parameters } = args;
     const { data: resolvedPalette } = useProjectColorPalette(projectUuid, {
-        dashboardUuid: isDashboardArgs(args) ? args.dashboardUuid : undefined,
+        dashboardUuid:
+            isDashboardArgs(args) && !args.isEmbed
+                ? args.dashboardUuid
+                : undefined,
     });
 
-    const isEmbedDashboard = isDashboardArgs(args) && args.isEmbed === true;
+    const embedDashboard = isEmbedDashboardArgs(args);
 
     // Step 1: Get the chart. Embed dashboards must use the embed-only
     // endpoint, which authorizes via dashboard tile membership; the
@@ -87,13 +108,11 @@ export const useSavedSqlChartResults = (
         [
             'savedSqlChart',
             savedSqlUuid ?? slug,
-            isEmbedDashboard ? 'embed' : 'registered',
-            isEmbedDashboard && isDashboardArgs(args)
-                ? args.tileUuid
-                : undefined,
+            embedDashboard ? 'embed' : 'registered',
+            embedDashboard ? args.tileUuid : undefined,
         ],
         async () => {
-            if (isEmbedDashboard && isDashboardArgs(args)) {
+            if (isEmbedDashboardArgs(args)) {
                 return fetchEmbedDashboardSqlChartTile({
                     projectUuid: projectUuid!,
                     tileUuid: args.tileUuid,
@@ -107,9 +126,8 @@ export const useSavedSqlChartResults = (
         },
         {
             enabled:
-                (isEmbedDashboard
-                    ? isDashboardArgs(args) && !!args.tileUuid
-                    : !!savedSqlUuid || !!slug) && !!projectUuid,
+                (embedDashboard ? !!args.tileUuid : !!savedSqlUuid || !!slug) &&
+                !!projectUuid,
             ...retryConfig,
         },
     );
@@ -125,40 +143,37 @@ export const useSavedSqlChartResults = (
                 // Safe to assume these are defined because of the enabled flag
                 const chart = chartQuery.data!;
 
-                let { originalColumns, ...pivotChartData } = isDashboardArgs(
-                    args,
-                )
-                    ? args.isEmbed
-                        ? await getEmbedDashboardSqlChartPivotChartData({
-                              projectUuid: projectUuid!,
-                              tileUuid: args.tileUuid,
-                              dashboardFilters: args.dashboardFilters,
-                              dashboardSorts: args.dashboardSorts,
-                              parameters,
-                          })
-                        : savedSqlUuid
-                          ? await getDashboardSqlChartPivotChartData({
-                                projectUuid: projectUuid!,
-                                dashboardUuid: args.dashboardUuid,
-                                tileUuid: args.tileUuid,
-                                dashboardFilters: args.dashboardFilters,
-                                dashboardSorts: args.dashboardSorts,
-                                savedSqlUuid,
-                                context: args.context as QueryExecutionContext,
-                                parameters,
-                            })
-                          : await getSqlChartPivotChartData({
-                                projectUuid: projectUuid!,
-                                savedSqlUuid: chart.savedSqlUuid,
-                                context: context as QueryExecutionContext,
-                                parameters,
-                            })
-                    : await getSqlChartPivotChartData({
-                          projectUuid: projectUuid!,
-                          savedSqlUuid: chart.savedSqlUuid,
-                          context: context as QueryExecutionContext,
-                          parameters,
-                      });
+                let pivotResult;
+                if (isEmbedDashboardArgs(args)) {
+                    pivotResult = await getEmbedDashboardSqlChartPivotChartData(
+                        {
+                            projectUuid: projectUuid!,
+                            tileUuid: args.tileUuid,
+                            dashboardFilters: args.dashboardFilters,
+                            dashboardSorts: args.dashboardSorts,
+                            parameters,
+                        },
+                    );
+                } else if (isRegisteredDashboardArgs(args) && savedSqlUuid) {
+                    pivotResult = await getDashboardSqlChartPivotChartData({
+                        projectUuid: projectUuid!,
+                        dashboardUuid: args.dashboardUuid,
+                        tileUuid: args.tileUuid,
+                        dashboardFilters: args.dashboardFilters,
+                        dashboardSorts: args.dashboardSorts,
+                        savedSqlUuid,
+                        context: args.context as QueryExecutionContext,
+                        parameters,
+                    });
+                } else {
+                    pivotResult = await getSqlChartPivotChartData({
+                        projectUuid: projectUuid!,
+                        savedSqlUuid: chart.savedSqlUuid,
+                        context: context as QueryExecutionContext,
+                        parameters,
+                    });
+                }
+                const { originalColumns, ...pivotChartData } = pivotResult;
 
                 const vizConfig = isVizTableConfig(chart.config)
                     ? chart.config.columns
@@ -217,7 +232,7 @@ export const useSavedSqlChartResults = (
             enabled:
                 !!chartQuery.data &&
                 !!projectUuid &&
-                (isEmbedDashboard || !!savedSqlUuid || !!slug),
+                (embedDashboard || !!savedSqlUuid || !!slug),
             ...retryConfig,
         },
     );
@@ -235,38 +250,37 @@ export const useSavedSqlChartResults = (
             // 1. limit is null (meaning "all results" - should ignore existing query limits)
             // 2. limit is different from current query
             if (limit === null || limit !== chartQuery.data.limit) {
-                const queryForDownload = isDashboardArgs(args)
-                    ? args.isEmbed
-                        ? await getEmbedDashboardSqlChartPivotChartData({
-                              projectUuid: projectUuid!,
-                              tileUuid: args.tileUuid,
-                              dashboardFilters: args.dashboardFilters,
-                              dashboardSorts: args.dashboardSorts,
-                              limit: limit ?? MAX_SAFE_INTEGER,
-                          })
-                        : savedSqlUuid
-                          ? await getDashboardSqlChartPivotChartData({
-                                projectUuid: projectUuid!,
-                                dashboardUuid: args.dashboardUuid,
-                                tileUuid: args.tileUuid,
-                                dashboardFilters: args.dashboardFilters,
-                                dashboardSorts: args.dashboardSorts,
-                                savedSqlUuid,
-                                context: args.context as QueryExecutionContext,
-                                limit: limit ?? MAX_SAFE_INTEGER,
-                            })
-                          : await getSqlChartPivotChartData({
-                                projectUuid: projectUuid!,
-                                savedSqlUuid: chartQuery.data.savedSqlUuid,
-                                context: context as QueryExecutionContext,
-                                limit: limit ?? MAX_SAFE_INTEGER,
-                            })
-                    : await getSqlChartPivotChartData({
-                          projectUuid: projectUuid!,
-                          savedSqlUuid: chartQuery.data.savedSqlUuid,
-                          context: context as QueryExecutionContext,
-                          limit: limit ?? MAX_SAFE_INTEGER,
-                      });
+                let queryForDownload;
+                if (isEmbedDashboardArgs(args)) {
+                    queryForDownload =
+                        await getEmbedDashboardSqlChartPivotChartData({
+                            projectUuid: projectUuid!,
+                            tileUuid: args.tileUuid,
+                            dashboardFilters: args.dashboardFilters,
+                            dashboardSorts: args.dashboardSorts,
+                            limit: limit ?? MAX_SAFE_INTEGER,
+                        });
+                } else if (isRegisteredDashboardArgs(args) && savedSqlUuid) {
+                    queryForDownload = await getDashboardSqlChartPivotChartData(
+                        {
+                            projectUuid: projectUuid!,
+                            dashboardUuid: args.dashboardUuid,
+                            tileUuid: args.tileUuid,
+                            dashboardFilters: args.dashboardFilters,
+                            dashboardSorts: args.dashboardSorts,
+                            savedSqlUuid,
+                            context: args.context as QueryExecutionContext,
+                            limit: limit ?? MAX_SAFE_INTEGER,
+                        },
+                    );
+                } else {
+                    queryForDownload = await getSqlChartPivotChartData({
+                        projectUuid: projectUuid!,
+                        savedSqlUuid: chartQuery.data.savedSqlUuid,
+                        context: context as QueryExecutionContext,
+                        limit: limit ?? MAX_SAFE_INTEGER,
+                    });
+                }
                 queryUuidToDownload = queryForDownload.queryUuid;
             }
             return queryUuidToDownload;

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
@@ -40,6 +40,19 @@ export const fetchSavedSqlChart = async ({
         body: undefined,
     });
 
+export const fetchEmbedDashboardSqlChartTile = async ({
+    projectUuid,
+    tileUuid,
+}: {
+    projectUuid: string;
+    tileUuid: string;
+}) =>
+    lightdashApi<SqlChart>({
+        url: `/embed/${projectUuid}/sql-chart-tile/${tileUuid}`,
+        method: 'GET',
+        body: undefined,
+    });
+
 const createSavedSqlChart = async (projectUuid: string, data: CreateSqlChart) =>
     lightdashApi<ApiCreateSqlChart['results']>({
         url: `/projects/${projectUuid}/sqlRunner/saved`,


### PR DESCRIPTION
Closes: [PROD-7746](https://linear.app/lightdash/issue/PROD-7746/sql-runner-charts-dont-load-in-embedded-dashboard).

PR 3 of 3 for PROD-7746. Wires `DashboardSqlChartTile` to the embed-only API routes when rendered inside an embedded dashboard, flipping the user-visible bit: SQL chart tiles in embed dashboards now render data instead of `Account is not a registered user`.

Stacks on top of PR 2 ([#23284](https://github.com/lightdash/lightdash/pull/23284)) which adds the backend embed surface. Without that, the new routes don't exist. PR 1 ([#23282](https://github.com/lightdash/lightdash/pull/23282)) is also a prerequisite — the streamed result reader needs the JWT-forwarding fix or the second hop of every query 401's.

## Changes

**Frontend**
- `useSavedSqlChartResults` accepts an `isEmbed` flag (dashboard args only). When set: chart-definition fetch goes through `fetchEmbedDashboardSqlChartTile` instead of `fetchSavedSqlChart`; pivot-query goes through `getEmbedDashboardSqlChartPivotChartData` instead of `getDashboardSqlChartPivotChartData`. The download-query path branches the same way.
- New API wrappers: `fetchEmbedDashboardSqlChartTile` (`useSavedSqlCharts.tsx`), `executeEmbedDashboardSqlChartPivotQuery` + `getEmbedDashboardSqlChartPivotChartData` (`executeQuery.ts` + `sqlRunnerPivotQueries.ts`).
- `DashboardSqlChartTile` accepts an `isEmbed?` prop and forwards it to the hook. Non-embed callers are unaffected (defaults to `undefined`).
- `EmbedDashboard.tsx` passes `isEmbed` when rendering `SQL_CHART` tiles.

## Resolver semantics

```
EmbedDashboard renders SQL_CHART tile
  └─ DashboardSqlChartTile(isEmbed=true)
      └─ useSavedSqlChartResults({ isEmbed, tileUuid, dashboardFilters, … })
          ├─ chart def    → GET  /api/v1/embed/:proj/sql-chart-tile/:tileUuid
          └─ pivot query  → POST /api/v1/embed/:proj/query/dashboard-sql-chart
                           ↓ returns queryUuid
                           GET  /api/v2/.../query/:queryUuid/results  (PR 1 fixed the JWT header here)
```

The non-embed path (regular dashboard view, SQL Runner) is untouched. The hook keeps its existing argument shape; `isEmbed` is an optional field on the dashboard variant of the args.

## Test plan

- [x] `pnpm -F frontend typecheck && pnpm -F frontend lint`
- [x] Manual: opened a generated embed URL for a dashboard containing a SQL chart tile; chart renders the same rows the registered viewer sees (was: `SQL Chart — Account is not a registered user`).
- [x] Manual API regression: POST + GET on the new embed routes return 200 with the expected payload shape.
- [ ] Manual: verify SQL chart tile still renders in the regular (non-embed) dashboard view (non-embed branch unchanged).
- [ ] Manual: verify saved-chart, markdown, loom, heading and data-app tiles still render in embed (unchanged paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)