### PR TITLE
fix(warehouses): coerce non-string BigQuery label values before lowercasing

### DIFF
--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -45,6 +45,67 @@ describe('BigqueryWarehouseClient', () => {
     });
 });
 
+describe('BigqueryWarehouseClient.sanitizeLabelsWithValues', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it('returns undefined when given no labels', () => {
+        expect(
+            BigqueryWarehouseClient.sanitizeLabelsWithValues(undefined),
+        ).toBeUndefined();
+    });
+
+    it('lowercases and normalises string values', () => {
+        expect(
+            BigqueryWarehouseClient.sanitizeLabelsWithValues({
+                Scheduler_Uuid: 'ABC-123',
+            }),
+        ).toEqual({ scheduler_uuid: 'abc-123' });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('coerces numeric values without crashing and logs a warning', () => {
+        const result = BigqueryWarehouseClient.sanitizeLabelsWithValues({
+            job_id: 224187 as unknown as string,
+        });
+        expect(result).toEqual({ job_id: '224187' });
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('coerced non-string label value'),
+            { key: 'job_id', valueType: 'number' },
+        );
+    });
+
+    it('replaces null/undefined with empty_value silently', () => {
+        const result = BigqueryWarehouseClient.sanitizeLabelsWithValues({
+            scheduler_name: null as unknown as string,
+            saved_sql_uuid: undefined as unknown as string,
+        });
+        expect(result).toEqual({
+            scheduler_name: 'empty_value',
+            saved_sql_uuid: 'empty_value',
+        });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('coerces boolean values', () => {
+        const result = BigqueryWarehouseClient.sanitizeLabelsWithValues({
+            embed: true as unknown as string,
+        });
+        expect(result).toEqual({ embed: 'true' });
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ valueType: 'boolean' }),
+        );
+    });
+});
+
 describe('BigquerySqlBuilder escaping', () => {
     const bigquerySqlBuilder = new BigquerySqlBuilder();
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -257,24 +257,44 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
      * Sanitize label key and values.
      * Keys and values can contain only lowercase letters, numeric characters, underscores, and dashes. All characters must use UTF-8 encoding, and international characters are allowed.
      * But also, keys can't be longer than 60 characters, or empty.
+     *
+     * Defensive String() coercion: the TS type promises `Record<string, string>`
+     * but callers (warehouse `queryTags`) can drift — a non-string value here
+     * would crash the whole job at `.toLowerCase()`, taking down every
+     * downstream sync/query. The warn log surfaces the rogue key so the
+     * source can be fixed.
      */
     static sanitizeLabelsWithValues(
         labels?: Record<string, string>,
     ): Record<string, string> | undefined {
-        return labels
-            ? Object.fromEntries(
-                  Object.entries(labels).map(([key, value]) => [
-                      key
-                          .toLowerCase()
-                          .replace(/[^a-z0-9_-]/g, '_')
-                          .substring(0, 60) || 'empty_key',
-                      value
-                          .toLowerCase()
-                          .replace(/[^a-z0-9_-]/g, '_')
-                          .substring(0, 60) || 'empty_value',
-                  ]),
-              )
-            : undefined;
+        if (!labels) return undefined;
+        return Object.fromEntries(
+            Object.entries(labels).map(([key, value]) => {
+                const safeKey = typeof key === 'string' ? key : String(key);
+                let safeValue: string;
+                if (typeof value === 'string') {
+                    safeValue = value;
+                } else if (value === null || value === undefined) {
+                    safeValue = '';
+                } else {
+                    console.warn(
+                        'BigqueryWarehouseClient.sanitizeLabelsWithValues: coerced non-string label value',
+                        { key: safeKey, valueType: typeof value },
+                    );
+                    safeValue = String(value);
+                }
+                return [
+                    safeKey
+                        .toLowerCase()
+                        .replace(/[^a-z0-9_-]/g, '_')
+                        .substring(0, 60) || 'empty_key',
+                    safeValue
+                        .toLowerCase()
+                        .replace(/[^a-z0-9_-]/g, '_')
+                        .substring(0, 60) || 'empty_value',
+                ];
+            }),
+        );
     }
 
     static getFieldsFromResponse(response: QueryRowsResponse[2] | undefined) {


### PR DESCRIPTION
## Summary

- Adds defensive `String()` coercion in `BigqueryWarehouseClient.sanitizeLabelsWithValues` so a non-string label value can no longer crash the entire BigQuery job at `.toLowerCase()`.
- Emits a one-line `console.warn` with `{ key, valueType }` for any unexpected non-string type so we can identify the rogue caller from Cloud Logging and fix it at the source.
- Silently maps `null`/`undefined` to `empty_value` (the existing behaviour for empty values, just made explicit so we don't pollute logs with expected misses).
- Five new unit tests pin the new contract.

## Context

Sentry [`LIGHTDASH-BACKEND-CQY`](https://lightdash.sentry.io/issues/LIGHTDASH-BACKEND-CQY) — `TypeError: value.toLowerCase is not a function` — has fired **858 times across 18 users in 24 hours**, escalating, and overwhelmingly on the `uploadGsheets` scheduler task. Two distinct customers have already opened tickets about wholesale-failing Google Sheets syncs.

Stack:

```
SchedulerTask.uploadGsheets
  → AsyncQueryService.executeSqlChartQueryAndGetResults
  → prepareSqlChartAsyncQueryArgs
  → warehouseClient.streamQuery
  → BigqueryWarehouseClient.createJob
  → BigqueryWarehouseClient.sanitizeLabelsWithValues
  → value.toLowerCase()   ← crash, value is not a string
```

The `RunQueryTags` type declares every field as `string`, so static analysis can't tell us which field is the non-string at runtime. The warn log is the diagnostic — once this deploys we'll know in <1 hour which `queryTag` is the offender and can patch the source.

## Test plan

- [x] `pnpm -F warehouses test -- BigqueryWarehouseClient` — 11/11 passing (6 existing + 5 new)
- [x] `pnpm -F warehouses typecheck`
- [x] `pnpm -F warehouses lint`
- [ ] After merge: filter Cloud Logging for `coerced non-string label value` and patch the source of the rogue `queryTag` so the warn log goes silent again
- [ ] Resolve Sentry `LIGHTDASH-BACKEND-CQY` once deploy lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)