### PR TITLE
fix: include orphan tiles in scheduled tab-filtered PDF exports (PROD-2505)

### DIFF
--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -8,6 +8,7 @@ import {
     assertUnreachable,
     DashboardTileTypes,
     isDashboardScheduler,
+    isTileInSelectedTabs,
     SessionStorageKeys,
 } from '@lightdash/common';
 import { useSessionStorage } from '@mantine/hooks';
@@ -318,8 +319,11 @@ const MinimalDashboard: FC = () => {
         const filteredTiles =
             dashboard?.tiles.filter((tile) => {
                 // If there are selected tabs when sending now/scheduling, aggregate ALL tiles into one view.
+                // Orphan tiles (tabUuid null/undefined) are always included so picked-tab PDF
+                // exports surface legacy tiles on the first tab, matching the backend rule in
+                // isTileInSelectedTabs (PROD-2505).
                 if (schedulerTabsSelected) {
-                    return schedulerTabsSelected.includes(tile.tabUuid);
+                    return isTileInSelectedTabs(tile, schedulerTabsSelected);
                 }
 
                 // This is when viewed a dashboard with tabs in mobile mode - you can navigate between tabs.


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-2505/issues-with-orphan-tiles-in-dashboards-with-tabs](https://linear.app/lightdash/issue/PROD-2505/issues-with-orphan-tiles-in-dashboards-with-tabs)

### Description:

Replaces the inline `schedulerTabsSelected.includes(tile.tabUuid)` check with the shared `isTileInSelectedTabs` utility when filtering dashboard tiles for minimal/scheduled views. This ensures that orphan tiles (those with a `null` or `undefined` `tabUuid`) are always included in scheduled PDF exports, matching the existing backend rule. Previously, orphan tiles were silently excluded from tab-scoped exports, causing legacy tiles to go missing in generated PDFs.