### PR TITLE
fix: respect `hiddenDimensionFieldIds` in pivot XLSX and CSV output

### DIFF
--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -1544,6 +1544,127 @@ describe('ExcelService', () => {
             // returns null → no date conversion should happen
             expect(dateCells).toHaveLength(0);
         });
+
+        it('omits a hidden row-index dimension from the XLSX pivot output (regression guard for hiddenDimensionFieldIds)', async () => {
+            // Regression guard: PivotConfig.hiddenDimensionFieldIds must cause the
+            // hidden dimension to be absent from the rendered headers and body cells.
+            // This mirrors the CSV regression guard in pivotResultsAsCsv.test.ts.
+            const pivotDimension = 'payments_payment_method';
+            const indexDimension = 'customers_created_month'; // will be hidden
+            const metric = 'payments_total_revenue';
+
+            const itemMap: ItemsMap = {
+                [pivotDimension]: {
+                    name: 'payment_method',
+                    table: 'payments',
+                    tableLabel: 'Payments',
+                    label: 'Payment method',
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    hidden: false,
+                    sql: '${TABLE}.payment_method',
+                },
+                [indexDimension]: {
+                    name: 'created_month',
+                    table: 'customers',
+                    tableLabel: 'Customers',
+                    label: 'Created month',
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    hidden: false,
+                    sql: '${TABLE}.created_month',
+                },
+                [metric]: {
+                    name: 'total_revenue',
+                    table: 'payments',
+                    tableLabel: 'Payments',
+                    label: 'Total revenue',
+                    fieldType: FieldType.METRIC,
+                    type: DimensionType.NUMBER,
+                    hidden: false,
+                    sql: 'SUM(${TABLE}.amount)',
+                },
+            };
+
+            const rows = [
+                {
+                    [pivotDimension]: 'credit_card',
+                    [indexDimension]: '2023-01',
+                    [metric]: 100,
+                },
+                {
+                    [pivotDimension]: 'bank_transfer',
+                    [indexDimension]: '2023-01',
+                    [metric]: 200,
+                },
+                {
+                    [pivotDimension]: 'credit_card',
+                    [indexDimension]: '2023-02',
+                    [metric]: 150,
+                },
+                {
+                    [pivotDimension]: 'bank_transfer',
+                    [indexDimension]: '2023-02',
+                    [metric]: 250,
+                },
+            ];
+
+            const metricQuery = {
+                exploreName: 'payments',
+                dimensions: [pivotDimension, indexDimension],
+                metrics: [metric],
+                filters: {},
+                sorts: [{ fieldId: indexDimension, descending: false }],
+                limit: 500,
+                tableCalculations: [],
+                additionalMetrics: [],
+                customDimensions: [],
+                metricOverrides: {},
+                dimensionOverrides: {},
+            };
+
+            // Hide the row-index dimension via hiddenDimensionFieldIds
+            const pivotConfig = {
+                pivotDimensions: [pivotDimension],
+                metricsAsRows: false,
+                hiddenDimensionFieldIds: [indexDimension],
+            };
+
+            const buffer = await ExcelService.downloadPivotTableXlsx({
+                rows,
+                itemMap,
+                metricQuery,
+                pivotConfig,
+                onlyRaw: false,
+                customLabels: undefined,
+                maxColumnLimit: 60,
+                pivotDetails: null,
+                enableImprovedExcelDates: true,
+            });
+
+            const workbook = new (await import('exceljs')).Workbook();
+            // @ts-ignore - Buffer type mismatch between exceljs and Node 20
+            await workbook.xlsx.load(buffer);
+            const worksheet = workbook.getWorksheet('Pivot Table');
+            expect(worksheet).toBeDefined();
+
+            const allCellValues: unknown[] = [];
+            worksheet!.eachRow((row) => {
+                row.eachCell({ includeEmpty: false }, (cell) => {
+                    allCellValues.push(cell.value);
+                });
+            });
+
+            // The hidden dimension's field values must not appear anywhere
+            expect(allCellValues).not.toContain('2023-01');
+            expect(allCellValues).not.toContain('2023-02');
+            // The hidden dimension's label must not appear in headers
+            expect(allCellValues).not.toContain('Created month');
+
+            // The pivot-column-header and metric values should still be present
+            expect(allCellValues).toContain('credit_card');
+            expect(allCellValues).toContain('bank_transfer');
+        });
     });
 
     describe('format expression integration', () => {

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -786,11 +786,19 @@ export const pivotQueryResults = ({
             ),
         ) ?? [];
 
+    // hasIndex: for rendering/display — true when there are visible index
+    // dimension columns (display-only filter applied).
     const hasIndex = indexValueTypes.length > 0;
     const hasHeader = headerValueTypes.length > 0;
 
+    // hasIndexForGrouping: true when there are row-grouping dimensions
+    // regardless of whether they're hidden from display. Used to correctly
+    // size dataValues and look up row indices even when all row dims are hidden.
+    const hasIndexForGrouping =
+        indexDimensions.length > 0 || pivotConfig.metricsAsRows;
+
     // Compute the size of the data values
-    const N_DATA_ROWS = hasIndex ? rowCount : 1;
+    const N_DATA_ROWS = hasIndexForGrouping ? rowCount : 1;
     const N_DATA_COLUMNS = hasHeader ? columnCount : 1;
 
     // Compute the data values
@@ -828,7 +836,7 @@ export const pivotQueryResults = ({
             const rowKeysString = rowKeys.map(String);
             const columnKeysString = columnKeys.map(String);
 
-            const rowIndex = hasIndex
+            const rowIndex = hasIndexForGrouping
                 ? getIndexByKey(rowIndices, rowKeysString)
                 : 0;
             const columnIndex = hasHeader

--- a/packages/common/src/pivot/pivotResultsAsCsv.test.ts
+++ b/packages/common/src/pivot/pivotResultsAsCsv.test.ts
@@ -186,4 +186,107 @@ describe('pivotResultsAsCsv', () => {
             expect(csvRow.length).toBe(dataResult.dataRows[i].length);
         });
     });
+
+    describe('hidden dimension filtering', () => {
+        it('omits a hidden pivot-column-header dimension from CSV headers', () => {
+            // METRIC_QUERY_2DIM_2METRIC has dimensions ['page', 'site'].
+            // When both are in pivotDimensions, 'site' becomes a pivot-column-header.
+            // Hiding 'site' via hiddenDimensionFieldIds must remove it from the output.
+            const result = pivotResultsAsCsv({
+                pivotConfig: {
+                    pivotDimensions: ['page', 'site'],
+                    metricsAsRows: false,
+                    hiddenDimensionFieldIds: ['site'],
+                },
+                rows: RESULT_ROWS_2DIM_2METRIC,
+                itemMap: buildItemsMap(),
+                metricQuery: {
+                    exploreName: 'test',
+                    ...METRIC_QUERY_2DIM_2METRIC,
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    customDimensions: [],
+                    metricOverrides: {},
+                    dimensionOverrides: {},
+                },
+                customLabels: undefined,
+                onlyRaw: false,
+                maxColumnLimit: 60,
+                pivotDetails: null,
+            });
+
+            const allValues = result.flat();
+            // The hidden dim's field id must not appear anywhere in the output
+            expect(allValues).not.toContain('site');
+            // The visible dim should still appear
+            expect(allValues).toContain('/home');
+        });
+
+        it('omits a hidden row-index dimension from CSV row values', () => {
+            // With pivotDimensions: ['page'], 'site' is a row-index dimension.
+            // Hiding 'site' via hiddenDimensionFieldIds must remove it from row cells.
+            const result = pivotResultsAsCsv({
+                pivotConfig: {
+                    pivotDimensions: ['page'],
+                    metricsAsRows: false,
+                    hiddenDimensionFieldIds: ['site'],
+                },
+                rows: RESULT_ROWS_2DIM_2METRIC,
+                itemMap: buildItemsMap(),
+                metricQuery: {
+                    exploreName: 'test',
+                    ...METRIC_QUERY_2DIM_2METRIC,
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    customDimensions: [],
+                    metricOverrides: {},
+                    dimensionOverrides: {},
+                },
+                customLabels: undefined,
+                onlyRaw: false,
+                maxColumnLimit: 60,
+                pivotDetails: null,
+            });
+
+            const allValues = result.flat();
+            // 'site' field values ('Blog', 'Docs') must not appear in the output
+            expect(allValues).not.toContain('Blog');
+            expect(allValues).not.toContain('Docs');
+            // Metric values should still be present
+            expect(allValues.some((v) => v !== '')).toBe(true);
+        });
+
+        it('shows all dimensions when hiddenDimensionFieldIds is empty', () => {
+            const result = pivotResultsAsCsv({
+                pivotConfig: {
+                    pivotDimensions: ['page'],
+                    metricsAsRows: false,
+                    hiddenDimensionFieldIds: [],
+                },
+                rows: RESULT_ROWS_2DIM_2METRIC,
+                itemMap: buildItemsMap(),
+                metricQuery: {
+                    exploreName: 'test',
+                    ...METRIC_QUERY_2DIM_2METRIC,
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    customDimensions: [],
+                    metricOverrides: {},
+                    dimensionOverrides: {},
+                },
+                customLabels: undefined,
+                onlyRaw: false,
+                maxColumnLimit: 60,
+                pivotDetails: null,
+            });
+
+            const allValues = result.flat();
+            // With no hidden dims, the row-index dimension values should appear
+            expect(allValues).toContain('Blog');
+            expect(allValues).toContain('Docs');
+        });
+    });
 });

