### PR TITLE
fix(ai): auto-approve sql in eval runs

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4658,6 +4658,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableSelfImprovement: agentSettings.enableSelfImprovement,
             canRunSql,
             autoApproveSql: options.autoApproveSql ?? false,
+            autoApproveSqlUserUuid: options.autoApproveSql
+                ? user.userUuid
+                : null,
             warehouseType,
             warehouseSchema,
             availableSkills,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2388,9 +2388,11 @@ export class AiAgentService extends BaseService {
         {
             agentUuid,
             threadUuid,
+            autoApproveSql = false,
         }: {
             agentUuid: string;
             threadUuid: string;
+            autoApproveSql?: boolean;
         },
     ): Promise<string> {
         try {
@@ -2427,6 +2429,7 @@ export class AiAgentService extends BaseService {
                     canManageAgent,
                     // Non-stream callers (eval, etc.) preserve flag-only gating.
                     enableSqlMode: true,
+                    autoApproveSql,
                 },
             );
             return response;
@@ -4463,6 +4466,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             stream: true;
             canManageAgent: boolean;
             enableSqlMode?: boolean;
+            autoApproveSql?: boolean;
             toolHints?: string[];
         },
     ): Promise<AgentResponseStream>;
@@ -4474,6 +4478,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             stream: false;
             canManageAgent: boolean;
             enableSqlMode?: boolean;
+            autoApproveSql?: boolean;
             toolHints?: string[];
         },
     ): Promise<string>;
@@ -4485,6 +4490,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             stream: false;
             canManageAgent: boolean;
             enableSqlMode?: boolean;
+            autoApproveSql?: boolean;
             toolHints?: string[];
         },
     ): Promise<string>;
