### PR TITLE
feat: support `hiddenDimensionFieldIds` and `sortOnlyColumns` in pivot configuration

### DIFF
--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -1408,5 +1408,66 @@ describe('derivePivotConfigurationFromChart', () => {
             // sortOnlyColumns should be empty or undefined (no hidden sort dim)
             expect(result?.sortOnlyColumns ?? []).toEqual([]);
         });
+
+        it('drops a hidden dimension from indexColumn even when it is NOT in sorts', () => {
+            // Hidden + not sorted → just dropped (not added to sortOnlyColumns either).
+            // orders_status is hidden (visible: false) and NOT in sorts.
+            // payments_payment_method is the pivot dimension (groupByColumn).
+            // Result: orders_status must NOT appear in indexColumn or sortOnlyColumns.
+            const chartConfig = {
+                type: ChartType.TABLE,
+                config: {
+                    columns: {
+                        orders_status: { visible: false },
+                    },
+                    pivotDimensions: ['payments_payment_method'],
+                    showSubtotals: false,
+                },
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig,
+                pivotConfig: { columns: ['payments_payment_method'] },
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                dimensions: ['payments_payment_method', 'orders_status'],
+                metrics: ['payments_total_revenue'],
+                // No sort on orders_status — it is purely hidden with no sort role.
+                sorts: [],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                mockItems,
+            );
+
+            expect(result).toBeDefined();
+
+            // orders_status must NOT appear in indexColumn
+            let indexRefs: string[];
+            if (Array.isArray(result?.indexColumn)) {
+                indexRefs = result!.indexColumn.map((c) => c.reference);
+            } else if (result?.indexColumn) {
+                indexRefs = [result.indexColumn.reference];
+            } else {
+                indexRefs = [];
+            }
+            expect(indexRefs).not.toContain('orders_status');
+
+            // orders_status must NOT appear in sortOnlyColumns (it's not sorted)
+            const sortOnlyRefs = (result?.sortOnlyColumns ?? []).map(
+                (c) => c.reference,
+            );
+            expect(sortOnlyRefs).not.toContain('orders_status');
+
+            // sortOnlyColumns should be empty (no hidden sort dim)
+            expect(result?.sortOnlyColumns ?? []).toEqual([]);
+        });
     });
 });

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -1304,4 +1304,109 @@ describe('derivePivotConfigurationFromChart', () => {
             expect(indexRefs).not.toContain('y_day');
         });
     });
+
+    describe('sort-only dimensions for Table charts', () => {
+        it('puts a hidden helper dimension in sortOnlyColumns instead of indexColumn', () => {
+            // orders_status is hidden (visible: false) but used for sort order.
+            // payments_payment_method is the pivot dimension (groupByColumn).
+            // Result: orders_status must appear in sortOnlyColumns, NOT in indexColumn.
+            const chartConfig = {
+                type: ChartType.TABLE,
+                config: {
+                    columns: {
+                        orders_status: { visible: false },
+                    },
+                    pivotDimensions: ['payments_payment_method'],
+                    showSubtotals: false,
+                },
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig,
+                pivotConfig: { columns: ['payments_payment_method'] },
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                // Both dims: payments_payment_method (pivot/groupBy) and
+                // orders_status (would be row-index but is hidden)
+                dimensions: ['payments_payment_method', 'orders_status'],
+                metrics: ['payments_total_revenue'],
+                sorts: [{ fieldId: 'orders_status', descending: false }],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                mockItems,
+            );
+
+            expect(result).toBeDefined();
+
+            // orders_status must NOT appear in indexColumn
+            let indexRefs: string[];
+            if (Array.isArray(result?.indexColumn)) {
+                indexRefs = result!.indexColumn.map((c) => c.reference);
+            } else if (result?.indexColumn) {
+                indexRefs = [result.indexColumn.reference];
+            } else {
+                indexRefs = [];
+            }
+            expect(indexRefs).not.toContain('orders_status');
+
+            // orders_status MUST appear in sortOnlyColumns
+            expect(result?.sortOnlyColumns).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ reference: 'orders_status' }),
+                ]),
+            );
+        });
+
+        it('does not add a hidden dim to sortOnlyColumns when it is not in sorts', () => {
+            // If hidden but not in sorts, it should simply not appear anywhere.
+            const chartConfig = {
+                type: ChartType.TABLE,
+                config: {
+                    columns: {
+                        orders_status: { visible: false },
+                    },
+                    pivotDimensions: ['payments_payment_method'],
+                    showSubtotals: false,
+                },
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig,
+                pivotConfig: { columns: ['payments_payment_method'] },
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                dimensions: ['payments_payment_method', 'orders_status'],
+                metrics: ['payments_total_revenue'],
+                sorts: [
+                    {
+                        fieldId: 'payments_payment_method',
+                        descending: false,
+                    },
+                ],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                mockItems,
+            );
+
+            expect(result).toBeDefined();
+            // sortOnlyColumns should be empty or undefined (no hidden sort dim)
+            expect(result?.sortOnlyColumns ?? []).toEqual([]);
+        });
+    });
 });

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -16,6 +16,7 @@ import type { MetricQuery } from '../types/metricQuery';
 import type { PivotConfig, PivotConfiguration } from '../types/pivot';
 import {
     ChartType,
+    getHiddenTableFields,
     isCartesianChartConfig,
     type SavedChartDAO,
 } from '../types/savedCharts';
