### PR TITLE
[codex] Unify SQL auto-approval mode

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -169,7 +169,11 @@ import { getAvailableModels, getDefaultModel, getModel } from '../ai/models';
 import { matchesPreset } from '../ai/models/presets';
 import { BuiltInSkills } from '../ai/skills/builtInSkills';
 import { markSlackThreadAutoApproved } from '../ai/tools/sqlApprovals';
-import { AiAgentArgs, AiAgentDependencies } from '../ai/types/aiAgent';
+import {
+    AiAgentArgs,
+    AiAgentDependencies,
+    type SqlApprovalMode,
+} from '../ai/types/aiAgent';
 import {
     CreateChangeFn,
     DescribeWarehouseTableFn,
@@ -2388,11 +2392,11 @@ export class AiAgentService extends BaseService {
         {
             agentUuid,
             threadUuid,
-            autoApproveSql = false,
+            sqlApprovalMode = { type: 'manual' },
         }: {
             agentUuid: string;
             threadUuid: string;
-            autoApproveSql?: boolean;
+            sqlApprovalMode?: SqlApprovalMode;
         },
     ): Promise<string> {
         try {
@@ -2429,7 +2433,7 @@ export class AiAgentService extends BaseService {
                     canManageAgent,
                     // Non-stream callers (eval, etc.) preserve flag-only gating.
                     enableSqlMode: true,
-                    autoApproveSql,
+                    sqlApprovalMode,
                 },
             );
             return response;
@@ -4466,7 +4470,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             stream: true;
             canManageAgent: boolean;
             enableSqlMode?: boolean;
-            autoApproveSql?: boolean;
+            sqlApprovalMode?: SqlApprovalMode;
             toolHints?: string[];
         },
     ): Promise<AgentResponseStream>;
@@ -4478,7 +4482,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             stream: false;
             canManageAgent: boolean;
             enableSqlMode?: boolean;
-            autoApproveSql?: boolean;
+            sqlApprovalMode?: SqlApprovalMode;
             toolHints?: string[];
         },
     ): Promise<string>;
@@ -4490,7 +4494,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             stream: false;
             canManageAgent: boolean;
             enableSqlMode?: boolean;
-            autoApproveSql?: boolean;
+            sqlApprovalMode?: SqlApprovalMode;
             toolHints?: string[];
         },
     ): Promise<string>;
@@ -4501,7 +4505,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         options: {
             canManageAgent: boolean;
             enableSqlMode?: boolean;
-            autoApproveSql?: boolean;
+            sqlApprovalMode?: SqlApprovalMode;
             toolHints?: string[];
         } & (
             | {
@@ -4657,10 +4661,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableDataAccess: agentSettings.enableDataAccess,
             enableSelfImprovement: agentSettings.enableSelfImprovement,
             canRunSql,
-            autoApproveSql: options.autoApproveSql ?? false,
-            autoApproveSqlUserUuid: options.autoApproveSql
-                ? user.userUuid
-                : null,
+            sqlApprovalMode: options.sqlApprovalMode ?? { type: 'manual' },
             warehouseType,
             warehouseSchema,
             availableSkills,
@@ -7769,7 +7770,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             await this.generateAgentThreadResponse(sessionUser, {
                 agentUuid,
                 threadUuid,
-                autoApproveSql: true,
+                sqlApprovalMode: {
+                    type: 'auto',
+                    decidedByUserUuid: sessionUser.userUuid,
+                },
             });
 
             await this.aiAgentModel.updateEvalRunResult(result.resultUuid, {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4658,6 +4658,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableSelfImprovement: agentSettings.enableSelfImprovement,
             canRunSql,
             autoApproveSql: options.autoApproveSql ?? false,
+            autoApproveSqlUserUuid: options.autoApproveSql
+                ? user.userUuid
+                : null,
             warehouseType,
             warehouseSchema,
             availableSkills,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2388,9 +2388,11 @@ export class AiAgentService extends BaseService {
         {
             agentUuid,
             threadUuid,
+            autoApproveSql = false,
         }: {
             agentUuid: string;
             threadUuid: string;
+            autoApproveSql?: boolean;
         },
     ): Promise<string> {
         try {
@@ -2427,6 +2429,7 @@ export class AiAgentService extends BaseService {
                     canManageAgent,
                     // Non-stream callers (eval, etc.) preserve flag-only gating.
                     enableSqlMode: true,
+                    autoApproveSql,
                 },
             );
             return response;
@@ -4463,6 +4466,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             stream: true;
             canManageAgent: boolean;
             enableSqlMode?: boolean;
+            autoApproveSql?: boolean;
             toolHints?: string[];
         },
     ): Promise<AgentResponseStream>;
@@ -4474,6 +4478,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             stream: false;
             canManageAgent: boolean;
             enableSqlMode?: boolean;
+            autoApproveSql?: boolean;
             toolHints?: string[];
         },
     ): Promise<string>;
@@ -4485,6 +4490,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             stream: false;
             canManageAgent: boolean;
             enableSqlMode?: boolean;
+            autoApproveSql?: boolean;
             toolHints?: string[];
         },
     ): Promise<string>;
