### PR TITLE
feat(data-apps): add Claude model picker to chat input

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -159,6 +159,20 @@ When users send follow-up prompts, the system creates a new `DbAppVersion` and e
 
 This means Claude can see what it built previously and make targeted changes rather than starting from scratch.
 
+### Model selection
+
+The chat input carries a `ModelPicker` (next to the send button) that lets the user choose which Claude model runs the generation: `opus` (highest quality, best for complex apps), `sonnet` (default, balanced), or `haiku` (fastest). The choice is editable on every turn — `claude --continue` keeps the prior conversation context but accepts a fresh `--model` flag per invocation, so switching mid-iteration doesn't reset Claude's memory of what it already built.
+
+How it flows through the stack:
+
+- The frontend sends `claudeModel: 'opus' | 'sonnet' | 'haiku'` on `POST /api/v1/ee/projects/{projectUuid}/apps/` (generate) and `POST /api/v1/ee/projects/{projectUuid}/apps/{appUuid}/versions` (iterate).
+- The backend validates it against `DATA_APP_CLAUDE_MODELS` (`AppGenerateService.resolveClaudeModel`) and rejects unknown values rather than shelling out as `--model <anything>` to the Claude CLI inside the sandbox.
+- The resolved value is persisted per-version on `app_versions.resources.claudeModel` (JSONB) and carried through the scheduler payload to `runClaudeGeneration`, where it substitutes into the `--model ${model}` flag for the user-facing generation, the build auto-fix retries, and the post-build metadata (name + description) call.
+- Older versions and jobs queued before the picker shipped don't carry the field; both the pipeline and the picker fall back to `DEFAULT_DATA_APP_CLAUDE_MODEL` (`sonnet`) so existing builds and resumed sandboxes keep working.
+- The restore-notification call (`notifyClaudeOfRestore`) deliberately stays on a fixed model — it's a one-line FYI to the persistent Claude session, not a user-driven generation.
+
+The shared enum + default live in `packages/common/src/ee/apps/types.ts` (`DATA_APP_CLAUDE_MODELS`, `DataAppClaudeModel`, `DEFAULT_DATA_APP_CLAUDE_MODEL`) so the frontend picker, the request body, and the backend validation stay in sync.
+
 ### Cancellation
 
 Users can cancel a building version. This atomically marks it as `status='error'` in the database and pauses the sandbox

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -26,6 +26,7 @@ import {
     TableSelectionType,
     ValidateProjectPayload,
     WarehouseTypes,
+    type DataAppClaudeModel,
 } from '@lightdash/common';
 import Analytics, {
     Track as AnalyticsTrack,
@@ -1205,6 +1206,7 @@ export type DataAppCreatedEvent = BaseTrack & {
         version: number;
         promptLength: number;
         imageCount: number;
+        claudeModel: DataAppClaudeModel;
     };
 };
 
@@ -1219,6 +1221,7 @@ export type DataAppIteratedEvent = BaseTrack & {
         iterationNumber: number;
         promptLength: number;
         imageCount: number;
+        claudeModel: DataAppClaudeModel;
         previousVersionStatus: string | null;
         msSinceLastVersion: number | null;
     };
@@ -1246,6 +1249,7 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         appUuid: string;
         version: number;
         isIteration: boolean;
+        claudeModel: DataAppClaudeModel;
         wasResumed: boolean;
         totalDurationMs: number;
         sandboxMs?: number;