@@ -209,10 +210,34 @@ function getTablePivotConfiguration(
         }))
         .filter((col) => metricQuery.dimensions.includes(col.reference));
 
+    // Identify hidden dimensions (visible: false in columnProperties).
+    // Dimensions that are hidden AND appear in sorts become sortOnlyColumns —
+    // they drive sort order in the SQL but do not render as row-index columns.
+    const hiddenFieldIds = getHiddenTableFields(chartConfig);
+    const groupByRefs = new Set(groupByColumns.map((c) => c.reference));
+    const sortFieldIds = new Set(metricQuery.sorts.map((s) => s.fieldId));
+
+    const sortOnlyDimensions = metricQuery.dimensions
+        .filter(
+            (d) =>
+                hiddenFieldIds.includes(d) &&
+                sortFieldIds.has(d) &&
+                !groupByRefs.has(d),
+        )
+        .map((d) => ({
+            reference: d,
+            aggregation: VizAggregationOptions.ANY,
+        }));
+
+    // When computing index columns, treat hidden dims the same as value columns
+    // so they are excluded from indexColumn (preventing them from rendering as
+    // row-index columns while still allowing them to participate in sort CTEs).
+    const allValuesColumnsForIndex = [...valuesColumns, ...sortOnlyDimensions];
+
     // Find columns that are not groupBy or value columns (these become index columns)
     const indexColumn = getIndexColumn(
         groupByColumns,
-        valuesColumns,
+        allValuesColumnsForIndex,
         fields,
         metricQuery,
     );
