### PR TITLE
feat(impersonation): make user impersonation generally available

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -859,7 +859,6 @@ describe('legacy feature-flag env vars (compat repair for trivial-batch)', () =>
         ['CHANGE_CHART_EXPLORE_ENABLED', 'change-chart-explore'],
         ['GOOGLE_CHAT_ENABLED', 'google-chat-enabled'],
         ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
-        ['USER_IMPERSONATION_ENABLED', 'user-impersonation'],
         ['GROUPS_ENABLED', 'user-groups-enabled'],
         ['SHOW_EXECUTION_TIME', 'show-execution-time'],
         ['EMBEDDING_ENABLED', 'embedding'],

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1578,7 +1578,6 @@ const LEGACY_ENABLE_ENV_VARS: ReadonlyArray<
     // instances pick up the DB-backed flag as enabled without needing per-DB
     // bootstrapping.
     ['USE_SQL_PIVOT_RESULTS', 'use-sql-pivot-results'],
-    ['USER_IMPERSONATION_ENABLED', 'user-impersonation'],
     // GROUPS_ENABLED is also read by UserService for group-sync logic (separate
     // from the feature flag) — keep the config field, but translate the env
     // var to the unified allowlist for the flag system too.

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -2,7 +2,6 @@ import { LightdashInstallType } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { buildAccount } from '../../auth/account/account.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
-import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { GroupsModel } from '../../models/GroupsModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
@@ -32,7 +31,6 @@ describe('organization service', () => {
         organizationAllowedEmailDomainsModel:
             {} as OrganizationAllowedEmailDomainsModel,
         groupsModel: {} as GroupsModel,
-        featureFlagModel: {} as FeatureFlagModel,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -7,7 +7,6 @@ import {
     CreateColorPalette,
     CreateGroup,
     CreateOrganization,
-    FeatureFlags,
     ForbiddenError,
     Group,
     GroupWithMembers,
@@ -36,7 +35,6 @@ import {
 import { groupBy } from 'lodash';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
-import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { GroupsModel } from '../../models/GroupsModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
@@ -57,7 +55,6 @@ type OrganizationServiceArguments = {
     userModel: UserModel;
     groupsModel: GroupsModel;
     organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
-    featureFlagModel: FeatureFlagModel;
 };
 
 export class OrganizationService extends BaseService {
@@ -79,8 +76,6 @@ export class OrganizationService extends BaseService {
 
     private readonly groupsModel: GroupsModel;
 
-    private readonly featureFlagModel: FeatureFlagModel;
-
     constructor({
         lightdashConfig,
         analytics,
@@ -91,7 +86,6 @@ export class OrganizationService extends BaseService {
         userModel,
         groupsModel,
         organizationAllowedEmailDomainsModel,
-        featureFlagModel,
     }: OrganizationServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -104,7 +98,6 @@ export class OrganizationService extends BaseService {
         this.organizationAllowedEmailDomainsModel =
             organizationAllowedEmailDomainsModel;
         this.groupsModel = groupsModel;
-        this.featureFlagModel = featureFlagModel;
     }
 
     async get(account: Account): Promise<Organization> {
@@ -797,13 +790,6 @@ export class OrganizationService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
-        const flag = await this.featureFlagModel.get({
-            user,
-            featureFlagId: FeatureFlags.UserImpersonation,
-        });
-        if (!flag.enabled) {
-            return false;
-        }
         return this.organizationModel.getImpersonationEnabled(organizationUuid);
     }
 
@@ -823,15 +809,6 @@ export class OrganizationService extends BaseService {
             )
         ) {
             throw new ForbiddenError();
-        }
-        const flag = await this.featureFlagModel.get({
-            user,
-            featureFlagId: FeatureFlags.UserImpersonation,
-        });
-        if (!flag.enabled) {
-            throw new ForbiddenError(
-                'User impersonation is not enabled for this instance',
-            );
         }
         await this.organizationModel.updateImpersonationEnabled(
             organizationUuid,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -525,7 +525,6 @@ export class ServiceRepository
                     organizationAllowedEmailDomainsModel:
                         this.models.getOrganizationAllowedEmailDomainsModel(),
                     groupsModel: this.models.getGroupsModel(),
-                    featureFlagModel: this.models.getFeatureFlagModel(),
                 }),
         );
     }

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2042,10 +2042,10 @@ export class UserService extends BaseService {
             return requestUser;
         }
 
-        // If feature flag is off, clear any active impersonation
+        // If the org has disabled impersonation, clear any active session
         if (!(await this.isImpersonationEnabled(requestUser))) {
             this.logger.warn(
-                `Impersonation feature flag is disabled, clearing impersonation for admin ${passportUser.id}`,
+                `Impersonation disabled for organization, clearing impersonation for admin ${passportUser.id}`,
             );
             clearImpersonation();
             return requestUser;

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -58,12 +58,6 @@ export enum FeatureFlags {
     GoogleChatEnabled = 'google-chat-enabled',
 
     /**
-     * Enable admin user impersonation. When disabled, impersonation
-     * actions are blocked and active sessions are cleared.
-     */
-    UserImpersonation = 'user-impersonation',
-
-    /**
      * Enable custom group bins for string dimensions
      */
     CustomGroupBins = 'custom-group-bins',

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -119,13 +119,7 @@ const Settings: FC = () => {
         user: { data: user, isInitialLoading: isUserLoading, error: userError },
     } = useApp();
 
-    const { data: isUserImpersonationEnabled } = useServerFeatureFlag(
-        FeatureFlags.UserImpersonation,
-    );
-
-    const showImpersonationPanel =
-        isUserImpersonationEnabled?.enabled &&
-        user?.ability?.can('update', 'Organization');
+    const showImpersonationPanel = user?.ability?.can('update', 'Organization');
 
     const { data: leaveOrganizationFlag } = useServerFeatureFlag(
         FeatureFlags.LeaveOrganization,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-437

User impersonation is now generally available. The `user-impersonation` feature flag and the legacy `USER_IMPERSONATION_ENABLED` env-var mapping are gone — the per-org `organizations.impersonation_enabled` boolean is now the only switch, and org admins flip it from Settings → Organization without needing support to enable the flag.

```
Before:                          After:
USER_IMPERSONATION_ENABLED env   org toggle
  └─ user-impersonation flag       └─ impersonate
       └─ org toggle
            └─ impersonate
```

The 15-minute TTL, session-auth-only requirement, recursive/self-impersonation guards, audit events, and impersonation banner are unchanged. The kill-switch behaviour in `UserService.resolveSessionUser` is preserved — flipping the org toggle off still clears any in-flight impersonation on next request (the comment and log message there now correctly say "org disabled" instead of "feature flag disabled").

## Test plan

- [ ] Without `USER_IMPERSONATION_ENABLED` set, log in as an org admin → Settings → Organization shows the "User impersonation" card
- [ ] Flip the toggle on, then impersonate a non-admin from Settings → Users & groups → banner appears, target user's view rendered
- [ ] Stop impersonating, then flip the org toggle off → next request clears any active impersonation session
- [ ] Log in as a non-admin → `/generalSettings/organization` does not show the impersonation card
- [ ] `pnpm -F backend typecheck && pnpm -F frontend typecheck && pnpm -F common typecheck`
- [ ] `pnpm -F backend test:dev:nowatch` covering the touched services

🤖 Generated with [Claude Code](https://claude.com/claude-code)