--- a/packages/common/src/pivot/pivotResultsAsCsv.test.ts
+++ b/packages/common/src/pivot/pivotResultsAsCsv.test.ts
@@ -219,6 +219,9 @@ describe('pivotResultsAsCsv', () => {
             const allValues = result.flat();
             // The hidden dim's field id must not appear anywhere in the output
             expect(allValues).not.toContain('site');
+            // The hidden dim's formatted values must not appear in the output
+            expect(allValues).not.toContain('Blog');
+            expect(allValues).not.toContain('Docs');
             // The visible dim should still appear
             expect(allValues).toContain('/home');
         });
@@ -254,8 +257,8 @@ describe('pivotResultsAsCsv', () => {
             // 'site' field values ('Blog', 'Docs') must not appear in the output
             expect(allValues).not.toContain('Blog');
             expect(allValues).not.toContain('Docs');
-            // Metric values should still be present
-            expect(allValues.some((v) => v !== '')).toBe(true);
+            // Metric values like '6.0' (from views) and '7.0' (from devices) should be present
+            expect(allValues).toContain('6.0');
         });
 
         it('shows all dimensions when hiddenDimensionFieldIds is empty', () => {


### PR DESCRIPTION
Closes:

### Description:

Fixes a bug where pivot table exports (both XLSX and CSV) would produce incorrect output when `hiddenDimensionFieldIds` contained a row-index dimension. The root cause was that `pivotQueryResults` used `hasIndex` (which filters out hidden dimensions) to determine the number of data rows and to look up row indices. When all row-index dimensions were hidden, `hasIndex` would be `false`, collapsing all rows into a single row and causing data to be overwritten.

The fix introduces `hasIndexForGrouping`, which checks whether any row-grouping dimensions exist regardless of their visibility. This is used for sizing `dataValues` and resolving row indices, while `hasIndex` continues to control display-only rendering.

Regression tests have been added to verify that:
- Hidden row-index dimensions are excluded from XLSX pivot output (values and headers)
- Hidden pivot-column-header dimensions are excluded from CSV output
- Hidden row-index dimensions are excluded from CSV row values
- All dimensions appear correctly when `hiddenDimensionFieldIds` is empty