### PR TITLE
feat(data-apps): render data app tiles inside embedded dashboards

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -563,11 +563,27 @@ export default class App {
         // APPS_RUNTIME_ENABLED env var or the enable-data-apps feature flag.
         if (this.lightdashConfig.appRuntime.s3) {
             const analyticsModel = this.models.getAnalyticsModel();
+            // Frame-ancestors for the data-app preview iframe. Mirrors the
+            // `/embed/*` policy ('self' https://*) plus any explicit
+            // domains from `LIGHTDASH_IFRAME_EMBEDDING_DOMAINS` so SDK-
+            // hosted dashboards can render data-app tiles from customer
+            // origins (and local dev http origins like localhost:5173).
+            // Applied uniformly to session- and embed-minted tokens — the
+            // iframe's own CSP (`connect-src 'none'`, `script-src 'self'`)
+            // is the real protection; frame-ancestors is clickjacking
+            // defense-in-depth.
+            const previewFrameAncestors = [
+                "'self'",
+                'https://*',
+                ...this.lightdashConfig.security.contentSecurityPolicy
+                    .frameAncestors,
+            ];
             expressApp.use(
                 '/api/apps',
                 createAppPreviewRouter(
                     this.lightdashConfig.appRuntime,
                     this.lightdashConfig.lightdashSecret,
+                    previewFrameAncestors,
                     (p) => {
                         void analyticsModel.addAppViewEvent(
                             p.appUuid,

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -28,6 +28,7 @@ import {
     ExecuteAsyncDashboardSqlChartRequestParams,
     Explore,
     FieldValueSearchResult,
+    ForbiddenError,
     GetEmbedDashboardRequest,
     Item,
     MetricQueryResponse,
@@ -59,6 +60,7 @@ import {
     isAuthenticated,
 } from '../../controllers/authentication';
 import { BaseController } from '../../controllers/baseController';
+import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import { EmbedService } from '../services/EmbedService/EmbedService';
 
 export type ApiEmbedDashboardResponse = {
@@ -581,6 +583,106 @@ export class EmbedController extends BaseController {
             tableName,
             fieldId,
         });
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Synthesized user info for the embed JWT. Used by data app tiles to
+     * answer the SDK's `client.auth.getUser()` call without ever forwarding
+     * a request to the session-only `/api/v1/user` endpoint.
+     * @summary Get embed user info
+     */
+    @SuccessResponse('200', 'Success')
+    @Get('/user-info')
+    @OperationId('getEmbedUserInfo')
+    async getEmbedUserInfo(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<{
+        status: 'ok';
+        results: {
+            userUuid: string;
+            firstName: string;
+            lastName: string;
+            email: string;
+            role: string;
+            organizationUuid: string;
+            userAttributes: Record<string, string>;
+        };
+    }> {
+        this.setStatus(200);
+        assertEmbeddedAuth(req.account);
+        const { account } = req;
+
+        // Path projectUuid is authoritative on the URL but the JWT is the
+        // trust source — fail loudly on mismatch instead of silently serving
+        // the JWT's project.
+        if (projectUuid !== account.embed.projectUuid) {
+            throw new ForbiddenError(
+                'Project mismatch between URL and embed token',
+            );
+        }
+
+        // SDK's `getUser()` expects flat `string` values per attribute. The
+        // embed attribute store is `string[]` (an attribute can have multiple
+        // values). Take the first — the same compromise as how the embed
+        // explore filter consumes these today.
+        const userAttributes = Object.fromEntries(
+            Object.entries(account.access.controls?.userAttributes ?? {}).map(
+                ([key, values]) => [key, values[0] ?? ''],
+            ),
+        );
+
+        return {
+            status: 'ok',
+            results: {
+                userUuid: account.user.id,
+                firstName: '',
+                lastName: '',
+                email: account.user.email ?? '',
+                role: 'embed',
+                organizationUuid:
+                    account.embed.organization.organizationUuid ?? '',
+                userAttributes,
+            },
+        };
+    }
+
+    /**
+     * Resolve the latest ready version of a data app and mint a short-lived
+     * preview token for it. The token authorizes the iframe to load the
+     * built app bundle from `/api/apps/{appUuid}/versions/{version}/`.
+     * The app must be referenced by a tile on a dashboard in the embed's
+     * allowlist (or `allowAllDashboards` must be set).
+     * @summary Get embed data app preview token
+     */
+    @SuccessResponse('200', 'Success')
+    @Get('/apps/{appUuid}/preview-token')
+    @OperationId('getEmbedAppPreviewToken')
+    async getEmbedAppPreviewToken(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+    ): Promise<{
+        status: 'ok';
+        results: { token: string; version: number };
+    }> {
+        this.setStatus(200);
+        assertEmbeddedAuth(req.account);
+
+        if (projectUuid !== req.account.embed.projectUuid) {
+            throw new ForbiddenError(
+                'Project mismatch between URL and embed token',
+            );
+        }
+
+        const results = await this.services
+            .getAppGenerateService<AppGenerateService>()
+            .getEmbedAppPreviewToken(req.account, appUuid);
+
         return {
             status: 'ok',
             results,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -10,6 +10,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { subject } from '@casl/ability';
 import {
+    assertEmbeddedAuth,
     assertUnreachable,
     DATA_APP_CLAUDE_MODELS,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
@@ -22,6 +23,7 @@ import {
     NotFoundError,
     ParameterError,
     QueryExecutionContext,
+    type AnonymousAccount,
     type AppChartReference,
     type AppClarification,
     type AppDashboardReference,
@@ -4295,6 +4297,85 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             user.organizationUuid!,
             projectUuid,
         );
+    }
+
+    /**
+     * Mint a preview token for embed-side rendering of a data app, bundling
+     * the resolved latest ready version so the frontend doesn't need a
+     * separate round-trip to find it.
+     *
+     * The token is issued only when the data app is referenced by a tile on
+     * a dashboard in the embed's allowlist (or `allowAllDashboards` is set),
+     * mirroring how embedded charts are gated by whitelisted dashboards.
+     * The app must live in the embed's project — preview environments where
+     * the dashboard tile references a source-project app are explicitly out
+     * of scope and surface as a 404 to the frontend.
+     */
+    async getEmbedAppPreviewToken(
+        account: AnonymousAccount,
+        appUuid: string,
+    ): Promise<{ token: string; version: number }> {
+        assertEmbeddedAuth(account);
+
+        if (!isValidUuid(appUuid)) {
+            throw new ParameterError('Invalid UUID format');
+        }
+
+        const { projectUuid } = account.embed;
+        const app = await this.appModel.findApp(appUuid, projectUuid);
+        if (!app) {
+            throw new NotFoundError(`App not found: ${appUuid}`);
+        }
+
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('DataApp', {
+                    organizationUuid: app.organization_uuid,
+                    projectUuid: app.project_uuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access this data app',
+            );
+        }
+
+        if (!account.embed.allowAllDashboards) {
+            const dashboardsWithApp =
+                await this.appModel.findDashboardsContainingApp(
+                    appUuid,
+                    projectUuid,
+                );
+            const allowedDashboards = new Set(account.embed.dashboardUuids);
+            const onAllowedDashboard = dashboardsWithApp.some((d) =>
+                allowedDashboards.has(d),
+            );
+            if (!onAllowedDashboard) {
+                throw new ForbiddenError(
+                    'Data app is not authorized by this embed',
+                );
+            }
+        }
+
+        const latestReady = await this.appModel.getLatestReadyVersion(appUuid);
+        if (!latestReady) {
+            throw new NotFoundError(
+                `Data app has no ready version yet: ${appUuid}`,
+            );
+        }
+
+        const token = mintPreviewToken(
+            this.lightdashConfig.lightdashSecret,
+            appUuid,
+            latestReady.version,
+            account.user.id,
+            app.organization_uuid,
+            projectUuid,
+        );
+
+        return { token, version: latestReady.version };
     }
 
     /**

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1767,6 +1767,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                canViewDataApps: { dataType: 'boolean' },
                 canViewUnderlyingData: { dataType: 'boolean' },
                 canExplore: { dataType: 'boolean' },
                 canExportPagePdf: { dataType: 'boolean' },
@@ -35596,6 +35597,130 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'searchFilterValues',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsEmbedController_getEmbedUserInfo: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/embed/:projectUuid/user-info',
+        ...fetchMiddlewares<RequestHandler>(EmbedController),
+        ...fetchMiddlewares<RequestHandler>(
+            EmbedController.prototype.getEmbedUserInfo,
+        ),
+
+        async function EmbedController_getEmbedUserInfo(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsEmbedController_getEmbedUserInfo,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<EmbedController>(EmbedController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getEmbedUserInfo',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsEmbedController_getEmbedAppPreviewToken: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/embed/:projectUuid/apps/:appUuid/preview-token',
+        ...fetchMiddlewares<RequestHandler>(EmbedController),
+        ...fetchMiddlewares<RequestHandler>(
+            EmbedController.prototype.getEmbedAppPreviewToken,
+        ),
+
+        async function EmbedController_getEmbedAppPreviewToken(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsEmbedController_getEmbedAppPreviewToken,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<EmbedController>(EmbedController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getEmbedAppPreviewToken',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1799,6 +1799,9 @@
             },
             "CommonEmbedJwtContent": {
                 "properties": {
+                    "canViewDataApps": {
+                        "type": "boolean"
+                    },
                     "canViewUnderlyingData": {
                         "type": "boolean"
                     },
@@ -33315,7 +33318,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2984.4",
+        "version": "0.2989.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -14,6 +14,12 @@ import {
     type DbApp,
     type DbAppVersion,
 } from '../database/entities/apps';
+import {
+    DashboardsTableName,
+    DashboardTileDataAppsTableName,
+    DashboardTilesTableName,
+    DashboardVersionsTableName,
+} from '../database/entities/dashboards';
 import { OrganizationTableName } from '../database/entities/organizations';
 import { PinnedAppTableName } from '../database/entities/pinnedList';
 import { ProjectTableName } from '../database/entities/projects';
@@ -702,6 +708,74 @@ export class AppModel {
         await this.database(AppsTableName)
             .where({ app_id: appId })
             .update({ sandbox_id: sandboxId });
+    }
+
+    /**
+     * Returns the UUIDs of dashboards in `projectUuid` whose latest version
+     * contains a tile referencing `appUuid`. Old versions are intentionally
+     * ignored: if a dashboard once contained the app but no longer does,
+     * embedding that dashboard must not implicitly authorize the app.
+     */
+    async findDashboardsContainingApp(
+        appUuid: string,
+        projectUuid: string,
+    ): Promise<string[]> {
+        const latestVersionsCte = 'latest_dashboard_versions';
+        const rows = await this.database
+            .with(latestVersionsCte, (qb) => {
+                void qb
+                    .select({
+                        dashboard_uuid: `${DashboardsTableName}.dashboard_uuid`,
+                        dashboard_version_id: this.database.raw(
+                            `MAX(${DashboardVersionsTableName}.dashboard_version_id)`,
+                        ),
+                    })
+                    .from(DashboardsTableName)
+                    .innerJoin(SpaceTableName, function joinSpaces() {
+                        this.on(
+                            `${DashboardsTableName}.space_id`,
+                            '=',
+                            `${SpaceTableName}.space_id`,
+                        ).andOnNull(`${SpaceTableName}.deleted_at`);
+                    })
+                    .innerJoin(
+                        ProjectTableName,
+                        `${SpaceTableName}.project_id`,
+                        `${ProjectTableName}.project_id`,
+                    )
+                    .innerJoin(
+                        DashboardVersionsTableName,
+                        `${DashboardsTableName}.dashboard_id`,
+                        `${DashboardVersionsTableName}.dashboard_id`,
+                    )
+                    .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                    .whereNull(`${DashboardsTableName}.deleted_at`)
+                    .groupBy(`${DashboardsTableName}.dashboard_uuid`);
+            })
+            .select<{ dashboard_uuid: string }[]>(
+                `${latestVersionsCte}.dashboard_uuid`,
+            )
+            .distinct()
+            .from(latestVersionsCte)
+            .innerJoin(
+                DashboardTilesTableName,
+                `${DashboardTilesTableName}.dashboard_version_id`,
+                `${latestVersionsCte}.dashboard_version_id`,
+            )
+            .innerJoin(DashboardTileDataAppsTableName, function joinTiles() {
+                this.on(
+                    `${DashboardTileDataAppsTableName}.dashboard_tile_uuid`,
+                    '=',
+                    `${DashboardTilesTableName}.dashboard_tile_uuid`,
+                ).andOn(
+                    `${DashboardTileDataAppsTableName}.dashboard_version_id`,
+                    '=',
+                    `${DashboardTilesTableName}.dashboard_version_id`,
+                );
+            })
+            .where(`${DashboardTileDataAppsTableName}.app_uuid`, appUuid);
+
+        return rows.map((r) => r.dashboard_uuid);
     }
 
     /**

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -28,8 +28,11 @@ const CONTENT_TYPE_BY_EXT: Record<string, string> = {
     '.map': 'application/json',
 };
 
-const buildCspHeader = (config: AppRuntimeConfig): string => {
-    const { lightdashOrigin, cdnOrigin, cspAllowedOrigins } = config;
+const buildCspHeader = (
+    config: AppRuntimeConfig,
+    frameAncestors: string[],
+): string => {
+    const { cdnOrigin, cspAllowedOrigins } = config;
 
     const extra = cspAllowedOrigins.length
         ? ` ${cspAllowedOrigins.join(' ')}`
@@ -42,7 +45,7 @@ const buildCspHeader = (config: AppRuntimeConfig): string => {
         `connect-src 'none'`,
         `img-src 'self' data:${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
         `font-src 'self'${extra}${cdnOrigin ? ` ${cdnOrigin}` : ''}`,
-        `frame-ancestors ${lightdashOrigin}`,
+        `frame-ancestors ${frameAncestors.join(' ')}`,
         `object-src 'none'`,
         `base-uri 'none'`,
     ];
@@ -75,6 +78,17 @@ const injectTokenIntoAssetUrls = (html: string, token: string): string =>
 export const createAppPreviewRouter = (
     config: AppRuntimeConfig,
     lightdashSecret: string,
+    /**
+     * Frame-ancestor allowlist applied to every preview iframe. Matches the
+     * `/embed/*` policy (`'self' https://*`) plus the explicit domains in
+     * `LIGHTDASH_IFRAME_EMBEDDING_DOMAINS` — see App.ts. Both session and
+     * embed-minted tokens use the same list; the broader allowlist costs
+     * little since the iframe is sandboxed (`allow-scripts allow-modals`)
+     * and the `connect-src 'none'` directive blocks the iframe from
+     * exfiltrating data on its own — backend traffic only flows through
+     * the parent-mediated postMessage bridge.
+     */
+    frameAncestors: string[],
     onPreviewView?: (payload: PreviewTokenPayload) => void,
 ): Router => {
     const router = express.Router({ strict: true });
@@ -114,7 +128,7 @@ export const createAppPreviewRouter = (
               })
             : null;
 
-    const cspHeaderValue = buildCspHeader(config);
+    const cspHeaderValue = buildCspHeader(config, frameAncestors);
 
     const setSecurityHeaders = (res: express.Response): void => {
         res.setHeader('Content-Security-Policy', cspHeaderValue);

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -51,6 +51,27 @@ const dashboardAbilities: EmbeddedAbilityBuilder = ({
         projectUuid: embed.projectUuid,
     });
 
+    // Data app tiles require an explicit opt-in on the JWT — same trust
+    // model as canExplore. Off by default, the data app tile renders as a
+    // "not authorized" placeholder. With the flag set, the customer is
+    // accepting that the embed user can run the data app's metric queries
+    // (arbitrary against any explore in the project, still filtered at
+    // query time by the JWT's user attributes via getFilteredExplore).
+    if (
+        embedUser.content.type === 'dashboard' &&
+        embedUser.content.canViewDataApps
+    ) {
+        can('view', 'Explore', {
+            organizationUuid: organization.organizationUuid,
+            projectUuid: embed.projectUuid,
+        });
+
+        can('view', 'DataApp', {
+            organizationUuid: organization.organizationUuid,
+            projectUuid: embed.projectUuid,
+        });
+    }
+
     return { embedUser, content, embed, builder, externalId };
 };
 

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -72,6 +72,14 @@ export const InteractivityOptionsSchema = z.object({
     canDateZoom: z.boolean().optional(),
     canExplore: z.boolean().optional(),
     canViewUnderlyingData: z.boolean().optional(),
+    // Authorizes embed users to view data app tiles on the dashboard.
+    // Off by default — without it, data app tiles render as a placeholder.
+    // Setting it grants the embed JWT the broader CASL abilities a data app
+    // needs (view:DataApp + view:Explore project-wide) so it can mint a
+    // preview token and run its arbitrary metric queries. Mirrors the
+    // existing canExplore opt-in: an explicit decision to widen the embed's
+    // surface beyond pre-built chart queries.
+    canViewDataApps: z.boolean().optional(),
 });
 
 export type InteractivityOptions = z.infer<typeof InteractivityOptionsSchema>;
@@ -161,6 +169,7 @@ export type CommonEmbedJwtContent = {
     canExportPagePdf?: boolean;
     canExplore?: boolean;
     canViewUnderlyingData?: boolean;
+    canViewDataApps?: boolean;
 };
 
 type CommonChartEmbedJwtContent = {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -26,6 +26,7 @@ import useEmbed from '../../../../providers/Embed/useEmbed';
 import { useEmbedDashboard } from '../hooks';
 import EmbedDashboardChartTile from './EmbedDashboardChartTile';
 import EmbedDashboardHeader from './EmbedDashboardHeader';
+import EmbedDataAppTile from './EmbedDataAppTile';
 import { EmbedHeadingTile } from './EmbedHeadingTile';
 import { EmbedMarkdownTile } from './EmbedMarkdownTile';
 import '../../../../../styles/react-grid.css';
@@ -131,10 +132,10 @@ const EmbedDashboardGrid: FC<{
                                 dashboardSlug={dashboard.slug}
                             />
                         ) : tile.type === DashboardTileTypes.DATA_APP ? (
-                            <SuboptimalState
+                            <EmbedDataAppTile
                                 key={tile.uuid}
-                                title="Data app tile"
-                                description="Data apps cannot be rendered in embedded dashboards yet."
+                                tile={tile}
+                                projectUuid={projectUuid}
                             />
                         ) : (
                             assertUnreachable(

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
@@ -1,0 +1,104 @@
+import { type DashboardDataAppTile } from '@lightdash/common';
+import { Box, Loader, Stack } from '@mantine-8/core';
+import { IconAppsOff } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
+import TileBase from '../../../../../components/DashboardTiles/TileBase';
+import AppIframePreview from '../../../../../features/apps/AppIframePreview';
+import { useEmbedAppPreviewToken } from '../../../../../features/apps/hooks/useEmbedAppPreviewToken';
+import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
+import useDashboardFiltersForTile from '../../../../../hooks/dashboard/useDashboardFiltersForTile';
+import { convertDateDashboardFilters } from '../../../../../utils/dateFilter';
+
+type Props = {
+    tile: DashboardDataAppTile;
+    projectUuid: string;
+};
+
+/**
+ * Embed-mode counterpart to `DashboardDataAppTile`. Mints the preview token
+ * via the embed-specific endpoint (which gates on the embed's dashboard
+ * allowlist) and stamps tile-scoped dashboard filters onto the iframe URL
+ * the same way as the non-embed tile.
+ *
+ * Unlike the non-embed tile, this one has no edit menu, no comments, no
+ * preview-project detection, and no per-user ability checks. Cross-project
+ * apps (preview environments) surface as a backend 404 — rendered here as
+ * the "Data app not available" placeholder.
+ */
+const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
+    const {
+        properties: { title, appUuid, appDeletedAt },
+        uuid,
+    } = tile;
+
+    const tileDashboardFilters = useDashboardFiltersForTile(uuid);
+    const dashboardFiltersForApp = useMemo(
+        () => convertDateDashboardFilters(tileDashboardFilters),
+        [tileDashboardFilters],
+    );
+
+    const previewOrigin = usePreviewOrigin();
+    // Skip the round-trip when the backend already flagged the app as gone.
+    const shouldFetch = !!projectUuid && !!appUuid && !appDeletedAt;
+    const tokenQuery = useEmbedAppPreviewToken(
+        shouldFetch ? projectUuid : undefined,
+        shouldFetch ? appUuid : undefined,
+    );
+
+    // Bumping the URL whenever filters change forces the iframe to remount so
+    // its mount-time metric queries re-fire — matching DashboardDataAppTile.
+    const filtersKey = useMemo(
+        () => JSON.stringify(dashboardFiltersForApp),
+        [dashboardFiltersForApp],
+    );
+
+    const previewUrl = tokenQuery.data
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/?token=${tokenQuery.data.token}&f=${encodeURIComponent(
+              filtersKey,
+          )}#transport=postMessage&projectUuid=${projectUuid}`
+        : undefined;
+
+    const statusCode = tokenQuery.error?.error?.statusCode;
+    const isNotFound = !!appDeletedAt || statusCode === 404;
+    const isForbidden = statusCode === 403;
+
+    return (
+        <TileBase
+            tile={tile}
+            title={title}
+            isEditMode={false}
+            onDelete={() => {}}
+            onEdit={() => {}}
+        >
+            <Box className="non-draggable" style={{ flex: 1, minHeight: 0 }}>
+                {isNotFound ? (
+                    <SuboptimalState
+                        icon={IconAppsOff}
+                        title="Data app not available"
+                        description="This data app no longer exists or hasn't finished building yet."
+                    />
+                ) : isForbidden ? (
+                    <SuboptimalState
+                        icon={IconAppsOff}
+                        title="No access"
+                        description="This data app isn't authorized for this embed."
+                    />
+                ) : tokenQuery.isLoading || !previewUrl ? (
+                    <Stack align="center" justify="center" h="100%">
+                        <Loader size="sm" />
+                    </Stack>
+                ) : (
+                    <AppIframePreview
+                        src={previewUrl}
+                        expectedPreviewOrigin={previewOrigin}
+                        identityKey={`${appUuid}:${tokenQuery.data!.version}`}
+                        dashboardFilters={dashboardFiltersForApp}
+                    />
+                )}
+            </Box>
+        </TileBase>
+    );
+};
+
+export default EmbedDataAppTile;

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -268,6 +268,7 @@ const data = {
         canDateZoom: {{canDateZoom}},
         canExplore: {{canExplore}},
         canViewUnderlyingData: {{canViewUnderlyingData}},
+        canViewDataApps: {{canViewDataApps}},
     },
     user: {
         externalId: {{externalId}},
@@ -305,6 +306,7 @@ data = {
         "canDateZoom": {{canDateZoom}},
         "canExplore": {{canExplore}},
         "canViewUnderlyingData": {{canViewUnderlyingData}},
+        "canViewDataApps": {{canViewDataApps}},
     },
     "user": {
         "externalId": {{externalId}},
@@ -352,6 +354,7 @@ func main() {
             CanDateZoom bool \`json:"canDateZoom"\`
             CanExplore bool \`json:"canExplore"\`
             CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
+            CanViewDataApps bool \`json:"canViewDataApps"\`
         } \`json:"content"\`
         UserAttributes map[string]string \`json:"userAttributes"\`
         jwt.StandardClaims
@@ -381,6 +384,7 @@ func main() {
             CanDateZoom bool \`json:"canDateZoom"\`
             CanExplore bool \`json:"canExplore"\`
             CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
+            CanViewDataApps bool \`json:"canViewDataApps"\`
         }{
             Type:          "dashboard",
             ProjectUuid:   projectUuid,
@@ -405,6 +409,7 @@ func main() {
             CanDateZoom: {{canDateZoom}},
             CanExplore: {{canExplore}},
             CanViewUnderlyingData: {{canViewUnderlyingData}},
+            CanViewDataApps: {{canViewDataApps}},
         },
         User: &struct {
             ExternalId *string \`json:"externalId,omitempty"\`
@@ -579,6 +584,7 @@ const data = {
         canDateZoom: {{canDateZoom}},
         canExplore: {{canExplore}},
         canViewUnderlyingData: {{canViewUnderlyingData}},
+        canViewDataApps: {{canViewDataApps}},
     },
     user: {
         externalId: {{externalId}},
@@ -615,6 +621,7 @@ data = {
         "canDateZoom": {{canDateZoom}},
         "canExplore": {{canExplore}},
         "canViewUnderlyingData": {{canViewUnderlyingData}},
+        "canViewDataApps": {{canViewDataApps}},
     },
     "user": {
         "externalId": {{externalId}},
@@ -660,6 +667,7 @@ func main() {
             CanDateZoom bool \`json:"canDateZoom"\`
             CanExplore bool \`json:"canExplore"\`
             CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
+            CanViewDataApps bool \`json:"canViewDataApps"\`
         } \`json:"content"\`
         UserAttributes map[string]string \`json:"userAttributes"\`
         jwt.StandardClaims
@@ -688,6 +696,7 @@ func main() {
             CanDateZoom bool \`json:"canDateZoom"\`
             CanExplore bool \`json:"canExplore"\`
             CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
+            CanViewDataApps bool \`json:"canViewDataApps"\`
         }{
             Type:          "dashboard",
             ProjectUuid:   projectUuid,
@@ -712,6 +721,7 @@ func main() {
             CanDateZoom: {{canDateZoom}},
             CanExplore: {{canExplore}},
             CanViewUnderlyingData: {{canViewUnderlyingData}},
+            CanViewDataApps: {{canViewDataApps}},
         },
         User: &struct {
             ExternalId *string \`json:"externalId,omitempty"\`
@@ -855,6 +865,10 @@ const getBackendCodeSnippet = (
                 .replace(
                     '{{canExplore}}',
                     languageBoolean(language, data.content.canExplore),
+                )
+                .replace(
+                    '{{canViewDataApps}}',
+                    languageBoolean(language, data.content.canViewDataApps),
                 );
             break;
         case 'chart':

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     FilterInteractivityValues,
     type ApiError,
     type CreateEmbedJwt,
@@ -23,9 +24,16 @@ import {
     Text,
     TextInput,
     Title,
+    Tooltip,
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
-import { IconEye, IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
+import {
+    IconEye,
+    IconInfoCircle,
+    IconLink,
+    IconPlus,
+    IconTrash,
+} from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
 import { useCallback, useState, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
@@ -34,6 +42,7 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useAsyncClipboard } from '../../../../hooks/useAsyncClipboard';
 import useUser from '../../../../hooks/user/useUser';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import EmbedCodeSnippet, { type EmbedMethod } from './EmbedCodeSnippet';
 import EmbedFiltersInteractivity from './EmbedFiltersInteractivity';
 
@@ -75,6 +84,7 @@ type FormValues = {
     canDateZoom?: boolean;
     canExplore?: boolean;
     canViewUnderlyingData?: boolean;
+    canViewDataApps?: boolean;
 } & IntrinsicUserAttributes;
 
 const EmbedPreviewDashboardForm: FC<{
@@ -86,6 +96,8 @@ const EmbedPreviewDashboardForm: FC<{
         useEmbedUrlCreateMutation(projectUuid);
     const { data: user } = useUser(true);
     const [embedMethod, setEmbedMethod] = useState<EmbedMethod>('iframe');
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const dataAppsEnabled = dataAppsFlag.data?.enabled === true;
 
     const form = useForm<FormValues>({
         initialValues: {
@@ -110,6 +122,7 @@ const EmbedPreviewDashboardForm: FC<{
             canExportPagePdf: true,
             canExplore: false,
             canViewUnderlyingData: false,
+            canViewDataApps: false,
         },
         validate: {
             dashboardUuid: (value: undefined | string) => {
@@ -151,6 +164,7 @@ const EmbedPreviewDashboardForm: FC<{
                     canExportPagePdf: values.canExportPagePdf ?? true,
                     canExplore: values.canExplore,
                     canViewUnderlyingData: values.canViewUnderlyingData,
+                    canViewDataApps: values.canViewDataApps,
                 },
                 userAttributes: values.userAttributes.reduce(
                     (acc, item) => ({
@@ -393,6 +407,34 @@ const EmbedPreviewDashboardForm: FC<{
                                     )}
                                     label="View underlying data"
                                 />
+                                {dataAppsEnabled && (
+                                    <Switch
+                                        {...form.getInputProps(
+                                            'canViewDataApps',
+                                            { type: 'checkbox' },
+                                        )}
+                                        label={
+                                            <Group gap="xs">
+                                                <Text inherit>
+                                                    View data apps
+                                                </Text>
+                                                <Tooltip
+                                                    label="Grants project-wide explore access so the data app can run its metric queries."
+                                                    withArrow
+                                                    withinPortal
+                                                    multiline
+                                                    maw="300px"
+                                                    position="right"
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconInfoCircle}
+                                                        size="sm"
+                                                    />
+                                                </Tooltip>
+                                            </Group>
+                                        }
+                                    />
+                                )}
                             </Stack>
                         </Stack>
                     </Stack>

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -1,5 +1,24 @@
-import { type DashboardFilters } from '@lightdash/common';
+import { JWT_HEADER_NAME, type DashboardFilters } from '@lightdash/common';
 import { useCallback, useEffect, type RefObject } from 'react';
+import useEmbed from '../../../ee/providers/Embed/useEmbed';
+
+// Same key the SDK persists `instanceUrl` under (sdk/index.tsx, api.ts).
+// Duplicated rather than imported to avoid threading a shared export through
+// the SDK build. Keep in sync if the key changes there.
+const LIGHTDASH_SDK_INSTANCE_URL_KEY = '__lightdash_sdk_instance_url';
+
+/**
+ * In SDK embeds the host page is the consuming app's origin, so a relative
+ * `fetch('/api/v2/...')` would hit *their* dev server, not Lightdash. When
+ * the SDK has stashed an instance URL in sessionStorage, prepend it.
+ */
+const resolveFetchUrl = (path: string): string => {
+    if (typeof window === 'undefined') return path;
+    const instanceUrl = sessionStorage.getItem(LIGHTDASH_SDK_INSTANCE_URL_KEY);
+    if (!instanceUrl) return path;
+    // SDK persists with a trailing slash; `path` always starts with `/`.
+    return `${instanceUrl.replace(/\/$/, '')}${path}`;
+};
 
 export type QueryEventTableCalculation = {
     name: string;
@@ -120,6 +139,15 @@ export function useAppSdkBridge(
      */
     dashboardFilters?: DashboardFilters,
 ) {
+    // Embed mode adapts the bridge's outgoing fetches in two ways:
+    //   - Attaches the embed JWT header in lieu of session cookies
+    //     (the parent in embed mode has no session, only the JWT).
+    //   - Rewrites `GET /api/v1/user` to the embed-specific user-info
+    //     endpoint so that existing data apps built before embedding existed
+    //     don't break on `client.auth.getUser()`. The SDK protocol is
+    //     unchanged — the rewrite happens entirely on the parent side.
+    const { embedToken, projectUuid: embedProjectUuid } = useEmbed();
+
     const handleMessage = useCallback(
         async (event: MessageEvent) => {
             if (event.source !== iframeRef.current?.contentWindow) return;
@@ -222,10 +250,29 @@ export function useAppSdkBridge(
                 }
             }
 
+            // In embed mode, rewrite the user-info fetch to the embed
+            // endpoint so the SDK's getUser() resolves against the JWT's
+            // synthesized user instead of a session-only route.
+            const effectivePath =
+                embedToken &&
+                embedProjectUuid &&
+                method.toUpperCase() === 'GET' &&
+                path === '/api/v1/user'
+                    ? `/api/v1/embed/${embedProjectUuid}/user-info`
+                    : path;
+
             try {
-                const res = await fetch(path, {
+                // SDK embeds: a bare `fetch(path)` resolves against the
+                // host's origin, not Lightdash. Rewrite to an absolute URL
+                // against the SDK's stashed instance URL when present.
+                const res = await fetch(resolveFetchUrl(effectivePath), {
                     method,
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: {
+                        'Content-Type': 'application/json',
+                        ...(embedToken
+                            ? { [JWT_HEADER_NAME]: embedToken }
+                            : {}),
+                    },
                     ...(effectiveBody
                         ? { body: JSON.stringify(effectiveBody) }
                         : {}),
@@ -347,6 +394,8 @@ export function useAppSdkBridge(
             onInspectorAvailable,
             onScreenshotAvailable,
             dashboardFilters,
+            embedToken,
+            embedProjectUuid,
         ],
     );
 

--- a/packages/frontend/src/features/apps/hooks/useEmbedAppPreviewToken.ts
+++ b/packages/frontend/src/features/apps/hooks/useEmbedAppPreviewToken.ts
@@ -1,0 +1,37 @@
+import { type ApiError } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+export type EmbedAppPreviewToken = {
+    token: string;
+    version: number;
+};
+
+const fetchEmbedAppPreviewToken = async (
+    projectUuid: string,
+    appUuid: string,
+): Promise<EmbedAppPreviewToken> => {
+    return lightdashApi<EmbedAppPreviewToken>({
+        method: 'GET',
+        url: `/embed/${projectUuid}/apps/${appUuid}/preview-token`,
+    });
+};
+
+/**
+ * Embed-side variant of `useAppPreviewToken`. Resolves the latest ready
+ * version of the data app *and* mints a token in a single round-trip — the
+ * embed dashboard API doesn't bake version metadata into the tile, and
+ * `useGetApp` is session-only.
+ *
+ * `lightdashApi` automatically attaches the embed JWT header when called
+ * from inside an `EmbedProvider`.
+ */
+export const useEmbedAppPreviewToken = (
+    projectUuid: string | undefined,
+    appUuid: string | undefined,
+) =>
+    useQuery<EmbedAppPreviewToken, ApiError>({
+        queryKey: ['embed-app-preview-token', projectUuid, appUuid],
+        queryFn: () => fetchEmbedAppPreviewToken(projectUuid!, appUuid!),
+        enabled: !!projectUuid && !!appUuid,
+    });

--- a/packages/frontend/src/features/apps/previewOrigin.ts
+++ b/packages/frontend/src/features/apps/previewOrigin.ts
@@ -1,11 +1,32 @@
 import useApp from '../../providers/App/useApp';
 
+// Duplicated from api.ts / sdk/index.tsx — those keep it as a private
+// constant; threading a shared export through the SDK build is more churn
+// than warranted for a three-line dep. Keep these in sync.
+const LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY =
+    '__lightdash_sdk_instance_url';
+
 /**
- * Origin where data-app preview iframes load. Falls back to the current
- * page's origin when no preview origin is configured (dev / pre-cutover) so
- * previews continue to render same-origin.
+ * Origin where data-app preview iframes load. Resolution order:
+ *   1. Explicit `dataApps.previewOrigin` from the backend health endpoint
+ *      (set in prod when previews are served from a dedicated subdomain).
+ *   2. The SDK-stored instance URL — in SDK embeds the page origin is the
+ *      *consuming app's* origin, not Lightdash. Without this fallback the
+ *      iframe would try to load app assets from the host dev server.
+ *   3. The page's own origin — correct for in-app rendering and the
+ *      iframe-embed flow (the page is already served by Lightdash).
  */
 export const usePreviewOrigin = (): string => {
     const { health } = useApp();
-    return health.data?.dataApps.previewOrigin ?? window.location.origin;
+    if (health.data?.dataApps.previewOrigin) {
+        return health.data.dataApps.previewOrigin;
+    }
+    const sdkInstanceUrl = sessionStorage.getItem(
+        LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY,
+    );
+    if (sdkInstanceUrl) {
+        // SDK persists with a trailing slash; strip to match origin shape.
+        return sdkInstanceUrl.replace(/\/$/, '');
+    }
+    return window.location.origin;
 };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7742/i-want-to-embed-data-apps

### Description:
Routes data-app metric queries through the embed JWT so the same user attributes that gate dashboard charts also apply to data apps. Backend mints preview tokens from an embed-side endpoint gated by the dashboard allowlist; the iframe SDK protocol is unchanged so existing data apps work in embed mode without rebuilding.



### Tested:

✅ Link
✅ Iframe
✅ SDK
✅ Fails without explicit Data App toggle
✅ User attributes (e.g. via sql filter)

<img width="4980" height="2764" alt="image" src="https://github.com/user-attachments/assets/3ce367b7-2f4d-4a67-84c1-27093ec152aa" />

Without the permissions:
<img width="765" height="278" alt="image" src="https://github.com/user-attachments/assets/59f8601e-410b-4c25-86d9-ffefc6f83d02" />