@@ -4495,6 +4501,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         options: {
             canManageAgent: boolean;
             enableSqlMode?: boolean;
+            autoApproveSql?: boolean;
             toolHints?: string[];
         } & (
             | {
@@ -4650,6 +4657,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableDataAccess: agentSettings.enableDataAccess,
             enableSelfImprovement: agentSettings.enableSelfImprovement,
             canRunSql,
+            autoApproveSql: options.autoApproveSql ?? false,
             warehouseType,
             warehouseSchema,
             availableSkills,
@@ -7758,6 +7766,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             await this.generateAgentThreadResponse(sessionUser, {
                 agentUuid,
                 threadUuid,
+                autoApproveSql: true,
             });
 
             await this.aiAgentModel.updateEvalRunResult(result.resultUuid, {

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -215,6 +215,7 @@ const getAgentTools = (
               siteUrl: args.siteUrl,
               waitForSqlApproval: dependencies.waitForSqlApproval,
               recordSqlApproval: dependencies.recordSqlApproval,
+              autoApproveSql: args.autoApproveSql,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -216,6 +216,7 @@ const getAgentTools = (
               waitForSqlApproval: dependencies.waitForSqlApproval,
               recordSqlApproval: dependencies.recordSqlApproval,
               autoApproveSql: args.autoApproveSql,
+              autoApproveSqlUserUuid: args.autoApproveSqlUserUuid,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -1,0 +1,101 @@
+import { type AiWebAppPrompt } from '@lightdash/common';
+import { getRunSql } from './runSql';
+
+type RunSqlTool = ReturnType<typeof getRunSql>;
+type RunSqlOutput = {
+    result: string;
+    metadata?: { status: string };
+};
+
+const executeRunSql = (tool: RunSqlTool, toolCallId: string = 'tool-call-1') =>
+    tool.execute!(
+        {
+            sql: 'select 1 as answer',
+            limit: 500,
+        },
+        {
+            messages: [],
+            toolCallId,
+        },
+    ) as Promise<RunSqlOutput>;
+
+const makePrompt = (): AiWebAppPrompt => ({
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+    promptUuid: 'prompt-uuid',
+    threadUuid: 'thread-uuid',
+    createdByUserUuid: 'user-uuid',
+    userUuid: 'user-uuid',
+    prompt: 'How many users do we have?',
+    createdAt: new Date('2026-05-19T00:00:00Z'),
+    response: null,
+    errorMessage: null,
+    humanScore: null,
+    modelConfig: null,
+});
+
+const makeTool = ({
+    autoApproveSql = false,
+    waitForSqlApproval = jest.fn().mockResolvedValue('approved'),
+    recordSqlApproval = jest.fn().mockResolvedValue(true),
+} = {}) => {
+    const dependencies = {
+        updateProgress: jest.fn().mockResolvedValue(undefined),
+        runSqlJob: jest.fn().mockResolvedValue({
+            rows: [{ answer: 1 }],
+            columns: ['answer'],
+            rowCount: 1,
+        }),
+        getPrompt: jest.fn().mockResolvedValue(makePrompt()),
+        sendFile: jest.fn().mockResolvedValue(undefined),
+        updateSlackMessage: jest.fn().mockResolvedValue(undefined),
+        siteUrl: 'https://lightdash.example',
+        waitForSqlApproval,
+        recordSqlApproval,
+        autoApproveSql,
+    };
+
+    return {
+        tool: getRunSql(dependencies),
+        dependencies,
+    };
+};
+
+describe('getRunSql', () => {
+    it('auto-approves SQL without waiting for human approval', async () => {
+        const { tool, dependencies } = makeTool({ autoApproveSql: true });
+
+        const output = await executeRunSql(tool);
+
+        expect(dependencies.recordSqlApproval).toHaveBeenCalledWith(
+            'tool-call-1',
+            'approved',
+            null,
+        );
+        expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
+        expect(dependencies.runSqlJob).toHaveBeenCalledWith({
+            sql: 'select 1 as answer',
+            limit: 500,
+        });
+        expect(dependencies.updateProgress).not.toHaveBeenCalledWith(
+            'Awaiting approval to run SQL...',
+        );
+        expect(output.metadata?.status).toBe('success');
+    });
+
+    it('waits for approval by default', async () => {
+        const { tool, dependencies } = makeTool();
+
+        const output = await executeRunSql(tool);
+
+        expect(dependencies.recordSqlApproval).not.toHaveBeenCalled();
+        expect(dependencies.waitForSqlApproval).toHaveBeenCalledWith(
+            'tool-call-1',
+        );
+        expect(dependencies.updateProgress).toHaveBeenCalledWith(
+            'Awaiting approval to run SQL...',
+        );
+        expect(output.metadata?.status).toBe('success');
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -6,6 +6,12 @@ type RunSqlOutput = {
     result: string;
     metadata?: { status: string };
 };
+type MakeToolOptions = {
+    autoApproveSql?: boolean;
+    autoApproveSqlUserUuid?: string | null;
+    waitForSqlApproval?: jest.Mock;
+    recordSqlApproval?: jest.Mock;
+};
 
 const executeRunSql = (tool: RunSqlTool, toolCallId: string = 'tool-call-1') =>
     tool.execute!(
@@ -37,9 +43,10 @@ const makePrompt = (): AiWebAppPrompt => ({
 
 const makeTool = ({
     autoApproveSql = false,
+    autoApproveSqlUserUuid = null,
     waitForSqlApproval = jest.fn().mockResolvedValue('approved'),
     recordSqlApproval = jest.fn().mockResolvedValue(true),
-} = {}) => {
+}: MakeToolOptions = {}) => {
     const dependencies = {
         updateProgress: jest.fn().mockResolvedValue(undefined),
         runSqlJob: jest.fn().mockResolvedValue({
@@ -54,6 +61,7 @@ const makeTool = ({
         waitForSqlApproval,
         recordSqlApproval,
         autoApproveSql,
+        autoApproveSqlUserUuid,
     };
 
     return {
@@ -64,14 +72,17 @@ const makeTool = ({
 
 describe('getRunSql', () => {
     it('auto-approves SQL without waiting for human approval', async () => {
-        const { tool, dependencies } = makeTool({ autoApproveSql: true });
+        const { tool, dependencies } = makeTool({
+            autoApproveSql: true,
+            autoApproveSqlUserUuid: 'user-uuid',
+        });
 
         const output = await executeRunSql(tool);
 
         expect(dependencies.recordSqlApproval).toHaveBeenCalledWith(
             'tool-call-1',
             'approved',
-            null,
+            'user-uuid',
         );
         expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
         expect(dependencies.runSqlJob).toHaveBeenCalledWith({

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -29,6 +29,7 @@ type Dependencies = {
     waitForSqlApproval: WaitForSqlApprovalFn;
     recordSqlApproval: RecordSqlApprovalFn;
     autoApproveSql?: boolean;
+    autoApproveSqlUserUuid?: string | null;
 };
 
 // Strip --line and /* block */ comments + string literals so subsequent
@@ -75,6 +76,7 @@ export const getRunSql = ({
     waitForSqlApproval,
     recordSqlApproval,
     autoApproveSql = false,
+    autoApproveSqlUserUuid = null,
 }: Dependencies) =>
     tool({
         description: toolRunSqlArgsSchema.description,
@@ -117,7 +119,11 @@ export const getRunSql = ({
                     if (isSlack) {
                         await renderState({ kind: 'approved', sql });
                     }
-                    await recordSqlApproval(toolCallId, 'approved', null);
+                    await recordSqlApproval(
+                        toolCallId,
+                        'approved',
+                        autoApproveSql ? autoApproveSqlUserUuid : null,
+                    );
                 } else if (isSlack) {
                     await renderState({
                         kind: 'pending',

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -28,6 +28,7 @@ type Dependencies = {
     siteUrl: string;
     waitForSqlApproval: WaitForSqlApprovalFn;
     recordSqlApproval: RecordSqlApprovalFn;
+    autoApproveSql?: boolean;
 };
 
 // Strip --line and /* block */ comments + string literals so subsequent
@@ -73,6 +74,7 @@ export const getRunSql = ({
     siteUrl,
     waitForSqlApproval,
     recordSqlApproval,
+    autoApproveSql = false,
 }: Dependencies) =>
     tool({
         description: toolRunSqlArgsSchema.description,
@@ -93,6 +95,7 @@ export const getRunSql = ({
             const isSlack = isSlackPrompt(prompt);
             const slackAutoApproved =
                 isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
+            const shouldAutoApprove = autoApproveSql || slackAutoApproved;
 
             // Render a runSql state INTO the bot's existing progress message
             // (the bolt-gif "Thinking…" message at response_slack_ts). One
@@ -110,8 +113,11 @@ export const getRunSql = ({
             };
 
             try {
-                if (slackAutoApproved) {
-                    await renderState({ kind: 'approved', sql });
+                if (shouldAutoApprove) {
+                    if (isSlack) {
+                        await renderState({ kind: 'approved', sql });
+                    }
+                    await recordSqlApproval(toolCallId, 'approved', null);
                 } else if (isSlack) {
                     await renderState({
                         kind: 'pending',
@@ -123,14 +129,9 @@ export const getRunSql = ({
                     await updateProgress('Awaiting approval to run SQL...');
                 }
 
-                // Auto-approval: pre-record the decision so the poller in
-                // waitForSqlApproval picks it up on its first poll. Approvals
-                // are DB-backed (ai_sql_approval) so this works across pods
-                // and survives restarts.
-                if (slackAutoApproved) {
-                    await recordSqlApproval(toolCallId, 'approved', null);
-                }
-                const decision = await waitForSqlApproval(toolCallId);
+                const decision = shouldAutoApprove
+                    ? 'approved'
+                    : await waitForSqlApproval(toolCallId);
                 if (decision === 'rejected') {
                     await renderState({ kind: 'rejected', sql });
                     return {

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -71,6 +71,7 @@ export type AiAgentArgs = AnyAiModel & {
     enableDataAccess: boolean;
     enableSelfImprovement: boolean;
     canRunSql: boolean;
+    autoApproveSql: boolean;
     warehouseType: WarehouseTypes | null;
     warehouseSchema: string | null;
     availableSkills: AiAgentSkillReference[];

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -72,6 +72,7 @@ export type AiAgentArgs = AnyAiModel & {
     enableSelfImprovement: boolean;
     canRunSql: boolean;
     autoApproveSql: boolean;
+    autoApproveSqlUserUuid: string | null;
     warehouseType: WarehouseTypes | null;
     warehouseSchema: string | null;
     availableSkills: AiAgentSkillReference[];


### PR DESCRIPTION
## Summary

- auto-approve `runSql` tool calls when AI agent evaluations run in the background
- keep existing web and Slack SQL approval behavior unchanged for interactive agent use
- add focused coverage for the SQL tool's auto-approve and default approval-wait paths

## Why

Eval jobs run without a human in the loop. When an eval prompt uses SQL mode, `runSql` could enter the normal approval wait flow and sit there until approval timed out, leaving eval results stuck or slow. Eval execution should still respect SQL Runner permission gating, but once the eval job is allowed to run SQL, the tool call should be approved automatically.

## Validation

- `pnpm --filter backend test -- --runTestsByPath src/ee/services/ai/tools/runSql.test.ts --runInBand`
- `git commit` pre-commit hook passed: backend linter/formatter and frontend unused export scan

## Notes

Backend typecheck was attempted earlier and is currently blocked by existing unrelated workspace issues: missing `gray-matter` / `fast-json-patch` type resolution and existing `isInternal` type mismatches in `SpaceService` / `PromoteService` mocks.
