### PR TITLE
feat(pivot): UI to hide pivot dimensions (flag-gated)

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -985,6 +985,7 @@ export const convertSqlPivotedRowsToPivotData = ({
         | 'columnTotals'
         | 'metricsAsRows'
         | 'hiddenMetricFieldIds'
+        | 'hiddenDimensionFieldIds'
         | 'visibleMetricFieldIds'
         | 'columnOrder'
     >; // only use properties that are not part of pivot details metadata
@@ -999,6 +1000,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     }
 
     const hiddenMetricFieldIds = pivotConfig.hiddenMetricFieldIds || [];
+    const hiddenDimensionFieldIds = pivotConfig.hiddenDimensionFieldIds || [];
     const { visibleMetricFieldIds } = pivotConfig;
     const columnOrder = pivotConfig.columnOrder || [];
 
@@ -1009,17 +1011,28 @@ export const convertSqlPivotedRowsToPivotData = ({
         return !hiddenMetricFieldIds.includes(fieldId);
     };
 
-    // Extract information from pivot details metadata
+    const isDimVisibleInPivot = (fieldId: string): boolean =>
+        !hiddenDimensionFieldIds.includes(fieldId);
+
+    // Extract information from pivot details metadata. Row-index dims that the
+    // user has hidden are dropped from the rendered index column list — the
+    // underlying SQL row grouping is unchanged, so data rows still align with
+    // the visible index values; we just don't render the hidden column.
     let indexColumns: string[];
     if (pivotDetails.indexColumn) {
         if (Array.isArray(pivotDetails.indexColumn)) {
             indexColumns = pivotDetails.indexColumn
                 .map((col) => col.reference)
+                .filter(isDimVisibleInPivot)
                 .sort(
                     (a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b),
                 );
         } else {
-            indexColumns = [pivotDetails.indexColumn.reference];
+            indexColumns = isDimVisibleInPivot(
+                pivotDetails.indexColumn.reference,
+            )
+                ? [pivotDetails.indexColumn.reference]
+                : [];
         }
     } else {
         indexColumns = [];

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -1,4 +1,9 @@
-import { getItemLabel, getItemMap, isField } from '@lightdash/common';
+import {
+    FeatureFlags,
+    getItemLabel,
+    getItemMap,
+    isField,
+} from '@lightdash/common';
 import { Box, Loader, Text } from '@mantine-8/core';
 import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import {
@@ -21,6 +26,7 @@ import type {
     useGetReadyQueryResults,
     useInfiniteQueryResults,
 } from '../../../hooks/useQueryResults';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import PivotTable from '../../common/PivotTable';
@@ -262,13 +268,21 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         [itemsMap, columnProperties],
     );
 
-    // Hidden field IDs from chart config, split by kind. Dims drop out of pivot
-    // headers / row index; metrics drop out of data columns. Both ship to the
-    // pivot reducer worker so the user's "Hide column" toggle takes effect
-    // without waiting for a new query.
+    // Hidden field IDs from chart config, split by kind. Dims drop out of
+    // pivot headers / row index; metrics drop out of data columns. Both ship
+    // to the pivot reducer worker so the user's "Hide column" toggle takes
+    // effect without waiting for a new query.
+    //
+    // PROD-2108 flag gate: unflagged users keep the pre-existing behavior
+    // (no dim filtering) so an existing chart with a stray `visible: false`
+    // on a dim doesn't suddenly start hiding columns.
+    const { data: hidePivotDimsFlag } = useServerFeatureFlag(
+        FeatureFlags.HidePivotDimensions,
+    );
+    const isHidePivotDimsEnabled = hidePivotDimsFlag?.enabled ?? false;
     const queryDimensions = query.data?.metricQuery?.dimensions;
     const { hiddenDimensionFieldIds, hiddenMetricFieldIds } = useMemo(() => {
-        if (!columnProperties) {
+        if (!columnProperties || !isHidePivotDimsEnabled) {
             return {
                 hiddenDimensionFieldIds: undefined,
                 hiddenMetricFieldIds: undefined,
@@ -290,7 +304,7 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
             hiddenDimensionFieldIds: hiddenDims,
             hiddenMetricFieldIds: hiddenMets,
         };
-    }, [columnProperties, queryDimensions]);
+    }, [columnProperties, queryDimensions, isHidePivotDimsEnabled]);
 
     // Convert pivoted query results to PivotData format for PivotTable
     // Only process when user is actually viewing grouped results

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -262,6 +262,36 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         [itemsMap, columnProperties],
     );
 
+    // Hidden field IDs from chart config, split by kind. Dims drop out of pivot
+    // headers / row index; metrics drop out of data columns. Both ship to the
+    // pivot reducer worker so the user's "Hide column" toggle takes effect
+    // without waiting for a new query.
+    const queryDimensions = query.data?.metricQuery?.dimensions;
+    const { hiddenDimensionFieldIds, hiddenMetricFieldIds } = useMemo(() => {
+        if (!columnProperties) {
+            return {
+                hiddenDimensionFieldIds: undefined,
+                hiddenMetricFieldIds: undefined,
+            };
+        }
+        const dimensionSet = new Set(queryDimensions ?? []);
+        const hiddenDims: string[] = [];
+        const hiddenMets: string[] = [];
+        for (const [fieldId, props] of Object.entries(columnProperties)) {
+            if (props.visible === false) {
+                if (dimensionSet.has(fieldId)) {
+                    hiddenDims.push(fieldId);
+                } else {
+                    hiddenMets.push(fieldId);
+                }
+            }
+        }
+        return {
+            hiddenDimensionFieldIds: hiddenDims,
+            hiddenMetricFieldIds: hiddenMets,
+        };
+    }, [columnProperties, queryDimensions]);
+
     // Convert pivoted query results to PivotData format for PivotTable
     // Only process when user is actually viewing grouped results
     const pivotTableQuery = usePivotTableData({
@@ -273,6 +303,8 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         getFieldLabel,
         columnLimit,
         parameters,
+        hiddenDimensionFieldIds,
+        hiddenMetricFieldIds,
     });
 
     const cellContextMenu = useCallback(

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -1,9 +1,4 @@
-import {
-    FeatureFlags,
-    getItemLabel,
-    getItemMap,
-    isField,
-} from '@lightdash/common';
+import { getItemLabel, getItemMap, isField } from '@lightdash/common';
 import { Box, Loader, Text } from '@mantine-8/core';
 import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import {
@@ -22,11 +17,11 @@ import {
 import { useColumns } from '../../../hooks/useColumns';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
+import { useIsHidePivotDimsEnabled } from '../../../hooks/useIsHidePivotDimsEnabled';
 import type {
     useGetReadyQueryResults,
     useInfiniteQueryResults,
 } from '../../../hooks/useQueryResults';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import PivotTable from '../../common/PivotTable';
@@ -276,10 +271,7 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
     // PROD-2108 flag gate: unflagged users keep the pre-existing behavior
     // (no dim filtering) so an existing chart with a stray `visible: false`
     // on a dim doesn't suddenly start hiding columns.
-    const { data: hidePivotDimsFlag } = useServerFeatureFlag(
-        FeatureFlags.HidePivotDimensions,
-    );
-    const isHidePivotDimsEnabled = hidePivotDimsFlag?.enabled ?? false;
+    const isHidePivotDimsEnabled = useIsHidePivotDimsEnabled();
     const queryDimensions = query.data?.metricQuery?.dimensions;
     const { hiddenDimensionFieldIds, hiddenMetricFieldIds } = useMemo(() => {
         if (!columnProperties || !isHidePivotDimsEnabled) {

--- a/packages/frontend/src/components/Explorer/ResultsCard/usePivotTableData.ts
+++ b/packages/frontend/src/components/Explorer/ResultsCard/usePivotTableData.ts
@@ -21,6 +21,10 @@ type UsePivotTableDataArgs = {
     getFieldLabel: (fieldId: string | null | undefined) => string | undefined;
     columnLimit?: number;
     parameters?: ParametersValuesMap;
+    /** Hidden field IDs that are dimensions (filtered out of pivot headers / row index). */
+    hiddenDimensionFieldIds?: string[];
+    /** Hidden field IDs that are metrics (filtered out of pivot data columns). */
+    hiddenMetricFieldIds?: string[];
 };
 
 type PivotTableDataState = {
@@ -47,6 +51,8 @@ export function usePivotTableData({
     getFieldLabel,
     columnLimit,
     parameters,
+    hiddenDimensionFieldIds,
+    hiddenMetricFieldIds,
 }: UsePivotTableDataArgs): PivotTableDataState {
     const worker = useWorker(createWorker);
     const [state, setState] = useState<PivotTableDataState>({
@@ -70,7 +76,8 @@ export function usePivotTableData({
                 metricsAsRows: false,
                 columnTotals: false,
                 rowTotals: false,
-                hiddenMetricFieldIds: [] as string[],
+                hiddenMetricFieldIds: hiddenMetricFieldIds ?? [],
+                hiddenDimensionFieldIds: hiddenDimensionFieldIds ?? [],
                 columnOrder,
             },
             getField,
@@ -88,6 +95,8 @@ export function usePivotTableData({
         getFieldLabel,
         columnLimit,
         parameters,
+        hiddenDimensionFieldIds,
+        hiddenMetricFieldIds,
     ]);
 
     useEffect(() => {

--- a/packages/frontend/src/components/SimpleTable/ExplorerPivotTable.tsx
+++ b/packages/frontend/src/components/SimpleTable/ExplorerPivotTable.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlags, FieldType, type SortField } from '@lightdash/common';
+import { FieldType, type SortField } from '@lightdash/common';
 import { Menu } from '@mantine-8/core';
 import { useCallback, useMemo, type ComponentProps, type FC } from 'react';
 import {
@@ -11,12 +11,16 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../features/explorer/store';
-import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import { useIsHidePivotDimsEnabled } from '../../hooks/useIsHidePivotDimsEnabled';
 import {
     matchesIdentity,
     normalizePivotValues,
     pivotValuesEqual,
 } from '../../utils/pivotSortIdentity';
+import {
+    getRowDims,
+    isFieldSubtotalGroupingLevel,
+} from '../../utils/pivotSubtotalGrouping';
 import { SortDirection } from '../../utils/sortUtils';
 import PivotTable, { type PivotSortMenuTarget } from '../common/PivotTable';
 import ColumnHeaderSortMenuOptions from '../Explorer/ResultsCard/ColumnHeaderSortMenuOptions';
@@ -52,21 +56,16 @@ const ExplorerPivotTable: FC<ExplorerPivotTableProps> = ({
         ? visualizationConfig.chartConfig
         : null;
 
-    const { data: hidePivotDimsFlag } = useServerFeatureFlag(
-        FeatureFlags.HidePivotDimensions,
-    );
-    const isHidePivotDimsEnabled = hidePivotDimsFlag?.enabled ?? false;
+    const isHidePivotDimsEnabled = useIsHidePivotDimsEnabled();
 
     const showSubtotals = chartConfig?.showSubtotals ?? false;
     const rowDims = useMemo(
-        () => dimensions.filter((d) => !pivotConfig?.columns?.includes(d)),
+        () => getRowDims(dimensions, pivotConfig?.columns),
         [dimensions, pivotConfig],
     );
     const isSubtotalGroupingLevel = useCallback(
         (fieldId: string) =>
-            showSubtotals &&
-            rowDims.includes(fieldId) &&
-            rowDims.indexOf(fieldId) < rowDims.length - 1,
+            isFieldSubtotalGroupingLevel(fieldId, rowDims, showSubtotals),
         [showSubtotals, rowDims],
     );
 

--- a/packages/frontend/src/components/SimpleTable/ExplorerPivotTable.tsx
+++ b/packages/frontend/src/components/SimpleTable/ExplorerPivotTable.tsx
@@ -1,14 +1,17 @@
-import { FieldType, type SortField } from '@lightdash/common';
+import { FeatureFlags, FieldType, type SortField } from '@lightdash/common';
 import { Menu } from '@mantine-8/core';
 import { useCallback, useMemo, type ComponentProps, type FC } from 'react';
 import {
     explorerActions,
+    selectDimensions,
     selectIsEditMode,
     selectMetrics,
+    selectPivotConfig,
     selectSorts,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../features/explorer/store';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import {
     matchesIdentity,
     normalizePivotValues,
@@ -17,6 +20,8 @@ import {
 import { SortDirection } from '../../utils/sortUtils';
 import PivotTable, { type PivotSortMenuTarget } from '../common/PivotTable';
 import ColumnHeaderSortMenuOptions from '../Explorer/ResultsCard/ColumnHeaderSortMenuOptions';
+import { isTableVisualizationConfig } from '../LightdashVisualization/types';
+import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 
 type ExplorerPivotTableProps = Omit<
     ComponentProps<typeof PivotTable>,
@@ -39,6 +44,31 @@ const ExplorerPivotTable: FC<ExplorerPivotTableProps> = ({
     const sorts = useExplorerSelector(selectSorts);
     const isEditMode = useExplorerSelector(selectIsEditMode);
     const metrics = useExplorerSelector(selectMetrics);
+    const dimensions = useExplorerSelector(selectDimensions);
+    const pivotConfig = useExplorerSelector(selectPivotConfig);
+
+    const { visualizationConfig } = useVisualizationContext();
+    const chartConfig = isTableVisualizationConfig(visualizationConfig)
+        ? visualizationConfig.chartConfig
+        : null;
+
+    const { data: hidePivotDimsFlag } = useServerFeatureFlag(
+        FeatureFlags.HidePivotDimensions,
+    );
+    const isHidePivotDimsEnabled = hidePivotDimsFlag?.enabled ?? false;
+
+    const showSubtotals = chartConfig?.showSubtotals ?? false;
+    const rowDims = useMemo(
+        () => dimensions.filter((d) => !pivotConfig?.columns?.includes(d)),
+        [dimensions, pivotConfig],
+    );
+    const isSubtotalGroupingLevel = useCallback(
+        (fieldId: string) =>
+            showSubtotals &&
+            rowDims.includes(fieldId) &&
+            rowDims.indexOf(fieldId) < rowDims.length - 1,
+        [showSubtotals, rowDims],
+    );
 
     // Sort axes:
     //   valueColumn — metric or pinned: drives row order
@@ -154,16 +184,50 @@ const ExplorerPivotTable: FC<ExplorerPivotTableProps> = ({
                     : SortDirection.ASC
                 : undefined;
 
+            const isDimTarget =
+                menuTarget.kind === 'indexDim' ||
+                menuTarget.kind === 'groupByDim';
+
             return (
-                <ColumnHeaderSortMenuOptions
-                    item={item}
-                    selectedDirection={selectedDirection}
-                    onSelect={(direction) => applySort(target, direction)}
-                    onRemove={() => removeSort(target)}
-                />
+                <>
+                    <ColumnHeaderSortMenuOptions
+                        item={item}
+                        selectedDirection={selectedDirection}
+                        onSelect={(direction) => applySort(target, direction)}
+                        onRemove={() => removeSort(target)}
+                    />
+                    {isHidePivotDimsEnabled && chartConfig && isDimTarget && (
+                        <>
+                            <Menu.Divider />
+                            <Menu.Item
+                                color="red"
+                                disabled={isSubtotalGroupingLevel(
+                                    menuTarget.reference,
+                                )}
+                                onClick={() => {
+                                    chartConfig.updateColumnProperty(
+                                        menuTarget.reference,
+                                        { visible: false },
+                                    );
+                                }}
+                            >
+                                Hide column
+                            </Menu.Item>
+                        </>
+                    )}
+                </>
             );
         },
-        [applySort, getField, removeSort, sorts, targetFromMenuTarget],
+        [
+            applySort,
+            chartConfig,
+            getField,
+            isHidePivotDimsEnabled,
+            isSubtotalGroupingLevel,
+            removeSort,
+            sorts,
+            targetFromMenuTarget,
+        ],
     );
 
     return (

--- a/packages/frontend/src/components/SimpleTable/ValueCellMenu.test.tsx
+++ b/packages/frontend/src/components/SimpleTable/ValueCellMenu.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * Regression tests for ValueCellMenu drill-down behavior with hidden pivot
+ * dimensions.
+ *
+ * DONE_WITH_CONCERNS: The intended regression guard (asserting that
+ * `getUnderlyingFieldValues` returns ALL dimension values — including hidden
+ * ones — when `hiddenDimensionFieldIds` is set) cannot be written as a
+ * unit test without a full TanStack Table + React mounting environment,
+ * because `getUnderlyingFieldValues` is a `useCallback` inside
+ * `PivotTable/index.tsx` that reads directly from `rows[rowIndex].getVisibleCells()`.
+ *
+ * KNOWN LIMITATION: Hidden row-index dimensions (excluded from
+ * `indexValues` via `indexDimensionsForDisplay` in `pivotQueryResults.ts`)
+ * will be ABSENT from the drill-down/underlying-data context passed to
+ * `openUnderlyingDataModal` / `openDrillDownModal`. This means:
+ *   - Right-click → "View underlying data" on a pivot cell may return broader
+ *     results than expected when a row-index dim is hidden.
+ *   - Right-click → "Drill into" on a metric cell may not correctly scope the
+ *     drill by the hidden dimension values.
+ *
+ * RECOMMENDED FIX (follow-up ticket):
+ *   Option A — Keep hidden dims in `indexValues` with a `hidden: true` marker;
+ *              `PivotTable` skips rendering them but `getUnderlyingFieldValues`
+ *              still collects their values.
+ *   Option B — Add a separate `hiddenIndexValues` array to `PivotData` that
+ *              `getUnderlyingFieldValues` merges alongside visible `indexValue`
+ *              cells.
+ *
+ * Note: `hiddenDimensionFieldIds` correctly excludes hidden dims from the
+ * rendered table AND from CSV/XLSX exports (tested in the common-package and
+ * backend test suites). The concern here is limited to the interactive
+ * drill-down path.
+ */
+
+// Intentionally empty — see comment above.
+export {};

--- a/packages/frontend/src/components/SimpleTable/ValueCellMenu.test.tsx
+++ b/packages/frontend/src/components/SimpleTable/ValueCellMenu.test.tsx
@@ -1,3 +1,5 @@
+import { describe, it } from 'vitest';
+
 /**
  * Regression tests for ValueCellMenu drill-down behavior with hidden pivot
  * dimensions.
@@ -31,6 +33,8 @@
  * backend test suites). The concern here is limited to the interactive
  * drill-down path.
  */
-
-// Intentionally empty — see comment above.
-export {};
+describe('ValueCellMenu — drill-down with hidden pivot dims', () => {
+    it.todo(
+        'getUnderlyingFieldValues includes hidden index dim values (follow-up ticket)',
+    );
+});

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -16,6 +16,10 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
+import {
+    getRowDims,
+    isFieldSubtotalGroupingLevel,
+} from '../../../utils/pivotSubtotalGrouping';
 import MantineIcon from '../../common/MantineIcon';
 import {
     isTableVisualizationConfig,
@@ -111,12 +115,10 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
         isTableVisualizationConfig(visualizationConfig) &&
         (visualizationConfig.chartConfig.showSubtotals ?? false);
     const dimensions = resultsData?.metricQuery?.dimensions ?? [];
-    const rowDims = dimensions.filter((d) => !pivotDimensions?.includes(d));
+    const rowDims = getRowDims(dimensions, pivotDimensions);
     const isSubtotalGroupingLevel =
         allowHidePivotDimension &&
-        showSubtotals &&
-        rowDims.includes(fieldId) &&
-        rowDims.indexOf(fieldId) < rowDims.length - 1;
+        isFieldSubtotalGroupingLevel(fieldId, rowDims, showSubtotals);
 
     // Pivoted dimensions become column headers and can't be frozen.
     const shouldShowFreezeToggle = !isPivotingDimension;

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -155,13 +155,11 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
                 label={
                     isSubtotalGroupingLevel
                         ? "Cannot hide while it's a subtotal grouping level"
-                        : isPivotingDimension && !allowHidePivotDimension
+                        : disableHidingDimensions
                           ? 'Cannot hide dimensions when pivoting'
-                          : disableHidingDimensions
-                            ? 'Cannot hide dimensions when pivoting'
-                            : isColumnVisible(fieldId)
-                              ? 'Hide column'
-                              : 'Show column'
+                          : isColumnVisible(fieldId)
+                            ? 'Hide column'
+                            : 'Show column'
                 }
             >
                 <Box
@@ -170,9 +168,7 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
                 >
                     <ActionIcon
                         disabled={
-                            disableHidingDimensions ||
-                            isSubtotalGroupingLevel ||
-                            (isPivotingDimension && !allowHidePivotDimension)
+                            disableHidingDimensions || isSubtotalGroupingLevel
                         }
                         variant="light"
                         onClick={() => {

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -6,7 +6,7 @@ import {
     Text,
     TextInput,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useDebouncedState } from '@mantine/hooks';
 import {
     IconEye,
@@ -69,13 +69,21 @@ type ColumnConfigurationProps = {
      * When provided, the freeze toggle controls all listed fieldIds together.
      */
     syncFreezeWith?: string[];
+
+    /**
+     * When true, allow hiding even when the field is a pivot dimension.
+     * Used by the hide-pivot-dimensions feature (flag-gated externally).
+     */
+    allowHidePivotDimension?: boolean;
 };
 
 const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
     fieldId,
     syncFreezeWith,
+    allowHidePivotDimension = false,
 }) => {
-    const { pivotDimensions, visualizationConfig } = useVisualizationContext();
+    const { pivotDimensions, visualizationConfig, resultsData } =
+        useVisualizationContext();
 
     const [isShowTooltipVisible, setShowTooltipVisible] = useState(false);
     const [isFreezeTooltipVisible, setFreezeTooltipVisible] = useState(false);
@@ -93,7 +101,22 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
     const field = getField(fieldId);
     const columnWidth = columnProperties[fieldId]?.width;
     const isPivotingDimension = pivotDimensions?.includes(fieldId);
-    const disableHidingDimensions = !!(pivotDimensions && isDimension(field));
+    const disableHidingDimensions =
+        !!(pivotDimensions && isDimension(field)) && !allowHidePivotDimension;
+
+    // When allowHidePivotDimension is true, compute the subtotal-grouping
+    // guard: hiding is forbidden for non-leaf row-index dims when subtotals
+    // are enabled (hiding them would corrupt the subtotal grouping).
+    const showSubtotals =
+        isTableVisualizationConfig(visualizationConfig) &&
+        (visualizationConfig.chartConfig.showSubtotals ?? false);
+    const dimensions = resultsData?.metricQuery?.dimensions ?? [];
+    const rowDims = dimensions.filter((d) => !pivotDimensions?.includes(d));
+    const isSubtotalGroupingLevel =
+        allowHidePivotDimension &&
+        showSubtotals &&
+        rowDims.includes(fieldId) &&
+        rowDims.indexOf(fieldId) < rowDims.length - 1;
 
     // Pivoted dimensions become column headers and can't be frozen.
     const shouldShowFreezeToggle = !isPivotingDimension;
@@ -116,12 +139,8 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
     };
 
     return (
-        <Group spacing="xs" noWrap style={{ flexGrow: 1 }}>
-            <Box
-                style={{
-                    flexGrow: 1,
-                }}
-            >
+        <Group gap="xs" wrap="nowrap" style={{ flexGrow: 1 }}>
+            <Box style={{ flexGrow: 1 }}>
                 <ColumnConfigurationInput
                     fieldId={fieldId}
                     chartConfig={visualizationConfig.chartConfig}
@@ -134,13 +153,15 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
                 opened={isShowTooltipVisible}
                 withinPortal
                 label={
-                    isPivotingDimension
-                        ? 'Cannot hide dimensions when pivoting'
-                        : disableHidingDimensions
+                    isSubtotalGroupingLevel
+                        ? "Cannot hide while it's a subtotal grouping level"
+                        : isPivotingDimension && !allowHidePivotDimension
                           ? 'Cannot hide dimensions when pivoting'
-                          : isColumnVisible(fieldId)
-                            ? 'Hide column'
-                            : 'Show column'
+                          : disableHidingDimensions
+                            ? 'Cannot hide dimensions when pivoting'
+                            : isColumnVisible(fieldId)
+                              ? 'Hide column'
+                              : 'Show column'
                 }
             >
                 <Box
@@ -150,7 +171,8 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
                     <ActionIcon
                         disabled={
                             disableHidingDimensions ||
-                            pivotDimensions?.includes(fieldId)
+                            isSubtotalGroupingLevel ||
+                            (isPivotingDimension && !allowHidePivotDimension)
                         }
                         variant="light"
                         onClick={() => {
@@ -162,7 +184,10 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
                             // but for now work around it by managing the tooltip
                             // and closing it when the button is clicked.
                             setShowTooltipVisible(false);
-                            if (!disableHidingDimensions) {
+                            if (
+                                !disableHidingDimensions &&
+                                !isSubtotalGroupingLevel
+                            ) {
                                 updateColumnProperty(fieldId, {
                                     visible: !isColumnVisible(fieldId),
                                 });
@@ -216,8 +241,8 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
                     label="Reset column width to auto"
                 >
                     <Group
-                        spacing={2}
-                        noWrap
+                        gap={2}
+                        wrap="nowrap"
                         className={styles.widthBadge}
                         bg="ldGray.1"
                         px={4}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
@@ -3,7 +3,7 @@ import {
     Droppable,
     type DraggableStateSnapshot,
 } from '@hello-pangea/dnd';
-import { Group, Stack, Text } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import React, { type FC } from 'react';
 import { createPortal } from 'react-dom';
 import { GrabIcon } from '../common/GrabIcon';
@@ -26,6 +26,7 @@ type DroppableItemsListProps = {
     isDragging: boolean;
     disableReorder: boolean;
     placeholder?: string;
+    allowHidePivotDimension?: boolean;
 };
 
 const DroppableItemsList: FC<DroppableItemsListProps> = ({
@@ -34,14 +35,15 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
     isDragging,
     disableReorder,
     placeholder,
+    allowHidePivotDimension = false,
 }) => {
     const hasItems = itemIds.length > 0;
     return (
         <Stack
-            spacing="xs"
-            sx={(theme) => ({
+            gap="xs"
+            style={(theme) => ({
                 padding: theme.spacing.xs,
-                backgroundColor: theme.colors.ldGray['0'],
+                backgroundColor: theme.colors.ldGray?.[0],
                 borderRadius: theme.radius.sm,
             })}
         >
@@ -49,7 +51,7 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
                 {(dropProps, droppableSnapshot) => (
                     <Stack
                         {...dropProps.droppableProps}
-                        spacing="xs"
+                        gap="xs"
                         ref={dropProps.innerRef}
                         mih={isDragging ? '30px' : undefined}
                         bg={
@@ -61,7 +63,7 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
                         }
                     >
                         {!isDragging && !hasItems ? (
-                            <Text size="xs" color="ldGray.6" m="xs" ta="center">
+                            <Text size="xs" c="ldGray.6" m="xs" ta="center">
                                 {placeholder}
                             </Text>
                         ) : null}
@@ -81,8 +83,8 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
                                 ) => (
                                     <DraggablePortalHandler snapshot={snapshot}>
                                         <Group
-                                            noWrap
-                                            spacing="xs"
+                                            wrap="nowrap"
+                                            gap="xs"
                                             ref={innerRef}
                                             {...draggableProps}
                                             style={{
@@ -103,6 +105,9 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
 
                                             <ColumnConfiguration
                                                 fieldId={itemId}
+                                                allowHidePivotDimension={
+                                                    allowHidePivotDimension
+                                                }
                                             />
                                         </Group>
                                     </DraggablePortalHandler>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -1,7 +1,9 @@
 import { DragDropContext, type DropResult } from '@hello-pangea/dnd';
+import { FeatureFlags } from '@lightdash/common';
 import { Box, Checkbox, Stack, Switch, Tooltip } from '@mantine-8/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
@@ -25,6 +27,11 @@ const GeneralSettings: FC = () => {
     } = useVisualizationContext();
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const { showToastError } = useToaster();
+
+    const { data: hidePivotDimsFlag } = useServerFeatureFlag(
+        FeatureFlags.HidePivotDimensions,
+    );
+    const isHidePivotDimsEnabled = hidePivotDimsFlag?.enabled ?? false;
     const { dimensions } = resultsData?.metricQuery || {
         dimensions: [] as string[],
     };
@@ -181,6 +188,7 @@ const GeneralSettings: FC = () => {
                             placeholder={
                                 'Drag dimensions into this area to pivot your table'
                             }
+                            allowHidePivotDimension={isHidePivotDimsEnabled}
                         />
 
                         <Config.Heading>Rows</Config.Heading>
@@ -192,6 +200,7 @@ const GeneralSettings: FC = () => {
                             placeholder={
                                 'Drag dimensions into this area to group your data'
                             }
+                            allowHidePivotDimension={isHidePivotDimsEnabled}
                         />
                     </Config.Section>
                 </Config>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -1,9 +1,8 @@
 import { DragDropContext, type DropResult } from '@hello-pangea/dnd';
-import { FeatureFlags } from '@lightdash/common';
 import { Box, Checkbox, Stack, Switch, Tooltip } from '@mantine-8/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { useIsHidePivotDimsEnabled } from '../../../hooks/useIsHidePivotDimsEnabled';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
@@ -28,10 +27,7 @@ const GeneralSettings: FC = () => {
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const { showToastError } = useToaster();
 
-    const { data: hidePivotDimsFlag } = useServerFeatureFlag(
-        FeatureFlags.HidePivotDimensions,
-    );
-    const isHidePivotDimsEnabled = hidePivotDimsFlag?.enabled ?? false;
+    const isHidePivotDimsEnabled = useIsHidePivotDimsEnabled();
     const { dimensions } = resultsData?.metricQuery || {
         dimensions: [] as string[],
     };

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -78,6 +78,7 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             tableConfig: {
                 columnOrder,
             },
+            metricQuery: resultsData?.metricQuery,
         });
 
         const getChartDownloadQueryUuid = useCallback(

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -1,6 +1,5 @@
 import {
     convertFormattedValue,
-    FeatureFlags,
     getItemLabel,
     isCustomDimension,
     isDimension,
@@ -28,8 +27,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
 import { useCalculateSubtotals } from '../useCalculateSubtotals';
 import { useCalculateTotal } from '../useCalculateTotal';
+import { useIsHidePivotDimsEnabled } from '../useIsHidePivotDimsEnabled';
 import { type InfiniteQueryResults } from '../useQueryResults';
-import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import getDataAndColumns from './getDataAndColumns';
 
 const createWorker = createWorkerFactory(
@@ -166,10 +165,7 @@ const useTableConfig = (
     // `columnProperties[dim].visible: false` (set by clicks during the era of
     // the buggy guard) keep rendering the dim. Flag-on opts into the new
     // behavior.
-    const { data: hidePivotDimsFlag } = useServerFeatureFlag(
-        FeatureFlags.HidePivotDimensions,
-    );
-    const isHidePivotDimsEnabled = hidePivotDimsFlag?.enabled ?? false;
+    const isHidePivotDimsEnabled = useIsHidePivotDimsEnabled();
 
     const isColumnVisible = useCallback(
         (fieldId: string) => {

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -157,21 +157,14 @@ const useTableConfig = (
 
     // This is controlled by the state in this component.
     // User configures the names and visibilty of these in the config panel
+    // Reads the persisted visibility directly. The previous short-circuit that
+    // forced dimensions to always render while pivoting was a guard against an
+    // older bug where filtering an index dimension corrupted metric values —
+    // the indexDimensionsForGrouping/ForDisplay split in pivotQueryResults
+    // (PROD-2108 data layer) solves that, so the guard is obsolete.
     const isColumnVisible = useCallback(
-        (fieldId: string) => {
-            // we should always show dimensions when pivoting
-            // hiding a dimension randomly removes values from all metrics
-            if (
-                pivotDimensions &&
-                pivotDimensions.length > 0 &&
-                isDimension(getField(fieldId))
-            ) {
-                return true;
-            }
-
-            return columnProperties[fieldId]?.visible ?? true;
-        },
-        [pivotDimensions, getField, columnProperties],
+        (fieldId: string) => columnProperties[fieldId]?.visible ?? true,
+        [columnProperties],
     );
     const isColumnFrozen = useCallback(
         (fieldId: string) => columnProperties[fieldId]?.frozen === true,
@@ -355,11 +348,22 @@ const useTableConfig = (
             );
         });
 
+        const hiddenDimensionFieldIds = selectedItemIds?.filter((fieldId) => {
+            const field = getField(fieldId);
+            return (
+                !isColumnVisible(fieldId) &&
+                field &&
+                isField(field) &&
+                isDimension(field)
+            );
+        });
+
         const pivotConfig: PivotConfig = {
             pivotDimensions,
             metricsAsRows,
             columnOrder,
             hiddenMetricFieldIds,
+            hiddenDimensionFieldIds,
             columnTotals: tableChartConfig?.showColumnCalculation,
             rowTotals: tableChartConfig?.showRowCalculation,
         };

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -1,5 +1,6 @@
 import {
     convertFormattedValue,
+    FeatureFlags,
     getItemLabel,
     isCustomDimension,
     isDimension,
@@ -28,6 +29,7 @@ import useEmbed from '../../ee/providers/Embed/useEmbed';
 import { useCalculateSubtotals } from '../useCalculateSubtotals';
 import { useCalculateTotal } from '../useCalculateTotal';
 import { type InfiniteQueryResults } from '../useQueryResults';
+import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import getDataAndColumns from './getDataAndColumns';
 
 const createWorker = createWorkerFactory(
@@ -155,16 +157,33 @@ const useTableConfig = (
         [getFieldLabelOverride, getFieldLabelDefault],
     );
 
-    // This is controlled by the state in this component.
-    // User configures the names and visibilty of these in the config panel
-    // Reads the persisted visibility directly. The previous short-circuit that
-    // forced dimensions to always render while pivoting was a guard against an
-    // older bug where filtering an index dimension corrupted metric values —
-    // the indexDimensionsForGrouping/ForDisplay split in pivotQueryResults
-    // (PROD-2108 data layer) solves that, so the guard is obsolete.
+    // PROD-2108 flag gate. When off, preserve the legacy short-circuit that
+    // forced dimensions to always render while pivoting — it guarded against
+    // an older pivot reducer bug where filtering an index dim corrupted
+    // metric values. The PR 2 indexDimensionsForGrouping/ForDisplay split
+    // fixes that root cause, but we only honor the persisted dim visibility
+    // when the flag is on, so existing charts that have an unintentional
+    // `columnProperties[dim].visible: false` (set by clicks during the era of
+    // the buggy guard) keep rendering the dim. Flag-on opts into the new
+    // behavior.
+    const { data: hidePivotDimsFlag } = useServerFeatureFlag(
+        FeatureFlags.HidePivotDimensions,
+    );
+    const isHidePivotDimsEnabled = hidePivotDimsFlag?.enabled ?? false;
+
     const isColumnVisible = useCallback(
-        (fieldId: string) => columnProperties[fieldId]?.visible ?? true,
-        [columnProperties],
+        (fieldId: string) => {
+            if (
+                !isHidePivotDimsEnabled &&
+                pivotDimensions &&
+                pivotDimensions.length > 0 &&
+                isDimension(getField(fieldId))
+            ) {
+                return true;
+            }
+            return columnProperties[fieldId]?.visible ?? true;
+        },
+        [columnProperties, isHidePivotDimsEnabled, pivotDimensions, getField],
     );
     const isColumnFrozen = useCallback(
         (fieldId: string) => columnProperties[fieldId]?.frozen === true,
@@ -348,16 +367,22 @@ const useTableConfig = (
             );
         });
 
-        const hiddenDimensionFieldIds = selectedItemIds?.filter((fieldId) => {
-            const field = getField(fieldId);
-            if (!field || isColumnVisible(fieldId)) return false;
-            // Custom SQL dimensions are not `Field`s but still behave as dims
-            // in the pivot (they can drive sort order via sortOnlyDimensions).
-            return (
-                (isField(field) && isDimension(field)) ||
-                isCustomDimension(field)
-            );
-        });
+        // Only populate the dim-side hidden list when the flag is on. Without
+        // it, isColumnVisible still applies the legacy short-circuit for dims
+        // and we keep the pre-PROD-2108 contract (no dim filtering downstream).
+        const hiddenDimensionFieldIds = isHidePivotDimsEnabled
+            ? selectedItemIds?.filter((fieldId) => {
+                  const field = getField(fieldId);
+                  if (!field || isColumnVisible(fieldId)) return false;
+                  // Custom SQL dimensions are not `Field`s but still behave
+                  // as dims in the pivot (driving sort order via
+                  // sortOnlyDimensions).
+                  return (
+                      (isField(field) && isDimension(field)) ||
+                      isCustomDimension(field)
+                  );
+              })
+            : undefined;
 
         const pivotConfig: PivotConfig = {
             pivotDimensions,
@@ -430,6 +455,7 @@ const useTableConfig = (
         metricsAsRows,
         selectedItemIds,
         isColumnVisible,
+        isHidePivotDimsEnabled,
         getField,
         getFieldLabel,
         tableChartConfig?.showColumnCalculation,

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -350,11 +350,12 @@ const useTableConfig = (
 
         const hiddenDimensionFieldIds = selectedItemIds?.filter((fieldId) => {
             const field = getField(fieldId);
+            if (!field || isColumnVisible(fieldId)) return false;
+            // Custom SQL dimensions are not `Field`s but still behave as dims
+            // in the pivot (they can drive sort order via sortOnlyDimensions).
             return (
-                !isColumnVisible(fieldId) &&
-                field &&
-                isField(field) &&
-                isDimension(field)
+                (isField(field) && isDimension(field)) ||
+                isCustomDimension(field)
             );
         });
 

--- a/packages/frontend/src/hooks/useIsHidePivotDimsEnabled.ts
+++ b/packages/frontend/src/hooks/useIsHidePivotDimsEnabled.ts
@@ -1,0 +1,11 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
+
+/**
+ * Returns whether the `hide-pivot-dimensions` feature flag is on. Wraps the
+ * standard server-flag lookup so callers don't repeat the boilerplate.
+ */
+export const useIsHidePivotDimsEnabled = (): boolean => {
+    const { data } = useServerFeatureFlag(FeatureFlags.HidePivotDimensions);
+    return data?.enabled ?? false;
+};

--- a/packages/frontend/src/utils/pivotSubtotalGrouping.ts
+++ b/packages/frontend/src/utils/pivotSubtotalGrouping.ts
@@ -1,0 +1,30 @@
+/**
+ * Returns true when a field is a non-leaf row-index dim and subtotals are on
+ * — i.e., hiding it would corrupt subtotal aggregation. Used by the pivot UI
+ * to disable the hide affordance for those fields.
+ *
+ * `rowDims` is the ordered list of row-index dimensions (dims selected in
+ * the query that aren't in the pivot columns). The leaf row dim (last entry)
+ * never groups subtotals, so it's always safe to hide.
+ */
+export const isFieldSubtotalGroupingLevel = (
+    fieldId: string,
+    rowDims: string[],
+    showSubtotals: boolean,
+): boolean => {
+    if (!showSubtotals) return false;
+    const index = rowDims.indexOf(fieldId);
+    return index !== -1 && index < rowDims.length - 1;
+};
+
+/**
+ * Derive row-index dimensions from the metric query + pivot config.
+ * Row dims = all selected dims that aren't pivoted as column headers.
+ */
+export const getRowDims = (
+    dimensions: string[],
+    pivotedDims: string[] | undefined,
+): string[] => {
+    const pivotSet = new Set(pivotedDims ?? []);
+    return dimensions.filter((d) => !pivotSet.has(d));
+};


### PR DESCRIPTION
## Summary

Surfaces the hide-pivot-dimension UI behind the `HidePivotDimensions` feature flag (added in #23289):

- **"Hide column" menu item** on pivot dimension headers (`indexDim` / `groupByDim` kinds), wired via the existing `renderSortMenu` machinery from #23046.
- **Visibility toggle** on the pivot config panel's column/row dimension lists.
- **Subtotal-grouping guard:** hide is disabled (with tooltip) for non-leaf row-index dims when subtotals are on — per the product call to forbid hide on grouping levels.

The flag itself, the data-layer support, and the export-pipeline regression guards are all in earlier PRs in this stack (#23289 / #23291 / #23301). This PR only ships the user-facing affordances.

## Known limitation

Drill-down on a row with a hidden row-index dim returns broader-than-precise context (the dim isn't included in `getVisibleCells()`). Documented as a follow-up via `it.todo` in `ValueCellMenu.test.tsx`. Safe failure mode (returns more rows, not wrong rows). Primary use case is sort-helper dims, where drill-down on the helper itself isn't expected to work.

## Note

Includes Mantine v6 → v8 migration spillover in `ColumnConfiguration.tsx` and `DroppableItemsList.tsx` — the components being touched were on v6; project policy is to migrate v6 components you encounter.

## Test plan

- [ ] Toggle `hide-pivot-dimensions` flag on; verify "Hide column" appears on the pivot dim sort menu.
- [ ] Hide a row-index dim → confirm it's absent from rendered pivot and from CSV/XLSX exports.
- [ ] Enable subtotals; verify hide icon is disabled on non-leaf row dims with the tooltip.
- [ ] Toggle flag off → confirm all new affordances disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)