### PR TITLE
fix: refine AI chat composer spacing and dark-mode surface

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.module.css
@@ -1,0 +1,11 @@
+.composerFooter {
+    padding-top: 0;
+
+    @mixin light {
+        background: var(--mantine-color-body);
+    }
+
+    @mixin dark {
+        background: var(--mantine-color-body);
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -12,6 +12,7 @@ import { AddToEvalModal } from '../Admin/AddToEvalModal';
 import { AssistantBubble } from './AgentChatAssistantBubble';
 import { UserBubble } from './AgentChatUserBubble';
 import ThreadScrollToBottom from './ScrollToBottom';
+import styles from './AgentChatDisplay.module.css';
 import { ChatElementsUtils } from './utils';
 
 type Props = {
@@ -53,77 +54,86 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
             style={{ flexGrow: 1, overflowY: 'auto' }}
             pt="md"
         >
-            <Stack
-                {...ChatElementsUtils.centeredElementProps}
-                gap="xl"
-                style={{ flexGrow: 1 }}
-            >
-                <Stack flex={1} style={{ flexGrow: 1 }}>
-                    {thread.messages.map((message, i, xs) => (
-                        <Fragment key={`${message.role}-${message.uuid}`}>
-                            {ChatElementsUtils.shouldRenderDivider(
-                                message,
-                                i,
-                                xs,
-                            ) && (
-                                <Divider
-                                    label={
-                                        message.createdAt
-                                            ? ChatElementsUtils.getDividerLabel(
-                                                  message.createdAt,
-                                              )
-                                            : undefined
-                                    }
-                                    labelPosition="center"
-                                    my="sm"
-                                />
-                            )}
+            <Flex direction="column" style={{ flexGrow: 1, minHeight: '100%' }}>
+                <Stack
+                    w={ChatElementsUtils.centeredElementProps.w}
+                    maw={ChatElementsUtils.centeredElementProps.maw}
+                    mx={ChatElementsUtils.centeredElementProps.mx}
+                    px={ChatElementsUtils.centeredElementProps.px}
+                    pb="md"
+                    gap="xl"
+                    style={{ flexGrow: 1 }}
+                >
+                    <Stack flex={1} style={{ flexGrow: 1 }}>
+                        {thread.messages.map((message, i, xs) => (
+                            <Fragment key={`${message.role}-${message.uuid}`}>
+                                {ChatElementsUtils.shouldRenderDivider(
+                                    message,
+                                    i,
+                                    xs,
+                                ) && (
+                                    <Divider
+                                        label={
+                                            message.createdAt
+                                                ? ChatElementsUtils.getDividerLabel(
+                                                      message.createdAt,
+                                                  )
+                                                : undefined
+                                        }
+                                        labelPosition="center"
+                                        my="sm"
+                                    />
+                                )}
 
-                            {message.role === 'user' ? (
-                                <UserBubble message={message} />
-                            ) : (
-                                <ErrorBoundary>
-                                    {projectUuid && agentUuid && (
-                                        <AssistantBubble
-                                            message={message}
-                                            debug={debug}
-                                            projectUuid={projectUuid}
-                                            agentUuid={agentUuid}
-                                            onAddToEvals={
-                                                setAddToEvalsPromptUuid
-                                            }
-                                            showAddToEvalsButton={
-                                                showAddToEvalsButton
-                                            }
-                                            renderArtifactsInline={
-                                                renderArtifactsInline
-                                            }
-                                        />
-                                    )}
-                                </ErrorBoundary>
-                            )}
-                        </Fragment>
-                    ))}
+                                {message.role === 'user' ? (
+                                    <UserBubble message={message} />
+                                ) : (
+                                    <ErrorBoundary>
+                                        {projectUuid && agentUuid && (
+                                            <AssistantBubble
+                                                message={message}
+                                                debug={debug}
+                                                projectUuid={projectUuid}
+                                                agentUuid={agentUuid}
+                                                onAddToEvals={
+                                                    setAddToEvalsPromptUuid
+                                                }
+                                                showAddToEvalsButton={
+                                                    showAddToEvalsButton
+                                                }
+                                                renderArtifactsInline={
+                                                    renderArtifactsInline
+                                                }
+                                            />
+                                        )}
+                                    </ErrorBoundary>
+                                )}
+                            </Fragment>
+                        ))}
+                    </Stack>
+
+                    {enableAutoScroll && projectUuid && agentUuid ? (
+                        <ThreadScrollToBottom
+                            scrollAreaRef={viewport}
+                            projectUuid={projectUuid}
+                            agentUuid={agentUuid}
+                            threadUuid={thread.uuid}
+                        />
+                    ) : null}
                 </Stack>
 
-                {enableAutoScroll && projectUuid && agentUuid ? (
-                    <ThreadScrollToBottom
-                        scrollAreaRef={viewport}
-                        projectUuid={projectUuid}
-                        agentUuid={agentUuid}
-                        threadUuid={thread.uuid}
-                    />
+                {children ? (
+                    <Box
+                        className={styles.composerFooter}
+                        pos="sticky"
+                        bottom={0}
+                        w="100%"
+                        style={{ zIndex: getDefaultZIndex('app') - 1 }}
+                    >
+                        {children}
+                    </Box>
                 ) : null}
-
-                <Box
-                    pos="sticky"
-                    bottom={0}
-                    w="100%"
-                    style={{ zIndex: getDefaultZIndex('app') - 1 }}
-                >
-                    {children}
-                </Box>
-            </Stack>
+            </Flex>
 
             {showAddToEvalsButton &&
                 projectUuid &&

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -10,9 +10,9 @@ import {
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import { AddToEvalModal } from '../Admin/AddToEvalModal';
 import { AssistantBubble } from './AgentChatAssistantBubble';
+import styles from './AgentChatDisplay.module.css';
 import { UserBubble } from './AgentChatUserBubble';
 import ThreadScrollToBottom from './ScrollToBottom';
-import styles from './AgentChatDisplay.module.css';
 import { ChatElementsUtils } from './utils';
 
 type Props = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -143,7 +143,8 @@
 /* Minimal mode styles for existing threads */
 .minimalContainer {
     position: relative;
-    padding: var(--mantine-spacing-sm);
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm)
+        var(--mantine-spacing-sm);
 }
 
 /* ------------------------------------------------------------------ *
@@ -315,6 +316,14 @@
     background: transparent;
     flex: 1;
     min-width: 0;
+    --rte-bg: transparent;
+    --rte-border-color: transparent;
+
+    :global(.mantine-RichTextEditor-content),
+    :global(.mantine-8-RichTextEditor-content) {
+        background: transparent;
+        border: none;
+    }
 }
 
 .editorContent {
@@ -356,9 +365,11 @@
     max-height: 144px;
     overflow-y: auto;
     flex: 1;
+    background: transparent;
 
     :global(.ProseMirror) {
         outline: none;
+        background: transparent;
     }
 
     :global(p.is-empty.is-editor-empty::before) {


### PR DESCRIPTION
## Summary
- Kept the sticky AI chat composer full-width while preserving the pinned footer behavior.
- Added bottom breathing room to the message list so action icons are not clipped behind the composer.
- Removed the extra dark-mode inner surface in the minimal composer so the input matches the surrounding background.
- Tightened the minimal composer top spacing.

## Testing
- `oxlint` passed for the touched frontend files.
- Verified the updated chat layout and composer styling in the local browser.