@@ -1277,6 +1281,7 @@ export type DataAppVersionFailedEvent = BaseTrack & {
         appUuid: string;
         version: number;
         isIteration: boolean;
+        claudeModel: DataAppClaudeModel;
         failureStage:
             | 'sandbox'
             | 'catalog'

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -72,6 +72,7 @@ export class AppGenerateController extends BaseController {
             body.template,
             body.clarifications,
             body.spaceUuid,
+            body.claudeModel,
         );
         return {
             status: 'ok',
@@ -211,6 +212,7 @@ export class AppGenerateController extends BaseController {
             body.imageIds ?? [],
             body.charts,
             body.dashboard,
+            body.claudeModel,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -11,6 +11,8 @@ import {
 import { subject } from '@casl/ability';
 import {
     assertUnreachable,
+    DATA_APP_CLAUDE_MODELS,
+    DEFAULT_DATA_APP_CLAUDE_MODEL,
     FeatureFlags,
     ForbiddenError,
     formatPromptWithClarifications,
@@ -29,6 +31,7 @@ import {
     type CatalogItemSummary,
     type ChartReference,
     type ChartSampleData,
+    type DataAppClaudeModel,
     type DataAppTemplate,
     type SessionUser,
     type TogglePinnedItemInfo,
@@ -456,6 +459,29 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
+     * Resolve the user-supplied Claude model to a known value, defaulting when
+     * absent. Rejects unknown strings outright so a stray value can't shell
+     * out as `--model <anything>` against the Claude CLI inside the sandbox.
+     */
+    private static resolveClaudeModel(
+        claudeModel: DataAppClaudeModel | undefined,
+    ): DataAppClaudeModel {
+        if (claudeModel === undefined) {
+            return DEFAULT_DATA_APP_CLAUDE_MODEL;
+        }
+        if (
+            !(DATA_APP_CLAUDE_MODELS as readonly string[]).includes(claudeModel)
+        ) {
+            throw new ParameterError(
+                `Invalid claudeModel: ${claudeModel}. Allowed: ${DATA_APP_CLAUDE_MODELS.join(
+                    ', ',
+                )}`,
+            );
+        }
+        return claudeModel;
+    }
+
+    /**
      * Read the first few bytes of a stream, validate image magic bytes,
      * then return a new Readable that replays those bytes followed by
      * the rest of the original stream.
@@ -687,6 +713,8 @@ export class AppGenerateService extends BaseService {
                 appUuid: payload.appUuid,
                 version: payload.version,
                 isIteration: payload.isIteration,
+                claudeModel:
+                    payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL,
                 failureStage,
                 errorMessage: AppGenerateService.truncateEnd(
                     getErrorMessage(error),
@@ -1265,6 +1293,7 @@ export class AppGenerateService extends BaseService {
         version: number,
         continueSession: boolean,
         anthropicApiKey: string,
+        claudeModel: DataAppClaudeModel,
     ): Promise<{
         durationMs: number;
         responseText: string | null;
@@ -1297,7 +1326,7 @@ export class AppGenerateService extends BaseService {
 
             const result = await sandbox.commands.run(
                 `cat /tmp/prompt.txt | claude ${sessionFlags} ` +
-                    `--model sonnet ` +
+                    `--model ${claudeModel} ` +
                     `--verbose --output-format stream-json --include-partial-messages ` +
                     `--allowedTools "Read(//app/**),Read(//tmp/dbt-repo/**),Read(//tmp/images/**),Read(//tmp/metric-queries/**),Write(//app/src/**),Edit(//app/src/**),Glob(//app/**),Glob(//tmp/dbt-repo/**),Glob(//tmp/metric-queries/**),Grep(//app/**),Grep(//tmp/dbt-repo/**)" ` +
                     `--append-system-prompt-file /app/skill.md`,
@@ -1365,7 +1394,7 @@ export class AppGenerateService extends BaseService {
             const toolCallCount = processor.totalToolCalls;
             const durationMs = AppGenerateService.elapsed(start);
             this.logger.info(
-                `App ${appUuid}: Claude code generation completed (exit=${result.exitCode}, toolCalls=${toolCallCount}, ${durationMs}ms, attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
+                `App ${appUuid}: Claude code generation completed (model=${claudeModel}, exit=${result.exitCode}, toolCalls=${toolCallCount}, ${durationMs}ms, attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
             );
 
             if (result.exitCode === 0) {
@@ -1432,6 +1461,7 @@ export class AppGenerateService extends BaseService {
         appUuid: string,
         version: number,
         anthropicApiKey: string,
+        claudeModel: DataAppClaudeModel,
     ): Promise<{
         name: string;
         description: string;
@@ -1455,6 +1485,7 @@ export class AppGenerateService extends BaseService {
             version,
             true, // --continue: Claude remembers what it just built
             anthropicApiKey,
+            claudeModel,
         );
 
         const durationMs = AppGenerateService.elapsed(start);
@@ -1573,6 +1604,7 @@ export class AppGenerateService extends BaseService {
         appUuid: string,
         version: number,
         anthropicApiKey: string,
+        claudeModel: DataAppClaudeModel,
     ): Promise<{
         buildMs: number;
         fixAttempts: number;
@@ -1636,6 +1668,7 @@ export class AppGenerateService extends BaseService {
                 version,
                 true, // --continue: keep conversation context from generation
                 anthropicApiKey,
+                claudeModel,
             );
             fixGenerationMs += generation.durationMs;
 
@@ -1831,7 +1864,9 @@ export class AppGenerateService extends BaseService {
         const durations: Record<string, number> = {};
 
         this.logger.info(
-            `App ${appUuid}: pipeline started (version=${version}, status=${currentStatus}, isIteration=${isIteration})`,
+            `App ${appUuid}: pipeline started (version=${version}, status=${currentStatus}, isIteration=${isIteration}, model=${
+                payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL
+            })`,
         );
 
         // --- Stage: sandbox ---
@@ -1995,6 +2030,11 @@ export class AppGenerateService extends BaseService {
         chartReferences: ChartReference[] | undefined,
     ): Promise<void> {
         const { appUuid, version, projectUuid, prompt, template } = payload;
+        // Resolve the model once per pipeline run. Jobs enqueued before the
+        // picker shipped (or any future caller that omits the field) fall back
+        // to the default so we never run with `--model undefined`.
+        const claudeModel: DataAppClaudeModel =
+            payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL;
         const durations: Record<string, number> = { ...extraDurations };
         const shouldRun = (stage: AppVersionStatus) =>
             AppGenerateService.shouldRunStage(currentStatus, stage);
@@ -2091,6 +2131,7 @@ export class AppGenerateService extends BaseService {
                     version,
                     continueSession,
                     anthropicApiKey,
+                    claudeModel,
                 );
                 durations.generateMs = generation.durationMs;
                 responseText = generation.responseText;
@@ -2137,6 +2178,7 @@ export class AppGenerateService extends BaseService {
                     appUuid,
                     version,
                     anthropicApiKey,
+                    claudeModel,
                 );
                 durations.buildMs = buildResult.buildMs;
                 buildFixAttempts = buildResult.fixAttempts;
@@ -2178,6 +2220,7 @@ export class AppGenerateService extends BaseService {
                     appUuid,
                     version,
                     anthropicApiKey,
+                    claudeModel,
                 );
                 if (metadata) {
                     // Only fills fields the user hasn't already set — the
@@ -2295,7 +2338,7 @@ export class AppGenerateService extends BaseService {
 
         const totalMs = AppGenerateService.elapsed(overallStart);
         this.logger.info(
-            `App ${appUuid}: generation completed successfully in ${totalMs}ms (${Object.entries(
+            `App ${appUuid}: generation completed successfully in ${totalMs}ms (model=${claudeModel}, ${Object.entries(
                 durations,
             )
                 .map(([k, v]) => `${k}=${v}ms`)
@@ -2311,6 +2354,7 @@ export class AppGenerateService extends BaseService {
                 appUuid,
                 version,
                 isIteration: payload.isIteration,
+                claudeModel,
                 wasResumed,
                 totalDurationMs: totalMs,
                 sandboxMs: durations.sandboxMs,
@@ -2853,6 +2897,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         template?: DataAppTemplate,
         clarifications?: AppClarification[],
         spaceUuid?: string,
+        claudeModelInput?: DataAppClaudeModel,
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
         const organizationUuid = await this.getProjectOrgUuid(projectUuid);
@@ -2863,6 +2908,8 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             projectUuid,
             'Insufficient permissions to create data apps',
         );
+        const claudeModel =
+            AppGenerateService.resolveClaudeModel(claudeModelInput);
 
         // When the caller wants the app to live in a space directly, also
         // require manage rights on that space — same gate space EDITOR/ADMIN
@@ -2898,7 +2945,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         );
 
         this.logger.info(
-            `App ${appUuid}: generation started (promptLength=${prompt.length}, clarifications=${
+            `App ${appUuid}: generation started (model=${claudeModel}, promptLength=${prompt.length}, clarifications=${
                 clarifications?.length ?? 0
             })`,
         );
@@ -2920,6 +2967,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             charts: chartResources,
             dashboardName,
             clarifications: clarifications ?? [],
+            claudeModel,
         };
 
         // Persist app record so we can track status immediately. 'custom' is
@@ -2957,6 +3005,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 promptLength: prompt.length,
                 imageCount: imageIds.length,
                 template: template ?? null,
+                claudeModel,
                 samplesRequested: sampleStats.requested,
                 samplesAvailable: sampleStats.available,
                 clarificationCount: clarifications?.length ?? 0,
@@ -2975,6 +3024,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             isIteration: false,
             chartReferences:
                 chartReferences.length > 0 ? chartReferences : undefined,
+            claudeModel,
         });
 
         return { appUuid, version };
@@ -2988,10 +3038,13 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         imageIds: string[],
         charts?: AppChartReference[],
         dashboard?: AppDashboardReference,
+        claudeModelInput?: DataAppClaudeModel,
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
 
         AppGenerateService.validateImageIds(imageIds);
+        const claudeModel =
+            AppGenerateService.resolveClaudeModel(claudeModelInput);
 
         const app = await this.appModel.getApp(appUuid, projectUuid);
         await this.assertCanManageApp(
@@ -3013,7 +3066,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         const newVersion = (latestVersion?.version ?? 0) + 1;
 
         this.logger.info(
-            `App ${appUuid}: iteration started (version=${newVersion}, promptLength=${prompt.length})`,
+            `App ${appUuid}: iteration started (version=${newVersion}, model=${claudeModel}, promptLength=${prompt.length})`,
         );
 
         const { refs, dashboardName } = await this.collectChartReferences(
@@ -3032,6 +3085,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             charts: chartResources,
             dashboardName,
             clarifications: [],
+            claudeModel,
         };
 
         await this.appModel.createVersion(
@@ -3053,6 +3107,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 iterationNumber: newVersion - 1,
                 promptLength: prompt.length,
                 imageCount: imageIds.length,
+                claudeModel,
                 previousVersionStatus: latestVersion?.status ?? null,
                 msSinceLastVersion: latestVersion?.created_at
                     ? Date.now() - latestVersion.created_at.getTime()
@@ -3073,6 +3128,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             isIteration: true,
             chartReferences:
                 chartReferences.length > 0 ? chartReferences : undefined,
+            claudeModel,
         });
 
         return { appUuid, version: newVersion };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8148,11 +8148,25 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppClaudeModel: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['opus'] },
+                { dataType: 'enum', enums: ['sonnet'] },
+                { dataType: 'enum', enums: ['haiku'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     GenerateAppRequestBody: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                claudeModel: { ref: 'DataAppClaudeModel' },
                 spaceUuid: { dataType: 'string' },
                 clarifications: {
                     dataType: 'array',
@@ -8312,6 +8326,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                claudeModel: { ref: 'DataAppClaudeModel' },
                 clarifications: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'AppClarification' },
@@ -11238,11 +11253,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -11300,11 +11315,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -11341,11 +11356,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -11869,11 +11884,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -11888,11 +11903,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -11907,11 +11922,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -11926,11 +11941,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -11945,11 +11960,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -23127,7 +23142,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -23137,7 +23152,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -23147,7 +23162,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -23160,7 +23175,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -23578,7 +23593,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -23588,7 +23603,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -23598,7 +23613,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -23611,7 +23626,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -9549,8 +9549,15 @@
                 "type": "object",
                 "description": "A clarifying question the backend posed to the user before the build, paired\nwith the user's answer. Persisted on the version's `resources.clarifications`\nso the chat can render them as a structured Q&A card on the user message."
             },
+            "DataAppClaudeModel": {
+                "type": "string",
+                "enum": ["opus", "sonnet", "haiku"]
+            },
             "GenerateAppRequestBody": {
                 "properties": {
+                    "claudeModel": {
+                        "$ref": "#/components/schemas/DataAppClaudeModel"
+                    },
                     "spaceUuid": {
                         "type": "string"
                     },
@@ -9709,6 +9716,9 @@
             },
             "AppVersionResources": {
                 "properties": {
+                    "claudeModel": {
+                        "$ref": "#/components/schemas/DataAppClaudeModel"
+                    },
                     "clarifications": {
                         "items": {
                             "$ref": "#/components/schemas/AppClarification"
@@ -12822,8 +12832,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -12881,8 +12891,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -12906,19 +12916,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -24417,22 +24414,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -24794,22 +24791,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -33318,7 +33315,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2984.0",
+        "version": "0.2984.4",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -45,6 +45,16 @@ export const DATA_APP_TEMPLATES = [
 export type DataAppTemplate = (typeof DATA_APP_TEMPLATES)[number];
 
 /**
+ * Claude model used to generate / iterate the data app inside the sandbox.
+ * Mapped to the Claude CLI's `--model <alias>` flag verbatim. Persisted
+ * per-version on `AppVersionResources.claudeModel` so the user can switch
+ * mid-iteration without losing the record of which model built which version.
+ */
+export const DATA_APP_CLAUDE_MODELS = ['opus', 'sonnet', 'haiku'] as const;
+export type DataAppClaudeModel = (typeof DATA_APP_CLAUDE_MODELS)[number];
+export const DEFAULT_DATA_APP_CLAUDE_MODEL: DataAppClaudeModel = 'sonnet';
+
+/**
  * A saved-chart reference attached to a generation request.
  * `includeSampleData` is opt-in per chart: when true the backend runs the
  * underlying metric query and inlines a small sample of rows into the
@@ -107,6 +117,11 @@ export type GenerateAppRequestBody = {
     // EDITOR/ADMIN, or project admin). When omitted, the app is created as
     // personal and can be moved into a space later.
     spaceUuid?: string;
+    // Claude model to use for this version's generation. Defaults to
+    // DEFAULT_DATA_APP_CLAUDE_MODEL on the backend when absent. Can be
+    // switched between iterations — `claude --continue` keeps the prior
+    // conversation context but accepts a fresh `--model` flag per turn.
+    claudeModel?: DataAppClaudeModel;
 };
 
 export type ApiClarifyAppRequest = {
@@ -150,6 +165,11 @@ export type AppVersionResources = {
     // own card on the user message — rather than mashing them into the
     // prompt text. Empty array when the user skipped or wasn't asked.
     clarifications: AppClarification[];
+    // Claude model the user picked for this version (sonnet / haiku).
+    // Optional for backwards compatibility — versions built before the picker
+    // shipped don't carry the field; readers should fall back to
+    // DEFAULT_DATA_APP_CLAUDE_MODEL.
+    claudeModel?: DataAppClaudeModel;
 };
 
 export type ApiAppImageUrlResponse = ApiSuccess<{

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -2,6 +2,7 @@ import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
     type ChartReference,
+    type DataAppClaudeModel,
     type DataAppTemplate,
     type EmbedArtifactVersionJobPayload,
     type GenerateArtifactQuestionJobPayload,
@@ -45,6 +46,10 @@ export type AppGeneratePipelineJobPayload = TraceTaskBase & {
     imageIds?: string[];
     isIteration: boolean;
     chartReferences?: ChartReference[];
+    // Claude model the user picked for this version. Absent on jobs enqueued
+    // before the picker shipped — the pipeline falls back to
+    // DEFAULT_DATA_APP_CLAUDE_MODEL in that case.
+    claudeModel?: DataAppClaudeModel;
 };
 
 export const EE_SCHEDULER_TASKS = {

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -1,4 +1,8 @@
-import { ChartKind, type ChartContent } from '@lightdash/common';
+import {
+    ChartKind,
+    type ChartContent,
+    type DataAppClaudeModel,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -21,6 +25,7 @@ import {
     IconCamera,
     IconChartBar,
     IconCheck,
+    IconChevronDown,
     IconClick,
     IconDatabase,
     IconDatabasePlus,
@@ -123,6 +128,139 @@ export const InspectButton: FC<{
         </ActionIcon>
     </Tooltip>
 );
+
+type ModelOption = {
+    value: DataAppClaudeModel;
+    label: string;
+    // Short advantage line shown in the popover. Together with the order
+    // below, these form a capability spectrum (premium → balanced → budget)
+    // so the trade-off is legible at a glance.
+    tagline: string;
+    isDefault?: boolean;
+};
+
+// Order: capability descending — Opus (highest quality) → Sonnet (default) →
+// Haiku (fastest). The "Default" tag on Sonnet anchors the recommendation
+// without forcing it to position 0.
+const MODEL_OPTIONS: ModelOption[] = [
+    {
+        value: 'opus',
+        label: 'Opus',
+        tagline: 'Highest quality. Best for complex apps. Slowest.',
+    },
+    {
+        value: 'sonnet',
+        label: 'Sonnet',
+        tagline: 'Balanced quality and speed. Good fit for most apps.',
+        isDefault: true,
+    },
+    {
+        value: 'haiku',
+        label: 'Haiku',
+        tagline: 'Fastest. Best for quick iterations and simple tweaks.',
+    },
+];
+
+// Lookup helper. The type union and MODEL_OPTIONS are kept in sync via
+// DATA_APP_CLAUDE_MODELS, but the underlying value can ultimately come from
+// the JSONB `resources.claudeModel` column — so a stale or hand-edited row
+// could land here as a string outside the union at runtime. Fall back to the
+// default option rather than throw, so a corrupt row never crashes the
+// AppGenerate page; the user can still pick a valid model from the popover.
+const findModelOption = (value: DataAppClaudeModel): ModelOption =>
+    MODEL_OPTIONS.find((o) => o.value === value) ??
+    MODEL_OPTIONS.find((o) => o.isDefault) ??
+    MODEL_OPTIONS[0];
+
+/**
+ * Picker for the Claude model the agent uses to build the data app.
+ *
+ * Inline next to the send button so the choice is visible at submit time;
+ * also editable mid-iteration — `claude --continue` accepts a fresh
+ * `--model` flag each turn while preserving the prior conversation context.
+ *
+ * The label of the current choice ("Sonnet" / "Haiku") is shown on the
+ * trigger so the user doesn't have to open the popover to confirm what
+ * they're about to run with. The advantages are summarised in the popover
+ * itself rather than a tooltip, so both options are visible at the same time.
+ */
+export const ModelPicker: FC<{
+    value: DataAppClaudeModel;
+    onChange: (value: DataAppClaudeModel) => void;
+    disabled?: boolean;
+}> = ({ value, onChange, disabled }) => {
+    const [opened, setOpened] = useState(false);
+    const current = findModelOption(value);
+
+    return (
+        <Popover
+            opened={opened}
+            onChange={setOpened}
+            position="top-end"
+            offset={8}
+            shadow="md"
+            trapFocus
+        >
+            <Popover.Target>
+                <Button
+                    variant="default"
+                    size="md"
+                    radius="md"
+                    color="gray"
+                    onClick={() => setOpened((o) => !o)}
+                    disabled={disabled}
+                    rightSection={
+                        <MantineIcon icon={IconChevronDown} size={14} />
+                    }
+                    aria-label={`Claude model: ${current.label}`}
+                >
+                    {current.label}
+                </Button>
+            </Popover.Target>
+            <Popover.Dropdown className={classes.queryDropdown} p={0}>
+                <Box py="xs">
+                    {MODEL_OPTIONS.map((opt) => {
+                        const isActive = opt.value === value;
+                        return (
+                            <UnstyledButton
+                                key={opt.value}
+                                className={classes.attachMenuItem}
+                                onClick={() => {
+                                    onChange(opt.value);
+                                    setOpened(false);
+                                }}
+                                aria-pressed={isActive}
+                            >
+                                <Box flex={1}>
+                                    <Group gap="xs" align="center">
+                                        <Text size="sm" fw={500}>
+                                            {opt.label}
+                                        </Text>
+                                        {opt.isDefault && (
+                                            <Text size="xs" c="dimmed">
+                                                Default
+                                            </Text>
+                                        )}
+                                        {isActive && (
+                                            <MantineIcon
+                                                icon={IconCheck}
+                                                size={14}
+                                                color="indigo.6"
+                                            />
+                                        )}
+                                    </Group>
+                                    <Text size="xs" c="dimmed">
+                                        {opt.tagline}
+                                    </Text>
+                                </Box>
+                            </UnstyledButton>
+                        );
+                    })}
+                </Box>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
 
 /**
  * Internal: chart list with search. Used inside `AttachButton`'s popover.

--- a/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
@@ -4,6 +4,7 @@ import {
     type AppChartReference,
     type AppClarification,
     type AppDashboardReference,
+    type DataAppClaudeModel,
     type DataAppTemplate,
 } from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
@@ -19,6 +20,7 @@ type GenerateAppParams = {
     dashboard?: AppDashboardReference;
     clarifications?: AppClarification[];
     spaceUuid?: string; // create directly inside this space (skips the personal-app step)
+    claudeModel?: DataAppClaudeModel;
 };
 
 type GenerateAppResult = ApiGenerateAppResponse['results'];
@@ -33,6 +35,7 @@ const generateApp = async ({
     dashboard,
     clarifications,
     spaceUuid,
+    claudeModel,
 }: GenerateAppParams): Promise<GenerateAppResult> => {
     const data = await lightdashApi<GenerateAppResult>({
         method: 'POST',
@@ -46,6 +49,7 @@ const generateApp = async ({
             dashboard,
             clarifications,
             spaceUuid,
+            claudeModel,
         }),
     });
     return data;

--- a/packages/frontend/src/features/apps/hooks/useIterateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useIterateApp.ts
@@ -3,6 +3,7 @@ import {
     type ApiGenerateAppResponse,
     type AppChartReference,
     type AppDashboardReference,
+    type DataAppClaudeModel,
 } from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
@@ -14,6 +15,7 @@ type IterateAppParams = {
     imageIds?: string[];
     charts?: AppChartReference[];
     dashboard?: AppDashboardReference;
+    claudeModel?: DataAppClaudeModel;
 };
 
 type IterateAppResult = ApiGenerateAppResponse['results'];
@@ -25,11 +27,18 @@ const iterateApp = async ({
     imageIds,
     charts,
     dashboard,
+    claudeModel,
 }: IterateAppParams): Promise<IterateAppResult> => {
     const data = await lightdashApi<IterateAppResult>({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/apps/${appUuid}/versions`,
-        body: JSON.stringify({ prompt, imageIds, charts, dashboard }),
+        body: JSON.stringify({
+            prompt,
+            imageIds,
+            charts,
+            dashboard,
+            claudeModel,
+        }),
     });
     return data;
 };

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ChartKind,
     ContentType,
+    DEFAULT_DATA_APP_CLAUDE_MODEL,
     FeatureFlags,
     isAppVersionInProgress,
     ResourceViewItemType,
@@ -9,6 +10,7 @@ import {
     type AppChartReference,
     type AppClarification,
     type AppDashboardReference,
+    type DataAppClaudeModel,
     type DataAppTemplate,
 } from '@lightdash/common';
 import {
@@ -83,6 +85,7 @@ import AppPromptEditor, {
 import {
     AttachButton,
     InspectButton,
+    ModelPicker,
     ScreenshotButton,
     SelectedDashboardSection,
     SelectedImageSection,
@@ -301,6 +304,20 @@ const AppGenerate: FC = () => {
     //             wizard no longer asks any questions of its own.
     const [selectedTemplate, setSelectedTemplate] =
         useState<DataAppTemplate | null>(null);
+    // Claude model used for the next submit. By default, derived from the
+    // most recent version's persisted `resources.claudeModel` so reopening
+    // an app pre-selects whatever model it was last built with. The user's
+    // explicit pick (tracked in `modelOverride` below) wins until they
+    // navigate to a different app. Per-version persistence happens
+    // server-side on `AppVersionResources.claudeModel`.
+    //
+    // Keyed by appUuid (mirrors the `pin` lifecycle) so the override
+    // self-invalidates when the user navigates — no useEffect+setState
+    // chain (lightdash frontend rule).
+    const [modelOverride, setModelOverride] = useState<{
+        appUuid: string | null; // null = override set from the new-app page
+        model: DataAppClaudeModel;
+    } | null>(null);
     const [wizardStage, setWizardStage] = useState<'pick' | 'confirm'>('pick');
     const [imageAttachments, setImageAttachments] = useState<
         Array<{
@@ -460,6 +477,10 @@ const AppGenerate: FC = () => {
         charts: AppChartReference[] | undefined;
         dashboard: AppDashboardReference | undefined;
         spaceUuid: string | undefined;
+        // Snapshot of `selectedModel` at submit time so a mid-clarification
+        // model switch doesn't change which model the build kicks off with —
+        // the user's intent was captured when they pressed send.
+        claudeModel: DataAppClaudeModel;
     } | null>(null);
     const [clarificationAnswers, setClarificationAnswers] = useState<string[]>(
         [],
@@ -785,6 +806,46 @@ const AppGenerate: FC = () => {
                 .find((v) => v.status === 'ready') ?? null
         );
     }, [allVersions]);
+
+    // Last Claude model used on this app, sourced from the most recent
+    // version (any status — a still-building version's model is already a
+    // valid signal of the user's intent). `null` when no version data is
+    // loaded yet or older versions didn't persist the field.
+    const latestVersionModel: DataAppClaudeModel | null = useMemo(() => {
+        if (allVersions.length === 0) return null;
+        const latest = [...allVersions].sort(
+            (a, b) => b.version - a.version,
+        )[0];
+        return latest.resources?.claudeModel ?? null;
+    }, [allVersions]);
+
+    // Effective model for the picker / next submit:
+    // user's explicit pick (if it's for this app) > latest version's model
+    // > default. Pure derivation; no useEffect+setState chain.
+    //
+    // A `null` appUuid on the override means the pick was made from the
+    // new-app page (no activeAppUuid yet). It keeps matching even after
+    // `activeAppUuid` materialises to the newly created app's UUID, so the
+    // trigger button doesn't briefly flash the default model between submit
+    // and the first version fetch. The route mount boundary
+    // (/apps/generate → /apps/:appUuid) drops local state on real
+    // navigation, which keeps this from leaking across apps.
+    const selectedModel: DataAppClaudeModel = useMemo(() => {
+        if (modelOverride) {
+            const overrideAppUuid = modelOverride.appUuid;
+            if (overrideAppUuid === null || overrideAppUuid === activeAppUuid) {
+                return modelOverride.model;
+            }
+        }
+        return latestVersionModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL;
+    }, [modelOverride, activeAppUuid, latestVersionModel]);
+
+    const handleModelChange = useCallback(
+        (model: DataAppClaudeModel) => {
+            setModelOverride({ appUuid: activeAppUuid ?? null, model });
+        },
+        [activeAppUuid],
+    );
 
     // User-pinned version override. `null` = follow latest ready (default).
     // We snapshot the app uuid and the latest ready version at the moment of
@@ -1252,6 +1313,7 @@ const AppGenerate: FC = () => {
                             charts,
                             dashboard,
                             spaceUuid: targetSpaceUuid,
+                            claudeModel: selectedModel,
                         });
                         setClarificationAnswers(
                             new Array(questions.length).fill(''),
@@ -1282,6 +1344,7 @@ const AppGenerate: FC = () => {
                         imageIds,
                         charts,
                         dashboard,
+                        claudeModel: selectedModel,
                     },
                     callbacks,
                 );
@@ -1296,6 +1359,7 @@ const AppGenerate: FC = () => {
                         charts,
                         dashboard,
                         spaceUuid: targetSpaceUuid,
+                        claudeModel: selectedModel,
                     },
                     callbacks,
                 );
@@ -1363,6 +1427,7 @@ const AppGenerate: FC = () => {
                 clarifications:
                     clarifications.length > 0 ? clarifications : undefined,
                 spaceUuid: captured.spaceUuid,
+                claudeModel: captured.claudeModel,
             },
             buildSubmitCallbacks(),
         );
@@ -2099,6 +2164,11 @@ const AppGenerate: FC = () => {
                                                     )
                                                 }
                                                 disabled={!inspectorAvailable}
+                                            />
+                                            <ModelPicker
+                                                value={selectedModel}
+                                                onChange={handleModelChange}
+                                                disabled={isLoading}
                                             />
                                             {isBuilding ? (
                                                 <ActionIcon


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-448/investigate-1st-prompt-to-result-speed

### Description:
Lets the user choose between Opus, Sonnet (default), and Haiku per version. Editable mid-iteration — claude --continue keeps the prior session but accepts a fresh --model flag each turn. The choice is persisted per-version on app_versions.resources.claudeModel; absent values fall back to DEFAULT_DATA_APP_CLAUDE_MODEL so in-flight jobs and older versions keep working.

<img width="765" height="278" alt="image" src="https://github.com/user-attachments/assets/ca245e2f-9345-4175-a097-426a335f84e8" />
