### PR TITLE
feat: add dashboard AI agent context bridge for live content refresh

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -2314,19 +2314,15 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
         props.tile.properties?.savedChartUuid,
     );
 
-    // Use fresh chart data from useSavedQuery (which is properly cache-invalidated
-    // on verify/unverify) to keep verification status up-to-date without requiring
-    // a full page refresh.
-    const readyQueryDataWithFreshVerification = useMemo(() => {
+    // Use fresh chart data from useSavedQuery to keep dashboard tiles aligned
+    // with chart edits without requiring a full page refresh.
+    const readyQueryDataWithFreshChart = useMemo(() => {
         if (!readyQuery.data) return undefined;
         const freshChart = readyQuery.chartQuery?.data;
         if (!freshChart) return readyQuery.data;
         return {
             ...readyQuery.data,
-            chart: {
-                ...readyQuery.data.chart,
-                verification: freshChart.verification,
-            },
+            chart: freshChart,
         };
     }, [readyQuery.data, readyQuery.chartQuery?.data]);
 
@@ -2358,7 +2354,7 @@ const DashboardChartTile: FC<DashboardChartTileProps> = (props) => {
             {...props}
             isLoading={isLoading}
             resultsData={resultsData}
-            dashboardChartReadyQuery={readyQueryDataWithFreshVerification}
+            dashboardChartReadyQuery={readyQueryDataWithFreshChart}
             error={orphanedChartError ?? readyQuery.error ?? resultsData.error}
         />
     );

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -30,7 +30,7 @@ import { invalidateContent } from '../useContent';
 import useQueryError from '../useQueryError';
 import useDashboardStorage from './useDashboardStorage';
 
-const getDashboard = async (id: string, projectUuid: string) =>
+export const getDashboard = async (id: string, projectUuid: string) =>
     lightdashApi<Dashboard>({
         url: `/projects/${projectUuid}/dashboards/${id}`,
         version: 'v2',

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -84,7 +84,7 @@ const updateSavedQuery = async (
     });
 };
 
-const getSavedQuery = async (
+export const getSavedQuery = async (
     id: string,
     projectUuid: string,
 ): Promise<SavedChart> =>

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -32,6 +32,7 @@ import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
 import useApp from '../providers/App/useApp';
+import DashboardAiAgentContextBridge from '../providers/Dashboard/DashboardAiAgentContextBridge';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../providers/Dashboard/useDashboardTileStatusContext';
@@ -895,6 +896,7 @@ const DashboardPage: FC = () => {
             projectUuid={projectUuid}
             dashboardCommentsCheck={dashboardCommentsCheck}
         >
+            <DashboardAiAgentContextBridge />
             <Dashboard />
         </DashboardProvider>
     );

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -1,0 +1,255 @@
+import {
+    type DashboardChartTile,
+    type DashboardFilters,
+    isDashboardChartTileType,
+} from '@lightdash/common';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useParams } from 'react-router';
+import { type StreamPart } from '../../ee/features/aiCopilot/store/aiAgentThreadStreamSlice';
+import { useAiAgentStoreSelector } from '../../ee/features/aiCopilot/store/hooks';
+import { getDashboard } from '../../hooks/dashboard/useDashboard';
+import { getSavedQuery } from '../../hooks/useSavedQuery';
+import useDashboardContext from './useDashboardContext';
+
+const emptyFilters: DashboardFilters = {
+    dimensions: [],
+    metrics: [],
+    tableCalculations: [],
+};
+
+type ToolOutput = {
+    metadata?: {
+        status?: 'success' | 'error';
+    };
+};
+
+type ToolCallPart = Extract<StreamPart, { type: 'toolCall' }>;
+type EditContentToolArgs = {
+    type?: 'dashboard' | 'chart';
+    slug?: string;
+};
+
+const isToolOutput = (value: unknown): value is ToolOutput =>
+    typeof value === 'object' && value !== null;
+
+const isFinalEditContentToolCall = (part: StreamPart): part is ToolCallPart =>
+    part.type === 'toolCall' &&
+    part.toolName === 'editContent' &&
+    part.isPreliminary === false &&
+    part.toolOutput !== undefined;
+
+const getEditContentToolArgs = (
+    value: unknown,
+): EditContentToolArgs | undefined =>
+    typeof value === 'object' && value !== null
+        ? (value as EditContentToolArgs)
+        : undefined;
+
+const DashboardAiAgentContextBridge = () => {
+    const queryClient = useQueryClient();
+    const { projectUuid, dashboardUuid } = useParams<{
+        projectUuid: string;
+        dashboardUuid: string;
+    }>();
+    const dashboard = useDashboardContext((c) => c.dashboard);
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+    const dashboardTemporaryFilters = useDashboardContext(
+        (c) => c.dashboardTemporaryFilters,
+    );
+    const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
+    const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
+    const setDashboardFilters = useDashboardContext(
+        (c) => c.setDashboardFilters,
+    );
+    const setOriginalDashboardFilters = useDashboardContext(
+        (c) => c.setOriginalDashboardFilters,
+    );
+    const setDashboardTemporaryFilters = useDashboardContext(
+        (c) => c.setDashboardTemporaryFilters,
+    );
+
+    const activeThreadId = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.activeThreadId,
+    );
+    const activeThreadParts = useAiAgentStoreSelector((state) =>
+        activeThreadId
+            ? (state.aiAgentThreadStream[activeThreadId]?.parts ?? [])
+            : [],
+    );
+
+    const handledToolCallIdsRef = useRef<Set<string>>(new Set());
+
+    const currentDashboardSlug = dashboard?.slug;
+    const dashboardQueryKey = useMemo(
+        () => ['saved_dashboard_query', dashboardUuid, projectUuid],
+        [dashboardUuid, projectUuid],
+    );
+
+    const relevantResults = useMemo(
+        () => activeThreadParts.filter(isFinalEditContentToolCall),
+        [activeThreadParts],
+    );
+
+    const refreshDashboard = useCallback(async () => {
+        if (!projectUuid || !dashboardUuid) return;
+
+        console.log(
+            '[DashboardAiAgentContextBridge] invalidating dashboard query',
+            {
+                slug: currentDashboardSlug,
+                queryKey: dashboardQueryKey,
+                before: {
+                    tiles: dashboardTiles,
+                    tabs: dashboardTabs,
+                    filters: dashboardFilters,
+                    temporaryFilters: dashboardTemporaryFilters,
+                },
+            },
+        );
+
+        const freshDashboard = await queryClient.fetchQuery({
+            queryKey: dashboardQueryKey,
+            queryFn: () => getDashboard(dashboardUuid, projectUuid),
+        });
+
+        console.log(
+            '[DashboardAiAgentContextBridge] applying fresh dashboard state',
+            {
+                slug: currentDashboardSlug,
+                after: {
+                    tiles: freshDashboard.tiles,
+                    tabs: freshDashboard.tabs,
+                    filters: freshDashboard.filters,
+                },
+            },
+        );
+
+        setDashboardTiles(freshDashboard.tiles);
+        setDashboardTabs(freshDashboard.tabs);
+        setDashboardFilters(freshDashboard.filters);
+        setOriginalDashboardFilters(freshDashboard.filters);
+        setDashboardTemporaryFilters(emptyFilters);
+    }, [
+        currentDashboardSlug,
+        dashboardFilters,
+        dashboardQueryKey,
+        dashboardTabs,
+        dashboardTemporaryFilters,
+        dashboardTiles,
+        dashboardUuid,
+        projectUuid,
+        queryClient,
+        setDashboardFilters,
+        setDashboardTabs,
+        setDashboardTemporaryFilters,
+        setDashboardTiles,
+        setOriginalDashboardFilters,
+    ]);
+
+    const refreshChartTiles = useCallback(
+        async (chartSlug: string) => {
+            if (!projectUuid || !dashboardUuid) return;
+
+            const matchingTiles = (dashboardTiles ?? []).filter(
+                (tile): tile is DashboardChartTile =>
+                    isDashboardChartTileType(tile) &&
+                    tile.properties.chartSlug === chartSlug &&
+                    !!tile.properties.savedChartUuid,
+            );
+
+            if (matchingTiles.length === 0) return;
+
+            const savedChartUuids = [
+                ...new Set(
+                    matchingTiles
+                        .map((tile) => tile.properties.savedChartUuid)
+                        .filter((uuid): uuid is string => !!uuid),
+                ),
+            ];
+
+            console.log(
+                '[DashboardAiAgentContextBridge] refreshing chart tiles',
+                {
+                    slug: chartSlug,
+                    savedChartUuids,
+                    tileUuids: matchingTiles.map((tile) => tile.uuid),
+                },
+            );
+
+            await Promise.all(
+                savedChartUuids.map(async (savedChartUuid) => {
+                    const freshChart = await queryClient.fetchQuery({
+                        queryKey: ['saved_query', savedChartUuid, projectUuid],
+                        queryFn: () =>
+                            getSavedQuery(savedChartUuid, projectUuid),
+                    });
+
+                    queryClient.setQueryData(
+                        ['saved_query', freshChart.slug, projectUuid],
+                        freshChart,
+                    );
+                }),
+            );
+
+            await queryClient.resetQueries({
+                predicate: (query) =>
+                    query.queryKey[0] === 'dashboard_chart_ready_query' &&
+                    query.queryKey[2] !== null &&
+                    savedChartUuids.includes(query.queryKey[2] as string) &&
+                    query.queryKey[3] === dashboardUuid,
+            });
+        },
+        [dashboardTiles, dashboardUuid, projectUuid, queryClient],
+    );
+
+    useEffect(() => {
+        if (!currentDashboardSlug) return;
+
+        for (const part of relevantResults) {
+            if (handledToolCallIdsRef.current.has(part.toolCallId)) continue;
+
+            handledToolCallIdsRef.current.add(part.toolCallId);
+
+            const toolArgs = getEditContentToolArgs(part.toolArgs);
+
+            if (toolArgs?.type !== 'dashboard' && toolArgs?.type !== 'chart') {
+                continue;
+            }
+
+            const toolOutput = part.toolOutput;
+            if (
+                !isToolOutput(toolOutput) ||
+                toolOutput.metadata?.status !== 'success' ||
+                !projectUuid ||
+                !dashboardUuid
+            ) {
+                continue;
+            }
+
+            switch (toolArgs.type) {
+                case 'chart':
+                    if (!toolArgs.slug) continue;
+                    void refreshChartTiles(toolArgs.slug);
+                    continue;
+                case 'dashboard':
+                    if (toolArgs.slug !== currentDashboardSlug) continue;
+                    void refreshDashboard();
+                    continue;
+            }
+        }
+    }, [
+        currentDashboardSlug,
+        dashboardUuid,
+        projectUuid,
+        relevantResults,
+        refreshChartTiles,
+        refreshDashboard,
+    ]);
+
+    return null;
+};
+
+export default DashboardAiAgentContextBridge;

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -1519,6 +1519,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         removeMetricDashboardFilter,
         resetDashboardFilters,
         setDashboardFilters,
+        setOriginalDashboardFilters,
         haveFiltersChanged,
         setHaveFiltersChanged,
         allFilterableFieldsMap,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -61,6 +61,7 @@ export type DashboardContextType = {
     isFetchingDashboardFilters: boolean;
     resetDashboardFilters: () => void;
     setDashboardFilters: Dispatch<SetStateAction<DashboardFilters>>;
+    setOriginalDashboardFilters: Dispatch<SetStateAction<DashboardFilters>>;
     setDashboardTemporaryFilters: Dispatch<SetStateAction<DashboardFilters>>;
     addDimensionDashboardFilter: (
         filter: DashboardFilterRule,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/ZAP-419/refresh-open-dashboard-after-ai-agent-content-edits

### Description:

Introduces a `DashboardAiAgentContextBridge` component that listens for successful `editContent` AI agent tool calls and reactively refreshes the dashboard UI without requiring a full page reload.

When the agent successfully edits a **dashboard**, the bridge re-fetches the dashboard from the backend and pushes the fresh tiles, tabs, and filters directly into the dashboard context, clearing any temporary filters in the process.

When the agent successfully edits a **chart**, the bridge identifies matching dashboard chart tiles by slug, re-fetches each affected saved chart, updates the query cache (both by UUID and slug), and resets the relevant tile result queries so charts re-execute with their updated configuration.

To support this, `setOriginalDashboardFilters` has been exposed on the `DashboardContextType` so the bridge can keep the original filter baseline in sync with the refreshed state.

A scratchpad document has also been added to track the broader AI agent revamp plan, covering frontend cache invalidation strategy, `editContent` safety improvements, a future `createContent` tool, skill coverage targets, and follow-up cleanup items.