### PR TITLE
fix(ai-agent): widen discoverFields step cap and quiet soft handoff errors

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
@@ -18,7 +18,7 @@ import { getAgentTelemetryConfig } from '../telemetry';
 import { DiscoverFieldsInput, discoverFieldsResultSchema } from './schema';
 import { getDiscoverFieldsSystemPrompt } from './systemPrompt';
 
-const SUBAGENT_STEP_CAP = 10;
+const SUBAGENT_STEP_CAP = 15;
 
 const SUBAGENT_PERSISTED_TOOL_NAMES = ['findExplores', 'findFields'] as const;
 type SubagentPersistedToolName = (typeof SUBAGENT_PERSISTED_TOOL_NAMES)[number];

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
@@ -239,10 +239,12 @@ export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
 
                 const handoff = extractHandoffFromSubmitResult(currentMessage);
                 if ('error' in handoff) {
+                    // Soft, parent-recoverable model-output anomaly; parent retries on tool-error.
                     yield {
                         result: toolErrorHandler(
                             new Error(handoff.error),
                             'Error discovering fields.',
+                            { captureToSentry: false },
                         ),
                         metadata: { status: 'error' as const },
                     };

--- a/packages/backend/src/ee/services/ai/utils/toolErrorHandler.ts
+++ b/packages/backend/src/ee/services/ai/utils/toolErrorHandler.ts
@@ -3,8 +3,15 @@ import * as Sentry from '@sentry/node';
 import Logger from '../../../../logging/logger';
 import { serializeData } from './serializeData';
 
-export const toolErrorHandler = (error: unknown, message: string) => {
-    Sentry.captureException(error);
+export const toolErrorHandler = (
+    error: unknown,
+    message: string,
+    options: { captureToSentry?: boolean } = {},
+) => {
+    const { captureToSentry = true } = options;
+    if (captureToSentry) {
+        Sentry.captureException(error);
+    }
 
     const errorMessage = `${message}
 


### PR DESCRIPTION
## Summary

Two-part fix for the AI agent's `discoverFields` subagent, prompted by Sentry issue `LIGHTDASH-BACKEND-CR0` ("Subagent did not call submitResult before the stream ended").

**1. Raise `SUBAGENT_STEP_CAP` from 10 → 15.**
Wide multi-explore workloads occasionally need more than 10 `findExplores` + `findFields` steps before the subagent can commit to a final `submitResult` handoff. Successful runs are already using up to 9 steps, leaving very little headroom. 15 gives a more realistic ceiling without inviting runaway loops.

**2. Skip `Sentry.captureException` for model-output anomalies in `discoverFields`.**
When the subagent's stream ends without a valid `submitResult` call (step-cap hit, malformed args, or empty output), the parent agent already retries on tool-error and produces a working user response. The Sentry capture is noise for a self-recovering condition. The error result string returned to the parent is unchanged — only the Sentry side-effect goes away.

## Implementation

- `toolErrorHandler` gains an optional `{ captureToSentry?: boolean }` parameter, defaulting to `true`. All existing callers keep current behavior.
- `discoverFields/tool.tsx` opts in with `{ captureToSentry: false }` only for the soft-handoff branch. Real exceptions in the outer `try/catch` still go through the default (Sentry-on) path.

## Regression analysis

- **Parent agent behavior**: identical. Same error string, same retry trigger.
- **Other `toolErrorHandler` call sites** (~15 across runQuery, findContent, findFields, etc.): unchanged. Default keeps Sentry capture on.
- **Outer exception handler** in `getDiscoverFields`: unchanged. Genuine throws (network errors, code bugs) still page Sentry.
- No schema, migration, or feature flag.

## Test plan

- [ ] CI green
- [ ] Confirm Sentry stops receiving `LIGHTDASH-BACKEND-CR0` events after deploy while parent agent continues to recover from soft handoff failures