### PR TITLE
chore: clarify patch format as RFC6902 in editContent tool description

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/editContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/editContent.ts
@@ -15,7 +15,9 @@ const toolEditContentArgsSchema = z
             .describe('Type of Lightdash content to edit.'),
         patch: z
             .unknown()
-            .describe('Patch to apply to the current dashboard or chart JSON.'),
+            .describe(
+                'RFC6902 Patch to apply to the current dashboard or chart JSON.',
+            ),
     })
     .describe(
         'Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting.',


### PR DESCRIPTION
Closes:

### Description:
Clarifies the `patch` parameter description in the `editContent` AI tool to explicitly specify that the patch format follows the RFC6902 standard.