@@ -221,6 +246,9 @@ function getTablePivotConfiguration(
         indexColumn,
         valuesColumns,
         groupByColumns,
+        ...(sortOnlyDimensions.length > 0 && {
+            sortOnlyColumns: sortOnlyDimensions,
+        }),
     };
 
     const pivotConfiguration: PivotConfiguration = {

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -211,28 +211,41 @@ function getTablePivotConfiguration(
         .filter((col) => metricQuery.dimensions.includes(col.reference));
 
     // Identify hidden dimensions (visible: false in columnProperties).
-    // Dimensions that are hidden AND appear in sorts become sortOnlyColumns —
+    // ANY hidden dim is excluded from indexColumn / groupByColumns.
+    // Among hidden dims, those that also appear in sorts become sortOnlyColumns —
     // they drive sort order in the SQL but do not render as row-index columns.
+    // Hidden dims that are NOT sorted are simply dropped entirely.
     const hiddenFieldIds = getHiddenTableFields(chartConfig);
     const groupByRefs = new Set(groupByColumns.map((c) => c.reference));
     const sortFieldIds = new Set(metricQuery.sorts.map((s) => s.fieldId));
 
+    // All hidden dims (regardless of sort status) — used to exclude from indexColumn.
+    const allHiddenDimRefs = new Set(
+        metricQuery.dimensions.filter(
+            (d) => hiddenFieldIds.includes(d) && !groupByRefs.has(d),
+        ),
+    );
+
+    // Subset of hidden dims that are also sorted → participate in SQL via sortOnlyColumns.
     const sortOnlyDimensions = metricQuery.dimensions
-        .filter(
-            (d) =>
-                hiddenFieldIds.includes(d) &&
-                sortFieldIds.has(d) &&
-                !groupByRefs.has(d),
-        )
+        .filter((d) => allHiddenDimRefs.has(d) && sortFieldIds.has(d))
         .map((d) => ({
             reference: d,
             aggregation: VizAggregationOptions.ANY,
         }));
 
-    // When computing index columns, treat hidden dims the same as value columns
+    // When computing index columns, treat ALL hidden dims the same as value columns
     // so they are excluded from indexColumn (preventing them from rendering as
-    // row-index columns while still allowing them to participate in sort CTEs).
-    const allValuesColumnsForIndex = [...valuesColumns, ...sortOnlyDimensions];
+    // row-index columns). This covers both sort-only hidden dims and hidden dims
+    // that are not sorted at all.
+    const hiddenDimPlaceholders = [...allHiddenDimRefs].map((d) => ({
+        reference: d,
+        aggregation: VizAggregationOptions.ANY,
+    }));
+    const allValuesColumnsForIndex = [
+        ...valuesColumns,
+        ...hiddenDimPlaceholders,
+    ];
 
     // Find columns that are not groupBy or value columns (these become index columns)
     const indexColumn = getIndexColumn(

--- a/packages/common/src/pivot/pivotConfig.test.ts
+++ b/packages/common/src/pivot/pivotConfig.test.ts
@@ -60,4 +60,112 @@ describe('getPivotConfig', () => {
             expect(result?.visibleMetricFieldIds).toBeUndefined();
         });
     });
+
+    describe('hidden field splitting for table charts', () => {
+        it('splits hidden fields into hiddenDimensionFieldIds and hiddenMetricFieldIds when metricQuery is provided', () => {
+            // Chart config has both a hidden dim (orders_status) and a hidden metric (payments_total_revenue)
+            const result = getPivotConfig({
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {
+                        columns: {
+                            orders_status: { visible: false },
+                            payments_total_revenue: { visible: false },
+                        },
+                    },
+                },
+                pivotConfig: { columns: ['payments_payment_method'] },
+                tableConfig: { columnOrder: [] },
+                metricQuery: {
+                    dimensions: ['payments_payment_method', 'orders_status'],
+                },
+            });
+
+            expect(result).toBeDefined();
+            // orders_status is a dimension → hiddenDimensionFieldIds
+            expect(result?.hiddenDimensionFieldIds).toEqual(['orders_status']);
+            // payments_total_revenue is NOT in dimensions → hiddenMetricFieldIds
+            expect(result?.hiddenMetricFieldIds).toEqual([
+                'payments_total_revenue',
+            ]);
+        });
+
+        it('only populates hiddenDimensionFieldIds when all hidden fields are dimensions', () => {
+            const result = getPivotConfig({
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {
+                        columns: {
+                            orders_status: { visible: false },
+                        },
+                    },
+                },
+                pivotConfig: { columns: ['payments_payment_method'] },
+                tableConfig: { columnOrder: [] },
+                metricQuery: {
+                    dimensions: ['payments_payment_method', 'orders_status'],
+                },
+            });
+
+            expect(result).toBeDefined();
+            expect(result?.hiddenDimensionFieldIds).toEqual(['orders_status']);
+            // No hidden metrics → should be absent (not an empty array)
+            expect(result?.hiddenMetricFieldIds).toBeUndefined();
+        });
+
+        it('only populates hiddenMetricFieldIds when all hidden fields are metrics', () => {
+            const result = getPivotConfig({
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {
+                        columns: {
+                            payments_total_revenue: { visible: false },
+                        },
+                    },
+                },
+                pivotConfig: { columns: ['payments_payment_method'] },
+                tableConfig: { columnOrder: [] },
+                metricQuery: {
+                    dimensions: ['payments_payment_method', 'orders_status'],
+                },
+            });
+
+            expect(result).toBeDefined();
+            // payments_total_revenue is not a dimension → hiddenMetricFieldIds
+            expect(result?.hiddenMetricFieldIds).toEqual([
+                'payments_total_revenue',
+            ]);
+            // No hidden dims → should be absent
+            expect(result?.hiddenDimensionFieldIds).toBeUndefined();
+        });
+
+        it('falls back to hiddenMetricFieldIds for all hidden fields when metricQuery is absent', () => {
+            // Backward-compat: callers that cannot provide metricQuery (e.g. ChartDownloadMenu)
+            // get the legacy flat list in hiddenMetricFieldIds.
+            const result = getPivotConfig({
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {
+                        columns: {
+                            orders_status: { visible: false },
+                            payments_total_revenue: { visible: false },
+                        },
+                    },
+                },
+                pivotConfig: { columns: ['payments_payment_method'] },
+                tableConfig: { columnOrder: [] },
+                // No metricQuery provided
+            });
+
+            expect(result).toBeDefined();
+            // Both fields land in hiddenMetricFieldIds (legacy behaviour)
+            expect(result?.hiddenMetricFieldIds).toEqual(
+                expect.arrayContaining([
+                    'orders_status',
+                    'payments_total_revenue',
+                ]),
+            );
+            expect(result?.hiddenDimensionFieldIds).toBeUndefined();
+        });
+    });
 });

