### PR TITLE
fix(timezone): persist gated displayTimezone on async query snapshot

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -537,6 +537,118 @@ describe('AsyncQueryService', () => {
             );
         });
 
+        // Regression: persisted metric_query.timezone must follow the gated
+        // displayTimezone, not the ungated resolvedTimezone — otherwise
+        // downstream readers (formatTimestamp, downloads, worker re-exec)
+        // apply a +TZ shift on flag-off orgs that have a project timezone.
+        test('persists displayTimezone=null when flag is off, even if a resolved timezone exists', async () => {
+            (
+                serviceWithCache.findResultsCache as jest.Mock
+            ).mockResolvedValueOnce({
+                cacheHit: false,
+                updatedAt: undefined,
+                expiresAt: undefined,
+            } satisfies MissCacheResult);
+
+            (
+                serviceWithCache.queryHistoryModel.create as jest.Mock
+            ).mockResolvedValue({ queryUuid: 'test-query-uuid' });
+
+            jest.spyOn(
+                serviceWithCache,
+                'runAsyncWarehouseQuery',
+            ).mockResolvedValue(undefined);
+
+            await serviceWithCache.executeAsyncQuery(
+                {
+                    account: sessionAccount,
+                    projectUuid,
+                    metricQuery: metricQueryMock,
+                    context: QueryExecutionContext.EXPLORE,
+                    dateZoom: undefined,
+                    queryTags: {
+                        query_context: QueryExecutionContext.EXPLORE,
+                    },
+                    explore: validExplore,
+                    invalidateCache: false,
+                    sql: 'SELECT * FROM test',
+                    fields: {},
+                    missingParameterReferences: [],
+                    // Resolved tz is set (project has query_timezone) but
+                    // the gating flag is off — SQL was built without a
+                    // timezone-aware DATE_TRUNC, so the persisted snapshot
+                    // must not carry the resolved value either.
+                    timezone: 'Asia/Tokyo',
+                    displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
+                },
+                { query: metricQueryMock },
+            );
+
+            expect(
+                serviceWithCache.queryHistoryModel.create,
+            ).toHaveBeenCalledWith(
+                sessionAccount,
+                expect.objectContaining({
+                    metricQuery: expect.objectContaining({
+                        timezone: undefined,
+                    }),
+                }),
+            );
+        });
+
+        test('persists displayTimezone when flag is on', async () => {
+            (
+                serviceWithCache.findResultsCache as jest.Mock
+            ).mockResolvedValueOnce({
+                cacheHit: false,
+                updatedAt: undefined,
+                expiresAt: undefined,
+            } satisfies MissCacheResult);
+
+            (
+                serviceWithCache.queryHistoryModel.create as jest.Mock
+            ).mockResolvedValue({ queryUuid: 'test-query-uuid' });
+
+            jest.spyOn(
+                serviceWithCache,
+                'runAsyncWarehouseQuery',
+            ).mockResolvedValue(undefined);
+
+            await serviceWithCache.executeAsyncQuery(
+                {
+                    account: sessionAccount,
+                    projectUuid,
+                    metricQuery: metricQueryMock,
+                    context: QueryExecutionContext.EXPLORE,
+                    dateZoom: undefined,
+                    queryTags: {
+                        query_context: QueryExecutionContext.EXPLORE,
+                    },
+                    explore: validExplore,
+                    invalidateCache: false,
+                    sql: 'SELECT * FROM test',
+                    fields: {},
+                    missingParameterReferences: [],
+                    timezone: 'Asia/Tokyo',
+                    displayTimezone: 'Asia/Tokyo',
+                    useTimezoneAwareDateTrunc: true,
+                },
+                { query: metricQueryMock },
+            );
+
+            expect(
+                serviceWithCache.queryHistoryModel.create,
+            ).toHaveBeenCalledWith(
+                sessionAccount,
+                expect.objectContaining({
+                    metricQuery: expect.objectContaining({
+                        timezone: 'Asia/Tokyo',
+                    }),
+                }),
+            );
+        });
+
         test('Cache Invalidation - Complete Flow', async () => {
             // GIVEN: invalidateCache: true is set
             const mockCacheResult: MissCacheResult = {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3162,11 +3162,14 @@ export class AsyncQueryService extends ProjectService {
                             fields: fieldsMap,
                             compiledSql: query,
                             requestParameters,
-                            // Persist the fully resolved timezone (chart >
-                            // user > project fallback) on the snapshot so
-                            // worker paths read it back without re-resolving
-                            // against an absent request account.
-                            metricQuery: { ...metricQuery, timezone },
+                            // Persist the gated display timezone (matches
+                            // what the SQL was built with). Storing the
+                            // ungated resolvedTimezone leaks a +TZ shift
+                            // through formatTimestamp on flag-off orgs.
+                            metricQuery: {
+                                ...metricQuery,
+                                timezone: displayTimezone ?? undefined,
+                            },
                             cacheKey,
                             pivotConfiguration: pivotConfiguration ?? null,
                         });


### PR DESCRIPTION
## Summary

`AsyncQueryService.executeAsyncQuery` was persisting the *ungated*
`resolvedTimezone` onto the `query_history` row's `metricQuery.timezone`
field, regardless of whether the `EnableTimezoneSupport` flag was on
for the org. Downstream consumers then read that value back as
`displayTimezone` and forwarded it to `formatTimestamp`, which converts
UTC instants into the named timezone.

For orgs that have a project `query_timezone` set but the flag off:

- The SQL builder correctly produces 2-arg `TIMESTAMP_TRUNC(col, DAY)`
  (no timezone-aware truncation, returns UTC instants).
- But every downstream formatter saw `displayTimezone = '<project tz>'`
  from the persisted snapshot, and shifted UTC values into that zone.
- Net visible effect: every timestamp displayed with a `+<project tz
  offset>` shift the user didn't ask for.

Affected read paths (all sourced from `queryHistory.metricQuery.timezone`):

- `AsyncQueryService.ts:820` — results-page row formatter
- `AsyncQueryService.ts:1175` — async download (CSV / Excel / GSheets)
- `AsyncQueryService.ts:1302` — pivot-table CSV download
- `AsyncQueryService.ts:2524` — scheduler worker query args
- `AsyncQueryService.ts:2560` — pre-aggregate worker query args
- `AsyncQueryService.ts:5576` — other read path

The fix swaps the persisted value to `displayTimezone ?? undefined`,
which already encodes the flag gate (`enabled ? resolvedTimezone : null`).
The cache key (`AsyncQueryService.ts:3138`) still uses the ungated
`resolvedTimezone` so two queries with different resolved tz never share
a cache entry.

The buggy line was introduced in #22911 (PROD-7528, user-level timezone
preference) — the intent was to let worker paths re-resolve without an
account context, but the implementation reached for the ungated value.

## Test plan

- [x] New unit test: \`persists displayTimezone=null when flag is off,
  even if a resolved timezone exists\` — asserts the snapshot does NOT
  carry the resolved tz when \`displayTimezone=null\` and
  \`useTimezoneAwareDateTrunc=false\`.
- [x] New unit test: \`persists displayTimezone when flag is on\` —
  asserts the snapshot carries \`displayTimezone\` when the flag is on.
- [x] Existing AsyncQueryService suite still green (27/27).
- [ ] Manual verification on a non-prod instance with a project
  \`query_timezone\` set to a non-UTC zone and the flag off: timestamps
  in results table, CSV export, and scheduled deliveries render as UTC,
  not in the project tz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #23337