### PR TITLE
fix: forward `redirect` param to SSO URL so post-login returns to correct page

### DIFF
--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -97,10 +97,17 @@ const Login: FC<{}> = () => {
     useEffect(() => {
         if (loginOptions && loginOptionsSuccess) {
             if (loginOptions.forceRedirect && loginOptions.redirectUri) {
-                window.location.href = loginOptions.redirectUri;
+                // Forward the post-login redirect target so the backend can
+                // persist it as `returnTo` (see `storeOIDCRedirect`). Without
+                // this, SSO-only orgs always land on `/` after auth.
+                const ssoUrl = new URL(loginOptions.redirectUri);
+                if (redirectUrl && redirectUrl !== '/') {
+                    ssoUrl.searchParams.set('redirect', redirectUrl);
+                }
+                window.location.href = ssoUrl.href;
             }
         }
-    }, [loginOptionsSuccess, loginOptions]);
+    }, [loginOptionsSuccess, loginOptions, redirectUrl]);
 
     const ssoOptions = loginOptions
         ? (loginOptions.showOptions.filter(


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-4795/when-im-logged-out-upon-viewing-a-certain-piece-of-content-i-am-not

### Description:
When a user belonging to an SSO-only organisation attempts to access a specific page, they were always redirected to `/` after completing authentication instead of being returned to their intended destination.

This fix appends the intended `redirect` URL as a query parameter to the SSO redirect URI before navigating the user to the identity provider. This allows the backend's `storeOIDCRedirect` to persist the `returnTo` value, ensuring users land on the correct page after completing SSO login. The `redirectUrl` dependency has also been added to the `useEffect` to keep the behaviour reactive to changes in the redirect target.