### PR TITLE
feat: use ai-agent-revamp feature flag for built-in skills

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4822,19 +4822,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     user.userUuid,
                 ),
         });
-        const { enabled: builtInSkillsEnabled } =
-            await this.featureFlagService.get({
-                user,
-                featureFlagId: FeatureFlags.AiBuiltInSkills,
-            });
-        const availableSkills = builtInSkillsEnabled
-            ? await BuiltInSkills.getAiAgentSkills()
-            : [];
         const { enabled: agentRevampEnabled } =
             await this.featureFlagService.get({
                 user,
                 featureFlagId: FeatureFlags.AiAgentRevamp,
             });
+        const availableSkills = agentRevampEnabled
+            ? await BuiltInSkills.getAiAgentSkills()
+            : [];
         const modelProperties = getModel(this.lightdashConfig.ai.copilot, {
             enableReasoning: prompt.modelConfig?.reasoning,
             modelName: prompt.modelConfig?.modelName,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -107,12 +107,8 @@ export enum FeatureFlags {
     AiAutopilot = 'ai-autopilot',
 
     /**
-     * Enable built-in agent skills and the loadSkill tool.
-     */
-    AiBuiltInSkills = 'ai-built-in-skills',
-
-    /**
-     * Enable AI agent content editing tools like readContent/editContent.
+     * Enable AI agent revamp features including built-in skills, the
+     * loadSkill tool, and content editing tools like readContent/editContent.
      * When enabled, these replace older dashboard-specific content lookup
      * tools in the agent tool surface.
      */


### PR DESCRIPTION
Closes:

### Description:

Consolidates the `AiBuiltInSkills` feature flag into the existing `AiAgentRevamp` flag. Built-in agent skills (including the `loadSkill` tool) are now gated behind `AiAgentRevamp` rather than a separate flag, reducing the number of flags needed to manage AI agent functionality.