### PR TITLE
feat: migrate operational tables to content table

### DIFF
--- a/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
@@ -13,13 +13,6 @@ import {
 } from '@tabler/icons-react';
 import { format } from 'date-fns';
 import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
-    type MRT_Virtualizer,
-} from 'mantine-react-table';
-import {
     useCallback,
     useEffect,
     useMemo,
@@ -33,6 +26,13 @@ import {
     useProjectCompileLogs,
     type ProjectCompileLog,
 } from '../../hooks/useProjectCompileLogs';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_SortingState,
+    type MRT_Virtualizer,
+} from '../common/InHouseTable';
 import MantineIcon from '../common/MantineIcon';
 import { CompilationHistoryTopToolbar } from './CompilationHistoryTopToolbar';
 import { CompilationLogDrawer } from './CompilationLogDrawer';
@@ -111,14 +111,6 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
 
     const totalDBRowCount = data?.pages?.[0]?.pagination?.totalResults ?? 0;
     const totalFetched = compileLogs.length;
-
-    // Temporary workaround to resolve a memoization issue with react-mantine-table.
-    // In certain scenarios, the content fails to render properly even when the data is updated.
-    // This issue may be addressed in a future library update.
-    const [tableData, setTableData] = useState<ProjectCompileLog[]>([]);
-    useEffect(() => {
-        setTableData(compileLogs);
-    }, [compileLogs]);
 
     // Callback to fetch more data when scrolling
     const fetchMoreOnBottomReached = useCallback(
@@ -276,7 +268,7 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
 
     const table = useMantineReactTable({
         columns,
-        data: tableData,
+        data: compileLogs,
         enableColumnResizing: false,
         enableRowNumbers: false,
         enablePagination: false,
@@ -376,7 +368,7 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
             ),
         },
         rowVirtualizerInstanceRef,
-        rowVirtualizerProps: { overscan: 10 },
+        rowVirtualizerProps: { estimateSize: () => 40, overscan: 10 },
         state: {
             isLoading,
             showAlertBanner: isError,

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
@@ -12,13 +12,13 @@ import {
     IconTable,
     IconTarget,
 } from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
     type MRT_SortingState,
-} from 'mantine-react-table';
-import { useCallback, useMemo, useState, type FC } from 'react';
+} from '../common/InHouseTable';
 import MantineIcon from '../common/MantineIcon';
 import {
     aggregateStats,

--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -42,12 +42,6 @@ import {
     IconTable,
 } from '@tabler/icons-react';
 import cronstrue from 'cronstrue';
-import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
-} from 'mantine-react-table';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { usePreAggregateMaterializations } from '../../hooks/usePreAggregateMaterializations';
 import {
@@ -59,6 +53,12 @@ import { useTimeAgo } from '../../hooks/useTimeAgo';
 import useSchedulerJobsContext from '../../providers/SchedulerJobs/useSchedulerJobsContext';
 import { formatDuration, formatFileSize } from '../../utils/formatters';
 import Callout from '../common/Callout';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_SortingState,
+} from '../common/InHouseTable';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';

--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -24,12 +24,6 @@ import {
     IconTextCaption,
 } from '@tabler/icons-react';
 import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_ColumnDef,
-    type MRT_Virtualizer,
-} from 'mantine-react-table';
-import {
     useCallback,
     useEffect,
     useMemo,
@@ -48,6 +42,12 @@ import {
     useSendNowSchedulerByUuid,
 } from '../../features/scheduler/hooks/useScheduler';
 import EmptyStateLoader from '../common/EmptyStateLoader';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_Virtualizer,
+} from '../common/InHouseTable';
 import MantineIcon from '../common/MantineIcon';
 import { LogsTopToolbar } from './LogsTopToolbar';
 import RunDetailsModal from './RunDetailsModal';
@@ -702,7 +702,7 @@ const LogsTable: FC<LogsTableProps> = ({
             },
         }),
         rowVirtualizerInstanceRef,
