### PR TITLE
fix(scheduler): resolve infinite spinner on test notification

### DIFF
--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -497,6 +497,9 @@ const getJobStatus = async (
 };
 
 export const pollJobStatus = async (jobId: string) => {
+    if (!jobId) {
+        throw new Error('Cannot poll job status: jobId is required');
+    }
     return new Promise<Record<string, AnyType> | null>((resolve, reject) =>
         getJobStatus(
             jobId,
@@ -604,7 +607,7 @@ const useSendNowJobStatus = (jobId: string | undefined) => {
 };
 
 export const useSendNowScheduler = () => {
-    const { showToastInfo, showToastApiError } = useToaster();
+    const { showToastInfo, showToastError, showToastApiError } = useToaster();
 
     const sendNowMutation = useMutation<
         ApiTestSchedulerResponse['results'],
@@ -623,15 +626,13 @@ export const useSendNowScheduler = () => {
         {
             mutationKey: ['sendNowScheduler'],
             onSuccess: (res) => {
-                pollJobStatus(res.jobId || '')
-                    .then((data) => {
-                        if (data?.status === SchedulerJobStatus.ERROR) {
-                            throw new Error(data?.details?.error);
-                        }
-                    })
-                    .catch((e) => {
-                        throw e;
+                if (!res.jobId) {
+                    notifications.hide('toast-info-job-status');
+                    showToastError({
+                        title: 'Failed to send scheduled delivery',
+                        subtitle: 'No job ID returned from server',
                     });
+                }
             },
             onError: (apiError: ApiError) => {
                 showToastApiError({
@@ -650,6 +651,8 @@ export const useSendNowScheduler = () => {
     const isLoading = useMemo(
         () =>
             sendNowMutation.isLoading ||
+            scheduledDeliveryJobStatus?.status ===
+                SchedulerJobStatus.SCHEDULED ||
             scheduledDeliveryJobStatus?.status === SchedulerJobStatus.STARTED,
         [scheduledDeliveryJobStatus?.status, sendNowMutation.isLoading],
     );
@@ -661,7 +664,7 @@ export const useSendNowScheduler = () => {
 };
 
 export const useSendNowSchedulerByUuid = (schedulerUuid: string) => {
-    const { showToastInfo, showToastApiError } = useToaster();
+    const { showToastInfo, showToastError, showToastApiError } = useToaster();
 
     const sendNowMutation = useMutation<
         ApiTestSchedulerResponse['results'],
@@ -680,15 +683,13 @@ export const useSendNowSchedulerByUuid = (schedulerUuid: string) => {
         {
             mutationKey: ['sendNowSchedulerByUuid', schedulerUuid],
             onSuccess: (res) => {
-                pollJobStatus(res.jobId || '')
-                    .then((data) => {
-                        if (data?.status === SchedulerJobStatus.ERROR) {
-                            throw new Error(data?.details?.error);
-                        }
-                    })
-                    .catch((e) => {
-                        throw e;
+                if (!res.jobId) {
+                    notifications.hide('toast-info-job-status');
+                    showToastError({
+                        title: 'Failed to send scheduled delivery',
+                        subtitle: 'No job ID returned from server',
                     });
+                }
             },
             onError: (apiError: ApiError) => {
                 showToastApiError({
@@ -707,6 +708,8 @@ export const useSendNowSchedulerByUuid = (schedulerUuid: string) => {
     const isLoading = useMemo(
         () =>
             sendNowMutation.isLoading ||
+            scheduledDeliveryJobStatus?.status ===
+                SchedulerJobStatus.SCHEDULED ||
             scheduledDeliveryJobStatus?.status === SchedulerJobStatus.STARTED,
         [scheduledDeliveryJobStatus?.status, sendNowMutation.isLoading],
     );


### PR DESCRIPTION
Closes: [PROD-3084](https://linear.app/lightdash/issue/PROD-3084/bug-test-notification-button-hangs-with-infinite-loading-spinner-for)

## Summary

Clicking "Test notification" / "Send now" on a Slack alert showed an indefinite "Processing Scheduled delivery…" toast that never resolved. The cron-driven delivery itself was unaffected — only the manual test path hung.

Affects both `useSendNowScheduler` (create-time test) and `useSendNowSchedulerByUuid` (paper-plane "Send now" on an existing scheduler).

## Root cause

Four issues compounded in `useScheduler.ts`:

```ts
// Before — onSuccess of both send-now mutations
pollJobStatus(res.jobId || '')
    .then((data) => {
        if (data?.status === SchedulerJobStatus.ERROR) {
            throw new Error(data?.details?.error);
        }
    })
    .catch((e) => {
        throw e; // unhandled — React Query never sees this
    });
```

1. **Empty `jobId` polled silently.** When `res.jobId` came back falsy, `pollJobStatus('')` issued `GET /schedulers/job//status`. Either the empty segment 404s and the rejection is swallowed, or the response is non-terminal and the recursive `setTimeout` loop runs forever — both end at "spinner never resolves".
2. **`throw e` inside `.catch()` is an unhandled rejection.** React Query's `onError` is never invoked, so the failure produces no error toast.
3. **Dual polling.** With a valid `jobId`, both `useSendNowJobStatus` (RQ, 2s interval) and `pollJobStatus` (manual, 2s recursive `setTimeout`) ran in parallel — doubling network traffic and racing on toast lifecycle.
4. **`SCHEDULED` not counted as loading.** `isLoading` only checked `STARTED`, so a job sitting in the queue showed no spinner.

## Fix

- Drop the manual `pollJobStatus` block from `onSuccess` in both hooks. `useSendNowJobStatus` already handles every status transition (`SCHEDULED` → `STARTED` → `COMPLETED` / `ERROR`) plus toast lifecycle.
- When `res.jobId` is falsy, hide the loading toast and show a red error toast immediately. The user gets feedback even in the degenerate backend-response case.
- Add `SCHEDULED` to the `isLoading` memo alongside `STARTED`.
- Defensive guard inside `pollJobStatus` itself — throws on empty `jobId` instead of issuing the broken request. Protects the 5+ unrelated callers (`useDashboard`, `useValidation`, `useRenameResource`, `ExportResults`, `ChangeChartExploreModal`) from the same trap.

Cause → fix mapping:

```
Cause #1  empty jobId polled silently     →  guard in pollJobStatus + error toast in onSuccess
Cause #2  swallowed rejection in .catch   →  manual poll removed entirely
Cause #3  dual polling                    →  manual poll removed entirely; RQ owns status
Cause #4  SCHEDULED not in isLoading      →  added to isLoading memo
```

- `packages/frontend/src/features/scheduler/hooks/useScheduler.ts` — all four changes above.

## Test plan

- [x] `pnpm -F frontend typecheck` — passes
- [x] `pnpm -F frontend lint` — clean for the changed file (2 pre-existing warnings in unrelated files)
- [x] Manual: forced `res.jobId = ''` locally → confirmed the original infinite-toast bug, then verified the fix surfaces a red "No job ID returned from server" toast and dismisses the loading state
- [x] Manual: normal Slack alert happy path — loading toast → success or error toast, no double polling in DevTools Network
- [ ] Manual: email scheduled-delivery test send still works (same hooks, different target)
- [ ] Manual: `SCHEDULED` jobs now show the spinner (verify by clicking Send now while the worker is paused / under load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)