--- a/packages/common/src/pivot/pivotConfig.test.ts
+++ b/packages/common/src/pivot/pivotConfig.test.ts
@@ -191,5 +191,57 @@ describe('getPivotConfig', () => {
             );
             expect(result?.hiddenDimensionFieldIds).toBeUndefined();
         });
+
+        it('routes hidden dimensions into hiddenDimensionFieldIds (not hiddenMetricFieldIds) when getPivotConfig receives metricQuery', () => {
+            // Regression guard: ChartDownloadMenu now passes metricQuery, so
+            // sort-helper dimensions must land in hiddenDimensionFieldIds and be
+            // excluded from the downloaded file.
+            const result = getPivotConfig({
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {
+                        columns: {
+                            sort_helper_dim: { visible: false },
+                        },
+                        showSubtotals: false,
+                    },
+                },
+                pivotConfig: { columns: ['shipping_method'] },
+                tableConfig: { columnOrder: [] },
+                metricQuery: {
+                    dimensions: ['shipping_method', 'sort_helper_dim'],
+                },
+            });
+
+            expect(result?.hiddenDimensionFieldIds).toEqual([
+                'sort_helper_dim',
+            ]);
+            // The hidden dim must NOT appear in hiddenMetricFieldIds, otherwise
+            // pivotQueryResults would ignore it and the dim leaks into the export.
+            expect(result?.hiddenMetricFieldIds).toBeUndefined();
+        });
+
+        it('falls back to hiddenMetricFieldIds when metricQuery is omitted (footgun: callers must pass metricQuery for dim hiding to work)', () => {
+            // Documentation test: demonstrates why ChartDownloadMenu MUST pass
+            // metricQuery. Without it the hidden sort-helper dim ends up in
+            // hiddenMetricFieldIds, which pivotQueryResults ignores for
+            // dimension-typed columns — so the dim leaks into the CSV/XLSX export.
+            const result = getPivotConfig({
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {
+                        columns: { sort_helper_dim: { visible: false } },
+                    },
+                },
+                pivotConfig: { columns: ['shipping_method'] },
+                tableConfig: { columnOrder: [] },
+                // metricQuery intentionally omitted
+            });
+
+            // Footgun: without metricQuery we can't classify, so hidden dims end up
+            // in hiddenMetricFieldIds — where pivotQueryResults will ignore them.
+            expect(result?.hiddenMetricFieldIds).toEqual(['sort_helper_dim']);
+            expect(result?.hiddenDimensionFieldIds).toBeUndefined();
+        });
     });
 });

--- a/packages/common/src/pivot/pivotConfig.test.ts
+++ b/packages/common/src/pivot/pivotConfig.test.ts
@@ -139,6 +139,30 @@ describe('getPivotConfig', () => {
             expect(result?.hiddenDimensionFieldIds).toBeUndefined();
         });
 