-        rowVirtualizerProps: { overscan: 10 },
+        rowVirtualizerProps: { estimateSize: () => 48, overscan: 10 },
         state: {
             isLoading,
             showAlertBanner: isError,

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -34,13 +34,6 @@ import {
     IconUser,
 } from '@tabler/icons-react';
 import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_ColumnDef,
-    type MRT_SortingState,
-    type MRT_Virtualizer,
-} from 'mantine-react-table';
-import {
     useCallback,
     useEffect,
     useMemo,
@@ -57,6 +50,13 @@ import { useProject } from '../../hooks/useProject';
 import GSheetsSvg from '../../svgs/google-sheets.svg?react';
 import GoogleChatSvg from '../../svgs/googlechat.svg?react';
 import SlackSvg from '../../svgs/slack.svg?react';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_SortingState,
+    type MRT_Virtualizer,
+} from '../common/InHouseTable';
 import MantineIcon from '../common/MantineIcon';
 import ReassignSchedulerOwnerModal from './ReassignSchedulerOwnerModal';
 import SchedulersViewActionMenu from './SchedulersViewActionMenu';
@@ -143,12 +143,6 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
     const totalDBRowCount = data?.pages?.[0]?.pagination?.totalResults ?? 0;
     const totalFetched = flatData.length;
     const { data: project } = useProject(projectUuid);
-
-    // Temporary workaround to resolve a memoization issue with react-mantine-table.
-    const [tableData, setTableData] = useState<SchedulerItem[]>([]);
-    useEffect(() => {
-        setTableData(flatData);
-    }, [flatData]);
 
     // Reassign owner modal state
     const [reassignModalOpen, setReassignModalOpen] = useState(false);
@@ -798,7 +792,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
 
     const table = useMantineReactTable({
         columns,
-        data: tableData,
+        data: flatData,
         enableColumnResizing: true,
         enableRowNumbers: false,
         enablePagination: false,
@@ -862,7 +856,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
         },
         mantineTableProps: {
             highlightOnHover: true,
-            withColumnBorders: Boolean(tableData.length),
+            withColumnBorders: Boolean(flatData.length),
         },
         mantineTableHeadCellProps: (props) => {
             const isLastColumn =
@@ -969,7 +963,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
             ),
         },
         rowVirtualizerInstanceRef,
-        rowVirtualizerProps: { overscan: 10 },
+        rowVirtualizerProps: { estimateSize: () => 72, overscan: 10 },
         state: {
             sorting,
             isLoading,

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -26,21 +26,20 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_ColumnDef,
-    type MRT_Virtualizer,
-} from 'mantine-react-table';
-import {
     useCallback,
     useEffect,
     useMemo,
     useRef,
-    useState,
     type FC,
     type UIEvent,
 } from 'react';
 import { useDeleteValidation } from '../../../hooks/validation/useValidation';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_Virtualizer,
+} from '../../common/InHouseTable';
 import MantineIcon from '../../common/MantineIcon';
 import { ChartIcon, IconBox } from '../../common/ResourceIcon';
 import { getLinkToResource } from '../utils/utils';
@@ -153,12 +152,6 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
         }
         return data;
     }, [data, pinnedValidation]);
-
-    // Workaround for memoization issue with mantine-react-table
-    const [displayData, setDisplayData] = useState<ValidationResponse[]>([]);
-    useEffect(() => {
-        setDisplayData(tableData);
-    }, [tableData]);
 
     const totalFetched = data.length;
 
@@ -331,7 +324,7 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
 
     const table = useMantineReactTable({
         columns,
-        data: displayData,
+        data: tableData,
         enableColumnResizing: false,
         enableRowNumbers: false,
         enablePagination: false,
@@ -406,7 +399,7 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
             ),
         },
         rowVirtualizerInstanceRef,
