### PR TITLE
feat: add `HidePivotDimensions` feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -173,6 +173,13 @@ export enum FeatureFlags {
      * fixed.
      */
     DataAppsScheduledDeliveries = 'data-apps-scheduled-deliveries',
+
+    /**
+     * Enable UI for hiding dimensions in pivot table charts (so a dimension
+     * can drive sort order without rendering or leaking into CSV/XLSX).
+     * Off by default while we validate with design partners before GA.
+     */
+    HidePivotDimensions = 'hide-pivot-dimensions',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
Relates to: PROD-2108

### Description:
Adds a new `HidePivotDimensions` feature flag (`hide-pivot-dimensions`) that enables a UI for hiding dimensions in pivot table charts. This allows a dimension to drive sort order without being rendered in the visualization or leaking into CSV/XLSX exports. The flag is off by default while we validate with design partners before general availability.