### PR TITLE
feat(ai-agents): make artifact panel resizable

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -89,6 +89,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                                 defaultSize={20}
                                 minSize={10}
                                 maxSize={40}
+                                order={1}
                                 collapsible
                                 className={`${styles.sidebar} ${
                                     !isResizing ? styles.sidebarTransition : ''
@@ -133,7 +134,12 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                 )}
 
                 <ErrorBoundary>
-                    <Panel className={styles.chat} id="chat" minSize={25}>
+                    <Panel
+                        className={styles.chat}
+                        id="chat"
+                        minSize={25}
+                        order={2}
+                    >
                         {Header && (
                             <Box className={styles.chatHeader}>{Header}</Box>
                         )}
@@ -141,15 +147,33 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                         <Box className={styles.chatContent}>{children}</Box>
                     </Panel>
                 </ErrorBoundary>
-            </PanelGroup>
 
-            {!isMobile && artifact && (
-                <ErrorBoundary>
-                    <div className={styles.floatingArtifactRegion}>
-                        <AiArtifactPanel artifact={artifact} />
-                    </div>
-                </ErrorBoundary>
-            )}
+                {!isMobile && artifact && (
+                    <Fragment>
+                        <PanelResizeHandle
+                            aria-label="Resize artifact panel"
+                            className={`${styles.resizeHandle} ${styles.artifactResizeHandle}`}
+                            hitAreaMargins={{ coarse: 16, fine: 8 }}
+                            onDragging={(isDragging) =>
+                                setIsResizing(isDragging)
+                            }
+                        />
+
+                        <ErrorBoundary>
+                            <Panel
+                                className={styles.floatingArtifactRegion}
+                                defaultSize={50}
+                                id="artifact"
+                                minSize={30}
+                                maxSize={70}
+                                order={3}
+                            >
+                                <AiArtifactPanel artifact={artifact} />
+                            </Panel>
+                        </ErrorBoundary>
+                    </Fragment>
+                )}
+            </PanelGroup>
 
             {isMobile && (
                 <Drawer

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
@@ -62,6 +62,21 @@
     }
 }
 
+.artifactResizeHandle {
+    flex: 0 0 0;
+    width: 0;
+    min-width: 0;
+    background-color: transparent;
+    position: relative;
+    z-index: 2;
+
+    &[data-resize-handle-state='hover'],
+    &[data-resize-handle-state='drag'] {
+        background-color: transparent;
+        box-shadow: none;
+    }
+}
+
 .artifact {
     box-shadow: var(--mantine-shadow-lg);
 }
@@ -79,13 +94,11 @@
 }
 
 .floatingArtifactRegion {
-    flex: 0 0 50%;
-    min-width: 420px;
-    max-width: 50vw;
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-sm)
         var(--mantine-spacing-sm) 0;
     min-height: 0;
     display: flex;
+    overflow: hidden;
 }
 
 .floatingArtifactRegion > * {


### PR DESCRIPTION
## Summary

Make the AI artifact floating panel resizable from the boundary between the chat and artifact areas.

## Details

- Moves the artifact region into the existing horizontal `react-resizable-panels` layout.
- Adds a resize handle for the artifact panel while keeping the visible resize affordance aligned with the artifact panel border instead of introducing an extra visible gutter.
- Keeps the current 50% default size and constrains desktop resizing to 30-70%.
- Adds explicit panel ordering for the conditionally rendered sidebar, chat, and artifact panels.

## Validation

- `corepack pnpm -F frontend run linter ./src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx`
- `corepack pnpm -F frontend exec oxfmt ./src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx ./src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css --check`
- `corepack pnpm -F frontend typecheck`
- Local Vite smoke load; full authenticated artifact flow could not be exercised without a local backend.