-        rowVirtualizerProps: { overscan: 10 },
+        rowVirtualizerProps: { estimateSize: () => 44, overscan: 10 },
         state: {
             isLoading,
             showAlertBanner: isError,

--- a/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
+++ b/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
@@ -19,11 +19,6 @@ import {
     IconDots,
     IconLayoutDashboard,
 } from '@tabler/icons-react';
-import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_ColumnDef,
-} from 'mantine-react-table';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import {
@@ -31,6 +26,11 @@ import {
     useUnverifyDashboardMutation,
 } from '../../hooks/useContentVerification';
 import { useVerifiedContentList } from '../../hooks/useVerifiedContentList';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+} from '../common/InHouseTable';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';

--- a/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
+++ b/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
@@ -25,12 +25,12 @@ import {
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { useMemo, type FC } from 'react';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
-} from 'mantine-react-table';
-import { useMemo, type FC } from 'react';
+} from '../../../components/common/InHouseTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
@@ -347,7 +347,7 @@ export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
         enableTopToolbar: false,
         mantinePaperProps: {
             shadow: undefined,
-            sx: {
+            style: {
                 border: `1px solid ${theme.colors.ldGray[2]}`,
                 borderRadius: theme.spacing.sm,
                 boxShadow: theme.shadows.subtle,
@@ -356,7 +356,7 @@ export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
             },
         },
         mantineTableContainerProps: {
-            sx: {
+            style: {
                 maxHeight: 500,
                 minHeight: '300px',
                 display: 'flex',
@@ -368,27 +368,14 @@ export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
             withColumnBorders: Boolean(allChanges.length),
         },
         mantineTableHeadRowProps: {
-            sx: {
+            style: {
                 boxShadow: 'none',
-                'th > div > div:last-child': {
-                    top: -10,
-                    right: -5,
-                },
-                'th > div > div:last-child > .mantine-Divider-root': {
-                    border: 'none',
-                },
             },
         },
         mantineTableHeadCellProps: (props) => {
-            const isAnyColumnResizing = props.table
-                .getAllColumns()
-                .some((c) => c.getIsResizing());
-
             const isLastColumn =
                 props.table.getAllColumns().indexOf(props.column) ===
                 props.table.getAllColumns().length - 1;
-
-            const canResize = props.column.getCanResize();
 
             return {
                 bg: 'ldGray.0',
@@ -407,30 +394,14 @@ export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
                           }`,
                     borderTop: 'none',
                     borderLeft: 'none',
-                },
-                sx: {
                     justifyContent: 'center',
-                    '&:hover': canResize
-                        ? {
-                              borderRight: !isAnyColumnResizing
-                                  ? `2px solid ${theme.colors.blue[3]} !important`
-                                  : undefined,
-                              transition: `border-right ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                          }
-                        : {},
                 },
             };
         },
         mantineTableBodyRowProps: () => {
             return {
-                sx: {
+                style: {
                     cursor: 'pointer',
-                    '&:hover': {
-                        td: {
-                            backgroundColor: theme.colors.ldGray[0],
-                            transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                        },
-                    },
                 },
             };
         },

--- a/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
@@ -30,12 +30,6 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import {
-    MantineReactTable,
-    useMantineReactTable,
-    type MRT_ColumnDef,
-    type MRT_Virtualizer,
-} from 'mantine-react-table';
-import {
     useCallback,
     useEffect,
     useMemo,
@@ -45,6 +39,12 @@ import {
     type UIEvent,
 } from 'react';
 import Callout from '../../../components/common/Callout';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_Virtualizer,
+} from '../../../components/common/InHouseTable';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { ChartIcon, IconBox } from '../../../components/common/ResourceIcon';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
@@ -189,14 +189,6 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
 
     const totalDBRowCount = data?.pages?.[0]?.pagination?.totalResults ?? 0;
     const totalFetched = flatData.length;
-
-    // Workaround for memoization issue with mantine-react-table
-    const [tableData, setTableData] = useState<DeletedContentWithDescendants[]>(
-        [],
-    );
-    useEffect(() => {
-        setTableData(flatData);
-    }, [flatData]);
 
     const { mutate: restoreContent, isLoading: isRestoring } =
         useRestoreDeletedContent(projectUuid);
@@ -487,7 +479,7 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
 
     const table = useMantineReactTable({
         columns,
-        data: tableData,
+        data: flatData,
         enableColumnResizing: true,
         enableRowNumbers: false,
         enablePagination: false,
@@ -532,7 +524,7 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
         },
         mantineTableProps: {
             highlightOnHover: true,
-            withColumnBorders: Boolean(tableData.length),
+            withColumnBorders: Boolean(flatData.length),
         },
         mantineTableHeadCellProps: (props) => {
             const isLastColumn =
@@ -648,7 +640,7 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
             </Group>
         ),
         rowVirtualizerInstanceRef,
-        rowVirtualizerProps: { overscan: 10 },
+        rowVirtualizerProps: { estimateSize: () => 72, overscan: 10 },
         state: {
             isLoading,
             showAlertBanner: isError,

--- a/packages/frontend/src/pages/DashboardVersionComparison.tsx
+++ b/packages/frontend/src/pages/DashboardVersionComparison.tsx
@@ -34,14 +34,14 @@ import {
     IconLayoutDashboard,
     IconSearch,
 } from '@tabler/icons-react';
+import { useMemo, useRef, useState } from 'react';
+import { EmptyState } from '../components/common/EmptyState';
+import { getConditionalRuleLabel } from '../components/common/Filters/FilterInputs/utils';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
-} from 'mantine-react-table';
-import { useMemo, useRef, useState } from 'react';
-import { EmptyState } from '../components/common/EmptyState';
-import { getConditionalRuleLabel } from '../components/common/Filters/FilterInputs/utils';
+} from '../components/common/InHouseTable';
 import MantineIcon from '../components/common/MantineIcon';
 import {
     useDashboardQuery,
@@ -368,6 +368,7 @@ const TilesTable = ({ data }: { data: any[] }) => {
         enableGlobalFilterModes: false,
         enableTopToolbar: true,
         enableBottomToolbar: false,
+        rowVirtualizerProps: { estimateSize: () => 40, overscan: 10 },
         initialState: {
             density: 'xs',
         },
@@ -766,6 +767,7 @@ const FiltersTable = ({ data }: { data: any[] }) => {
         enableGlobalFilterModes: false,
         enableTopToolbar: true,
         enableBottomToolbar: false,
+        rowVirtualizerProps: { estimateSize: () => 56, overscan: 10 },
         initialState: {
             density: 'xs',
         },


### PR DESCRIPTION
## Summary

Stacks on #23317 and migrates the remaining operational/content-admin tables to the in-house content table wrapper.

This PR covers:
- compilation history
- pre-aggregate stats and materializations
- scheduler logs and scheduler tables
- settings validator
- verified content
- changesets
- recently deleted
- dashboard version comparison tables

This slice preserves the compact/operational table behavior: virtualized lists, pagination, sticky headers, pinned/error rows, row clicks, bottom toolbar states, and row actions.

## Validation

- `pnpm --dir packages/frontend run linter src/components/CompilationHistory/CompilationHistoryTable.tsx src/components/PreAggregateAudit/PreAggregateStatsTable.tsx src/components/PreAggregateMaterializations/index.tsx src/components/SchedulersView/LogsTable.tsx src/components/SchedulersView/SchedulersTable.tsx src/components/SettingsValidator/ValidatorTable/index.tsx src/components/VerifiedContent/VerifiedContentPanel.tsx src/features/changesets/components/ProjectChangesets.tsx src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx src/pages/DashboardVersionComparison.tsx`
- `git diff --cached --check`

## Notes

This remains stacked. The final dependency cleanup is intentionally separate.