### PR TITLE
feat: bundle BigQuery scope into Google login flow to avoid double OAuth consent (PROD-7783)

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -25,6 +25,7 @@ export const lightdashConfigMock: LightdashConfig = {
             googleDriveApiKey: undefined,
             enableGCloudADC: false,
             enabled: false,
+            includeBigqueryScope: false,
         },
         okta: {
             loginPath: '',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1398,6 +1398,13 @@ export type AuthGoogleConfig = {
     googleDriveApiKey: string | undefined;
     enabled: boolean;
     enableGCloudADC: boolean;
+    /**
+     * When true, the Google login flow also requests the BigQuery scope so
+     * users on BigQuery SSO complete a single consent screen instead of two
+     * separate OAuth flows (one for login, one for BigQuery warehouse access).
+     * See PROD-7783.
+     */
+    includeBigqueryScope: boolean;
 };
 
 type AuthOktaConfig = {
@@ -1825,6 +1832,8 @@ export const parseConfig = (): LightdashConfig => {
                 googleDriveApiKey: process.env.GOOGLE_DRIVE_API_KEY,
                 enabled: process.env.AUTH_GOOGLE_ENABLED === 'true',
                 enableGCloudADC: process.env.AUTH_ENABLE_GCLOUD_ADC === 'true',
+                includeBigqueryScope:
+                    process.env.AUTH_GOOGLE_INCLUDE_BIGQUERY_SCOPE === 'true',
             },
             okta: {
                 oauth2Issuer: process.env.AUTH_OKTA_OAUTH_ISSUER,

--- a/packages/backend/src/controllers/authentication/strategies/googleStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/googleStrategy.ts
@@ -65,19 +65,6 @@ export const googlePassportStrategy: GoogleStrategy | undefined = !(
                   };
                   const hasBigqueryScope = params.scope.includes('bigquery');
 
-                  if (hasBigqueryScope) {
-                      // we'll also be adding the token to the warehouse credentials
-                      // so they can use it to query bigquery
-                      Logger.info(
-                          `Creating user warehouse credentials for bigquery on Google OAuth`,
-                      );
-                      await req.services
-                          .getUserService()
-                          .createBigqueryWarehouseCredentials(
-                              req.user!,
-                              refreshToken,
-                          );
-                  }
                   const user = await req.services
                       .getUserService()
                       .loginWithOpenId(
@@ -92,6 +79,18 @@ export const googlePassportStrategy: GoogleStrategy | undefined = !(
                               ),
                           },
                       );
+
+                  if (hasBigqueryScope && user) {
+                      Logger.info(
+                          `Creating user warehouse credentials for bigquery on Google OAuth`,
+                      );
+                      await req.services
+                          .getUserService()
+                          .createBigqueryWarehouseCredentials(
+                              user,
+                              refreshToken,
+                          );
+                  }
                   return done(null, user);
               } catch (e) {
                   if (e instanceof LightdashError) {

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -428,9 +428,23 @@ apiV1Router.get(
     lightdashConfig.auth.google.loginPath,
     storeOIDCRedirect,
     (req, res, next) => {
+        const { includeBigqueryScope } = lightdashConfig.auth.google;
+        const scope = ['profile', 'email'];
+        if (includeBigqueryScope) {
+            scope.push('https://www.googleapis.com/auth/bigquery');
+        }
         passport.authenticate('google', {
-            scope: ['profile', 'email'],
+            scope,
             loginHint: getLoginHint(req),
+            // Request a refresh token and force the consent screen so we can
+            // store BigQuery credentials. Only needed when the BigQuery scope
+            // is bundled into the login flow.
+            ...(includeBigqueryScope && {
+                accessType: 'offline',
+                prompt: 'consent',
+                session: false,
+                includeGrantedScopes: true,
+            }),
         })(req, res, next);
     },
 );


### PR DESCRIPTION
Closes:  https://linear.app/lightdash/issue/PROD-7783/auto-redirect-to-bigquery-oauth-after-google-sso-login
Closes: https://github.com/lightdash/lightdash/issues/23206

### Description:
When BigQuery SSO is enabled, users previously had to complete two separate OAuth consent screens — one for login and one for BigQuery warehouse access. This adds a new config option (`AUTH_GOOGLE_INCLUDE_BIGQUERY_SCOPE`) that, when enabled, bundles the BigQuery scope into the initial Google login flow so users only see a single consent screen.

When `includeBigqueryScope` is `true`, the login request includes the BigQuery scope alongside `profile` and `email`, and requests offline access with a forced consent prompt to ensure a refresh token is returned. The BigQuery warehouse credentials are then created after the user is resolved from the login flow, rather than before, ensuring the authenticated user object is available when storing the credentials.