### PR TITLE
fix: preserve original URL across SSO redirects via query param

### DIFF
--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -32,10 +32,20 @@ const PrivateRoute: FC<React.PropsWithChildren> = ({ children }) => {
     }
 
     if (!health.data?.isAuthenticated) {
+        // Also pass the original URL as a query param. State.from is the
+        // primary mechanism, but it can be lost across hard redirects
+        // (window.location.href = '/login'), server-issued res.redirect, and
+        // some browser refresh paths — the query param survives all of those.
+        const originalUrl = `${location.pathname}${location.search}${location.hash}`;
+        const search =
+            originalUrl && originalUrl !== '/'
+                ? `?redirect=${encodeURIComponent(originalUrl)}`
+                : '';
         return (
             <Navigate
                 to={{
                     pathname: '/login',
+                    search,
                 }}
                 state={{ from: location }}
             />

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -97,10 +97,17 @@ const Login: FC<{}> = () => {
     useEffect(() => {
         if (loginOptions && loginOptionsSuccess) {
             if (loginOptions.forceRedirect && loginOptions.redirectUri) {
-                window.location.href = loginOptions.redirectUri;
+                // Forward the redirect target so the backend can store it as
+                // returnTo and bring the user back to the original page after
+                // SSO completes (otherwise they'd land on `/`).
+                const ssoUrl = new URL(loginOptions.redirectUri);
+                if (redirectUrl && redirectUrl !== '/') {
+                    ssoUrl.searchParams.set('redirect', redirectUrl);
+                }
+                window.location.href = ssoUrl.href;
             }
         }
-    }, [loginOptionsSuccess, loginOptions]);
+    }, [loginOptionsSuccess, loginOptions, redirectUrl]);
 
     const ssoOptions = loginOptions
         ? (loginOptions.showOptions.filter(


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-4795/when-im-logged-out-upon-viewing-a-certain-piece-of-content-i-am-not

### Description:

When unauthenticated users visit a protected route, the original URL is now preserved as a `redirect` query parameter on the `/login` redirect. This complements the existing `state.from` mechanism, which can be lost across hard redirects (`window.location.href`), server-issued redirects, and certain browser refresh paths — the query parameter survives all of these cases.

For SSO flows with `forceRedirect`, the `redirect` query parameter is forwarded to the SSO URL so the backend can use it as a `returnTo` value, bringing the user back to their originally requested page after authentication completes instead of dropping them on `/`.