### PR TITLE
refactor: migrate AI admin tables to content table

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -25,14 +25,14 @@ import {
     IconUser,
     IconUsers,
 } from '@tabler/icons-react';
+import { useDeferredValue, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
-} from 'mantine-react-table';
-import { useDeferredValue, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
-import { LightdashUserAvatar } from '../../../../../components/Avatar';
+} from '../../../../../components/common/InHouseTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
     useGetSlack,
@@ -503,9 +503,6 @@ const AiAgentAdminAgentsTable = () => {
         mantineTableContainerProps: {
             style: {
                 maxHeight: 'calc(100dvh - 350px)',
-                minHeight: '600px',
-                display: 'flex',
-                flexDirection: 'column',
             },
         },
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -31,13 +31,6 @@ import {
     IconUser,
 } from '@tabler/icons-react';
 import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
-    type MRT_Virtualizer,
-} from 'mantine-react-table';
-import {
     useCallback,
     useDeferredValue,
     useEffect,
@@ -48,6 +41,13 @@ import {
 } from 'react';
 import { useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_SortingState,
+    type MRT_Virtualizer,
+} from '../../../../../components/common/InHouseTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useGetSlack } from '../../../../../hooks/slack/useSlack';
 import { useIsTruncated } from '../../../../../hooks/useIsTruncated';
@@ -600,19 +600,11 @@ const AiAgentAdminThreadsTable = ({
             const isSelected = selectedThread?.uuid === thread.uuid;
 
             return {
-                sx: {
+                style: {
                     cursor: 'pointer',
-                    '&:hover': {
-                        td: {
-                            backgroundColor: theme.colors.ldGray[0],
-                            transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                        },
-                    },
-                    ...(isSelected && {
-                        td: {
-                            backgroundColor: theme.colors.ldGray[1],
-                        },
-                    }),
+                    backgroundColor: isSelected
+                        ? theme.colors.ldGray[1]
+                        : undefined,
                 },
                 onClick: () => {
                     setSelectedThread?.(thread);
@@ -720,7 +712,7 @@ const AiAgentAdminThreadsTable = ({
             showGlobalFilter: true,
         },
         rowVirtualizerInstanceRef,
-        rowVirtualizerProps: { overscan: 40 },
+        rowVirtualizerProps: { estimateSize: () => 72, overscan: 40 },
         enableFilterMatchHighlighting: true,
         enableRowActions: false,
     });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
@@ -12,13 +12,13 @@ import {
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import { IconCircleX, IconDots, IconEye } from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import { useNavigate, useParams } from 'react-router';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
-} from 'mantine-react-table';
-import { useCallback, useMemo, useState, type FC } from 'react';
-import { useNavigate, useParams } from 'react-router';
+} from '../../../../../components/common/InHouseTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
@@ -16,13 +16,13 @@ import {
 } from '@mantine-8/core';
 import { IconPoint, IconPointFilled, IconTarget } from '@tabler/icons-react';
 import dayjs from 'dayjs';
+import { useMemo, type FC } from 'react';
+import { useNavigate } from 'react-router';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
-} from 'mantine-react-table';
-import { useMemo, type FC } from 'react';
-import { useNavigate } from 'react-router';
+} from '../../../../../components/common/InHouseTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
     useAiAgentEvaluationRunResults,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRuns.tsx
@@ -18,13 +18,13 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
+import { useMemo, type FC } from 'react';
+import { useNavigate } from 'react-router';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
-} from 'mantine-react-table';
-import { useMemo, type FC } from 'react';
-import { useNavigate } from 'react-router';
+} from '../../../../../components/common/InHouseTable';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
     useAiAgentEvaluationRuns,

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -41,13 +41,13 @@ import {
     IconUser,
     IconX,
 } from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import { Link } from 'react-router';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
-} from 'mantine-react-table';
-import { useCallback, useMemo, useState, type FC } from 'react';
-import { Link } from 'react-router';
+} from '../../../components/common/InHouseTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useCustomRoles } from '../customRoles/useCustomRoles';
 import { ProjectsHoverCard } from './ProjectsHoverCard';


### PR DESCRIPTION
## Summary

Stacks on #23315 and migrates the AI/admin-facing tables to the in-house content table wrapper.

This PR covers:
- AI Agent admin agents and threads tables
- verified artifacts table
- eval runs and eval run details tables
- service accounts table

It preserves the admin table behavior exercised during the migration: dense layouts, one-row views, selected-row backgrounds, row click affordances, virtualized infinite thread lists, and action/menu columns.

## Validation

- `pnpm --dir packages/frontend run linter src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx src/ee/features/aiCopilot/components/Evals/EvalRuns.tsx src/ee/features/serviceAccounts/ServiceAccountsTable.tsx`
- `git diff --cached --check`

## Notes

This remains stacked and does not remove the old dependency yet.