### PR TITLE
fix: drop legacy dashboard export scope rows and stop emitting console.warn for unknown scopes

### DIFF
--- a/packages/backend/src/database/migrations/20260519142606_remove_legacy_dashboard_export_scopes.ts
+++ b/packages/backend/src/database/migrations/20260519142606_remove_legacy_dashboard_export_scopes.ts
@@ -1,0 +1,43 @@
+import { Knex } from 'knex';
+
+const ScopedRolesTableName = 'scoped_roles';
+const LEGACY_DASHBOARD_EXPORT_SCOPES = [
+    'export:DashboardCsv',
+    'export:DashboardImage',
+    'export:DashboardPdf',
+];
+
+/**
+ * Strip three legacy scope names from `scoped_roles`. They were removed
+ * from the scope vocabulary in #22802 (they were never enforced at any
+ * endpoint — `manage:ExportCsv` is the real gate). Custom roles created
+ * before that PR still carry the legacy strings, and every request that
+ * loads such a role re-emits an `Invalid scope: ...` warning from
+ * `parseScopes`, dominating Cloud Logging volume.
+ *
+ * Wrapped in try/catch because this is best-effort cleanup: failing it
+ * would block later migrations, and the worst case (some legacy rows
+ * stick around) is recoverable by re-running the DELETE manually.
+ */
+export async function up(knex: Knex): Promise<void> {
+    try {
+        await knex(ScopedRolesTableName)
+            .whereIn('scope_name', LEGACY_DASHBOARD_EXPORT_SCOPES)
+            .delete();
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260519142606] Failed to remove legacy dashboard export scopes from ${ScopedRolesTableName}. Affected rows can be cleaned up manually with: DELETE FROM ${ScopedRolesTableName} WHERE scope_name IN (${LEGACY_DASHBOARD_EXPORT_SCOPES.map(
+                (s) => `'${s}'`,
+            ).join(', ')});`,
+            error,
+        );
+    }
+}
+
+export async function down(_knex: Knex): Promise<void> {
+    // No-op. The legacy scopes are no longer in the scope vocabulary, so
+    // there is nothing to restore them to — `parseScopes` would filter
+    // them out on the next load anyway. Rolling back the migration on
+    // the schema side is enough.
+}

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -60,6 +60,7 @@ import {
     DbUserUpdate,
     UserTableName,
 } from '../database/entities/users';
+import Logger from '../logging/logger';
 import { deprecatedHash, hash } from '../utils/hash';
 import {
     CachedPatSessionUser,
@@ -667,7 +668,7 @@ export class UserModel {
                 const scopes = customRoleScopes[user.role_uuid];
                 if (scopes) {
                     const builder = new AbilityBuilder<MemberAbility>(Ability);
-                    buildAbilityFromScopes(
+                    const invalid = buildAbilityFromScopes(
                         {
                             organizationUuid: user.organization_uuid as string,
                             userUuid: user.user_uuid,
@@ -682,6 +683,15 @@ export class UserModel {
                         },
                         builder,
                     );
+                    if (invalid.length > 0) {
+                        Logger.warn(
+                            `Service account ${
+                                user.user_uuid
+                            } custom role references scopes not in the runtime vocabulary: ${invalid.join(
+                                ', ',
+                            )}`,
+                        );
+                    }
                     await this.applyServiceAccountProjectMemberships(
                         user.user_id,
                         user.user_uuid,
@@ -731,18 +741,30 @@ export class UserModel {
                 featureFlagId: CommercialFeatureFlags.CustomRoles,
             }),
         ]);
-        const abilityBuilder = getUserAbilityBuilder({
-            user: lightdashUser,
-            projectProfiles: [...projectRoles, ...groupProjectRoles],
-            permissionsConfig: {
-                pat: this.lightdashConfig.auth.pat,
-            },
-            customRoleScopes,
-            customRolesEnabled:
-                this.lightdashConfig.customRoles.enabled ||
-                customRolesFlag.enabled,
-            isEnterprise: this.lightdashConfig.license.licenseKey !== undefined,
-        });
+        const { builder: abilityBuilder, invalidScopes } =
+            getUserAbilityBuilder({
+                user: lightdashUser,
+                projectProfiles: [...projectRoles, ...groupProjectRoles],
+                permissionsConfig: {
+                    pat: this.lightdashConfig.auth.pat,
+                },
+                customRoleScopes,
+                customRolesEnabled:
+                    this.lightdashConfig.customRoles.enabled ||
+                    customRolesFlag.enabled,
+                isEnterprise:
+                    this.lightdashConfig.license.licenseKey !== undefined,
+            });
+
+        if (invalidScopes.length > 0) {
+            Logger.warn(
+                `Custom role(s) for user ${
+                    lightdashUser.userUuid
+                } reference scopes not in the runtime vocabulary: ${[
+                    ...new Set(invalidScopes),
+                ].join(', ')}`,
+            );
+        }
 
         return {
             abilityBuilder,
@@ -799,12 +821,13 @@ export class UserModel {
         const isEnterprise =
             this.lightdashConfig.license.licenseKey !== undefined;
 
+        const aggregatedInvalidScopes = new Set<string>();
         for (const row of rows) {
             const scopes = row.role_uuid
                 ? customRoleScopes[row.role_uuid]
                 : undefined;
             if (scopes) {
-                buildAbilityFromScopes(
+                const invalid = buildAbilityFromScopes(
                     {
                         projectUuid: row.project_uuid,
                         userUuid,
@@ -816,6 +839,7 @@ export class UserModel {
                     },
                     builder,
                 );
+                invalid.forEach((s) => aggregatedInvalidScopes.add(s));
             } else {
                 projectMemberAbilities[row.role](
                     {
@@ -826,6 +850,13 @@ export class UserModel {
                     builder,
                 );
             }
+        }
+        if (aggregatedInvalidScopes.size > 0) {
+            Logger.warn(
+                `Service account ${userUuid} project custom roles reference scopes not in the runtime vocabulary: ${[
+                    ...aggregatedInvalidScopes,
+                ].join(', ')}`,
+            );
         }
     }
 

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -42,7 +42,7 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
         ])(
             '%s user without roleUuid uses the system role path (unchanged)',
             (role) => {
-                const builder = getUserAbilityBuilder({
+                const { builder } = getUserAbilityBuilder({
                     user: {
                         role,
                         organizationUuid: ORG_UUID,
@@ -59,7 +59,7 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
 
     describe('Custom-roles feature flag', () => {
         it('falls through to the system role path when customRolesEnabled=false (even if roleUuid is set)', () => {
-            const builder = getUserAbilityBuilder({
+            const { builder } = getUserAbilityBuilder({
                 user: {
                     role: OrganizationMemberRole.ADMIN,
                     organizationUuid: ORG_UUID,
@@ -78,7 +78,7 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
         });
 
         it('falls through to the system role path when customRolesEnabled=true but the role has no scopes loaded', () => {
-            const builder = getUserAbilityBuilder({
+            const { builder } = getUserAbilityBuilder({
                 user: {
                     role: OrganizationMemberRole.ADMIN,
                     organizationUuid: ORG_UUID,
@@ -101,7 +101,7 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
         it('uses the scope-derived path when roleUuid + customRolesEnabled + scopes are all present', () => {
             // A custom role granting only view:Dashboard. Admin's normal
             // abilities should NOT appear (e.g. manage:InviteLink).
-            const builder = getUserAbilityBuilder({
+            const { builder } = getUserAbilityBuilder({
                 user: {
                     role: OrganizationMemberRole.ADMIN, // ignored — custom role wins
                     organizationUuid: ORG_UUID,
@@ -131,7 +131,7 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
             const READ_ONLY_UUID = '22222222-2222-4222-a222-222222222222';
             const EDIT_UUID = '33333333-3333-4333-a333-333333333333';
 
-            const readOnlyBuilder = getUserAbilityBuilder({
+            const { builder: readOnlyBuilder } = getUserAbilityBuilder({
                 user: {
                     role: OrganizationMemberRole.MEMBER,
                     organizationUuid: ORG_UUID,
@@ -147,7 +147,7 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
                 customRolesEnabled: true,
             });
 
-            const editBuilder = getUserAbilityBuilder({
+            const { builder: editBuilder } = getUserAbilityBuilder({
                 user: {
                     role: OrganizationMemberRole.MEMBER,
                     organizationUuid: ORG_UUID,
@@ -176,7 +176,7 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
     describe('Project profile resolution still works alongside org-level custom roles', () => {
         it('combines org system role with project-level system role', () => {
             const PROJECT_UUID = 'test-project-uuid';
-            const builder = getUserAbilityBuilder({
+            const { builder } = getUserAbilityBuilder({
                 user: {
                     role: OrganizationMemberRole.MEMBER,
                     organizationUuid: ORG_UUID,

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -27,6 +27,11 @@ type UserAbilityBuilderArgs = {
 
 export const JWT_HEADER_NAME = 'lightdash-embed-token';
 
+export type UserAbilityBuilderResult = {
+    builder: AbilityBuilder<MemberAbility>;
+    invalidScopes: string[];
+};
+
 export const getUserAbilityBuilder = ({
     user,
     projectProfiles,
@@ -34,8 +39,9 @@ export const getUserAbilityBuilder = ({
     customRoleScopes,
     customRolesEnabled,
     isEnterprise,
-}: UserAbilityBuilderArgs) => {
+}: UserAbilityBuilderArgs): UserAbilityBuilderResult => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
+    const invalidScopes: string[] = [];
     if (user.role && user.organizationUuid) {
         // Org-level custom role: if the user's organization_memberships row
         // points at a role_uuid AND custom roles are enabled AND we have the
@@ -48,16 +54,18 @@ export const getUserAbilityBuilder = ({
                 : undefined;
 
         if (orgCustomRoleScopes) {
-            buildAbilityFromScopes(
-                {
-                    organizationUuid: user.organizationUuid,
-                    userUuid: user.userUuid,
-                    scopes: orgCustomRoleScopes,
-                    isEnterprise,
-                    organizationRole: user.role,
-                    permissionsConfig,
-                },
-                builder,
+            invalidScopes.push(
+                ...buildAbilityFromScopes(
+                    {
+                        organizationUuid: user.organizationUuid,
+                        userUuid: user.userUuid,
+                        scopes: orgCustomRoleScopes,
+                        isEnterprise,
+                        organizationRole: user.role,
+                        permissionsConfig,
+                    },
+                    builder,
+                ),
             );
         } else {
             applyOrganizationMemberAbilities({
@@ -88,16 +96,18 @@ export const getUserAbilityBuilder = ({
                     return;
                 }
 
-                buildAbilityFromScopes(
-                    {
-                        projectUuid: projectProfile.projectUuid,
-                        userUuid: user.userUuid,
-                        scopes,
-                        isEnterprise,
-                        organizationRole: user.role,
-                        permissionsConfig,
-                    },
-                    builder,
+                invalidScopes.push(
+                    ...buildAbilityFromScopes(
+                        {
+                            projectUuid: projectProfile.projectUuid,
+                            userUuid: user.userUuid,
+                            scopes,
+                            isEnterprise,
+                            organizationRole: user.role,
+                            permissionsConfig,
+                        },
+                        builder,
+                    ),
                 );
             } else {
                 projectMemberAbilities[projectProfile.role](
@@ -107,7 +117,7 @@ export const getUserAbilityBuilder = ({
             }
         });
     }
-    return builder;
+    return { builder, invalidScopes };
 };
 
 // Defines user ability for test purposes
@@ -122,7 +132,7 @@ export const defineUserAbility = (
     >[],
     customRoleScopes?: Record<Role['roleUuid'], RoleWithScopes['scopes']>,
 ): MemberAbility => {
-    const builder = getUserAbilityBuilder({
+    const { builder } = getUserAbilityBuilder({
         user,
         projectProfiles,
         permissionsConfig: {

--- a/packages/common/src/authorization/parseScopes.test.ts
+++ b/packages/common/src/authorization/parseScopes.test.ts
@@ -2,28 +2,29 @@ import { parseScopes } from './parseScopes';
 
 describe('parseScopes', () => {
     describe('with valid scopes', () => {
-        it('should return a Set of valid scope names for non-enterprise', () => {
+        it('should return valid scope names for non-enterprise', () => {
             const result = parseScopes({
                 scopes: ['view:dashboard', 'manage:dashboard'],
                 isEnterprise: false,
             });
 
-            expect(result).toBeInstanceOf(Set);
-            expect(result.size).toBe(2);
-            expect(result.has('view:Dashboard')).toBe(true);
-            expect(result.has('manage:Dashboard')).toBe(true);
+            expect(result.valid).toBeInstanceOf(Set);
+            expect(result.valid.size).toBe(2);
+            expect(result.valid.has('view:Dashboard')).toBe(true);
+            expect(result.valid.has('manage:Dashboard')).toBe(true);
+            expect(result.invalid).toEqual([]);
         });
 
-        it('should return a Set of valid scope names for enterprise', () => {
+        it('should return valid scope names for enterprise', () => {
             const result = parseScopes({
                 scopes: ['view:ai_agent', 'manage:ai_agent'],
                 isEnterprise: true,
             });
 
-            expect(result).toBeInstanceOf(Set);
-            expect(result.size).toBe(2);
-            expect(result.has('view:AiAgent')).toBe(true);
-            expect(result.has('manage:AiAgent')).toBe(true);
+            expect(result.valid.size).toBe(2);
+            expect(result.valid.has('view:AiAgent')).toBe(true);
+            expect(result.valid.has('manage:AiAgent')).toBe(true);
+            expect(result.invalid).toEqual([]);
         });
 
         it('should handle mixed case scope names correctly', () => {
@@ -32,9 +33,10 @@ describe('parseScopes', () => {
                 isEnterprise: true,
             });
 
-            expect(result.size).toBe(2);
-            expect(result.has('manage:CustomSql')).toBe(true);
-            expect(result.has('manage:PersonalAccessToken')).toBe(true);
+            expect(result.valid.size).toBe(2);
+            expect(result.valid.has('manage:CustomSql')).toBe(true);
+            expect(result.valid.has('manage:PersonalAccessToken')).toBe(true);
+            expect(result.invalid).toEqual([]);
         });
 
         it('should handle single scope correctly', () => {
@@ -43,8 +45,9 @@ describe('parseScopes', () => {
                 isEnterprise: false,
             });
 
-            expect(result.size).toBe(1);
-            expect(result.has('view:Project')).toBe(true);
+            expect(result.valid.size).toBe(1);
+            expect(result.valid.has('view:Project')).toBe(true);
+            expect(result.invalid).toEqual([]);
         });
 
         it('should handle empty scopes array', () => {
@@ -53,35 +56,54 @@ describe('parseScopes', () => {
                 isEnterprise: false,
             });
 
-            expect(result).toBeInstanceOf(Set);
-            expect(result.size).toBe(0);
+            expect(result.valid.size).toBe(0);
+            expect(result.invalid).toEqual([]);
         });
     });
 
     describe('with invalid scopes', () => {
-        it('should filter out invalid scope names', () => {
-            expect(
-                parseScopes({
-                    scopes: ['view:dashboard', 'invalid:scope'],
-                    isEnterprise: false,
-                }),
-            ).toEqual(new Set(['view:Dashboard']));
+        it('should separate invalid scope names from valid ones', () => {
+            const result = parseScopes({
+                scopes: ['view:dashboard', 'invalid:scope'],
+                isEnterprise: false,
+            });
+
+            expect(result.valid).toEqual(new Set(['view:Dashboard']));
+            expect(result.invalid).toEqual(['invalid:Scope']);
         });
 
-        it('should filter out enterprise scopes when not enterprise', () => {
-            expect(
-                parseScopes({
-                    scopes: ['view:dashboard', 'view:ai_agent'],
-                    isEnterprise: false,
-                }),
-            ).toEqual(new Set(['view:Dashboard']));
+        it('should treat enterprise-only scopes as invalid when not enterprise', () => {
+            const nonEnterprise = parseScopes({
+                scopes: ['view:dashboard', 'view:ai_agent'],
+                isEnterprise: false,
+            });
+            expect(nonEnterprise.valid).toEqual(new Set(['view:Dashboard']));
+            expect(nonEnterprise.invalid).toEqual(['view:AiAgent']);
 
-            expect(
-                parseScopes({
-                    scopes: ['view:dashboard', 'view:ai_agent'],
-                    isEnterprise: true,
-                }),
-            ).toEqual(new Set(['view:Dashboard', 'view:AiAgent']));
+            const enterprise = parseScopes({
+                scopes: ['view:dashboard', 'view:ai_agent'],
+                isEnterprise: true,
+            });
+            expect(enterprise.valid).toEqual(
+                new Set(['view:Dashboard', 'view:AiAgent']),
+            );
+            expect(enterprise.invalid).toEqual([]);
+        });
+
+        it('should not emit console warnings for invalid scopes', () => {
+            const warnSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+            parseScopes({
+                scopes: [
+                    'export:DashboardCsv',
+                    'export:DashboardPdf',
+                    'export:DashboardImage',
+                ],
+                isEnterprise: true,
+            });
+            expect(warnSpy).not.toHaveBeenCalled();
+            warnSpy.mockRestore();
         });
     });
 
@@ -96,9 +118,9 @@ describe('parseScopes', () => {
                 isEnterprise: true,
             });
 
-            expect(result.has('manage:CustomSql')).toBe(true);
-            expect(result.has('manage:PersonalAccessToken')).toBe(true);
-            expect(result.has('view:SemanticViewer')).toBe(true);
+            expect(result.valid.has('manage:CustomSql')).toBe(true);
+            expect(result.valid.has('manage:PersonalAccessToken')).toBe(true);
+            expect(result.valid.has('view:SemanticViewer')).toBe(true);
         });
 
         it('should handle camelCase input correctly', () => {
@@ -107,8 +129,8 @@ describe('parseScopes', () => {
                 isEnterprise: false,
             });
 
-            expect(result.has('view:Dashboard')).toBe(true);
-            expect(result.has('manage:SavedChart')).toBe(true);
+            expect(result.valid.has('view:Dashboard')).toBe(true);
+            expect(result.valid.has('manage:SavedChart')).toBe(true);
         });
 
         it('should handle mixed case input correctly', () => {
@@ -117,7 +139,7 @@ describe('parseScopes', () => {
                 isEnterprise: false,
             });
 
-            expect(result.has('view:UnderlyingData')).toBe(true);
+            expect(result.valid.has('view:UnderlyingData')).toBe(true);
         });
     });
 });

--- a/packages/common/src/authorization/parseScopes.ts
+++ b/packages/common/src/authorization/parseScopes.ts
@@ -23,27 +23,30 @@ export const normalizeScopeName = (scope: string): ScopeName => {
     return `${action}:${subject}${modifier ? `@${modifier}` : ''}` as ScopeName;
 };
 
+export type ParseScopesResult = {
+    valid: Set<ScopeName>;
+    invalid: string[];
+};
+
 export const parseScopes = ({
     scopes,
     isEnterprise,
 }: {
     scopes: string[];
     isEnterprise: boolean;
-}): Set<ScopeName> => {
+}): ParseScopesResult => {
     const scopeMap = getAllScopeMap({ isEnterprise });
-    const filtered = scopes.map(normalizeScopeName).filter((scope) => {
-        const foundScope = scopeMap[scope as ScopeName];
+    const valid = new Set<ScopeName>();
+    const invalid: string[] = [];
 
-        if (!foundScope) {
-            // eslint-disable-next-line no-console
-            console.warn(
-                `Invalid scope: ${scope}. Please check the scope name and try again.`,
-            );
-            return false;
+    scopes.forEach((rawScope) => {
+        const normalized = normalizeScopeName(rawScope);
+        if (scopeMap[normalized]) {
+            valid.add(normalized);
+        } else {
+            invalid.push(normalized);
         }
-
-        return true;
     });
 
-    return new Set(filtered);
+    return { valid, invalid };
 };

--- a/packages/common/src/authorization/roleToScopeMapping.test.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.test.ts
@@ -577,7 +577,7 @@ describe('roleToScopeMapping', () => {
                 ];
 
                 // Build ability using the combined role-based system
-                const roleBasedBuilder = getUserAbilityBuilder({
+                const { builder: roleBasedBuilder } = getUserAbilityBuilder({
                     user,
                     projectProfiles,
                     permissionsConfig: {

--- a/packages/common/src/authorization/scopeAbilityBuilder.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.ts
@@ -81,24 +81,28 @@ type BuilderOptions = {
 } & OptionalIdContext;
 
 /**
- * Apply CASL abilities from scopes to a builder
- * @param context - Context containing organization, project, user, and space access information
- * @param builder - CASL ability builder to add permissions to
+ * Apply CASL abilities from scopes to a builder. Returns the list of scope
+ * names that were rejected because they are not in the runtime vocabulary so
+ * the caller can log or report them with whatever logger it has on hand
+ * (`parseScopes` itself is side-effect free — `common` can't depend on the
+ * backend Winston logger).
  */
 export const buildAbilityFromScopes = (
     context: BuilderOptions,
     builder: AbilityBuilder<MemberAbility>,
-): void => {
+): string[] => {
     const isEnterprise = context.isEnterprise ?? false;
-    const scopes = parseScopes({
+    const { valid, invalid } = parseScopes({
         scopes: context.scopes,
         isEnterprise,
     });
     const parsedContext = {
         ...context,
-        scopes,
+        scopes: valid,
         isEnterprise,
     };
 
     applyScopeAbilities(parsedContext, builder);
+
+    return invalid;
 };


### PR DESCRIPTION
## Summary

Two related changes fixing log-volume noise from `parseScopes`.

**1. Migration (commit `005d2ee88e`)** — deletes `scoped_roles` rows where `scope_name` is one of `export:DashboardCsv`, `export:DashboardImage`, `export:DashboardPdf`. These strings were removed from the scope vocabulary in #22802 but never cleaned from the data, so every request that loads a custom role with one of them re-emits an `Invalid scope: ...` warning. The scopes were never enforced at any endpoint (`manage:ExportCsv` is the actual gate), so deleting them changes no behaviour for custom roles. `up()` is wrapped in `try/catch` so a failure can't block subsequent migrations; `down()` is a no-op (the legacy strings are no longer in the runtime vocabulary).

**2. Refactor (commit `fedbabb1fc`)** — addresses the underlying cause: `parseScopes` was calling `console.warn` directly, which writes to stderr with no way to throttle it via log level. Now `parseScopes` returns `{ valid, invalid }` and has no side effects. `buildAbilityFromScopes` and `getUserAbilityBuilder` propagate the invalid list to their callers. `UserModel` — the backend entry point that loads custom roles per request — logs the invalid scopes via Winston-backed `Logger.warn`, so the log level config governs the volume. `common` can't depend on the backend logger (wrong package direction), so keeping `parseScopes` pure and letting each caller choose its sink is the cleanest split.

## Test plan

Migration:
- [x] Seeded a custom role with 3 legacy scopes + 2 control scopes (`manage:ExportCsv`, `view:Dashboard`); ran the migration; confirmed only the 3 legacy rows were deleted and the parent role + control scopes were untouched.
- [x] Rolled back the migration; confirmed the migration row is removed from `knex_migrations` and the rows are *not* restored (no-op `down`).
- [x] Re-applied the migration on freshly seeded rows; cleanup is idempotent.

Refactor:
- [x] `parseScopes` direct verification — passing legacy strings returns `{ valid: ['view:Dashboard', 'manage:ExportCsv'], invalid: ['export:DashboardCsv', 'export:DashboardPdf'] }` with **zero `console.warn` calls**.
- [x] `buildAbilityFromScopes` returns the invalid scope list as `string[]` to its caller.
- [x] All 2045 common tests pass; common + backend typecheck pass; no new lint errors.
- [x] Restarted the running dev API; demo login + `/user` fetch both `ok`; no `Invalid scope:` or `Custom role(s)` warnings emitted in the backend log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)