@@ -4495,6 +4501,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         options: {
             canManageAgent: boolean;
             enableSqlMode?: boolean;
+            autoApproveSql?: boolean;
             toolHints?: string[];
         } & (
             | {
@@ -4650,6 +4657,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableDataAccess: agentSettings.enableDataAccess,
             enableSelfImprovement: agentSettings.enableSelfImprovement,
             canRunSql,
+            autoApproveSql: options.autoApproveSql ?? false,
             warehouseType,
             warehouseSchema,
             availableSkills,
@@ -7758,6 +7766,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             await this.generateAgentThreadResponse(sessionUser, {
                 agentUuid,
                 threadUuid,
+                autoApproveSql: true,
             });
 
             await this.aiAgentModel.updateEvalRunResult(result.resultUuid, {

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -215,6 +215,7 @@ const getAgentTools = (
               siteUrl: args.siteUrl,
               waitForSqlApproval: dependencies.waitForSqlApproval,
               recordSqlApproval: dependencies.recordSqlApproval,
+              autoApproveSql: args.autoApproveSql,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -216,6 +216,7 @@ const getAgentTools = (
               waitForSqlApproval: dependencies.waitForSqlApproval,
               recordSqlApproval: dependencies.recordSqlApproval,
               autoApproveSql: args.autoApproveSql,
+              autoApproveSqlUserUuid: args.autoApproveSqlUserUuid,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -215,8 +215,7 @@ const getAgentTools = (
               siteUrl: args.siteUrl,
               waitForSqlApproval: dependencies.waitForSqlApproval,
               recordSqlApproval: dependencies.recordSqlApproval,
-              autoApproveSql: args.autoApproveSql,
-              autoApproveSqlUserUuid: args.autoApproveSqlUserUuid,
+              sqlApprovalMode: args.sqlApprovalMode,
           })
         : null;
 

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -7,8 +7,7 @@ type RunSqlOutput = {
     metadata?: { status: string };
 };
 type MakeToolOptions = {
-    autoApproveSql?: boolean;
-    autoApproveSqlUserUuid?: string | null;
+    sqlApprovalMode?: Parameters<typeof getRunSql>[0]['sqlApprovalMode'];
     waitForSqlApproval?: jest.Mock;
     recordSqlApproval?: jest.Mock;
 };
@@ -42,8 +41,7 @@ const makePrompt = (): AiWebAppPrompt => ({
 });
 
 const makeTool = ({
-    autoApproveSql = false,
-    autoApproveSqlUserUuid = null,
+    sqlApprovalMode = { type: 'manual' },
     waitForSqlApproval = jest.fn().mockResolvedValue('approved'),
     recordSqlApproval = jest.fn().mockResolvedValue(true),
 }: MakeToolOptions = {}) => {
@@ -60,8 +58,7 @@ const makeTool = ({
         siteUrl: 'https://lightdash.example',
         waitForSqlApproval,
         recordSqlApproval,
-        autoApproveSql,
-        autoApproveSqlUserUuid,
+        sqlApprovalMode,
     };
 
     return {
@@ -73,8 +70,10 @@ const makeTool = ({
 describe('getRunSql', () => {
     it('auto-approves SQL without waiting for human approval', async () => {
         const { tool, dependencies } = makeTool({
-            autoApproveSql: true,
-            autoApproveSqlUserUuid: 'user-uuid',
+            sqlApprovalMode: {
+                type: 'auto',
+                decidedByUserUuid: 'user-uuid',
+            },
         });
 
         const output = await executeRunSql(tool);

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -1,0 +1,101 @@
+import { type AiWebAppPrompt } from '@lightdash/common';
+import { getRunSql } from './runSql';
+
+type RunSqlTool = ReturnType<typeof getRunSql>;
+type RunSqlOutput = {
+    result: string;
+    metadata?: { status: string };
+};
+
+const executeRunSql = (tool: RunSqlTool, toolCallId: string = 'tool-call-1') =>
+    tool.execute!(
+        {
+            sql: 'select 1 as answer',
+            limit: 500,
+        },
+        {
+            messages: [],
+            toolCallId,
+        },
+    ) as Promise<RunSqlOutput>;
+
+const makePrompt = (): AiWebAppPrompt => ({
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+    promptUuid: 'prompt-uuid',
+    threadUuid: 'thread-uuid',
+    createdByUserUuid: 'user-uuid',
+    userUuid: 'user-uuid',
+    prompt: 'How many users do we have?',
+    createdAt: new Date('2026-05-19T00:00:00Z'),
+    response: null,
+    errorMessage: null,
+    humanScore: null,
+    modelConfig: null,
+});
+
+const makeTool = ({
+    autoApproveSql = false,
+    waitForSqlApproval = jest.fn().mockResolvedValue('approved'),
+    recordSqlApproval = jest.fn().mockResolvedValue(true),
+} = {}) => {
+    const dependencies = {
+        updateProgress: jest.fn().mockResolvedValue(undefined),
+        runSqlJob: jest.fn().mockResolvedValue({
+            rows: [{ answer: 1 }],
+            columns: ['answer'],
+            rowCount: 1,
+        }),
+        getPrompt: jest.fn().mockResolvedValue(makePrompt()),
+        sendFile: jest.fn().mockResolvedValue(undefined),
+        updateSlackMessage: jest.fn().mockResolvedValue(undefined),
+        siteUrl: 'https://lightdash.example',
+        waitForSqlApproval,
+        recordSqlApproval,
+        autoApproveSql,
+    };
+
+    return {
+        tool: getRunSql(dependencies),
+        dependencies,
+    };
+};
+
+describe('getRunSql', () => {
+    it('auto-approves SQL without waiting for human approval', async () => {
+        const { tool, dependencies } = makeTool({ autoApproveSql: true });
+
+        const output = await executeRunSql(tool);
+
+        expect(dependencies.recordSqlApproval).toHaveBeenCalledWith(
+            'tool-call-1',
+            'approved',
+            null,
+        );
+        expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
+        expect(dependencies.runSqlJob).toHaveBeenCalledWith({
+            sql: 'select 1 as answer',
+            limit: 500,
+        });
+        expect(dependencies.updateProgress).not.toHaveBeenCalledWith(
+            'Awaiting approval to run SQL...',
+        );
+        expect(output.metadata?.status).toBe('success');
+    });
+
+    it('waits for approval by default', async () => {
+        const { tool, dependencies } = makeTool();
+
+        const output = await executeRunSql(tool);
+
+        expect(dependencies.recordSqlApproval).not.toHaveBeenCalled();
+        expect(dependencies.waitForSqlApproval).toHaveBeenCalledWith(
+            'tool-call-1',
+        );
+        expect(dependencies.updateProgress).toHaveBeenCalledWith(
+            'Awaiting approval to run SQL...',
+        );
+        expect(output.metadata?.status).toBe('success');
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -6,6 +6,12 @@ type RunSqlOutput = {
     result: string;
     metadata?: { status: string };
 };
+type MakeToolOptions = {
+    autoApproveSql?: boolean;
+    autoApproveSqlUserUuid?: string | null;
+    waitForSqlApproval?: jest.Mock;
+    recordSqlApproval?: jest.Mock;
+};
 
 const executeRunSql = (tool: RunSqlTool, toolCallId: string = 'tool-call-1') =>
     tool.execute!(
@@ -37,9 +43,10 @@ const makePrompt = (): AiWebAppPrompt => ({
 
 const makeTool = ({
     autoApproveSql = false,
+    autoApproveSqlUserUuid = null,
     waitForSqlApproval = jest.fn().mockResolvedValue('approved'),
     recordSqlApproval = jest.fn().mockResolvedValue(true),
-} = {}) => {
+}: MakeToolOptions = {}) => {
     const dependencies = {
         updateProgress: jest.fn().mockResolvedValue(undefined),
         runSqlJob: jest.fn().mockResolvedValue({
@@ -54,6 +61,7 @@ const makeTool = ({
         waitForSqlApproval,
         recordSqlApproval,
         autoApproveSql,
+        autoApproveSqlUserUuid,
     };
 
     return {
@@ -64,14 +72,17 @@ const makeTool = ({
 
 describe('getRunSql', () => {
     it('auto-approves SQL without waiting for human approval', async () => {
-        const { tool, dependencies } = makeTool({ autoApproveSql: true });
+        const { tool, dependencies } = makeTool({
+            autoApproveSql: true,
+            autoApproveSqlUserUuid: 'user-uuid',
+        });
 
         const output = await executeRunSql(tool);
 
         expect(dependencies.recordSqlApproval).toHaveBeenCalledWith(
             'tool-call-1',
             'approved',
-            null,
+            'user-uuid',
         );
         expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
         expect(dependencies.runSqlJob).toHaveBeenCalledWith({

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -29,6 +29,7 @@ type Dependencies = {
     waitForSqlApproval: WaitForSqlApprovalFn;
     recordSqlApproval: RecordSqlApprovalFn;
     autoApproveSql?: boolean;
+    autoApproveSqlUserUuid?: string | null;
 };
 
 // Strip --line and /* block */ comments + string literals so subsequent
@@ -75,6 +76,7 @@ export const getRunSql = ({
     waitForSqlApproval,
     recordSqlApproval,
     autoApproveSql = false,
+    autoApproveSqlUserUuid = null,
 }: Dependencies) =>
     tool({
         description: toolRunSqlArgsSchema.description,
@@ -117,7 +119,11 @@ export const getRunSql = ({
                     if (isSlack) {
                         await renderState({ kind: 'approved', sql });
                     }
-                    await recordSqlApproval(toolCallId, 'approved', null);
+                    await recordSqlApproval(
+                        toolCallId,
+                        'approved',
+                        autoApproveSql ? autoApproveSqlUserUuid : null,
+                    );
                 } else if (isSlack) {
                     await renderState({
                         kind: 'pending',

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
+import type { SqlApprovalMode } from '../types/aiAgent';
 import type {
     GetPromptFn,
     RecordSqlApprovalFn,
@@ -28,8 +29,7 @@ type Dependencies = {
     siteUrl: string;
     waitForSqlApproval: WaitForSqlApprovalFn;
     recordSqlApproval: RecordSqlApprovalFn;
-    autoApproveSql?: boolean;
-    autoApproveSqlUserUuid?: string | null;
+    sqlApprovalMode?: SqlApprovalMode;
 };
 
 // Strip --line and /* block */ comments + string literals so subsequent
@@ -75,8 +75,7 @@ export const getRunSql = ({
     siteUrl,
     waitForSqlApproval,
     recordSqlApproval,
-    autoApproveSql = false,
-    autoApproveSqlUserUuid = null,
+    sqlApprovalMode = { type: 'manual' },
 }: Dependencies) =>
     tool({
         description: toolRunSqlArgsSchema.description,
@@ -97,7 +96,8 @@ export const getRunSql = ({
             const isSlack = isSlackPrompt(prompt);
             const slackAutoApproved =
                 isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
-            const shouldAutoApprove = autoApproveSql || slackAutoApproved;
+            const shouldAutoApprove =
+                sqlApprovalMode.type === 'auto' || slackAutoApproved;
 
             // Render a runSql state INTO the bot's existing progress message
             // (the bolt-gif "Thinking…" message at response_slack_ts). One
@@ -122,7 +122,9 @@ export const getRunSql = ({
                     await recordSqlApproval(
                         toolCallId,
                         'approved',
-                        autoApproveSql ? autoApproveSqlUserUuid : null,
+                        sqlApprovalMode.type === 'auto'
+                            ? sqlApprovalMode.decidedByUserUuid
+                            : null,
                     );
                 } else if (isSlack) {
                     await renderState({

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -28,6 +28,7 @@ type Dependencies = {
     siteUrl: string;
     waitForSqlApproval: WaitForSqlApprovalFn;
     recordSqlApproval: RecordSqlApprovalFn;
+    autoApproveSql?: boolean;
 };
 
 // Strip --line and /* block */ comments + string literals so subsequent
@@ -73,6 +74,7 @@ export const getRunSql = ({
     siteUrl,
     waitForSqlApproval,
     recordSqlApproval,
+    autoApproveSql = false,
 }: Dependencies) =>
     tool({
         description: toolRunSqlArgsSchema.description,
@@ -93,6 +95,7 @@ export const getRunSql = ({
             const isSlack = isSlackPrompt(prompt);
             const slackAutoApproved =
                 isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
+            const shouldAutoApprove = autoApproveSql || slackAutoApproved;
 
             // Render a runSql state INTO the bot's existing progress message
             // (the bolt-gif "Thinking…" message at response_slack_ts). One
@@ -110,8 +113,11 @@ export const getRunSql = ({
             };
 
             try {
-                if (slackAutoApproved) {
-                    await renderState({ kind: 'approved', sql });
+                if (shouldAutoApprove) {
+                    if (isSlack) {
+                        await renderState({ kind: 'approved', sql });
+                    }
+                    await recordSqlApproval(toolCallId, 'approved', null);
                 } else if (isSlack) {
                     await renderState({
                         kind: 'pending',
@@ -123,14 +129,9 @@ export const getRunSql = ({
                     await updateProgress('Awaiting approval to run SQL...');
                 }
 
-                // Auto-approval: pre-record the decision so the poller in
-                // waitForSqlApproval picks it up on its first poll. Approvals
-                // are DB-backed (ai_sql_approval) so this works across pods
-                // and survives restarts.
-                if (slackAutoApproved) {
-                    await recordSqlApproval(toolCallId, 'approved', null);
-                }
-                const decision = await waitForSqlApproval(toolCallId);
+                const decision = shouldAutoApprove
+                    ? 'approved'
+                    : await waitForSqlApproval(toolCallId);
                 if (decision === 'rejected') {
                     await renderState({ kind: 'rejected', sql });
                     return {

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -71,6 +71,7 @@ export type AiAgentArgs = AnyAiModel & {
     enableDataAccess: boolean;
     enableSelfImprovement: boolean;
     canRunSql: boolean;
+    autoApproveSql: boolean;
     warehouseType: WarehouseTypes | null;
     warehouseSchema: string | null;
     availableSkills: AiAgentSkillReference[];

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -58,6 +58,10 @@ export type UnavailableMcpServer = {
     status: AiMcpServerConnectionStatus;
 };
 
+export type SqlApprovalMode =
+    | { type: 'manual' }
+    | { type: 'auto'; decidedByUserUuid: string | null };
+
 export type AiAgentArgs = AnyAiModel & {
     agentSettings: AiAgent;
     mcpServers: AiAgentMcpServer[];
@@ -71,8 +75,7 @@ export type AiAgentArgs = AnyAiModel & {
     enableDataAccess: boolean;
     enableSelfImprovement: boolean;
     canRunSql: boolean;
-    autoApproveSql: boolean;
-    autoApproveSqlUserUuid: string | null;
+    sqlApprovalMode: SqlApprovalMode;
     warehouseType: WarehouseTypes | null;
     warehouseSchema: string | null;
     availableSkills: AiAgentSkillReference[];

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -72,6 +72,7 @@ export type AiAgentArgs = AnyAiModel & {
     enableSelfImprovement: boolean;
     canRunSql: boolean;
     autoApproveSql: boolean;
+    autoApproveSqlUserUuid: string | null;
     warehouseType: WarehouseTypes | null;
     warehouseSchema: string | null;
     availableSkills: AiAgentSkillReference[];


### PR DESCRIPTION
## Summary

- Replaces the loose auto-approval boolean/user UUID pair with an explicit SqlApprovalMode type.

- Keeps eval SQL runs auto-approved with the eval runner recorded as the approver.

- Preserves Slack thread auto-approval as a separate null-audited path for now.

## Validation
- pnpm --filter backend test -- --runTestsByPath src/ee/services/ai/tools/runSql.test.ts --runInBand
- pre-commit hook: backend linter/formatter and frontend unused exports