### PR TITLE
feat: migrate resource and metrics tables to content table

### DIFF
--- a/packages/frontend/src/components/common/InHouseTable/InHouseTable.tsx
+++ b/packages/frontend/src/components/common/InHouseTable/InHouseTable.tsx
@@ -53,8 +53,6 @@ type SanitizedMantineProps<TElement extends HTMLElement> = Omit<
     style?: CSSProperties;
 };
 
-export const MantineReactTable = InHouseTable;
-
 const assignRef = <TElement,>(
     ref: React.Ref<TElement> | undefined,
     value: TElement | null,
@@ -242,6 +240,8 @@ const SortIcon = <TData extends RowData>({
         <IconArrowsSort size={14} />
     );
 };
+
+export const MantineReactTable = InHouseTable;
 
 const HeaderContent = <TData extends RowData>({
     header,

--- a/packages/frontend/src/components/common/InHouseTable/InHouseTable.tsx
+++ b/packages/frontend/src/components/common/InHouseTable/InHouseTable.tsx
@@ -241,8 +241,6 @@ const SortIcon = <TData extends RowData>({
     );
 };
 
-export const MantineReactTable = InHouseTable;
-
 const HeaderContent = <TData extends RowData>({
     header,
 }: {
@@ -971,3 +969,5 @@ export const InHouseTable = <TData extends RowData>({
         </Paper>
     );
 };
+
+export const MantineReactTable = InHouseTable;

--- a/packages/frontend/src/components/common/InHouseTable/InHouseTable.tsx
+++ b/packages/frontend/src/components/common/InHouseTable/InHouseTable.tsx
@@ -53,6 +53,8 @@ type SanitizedMantineProps<TElement extends HTMLElement> = Omit<
     style?: CSSProperties;
 };
 
+export const MantineReactTable = InHouseTable;
+
 const assignRef = <TElement,>(
     ref: React.Ref<TElement> | undefined,
     value: TElement | null,

--- a/packages/frontend/src/components/common/InHouseTable/index.ts
+++ b/packages/frontend/src/components/common/InHouseTable/index.ts
@@ -1,5 +1,5 @@
-export { InHouseTable } from './InHouseTable';
-export { useInHouseTable } from './useInHouseTable';
+export { InHouseTable, MantineReactTable } from './InHouseTable';
+export { useInHouseTable, useMantineReactTable } from './useInHouseTable';
 export type {
     InHouseTableColumnDef,
     InHouseTableInstance,

--- a/packages/frontend/src/components/common/InHouseTable/useInHouseTable.tsx
+++ b/packages/frontend/src/components/common/InHouseTable/useInHouseTable.tsx
@@ -37,6 +37,8 @@ const toRenderedValue = (value: unknown): ReactNode => {
     return value as ReactNode;
 };
 
+export const useMantineReactTable = useInHouseTable;
+
 const resolveNextState = <TValue,>(
     updater: TValue | ((old: TValue) => TValue),
     previous: TValue,

--- a/packages/frontend/src/components/common/InHouseTable/useInHouseTable.tsx
+++ b/packages/frontend/src/components/common/InHouseTable/useInHouseTable.tsx
@@ -37,8 +37,6 @@ const toRenderedValue = (value: unknown): ReactNode => {
     return value as ReactNode;
 };
 
-export const useMantineReactTable = useInHouseTable;
-
 const resolveNextState = <TValue,>(
     updater: TValue | ((old: TValue) => TValue),
     previous: TValue,
@@ -497,3 +495,5 @@ export const useInHouseTable = <TData extends RowData>(
 
     return table;
 };
+
+export const useMantineReactTable = useInHouseTable;

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -38,14 +38,6 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
-    type MRT_TableOptions,
-    type MRT_Virtualizer,
-} from 'mantine-react-table';
-import {
     useCallback,
     useDeferredValue,
     useEffect,
@@ -64,6 +56,14 @@ import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFla
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { useValidationUserAbility } from '../../../hooks/validation/useValidation';
 import useApp from '../../../providers/App/useApp';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_SortingState,
+    type MRT_TableOptions,
+    type MRT_Virtualizer,
+} from '../InHouseTable';
 import MantineIcon from '../MantineIcon';
 import TransferItemsModal from '../TransferItemsModal/TransferItemsModal';
 import AdminContentViewFilter from './AdminContentViewFilter';
@@ -535,31 +535,8 @@ const InfiniteResourceTable = ({
         mantineTableBodyRowProps: ({ row }) => {
             const isTableSelectionActive =
                 table.getIsSomeRowsSelected() || table.getIsAllRowsSelected();
-            const isSelected = row.getIsSelected();
 
             return {
-                sx: {
-                    cursor: 'pointer',
-                    'td:first-of-type > div > .explore-button-container': {
-                        visibility: 'hidden',
-                        opacity: 0,
-                    },
-                    '&:hover': {
-                        td: isSelected
-                            ? {}
-                            : {
-                                  backgroundColor: theme.colors.ldGray[0],
-                                  transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                              },
-
-                        'td:first-of-type > div > .explore-button-container': {
-                            visibility: 'visible',
-                            opacity: 1,
-                            transition: `visibility 0ms, opacity ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                        },
-                    },
-                },
-
                 onClick: () => {
                     if (isTableSelectionActive) {
                         row.toggleSelected();
@@ -788,7 +765,7 @@ const InfiniteResourceTable = ({
             columnVisibility: defaultColumnVisibility,
         },
         rowVirtualizerInstanceRef,
-        rowVirtualizerProps: { overscan: 40 },
+        rowVirtualizerProps: { estimateSize: () => 72, overscan: 40 },
         displayColumnDefOptions: {
             'mrt-row-actions': {
                 header: '',

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -188,6 +188,7 @@ const InfiniteResourceTableColumnName = ({
                 <Stack gap={2}>
                     <Group gap="xs" wrap="nowrap">
                         <Text
+                            fz="sm"
                             fw={600}
                             lineClamp={1}
                             style={{ overflowWrap: 'anywhere' }}

--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -1,8 +1,8 @@
 import { type CatalogField } from '@lightdash/common';
 import { Button, Tooltip } from '@mantine/core';
-import { type MRT_Row } from 'mantine-react-table';
 import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+import { type MRT_Row } from '../../../components/common/InHouseTable';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
@@ -9,8 +9,8 @@ import {
 import MarkdownPreview, {
     type MarkdownPreviewProps,
 } from '@uiw/react-markdown-preview';
-import { type MRT_TableInstance } from 'mantine-react-table';
 import { useEffect, useRef, type FC } from 'react';
+import { type MRT_TableInstance } from '../../../components/common/InHouseTable';
 import { useLockScroll } from '../../../hooks/useLockScroll';
 
 type Props = {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.module.css
@@ -1,3 +1,20 @@
 .noSelect {
     user-select: none;
 }
+
+.floatingTooltip {
+    position: fixed;
+    z-index: 10000;
+    width: max-content;
+    max-width: 250px;
+    padding: 4px 8px;
+    color: var(--mantine-color-white);
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    line-height: 1.3;
+    background-color: var(--mantine-color-dark-7);
+    border-radius: var(--mantine-radius-sm);
+    box-shadow: var(--mantine-shadow-sm);
+    pointer-events: none;
+    white-space: normal;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.tsx
@@ -1,31 +1,89 @@
-import { Group, Text, Tooltip } from '@mantine-8/core';
-import { type FC, type SVGProps } from 'react';
+import { Group, Text } from '@mantine-8/core';
+import {
+    useCallback,
+    useEffect,
+    type FC,
+    type MouseEvent,
+    type ReactNode,
+    type SVGProps,
+} from 'react';
 import styles from './MetricCatalogColumnHeaderCell.module.css';
+
+let tooltipElement: HTMLDivElement | null = null;
+
+const getTooltipElement = () => {
+    if (!tooltipElement) {
+        tooltipElement = document.createElement('div');
+        tooltipElement.className = styles.floatingTooltip;
+        document.body.appendChild(tooltipElement);
+    }
+
+    return tooltipElement;
+};
+
+const hideTooltip = () => {
+    tooltipElement?.remove();
+    tooltipElement = null;
+};
+
+const showTooltip = (label: string, target: HTMLElement) => {
+    const element = getTooltipElement();
+    const rect = target.getBoundingClientRect();
+
+    element.textContent = label;
+    element.style.left = `${rect.left}px`;
+    element.style.top = `${rect.bottom + 8}px`;
+
+    const tooltipRect = element.getBoundingClientRect();
+    const overflowRight = tooltipRect.right - window.innerWidth + 8;
+
+    if (overflowRight > 0) {
+        element.style.left = `${Math.max(8, rect.left - overflowRight)}px`;
+    }
+};
 
 export const MetricCatalogColumnHeaderCell = ({
     children,
+    disabled,
     Icon,
     tooltipLabel,
 }: {
-    children: React.ReactNode;
+    children: ReactNode;
+    disabled?: boolean;
     tooltipLabel?: string;
     Icon: FC<SVGProps<SVGSVGElement>>;
 }) => {
+    const handleShowTooltip = useCallback(
+        (event: MouseEvent<HTMLElement>) => {
+            if (!tooltipLabel || disabled) return;
+
+            showTooltip(tooltipLabel, event.currentTarget);
+        },
+        [disabled, tooltipLabel],
+    );
+
+    useEffect(() => {
+        if (disabled) hideTooltip();
+
+        return hideTooltip;
+    }, [disabled]);
+
     return (
-        <Tooltip
-            variant="xs"
-            label={tooltipLabel}
-            disabled={!tooltipLabel}
-            openDelay={200}
-            maw={250}
-            fz="xs"
+        <Group
+            gap={6}
+            h="100%"
+            mr={6}
+            onBlur={hideTooltip}
+            onFocus={handleShowTooltip}
+            onMouseDown={hideTooltip}
+            onMouseEnter={handleShowTooltip}
+            onMouseLeave={hideTooltip}
+            wrap="nowrap"
         >
-            <Group gap={6} mr={6} h="100%" wrap="nowrap">
-                <Icon />
-                <Text fz="xs" fw={600} c="ldGray.7" className={styles.noSelect}>
-                    {children}
-                </Text>
-            </Group>
-        </Tooltip>
+            <Icon />
+            <Text fz="xs" fw={600} c="ldGray.7" className={styles.noSelect}>
+                {children}
+            </Text>
+        </Group>
     );
 };

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.tsx
@@ -3,9 +3,9 @@ import {
     useCallback,
     useEffect,
     type FC,
-    type MouseEvent,
     type ReactNode,
     type SVGProps,
+    type SyntheticEvent,
 } from 'react';
 import styles from './MetricCatalogColumnHeaderCell.module.css';
 
@@ -54,7 +54,7 @@ export const MetricCatalogColumnHeaderCell = ({
     Icon: FC<SVGProps<SVGSVGElement>>;
 }) => {
     const handleShowTooltip = useCallback(
-        (event: MouseEvent<HTMLElement>) => {
+        (event: SyntheticEvent<HTMLElement>) => {
             if (!tooltipLabel || disabled) return;
 
             showTooltip(tooltipLabel, event.currentTarget);

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
@@ -1,6 +1,6 @@
 import { type CatalogField } from '@lightdash/common';
 import { Button, Text, Tooltip } from '@mantine-8/core';
-import { type MRT_Row } from 'mantine-react-table';
+import { type MRT_Row } from '../../../components/common/InHouseTable';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { BarChart } from '../../../svgs/metricsCatalog';
 import { EventName } from '../../../types/Events';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
@@ -3,8 +3,11 @@ import { Box, Text, useMantineTheme } from '@mantine/core';
 import MarkdownPreview, {
     type MarkdownPreviewProps,
 } from '@uiw/react-markdown-preview';
-import { type MRT_Row, type MRT_TableInstance } from 'mantine-react-table';
 import { useRef, useState, type FC } from 'react';
+import {
+    type MRT_Row,
+    type MRT_TableInstance,
+} from '../../../components/common/InHouseTable';
 import { useIsLineClamped } from '../../../hooks/useIsLineClamped';
 import { useAppDispatch, useAppSelector } from '../../sqlRunner/store/hooks';
 import { setDescriptionPopoverIsClosing } from '../store/metricsCatalogSlice';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -16,8 +16,11 @@ import EmojiPicker, {
     EmojiStyle,
     type EmojiClickData,
 } from 'emoji-picker-react';
-import { type MRT_Row, type MRT_TableInstance } from 'mantine-react-table';
 import { forwardRef, useCallback, useEffect, useState } from 'react';
+import {
+    type MRT_Row,
+    type MRT_TableInstance,
+} from '../../../components/common/InHouseTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { MetricIconPlaceholder } from '../../../svgs/metricsCatalog';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnOwner.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnOwner.tsx
@@ -1,8 +1,8 @@
 import { type CatalogField } from '@lightdash/common';
 import { Group, Paper, Text, Tooltip } from '@mantine-8/core';
-import { type MRT_Row } from 'mantine-react-table';
 import { type FC } from 'react';
 import { LightdashUserAvatar } from '../../../components/Avatar';
+import { type MRT_Row } from '../../../components/common/InHouseTable';
 
 type Props = {
     row: MRT_Row<CatalogField>;

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -2,8 +2,8 @@ import { SpotlightTableColumns, type CatalogField } from '@lightdash/common';
 import { Box, Button, Flex, Group, Text } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconPlus, IconUser } from '@tabler/icons-react';
-import { type MRT_ColumnDef } from 'mantine-react-table';
 import { useMemo } from 'react';
+import { type MRT_ColumnDef } from '../../../components/common/InHouseTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import {
     createMetricPreviewUnsavedChartVersion,
@@ -72,8 +72,14 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
         enableSorting: true,
         enableEditing: false,
         size: 150,
-        Header: ({ column }) => (
-            <MetricCatalogColumnHeaderCell Icon={Table} tooltipLabel="Table">
+        Header: ({ column, table }) => (
+            <MetricCatalogColumnHeaderCell
+                disabled={Boolean(
+                    table.getState().columnSizingInfo.isResizingColumn,
+                )}
+                Icon={Table}
+                tooltipLabel="Table"
+            >
                 {column.columnDef.header}
             </MetricCatalogColumnHeaderCell>
         ),
@@ -140,8 +146,11 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
         size: 400,
         minSize: 200,
         header: 'Description',
-        Header: ({ column }) => (
+        Header: ({ column, table }) => (
             <MetricCatalogColumnHeaderCell
+                disabled={Boolean(
+                    table.getState().columnSizingInfo.isResizingColumn,
+                )}
                 Icon={Description}
                 tooltipLabel="Defined in the metric's .yml file"
             >
@@ -162,16 +171,21 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
         mantineTableBodyCellProps: () => {
             return {
                 pos: 'relative',
-                sx: {
+                style: {
                     padding: 0,
+                },
+                sx: {
                     '&:hover': {
                         outline: 'none',
                     },
                 },
             };
         },
-        Header: ({ column }) => (
+        Header: ({ column, table }) => (
             <MetricCatalogColumnHeaderCell
+                disabled={Boolean(
+                    table.getState().columnSizingInfo.isResizingColumn,
+                )}
                 Icon={Tag}
                 tooltipLabel="Categories help you organize your metrics and KPIs. Click on the cell to add or edit a category, if you have the required permissions."
             >
@@ -313,15 +327,19 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
         enableEditing: false,
         size: 150,
         minSize: 100,
+        maxSize: 150,
         mantineTableBodyCellProps: () => {
             return {
-                sx: {
-                    justifyContent: 'center',
+                style: {
+                    textAlign: 'center',
                 },
             };
         },
-        Header: ({ column }) => (
+        Header: ({ column, table }) => (
             <MetricCatalogColumnHeaderCell
+                disabled={Boolean(
+                    table.getState().columnSizingInfo.isResizingColumn,
+                )}
                 Icon={Popularity}
                 tooltipLabel="Shows how many charts use this metric"
             >
@@ -337,8 +355,12 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
         enableEditing: false,
         size: 200,
         minSize: 100,
-        Header: ({ column }) => (
+        maxSize: 200,
+        Header: ({ column, table }) => (
             <MetricCatalogColumnHeaderCell
+                disabled={Boolean(
+                    table.getState().columnSizingInfo.isResizingColumn,
+                )}
                 Icon={() => (
                     <MantineIcon icon={IconUser} size={14} color="ldGray.5" />
                 )}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -209,7 +209,10 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
     const [lastDbtRefreshAt, setLastDbtRefreshAt] = useState<
         Date | undefined
     >();
-    const timeAgo = useTimeAgo(lastDbtRefreshAt || new Date());
+    const fallbackLastDbtRefreshAtRef = useRef(new Date());
+    const timeAgo = useTimeAgo(
+        lastDbtRefreshAt ?? fallbackLastDbtRefreshAtRef.current,
+    );
     const params = useParams<{ projectUuid: string }>();
     const { data: project } = useProject(projectUuid);
     const { user } = useApp();

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -13,7 +13,6 @@ import {
     Paper,
     Text,
     useMantineTheme,
-    type PaperProps,
 } from '@mantine/core';
 import {
     IconArrowDown,
@@ -21,12 +20,6 @@ import {
     IconArrowUp,
 } from '@tabler/icons-react';
 import { useIsMutating } from '@tanstack/react-query';
-import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_SortingState,
-    type MRT_Virtualizer,
-} from 'mantine-react-table';
 import {
     useCallback,
     useDeferredValue,
@@ -37,6 +30,12 @@ import {
     type FC,
     type UIEvent,
 } from 'react';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_SortingState,
+    type MRT_Virtualizer,
+} from '../../../components/common/InHouseTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -233,7 +232,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
     };
 
     // Reusable paper props to avoid duplicate when rendering tree view
-    const mantinePaperProps: PaperProps = useMemo(
+    const mantinePaperProps = useMemo(
         () => ({
             shadow: undefined,
             sx: {
@@ -241,7 +240,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                 borderRadius: theme.spacing.sm, // ! radius doesn't have rem(12) -> 0.75rem
                 boxShadow: theme.shadows.subtle,
                 display: 'flex',
-                flexDirection: 'column',
+                flexDirection: 'column' as const,
             },
         }),
         [theme],
@@ -435,26 +434,6 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                 },
             },
         },
-        mantineTableBodyRowProps: {
-            sx: {
-                'td:first-of-type > div > .explore-button-container': {
-                    visibility: 'hidden',
-                    opacity: 0,
-                },
-                '&:hover': {
-                    td: {
-                        backgroundColor: theme.colors.ldGray[0],
-                        transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                    },
-
-                    'td:first-of-type > div > .explore-button-container': {
-                        visibility: 'visible',
-                        opacity: 1,
-                        transition: `visibility 0ms, opacity ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                    },
-                },
-            },
-        },
         mantineTableBodyCellProps: (props) => {
             const isLastVisibleColumn =
                 props.table
@@ -596,7 +575,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
             showGlobalFilter: true, // Show search input by default
         },
         rowVirtualizerInstanceRef,
-        rowVirtualizerProps: { overscan: 40 },
+        rowVirtualizerProps: { estimateSize: () => 72, overscan: 40 },
         displayColumnDefOptions: {
             'mrt-row-actions': {
                 header: '',

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -46,10 +46,10 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import isEqual from 'lodash/isEqual';
-import { type MRT_TableInstance } from 'mantine-react-table';
 import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useDebounce } from 'react-use';
+import { type MRT_TableInstance } from '../../../../components/common/InHouseTable';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { TotalMetricsDot } from '../../../../svgs/metricsCatalog';

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -7,7 +7,7 @@ import {
     type SpotlightTableConfig,
 } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import type { MRT_SortingState } from 'mantine-react-table';
+import type { MRT_SortingState } from '../../../components/common/InHouseTable';
 import type { UserWithAbility } from '../../../hooks/user/useUser';
 import { SavedTreeEditMode } from '../types';
 

--- a/packages/frontend/src/hooks/useTimeAgo.ts
+++ b/packages/frontend/src/hooks/useTimeAgo.ts
@@ -1,5 +1,5 @@
 import { formatDistanceToNow, parseISO } from 'date-fns';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useInterval } from 'react-use';
 
 export const useTimeAgo = (
@@ -21,14 +21,23 @@ export const useTimeAgo = (
     }, [parsed]);
 
     const [timeAgo, setTimeAgo] = useState<string>(getTimeAgo());
+    const timeAgoRef = useRef(timeAgo);
+    const updateTimeAgo = useCallback(() => {
+        const nextTimeAgo = getTimeAgo();
+
+        if (timeAgoRef.current === nextTimeAgo) return;
+
+        timeAgoRef.current = nextTimeAgo;
+        setTimeAgo(nextTimeAgo);
+    }, [getTimeAgo]);
 
     useInterval(() => {
-        setTimeAgo(getTimeAgo());
+        updateTimeAgo();
     }, interval);
 
     useEffect(() => {
-        setTimeAgo(getTimeAgo());
-    }, [parsed, getTimeAgo]);
+        updateTimeAgo();
+    }, [parsed, updateTimeAgo]);
 
     return timeAgo;
 };


### PR DESCRIPTION
## Summary

Stacks on #23314 and migrates the Resource View and Metrics Catalog/Spotlight table paths to the in-house content table wrapper.

This PR covers:
- `InfiniteResourceTable`, including virtualized infinite scrolling, selection placement, row actions, cell editing, and bottom loaded-state toolbar behavior
- Metrics Catalog/Spotlight tables, including hover-only Explore actions, editable category cells, description overlays, usage buttons, and toolbar integration
- resize/perf hardening for the metrics table path, including memoized body rows during column resizing
- the Metrics Catalog header tooltip fix that avoids Mantine Tooltip ref churn while column resizing
- stable `useTimeAgo` behavior for the metrics panel during resize rerenders
- removal of the now-unused `useIsLineClamped` hook after the metrics description interaction no longer depends on clamping detection

## Validation

- `pnpm --dir packages/frontend run linter src/components/common/ResourceView/InfiniteResourceTable.tsx src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx src/features/metricsCatalog/components src/features/metricsCatalog/store/metricsCatalogSlice.ts src/hooks/useTimeAgo.ts`
- `pnpm --dir packages/frontend run linter src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx src/hooks/useTimeAgo.ts`
- `git diff --check`

## Notes

This is intentionally stacked on the table core PR. Dependency removal stays out until every MRT call site has moved.