### PR TITLE
fix: improve compaction divider label and add info tooltip

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -6,8 +6,9 @@ import {
     getDefaultZIndex,
     Stack,
     Text,
+    Tooltip,
 } from '@mantine-8/core';
-import { IconCrop } from '@tabler/icons-react';
+import { IconCrop, IconInfoCircle } from '@tabler/icons-react';
 import {
     Fragment,
     useRef,
@@ -60,8 +61,26 @@ const CompactionDivider = () => (
                 color="var(--mantine-color-gray-5)"
             />
             <Text size="xs" c="dimmed" fw={500}>
-                Conversation compacted
+                Summarized Conversation
             </Text>
+            <Tooltip
+                withinPortal
+                maw={320}
+                multiline
+                label="Lightdash automatically summarizes earlier messages when a conversation gets long, so responses stay fast and relevant."
+            >
+                <Box
+                    component="span"
+                    aria-label="About summarized conversations"
+                    style={{ display: 'inline-flex' }}
+                >
+                    <IconInfoCircle
+                        size={14}
+                        stroke={1.8}
+                        color="var(--mantine-color-gray-5)"
+                    />
+                </Box>
+            </Tooltip>
         </Flex>
     </Box>
 );


### PR DESCRIPTION
Closes:

### Description:

Updates the conversation compaction divider in the AI Copilot chat to rename "Conversation compacted" to "Summarized Conversation" and adds an info icon with a tooltip explaining that Lightdash automatically summarizes earlier messages when a conversation gets long to keep responses fast and relevant.