+        it('omits both hiddenDimensionFieldIds and hiddenMetricFieldIds when metricQuery is provided but no fields are hidden', () => {
+            const result = getPivotConfig({
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {
+                        columns: {
+                            orders_status: { visible: true },
+                            payments_total_revenue: { visible: true },
+                        },
+                    },
+                },
+                pivotConfig: { columns: ['payments_payment_method'] },
+                tableConfig: { columnOrder: [] },
+                metricQuery: {
+                    dimensions: ['payments_payment_method', 'orders_status'],
+                },
+            });
+
+            expect(result).toBeDefined();
+            // No hidden fields at all → both arrays must be absent (not empty arrays)
+            expect(result?.hiddenDimensionFieldIds).toBeUndefined();
+            expect(result?.hiddenMetricFieldIds).toBeUndefined();
+        });
+
         it('falls back to hiddenMetricFieldIds for all hidden fields when metricQuery is absent', () => {
             // Backward-compat: callers that cannot provide metricQuery (e.g. ChartDownloadMenu)
             // get the legacy flat list in hiddenMetricFieldIds.

--- a/packages/common/src/pivot/pivotConfig.ts
+++ b/packages/common/src/pivot/pivotConfig.ts
@@ -1,6 +1,7 @@
 /**
  * Functions for working with PivotConfig
  */
+import type { MetricQuery } from '../types/metricQuery';
 import type { PivotConfig } from '../types/pivot';
 import {
     ChartType,
@@ -9,22 +10,73 @@ import {
     type TableChartConfig,
 } from '../types/savedCharts';
 
+/**
+ * Split all hidden field IDs from a table chart config into dimension and metric
+ * buckets. The `dimensionFieldIds` set is derived from the metricQuery so we can
+ * classify each hidden field without needing a full ItemsMap.
+ *
+ * Fields that appear in metricQuery.dimensions are treated as dimensions; all
+ * others (metrics, table calculations, pivot dims, etc.) are treated as metrics
+ * for the purpose of the hidden-field filter in pivotQueryResults.
+ */
+function splitHiddenTableFieldsByKind(
+    tableChartConfig: TableChartConfig,
+    metricQuery: Pick<MetricQuery, 'dimensions'>,
+): { hiddenDimensions: string[]; hiddenMetrics: string[] } {
+    const allHidden = getHiddenTableFields(tableChartConfig);
+    const dimensionSet = new Set(metricQuery.dimensions);
+    const hiddenDimensions: string[] = [];
+    const hiddenMetrics: string[] = [];
+    for (const fieldId of allHidden) {
+        if (dimensionSet.has(fieldId)) {
+            hiddenDimensions.push(fieldId);
+        } else {
+            hiddenMetrics.push(fieldId);
+        }
+    }
+    return { hiddenDimensions, hiddenMetrics };
+}
+
 const getTablePivotConfig = (
     tableChartConfig: TableChartConfig,
     pivotConfig: CreateSavedChartVersion['pivotConfig'],
     tableConfig: CreateSavedChartVersion['tableConfig'],
-): PivotConfig | undefined =>
-    pivotConfig && pivotConfig.columns.length > 0
-        ? {
-              pivotDimensions: pivotConfig.columns,
-              metricsAsRows: tableChartConfig.config?.metricsAsRows ?? false,
-              hiddenMetricFieldIds: getHiddenTableFields(tableChartConfig),
-              columnOrder: tableConfig.columnOrder,
-              rowTotals: tableChartConfig.config?.showRowCalculation ?? false,
-              columnTotals:
-                  tableChartConfig.config?.showColumnCalculation ?? false,
-          }
-        : undefined;
+    metricQuery?: Pick<MetricQuery, 'dimensions'>,
+): PivotConfig | undefined => {
+    if (!pivotConfig || pivotConfig.columns.length === 0) {
+        return undefined;
+    }
+
+    if (metricQuery) {
+        const { hiddenDimensions, hiddenMetrics } =
+            splitHiddenTableFieldsByKind(tableChartConfig, metricQuery);
+        return {
+            pivotDimensions: pivotConfig.columns,
+            metricsAsRows: tableChartConfig.config?.metricsAsRows ?? false,
+            ...(hiddenMetrics.length > 0 && {
+                hiddenMetricFieldIds: hiddenMetrics,
+            }),
+            ...(hiddenDimensions.length > 0 && {
+                hiddenDimensionFieldIds: hiddenDimensions,
+            }),
+            columnOrder: tableConfig.columnOrder,
+            rowTotals: tableChartConfig.config?.showRowCalculation ?? false,
+            columnTotals:
+                tableChartConfig.config?.showColumnCalculation ?? false,
+        };
+    }
+
+    // Fallback: no metricQuery available — put all hidden fields in hiddenMetricFieldIds
+    // for backward compatibility (previous behaviour).
+    return {
+        pivotDimensions: pivotConfig.columns,
+        metricsAsRows: tableChartConfig.config?.metricsAsRows ?? false,
+        hiddenMetricFieldIds: getHiddenTableFields(tableChartConfig),
+        columnOrder: tableConfig.columnOrder,
+        rowTotals: tableChartConfig.config?.showRowCalculation ?? false,
+        columnTotals: tableChartConfig.config?.showColumnCalculation ?? false,
+    };
+};
 
 const getCartesianPivotConfig = (
     pivotConfig: CreateSavedChartVersion['pivotConfig'],
@@ -43,7 +95,7 @@ export const getPivotConfig = (
     savedChart: Pick<
         CreateSavedChartVersion,
         'chartConfig' | 'pivotConfig' | 'tableConfig'
-    >,
+    > & { metricQuery?: Pick<MetricQuery, 'dimensions'> },
 ): PivotConfig | undefined => {
     switch (savedChart.chartConfig.type) {
         case ChartType.TABLE:
@@ -51,6 +103,7 @@ export const getPivotConfig = (
                 savedChart.chartConfig,
                 savedChart.pivotConfig,
                 savedChart.tableConfig,
+                savedChart.metricQuery,
             );
         case ChartType.CARTESIAN:
             return getCartesianPivotConfig(savedChart.pivotConfig);
@@ -63,7 +116,7 @@ export const getDownloadPivotConfig = (
     savedChart: Pick<
         CreateSavedChartVersion,
         'chartConfig' | 'pivotConfig' | 'tableConfig'
-    >,
+    > & { metricQuery?: Pick<MetricQuery, 'dimensions'> },
     exportPivotedData: boolean = true,
 ): PivotConfig | undefined => {
     switch (savedChart.chartConfig.type) {
@@ -80,7 +133,7 @@ export const getDownloadPivotOptions = (
     savedChart: Pick<
         CreateSavedChartVersion,
         'chartConfig' | 'pivotConfig' | 'tableConfig'
-    >,
+    > & { metricQuery?: Pick<MetricQuery, 'dimensions'> },
     exportPivotedData: boolean = true,
 ): { pivotConfig: PivotConfig | undefined; exportPivotedData: boolean } => ({
     pivotConfig: getDownloadPivotConfig(savedChart, exportPivotedData),

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1763,6 +1763,89 @@ describe('parameter-aware cell formatting (PROD-437)', () => {
     });
 });
 
+describe('hiddenDimensionFieldIds in pivotQueryResults', () => {
+    it('omits a hidden pivot-column-header dimension from headerValueTypes', () => {
+        // page and site are both pivot dimensions; hide site
+        const result = pivotQueryResults({
+            pivotConfig: {
+                pivotDimensions: ['page', 'site'],
+                metricsAsRows: true,
+                hiddenDimensionFieldIds: ['site'],
+            },
+            metricQuery: METRIC_QUERY_2DIM_2METRIC,
+            rows: RESULT_ROWS_2DIM_2METRIC,
+            options: { maxColumns: 100 },
+            getField: (_fieldId) => undefined,
+            getFieldLabel: (fieldId) => fieldId,
+        });
+
+        const headerFieldIds = result.headerValueTypes.map((t) =>
+            'fieldId' in t ? t.fieldId : null,
+        );
+        expect(headerFieldIds).not.toContain('site');
+    });
+
+    it('omits a hidden row-index dimension from indexValueTypes', () => {
+        // No pivot dims so both page and site are row-index; hide page
+        const result = pivotQueryResults({
+            pivotConfig: {
+                pivotDimensions: [],
+                metricsAsRows: false,
+                hiddenDimensionFieldIds: ['page'],
+            },
+            metricQuery: METRIC_QUERY_2DIM_2METRIC,
+            rows: RESULT_ROWS_2DIM_2METRIC,
+            options: { maxColumns: 100 },
+            getField: (_fieldId) => undefined,
+            getFieldLabel: (fieldId) => fieldId,
+        });
+
+        const indexFieldIds = result.indexValueTypes.map((t) =>
+            'fieldId' in t ? t.fieldId : null,
+        );
+        expect(indexFieldIds).not.toContain('page');
+    });
+
+    it('preserves row grouping when a row-index dimension is hidden (rows still group correctly)', () => {
+        // With no hidden dims
+        const fullResult = pivotQueryResults({
+            pivotConfig: {
+                pivotDimensions: [],
+                metricsAsRows: false,
+                hiddenDimensionFieldIds: [],
+            },
+            metricQuery: METRIC_QUERY_2DIM_2METRIC,
+            rows: RESULT_ROWS_2DIM_2METRIC,
+            options: { maxColumns: 100 },
+            getField: (_fieldId) => undefined,
+            getFieldLabel: (fieldId) => fieldId,
+        });
+
+        // With page hidden — row count must stay the same (grouping uses full dims)
+        const hiddenResult = pivotQueryResults({
+            pivotConfig: {
+                pivotDimensions: [],
+                metricsAsRows: false,
+                hiddenDimensionFieldIds: ['page'],
+            },
+            metricQuery: METRIC_QUERY_2DIM_2METRIC,
+            rows: RESULT_ROWS_2DIM_2METRIC,
+            options: { maxColumns: 100 },
+            getField: (_fieldId) => undefined,
+            getFieldLabel: (fieldId) => fieldId,
+        });
+
+        // Row count must be unchanged: rows are still grouped by both page + site
+        expect(hiddenResult.rowsCount).toBe(fullResult.rowsCount);
+        // But indexValueTypes should only contain site (page is hidden)
+        const indexFieldIds = hiddenResult.indexValueTypes.map((t) =>
+            'fieldId' in t ? t.fieldId : null,
+        );
+        expect(indexFieldIds).not.toContain('page');
+        expect(indexFieldIds).toContain('site');
+    });
+});
+
 describe('convertSqlPivotedRowsToPivotData metric ordering (#19838 / #19919)', () => {
     it('orders metricsAsRows row labels by columnOrder, not valuesColumns first-occurrence', () => {
         // baseMetricsArray was previously derived via Array.from(new Set(...)),

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1782,7 +1782,8 @@ describe('hiddenDimensionFieldIds in pivotQueryResults', () => {
         const headerFieldIds = result.headerValueTypes.map((t) =>
             'fieldId' in t ? t.fieldId : null,
         );
-        expect(headerFieldIds).not.toContain('site');
+        expect(headerFieldIds).toContain('page'); // 'page' is still present
+        expect(headerFieldIds).not.toContain('site'); // 'site' is hidden
     });
 
     it('omits a hidden row-index dimension from indexValueTypes', () => {

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -564,6 +564,7 @@ export const pivotQueryResults = ({
     }
 
     const hiddenMetricFieldIds = pivotConfig.hiddenMetricFieldIds || [];
+    const hiddenDimensionFieldIds = pivotConfig.hiddenDimensionFieldIds || [];
     const { visibleMetricFieldIds } = pivotConfig;
 
     const isMetricVisible = (metricId: string): boolean => {
@@ -591,20 +592,30 @@ export const pivotQueryResults = ({
     const dimensions = [...metricQuery.dimensions];
 
     // Headers (column index)
-    const headerDimensions = pivotConfig.pivotDimensions.filter(
-        (pivotDimension) => dimensions.includes(pivotDimension),
-    );
+    // hiddenDimensionFieldIds dims are excluded from rendered headers; they
+    // still participate in the underlying query and can drive sort order.
+    const headerDimensions = pivotConfig.pivotDimensions
+        .filter((pivotDimension) => dimensions.includes(pivotDimension))
+        .filter((d) => !hiddenDimensionFieldIds.includes(d));
     const headerValueTypes = getHeaderValueTypes({
         metricsAsRows: pivotConfig.metricsAsRows,
         pivotDimensionNames: headerDimensions,
     });
 
     // Indices (row index)
-    const indexDimensions = dimensions
+    // indexDimensionsForGrouping: full set used to build row-grouping keys so
+    // that hidden dims still correctly delineate rows. indexDimensionsForDisplay
+    // is the filtered set actually emitted into indexValueTypes / indexValues.
+    const indexDimensionsForGrouping = dimensions
         .filter((d) => !pivotConfig.pivotDimensions.includes(d))
         .slice()
         .sort((a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b));
-    const indexDimensionValueTypes = indexDimensions.map<{
+    const indexDimensionsForDisplay = indexDimensionsForGrouping.filter(
+        (d) => !hiddenDimensionFieldIds.includes(d),
+    );
+    // Keep legacy name as an alias for grouping to minimise diff surface.
+    const indexDimensions = indexDimensionsForGrouping;
+    const indexDimensionValueTypes = indexDimensionsForDisplay.map<{
         type: FieldType.DIMENSION;
         fieldId: string;
     }>((d) => ({
@@ -645,7 +656,30 @@ export const pivotQueryResults = ({
         const row = rows[nRow];
 
         for (let nMetric = 0; nMetric < metrics.length; nMetric += 1) {
-            const indexRowValues = indexDimensions
+            // indexRowKeysValues: derived from the FULL dimension set so hidden
+            // dims still correctly partition rows (grouping, not display).
+            const indexRowKeysValues = indexDimensions
+                .map<PivotData['indexValues'][number][number]>((fieldId) => ({
+                    type: 'value',
+                    fieldId,
+                    value: getObjectValue(row, fieldId).value,
+                    colSpan: 1,
+                }))
+                .concat(
+                    pivotConfig.metricsAsRows
+                        ? [
+                              {
+                                  type: 'label',
+                                  fieldId: getArrayValue(metrics, nMetric)
+                                      .fieldId,
+                              },
+                          ]
+                        : [],
+                );
+
+            // indexRowValues: derived from display-only dims (hidden dims
+            // excluded). This is what gets pushed into indexValues / rendered.
+            const indexRowValues = indexDimensionsForDisplay
                 .map<PivotData['indexValues'][number][number]>((fieldId) => ({
                     type: 'value',
                     fieldId,
@@ -683,11 +717,13 @@ export const pivotQueryResults = ({
                           ],
                 );
 
-            // Write the index values
+            // Write the index values — use FULL key set for deduplication so
+            // that rows with the same display values but different hidden-dim
+            // values are not collapsed into one.
             if (
                 setIndexByKey(
                     rowIndices,
-                    indexRowValues.map((l) =>
+                    indexRowKeysValues.map((l) =>
                         l.type === 'value' ? String(l.value?.raw) : l.fieldId,
                     ),
                     rowCount,

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -11,6 +11,14 @@ export type PivotConfig = {
     visibleMetricFieldIds?: string[];
     columnTotals?: boolean;
     rowTotals?: boolean;
+    /**
+     * Dimensions (row-index or pivot-column-header) hidden from the rendered
+     * pivot and from exports. The dimension still participates in the
+     * underlying query and can drive sort order; it just doesn't render and
+     * is filtered out of CSV/XLSX. Mirrors `hiddenMetricFieldIds` for the
+     * dimension side.
+     */
+    hiddenDimensionFieldIds?: string[];
 };
 
 // Used in AsyncQueryService to execute pivoted queries


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Adds support for hidden dimensions in pivot table rendering. Dimensions marked as `visible: false` in a Table chart's column properties can now participate in query sorting without being rendered as row-index or column-header cells.

**`PivotConfig`** gains a new optional `hiddenDimensionFieldIds` field, mirroring the existing `hiddenMetricFieldIds` but for dimensions. Hidden dimensions are excluded from `headerValueTypes` (pivot column headers) and `indexValueTypes` (row-index columns), but row grouping still uses the full dimension set so that rows with identical visible values but different hidden-dimension values are not incorrectly collapsed.

**`derivePivotConfigurationFromChart`** (Table chart path) now detects hidden dimensions that appear in the query's `sorts` list and places them in a new `sortOnlyColumns` field on the pivot table config instead of `indexColumn`. This prevents them from being rendered as row-index columns while still allowing them to drive SQL sort order.

Key behavioral changes:
- A hidden dimension used only for sorting appears in `sortOnlyColumns`, not `indexColumn`.
- A hidden dimension not referenced in `sorts` is excluded entirely.
- Row deduplication keys are built from the full (including hidden) dimension set, preserving correct row partitioning.
- `pivotQueryResults` filters hidden dimensions out of rendered headers and index value types while keeping them in the grouping key computation.