### PR TITLE
feat: add `sortOnlyDimensions` support for hidden pivot-column sort dims

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -5171,4 +5171,202 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).toContain(`"${longRef}_ra" AS (`);
         });
     });
+
+    describe('sortOnlyDimensions — hidden pivot-column dims that drive column ORDER BY', () => {
+        // Fixture: orders_status is the visible pivot column; orders_status_priority
+        // is a hidden helper dim that drives column sort order (lower number = higher priority).
+        // The user sees column headers by orders_status only, sorted by status_priority ASC.
+
+        test('sortOnlyDimensions are included in group_by_query SELECT and GROUP BY', () => {
+            const pivotConfiguration = {
+                indexColumn: [
+                    {
+                        reference: 'customer_id',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'orders_status' }],
+                sortBy: [
+                    {
+                        reference: 'orders_status_priority',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+                sortOnlyDimensions: [{ reference: 'orders_status_priority' }],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // orders_status_priority must appear in group_by_query's SELECT and GROUP BY
+            expect(replaceWhitespace(result)).toContain(
+                '"orders_status", "orders_status_priority", "customer_id"',
+            );
+            expect(replaceWhitespace(result)).toContain(
+                'group by "orders_status", "orders_status_priority", "customer_id"',
+            );
+        });
+
+        test('sortOnlyDimensions does NOT spread orders_status_priority as a pivot column (no CASE WHEN for it)', () => {
+            const pivotConfiguration = {
+                indexColumn: [
+                    {
+                        reference: 'customer_id',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'orders_status' }],
+                sortBy: [
+                    {
+                        reference: 'orders_status_priority',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+                sortOnlyDimensions: [{ reference: 'orders_status_priority' }],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // pivot_query must pivot only on orders_status (the visible groupByColumn)
+            // and NOT include orders_status_priority in the DISTINCT SELECT of column_ranking
+            const collapsed = replaceWhitespace(result);
+
+            // column_ranking DISTINCT SELECT should only contain orders_status
+            const colRankingStart = collapsed.indexOf(
+                'column_ranking AS (SELECT DISTINCT',
+            );
+            expect(colRankingStart).toBeGreaterThanOrEqual(0);
+            // The DISTINCT SELECT should reference orders_status but not orders_status_priority
+            const colRankingEnd = collapsed.indexOf(
+                ', DENSE_RANK()',
+                colRankingStart,
+            );
+            const colRankingSelect = collapsed.slice(
+                colRankingStart,
+                colRankingEnd,
+            );
+            expect(colRankingSelect).toContain('"orders_status"');
+            expect(colRankingSelect).not.toContain('"orders_status_priority"');
+        });
+
+        test('sortOnlyDimensions influences column ORDER BY in column_ranking', () => {
+            const pivotConfiguration = {
+                indexColumn: [
+                    {
+                        reference: 'customer_id',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'orders_status' }],
+                sortBy: [
+                    {
+                        reference: 'orders_status_priority',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+                sortOnlyDimensions: [{ reference: 'orders_status_priority' }],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+            const collapsed = replaceWhitespace(result);
+
+            // column_ranking ORDER BY should include orders_status_priority
+            expect(collapsed).toContain(
+                'column_ranking AS (SELECT DISTINCT g."orders_status", DENSE_RANK() OVER (ORDER BY g."orders_status" ASC, g."orders_status_priority" ASC) AS "col_idx"',
+            );
+        });
+
+        test('sortOnlyDimensions with no sort entry — does not affect SQL (no column_ranking emitted for dim)', () => {
+            // When sortOnlyDimensions is set but the dim is NOT in sortBy, it should still
+            // appear in group_by_query but column_ranking should NOT be emitted (no hasDimSort).
+            const pivotConfiguration = {
+                indexColumn: [
+                    {
+                        reference: 'customer_id',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'orders_status' }],
+                sortBy: undefined,
+                sortOnlyDimensions: [{ reference: 'orders_status_priority' }],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // No column_ranking CTE since there's no sort on the dim
+            expect(result).not.toContain('column_ranking');
+        });
+
+        test('existing metric sort tests are unaffected when sortOnlyDimensions is absent', () => {
+            // Regression guard: standard metric sort path must not be broken
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: 'revenue', direction: SortByDirection.DESC },
+                ],
+                // No sortOnlyDimensions
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // Standard metric sort anchor CTEs must still be emitted
+            expect(result).toContain('"revenue_ca" AS (');
+            expect(result).toContain('column_ranking AS (');
+        });
+    });
 });

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -5309,8 +5309,11 @@ SELECT * FROM group_by_query LIMIT 50`);
         });
 
         test('sortOnlyDimensions with no sort entry — does not affect SQL (no column_ranking emitted for dim)', () => {
-            // When sortOnlyDimensions is set but the dim is NOT in sortBy, it should still
-            // appear in group_by_query but column_ranking should NOT be emitted (no hasDimSort).
+            // Defensive guard: derivePivotConfigFromChart only routes a dim into
+            // sortOnlyDimensions when it has a sort entry, so {sortOnlyDimensions: [...],
+            // sortBy: undefined} is not a state the data layer would produce. This test
+            // verifies the SQL builder degrades gracefully if it ever did (no
+            // column_ranking emitted, falls back to base group_by ordering).
             const pivotConfiguration = {
                 indexColumn: [
                     {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -134,6 +134,9 @@ export class PivotQueryBuilder {
         for (const col of this.pivotConfiguration.groupByColumns ?? []) {
             existingRefs.add(col.reference);
         }
+        for (const col of this.pivotConfiguration.sortOnlyDimensions ?? []) {
+            existingRefs.add(col.reference);
+        }
 
         const allTableCalculationIds = new Set(
             Object.values(this.itemsMap)
@@ -389,17 +392,28 @@ export class PivotQueryBuilder {
      * @param indexColumns - Columns to use as row identifiers
      * @param valuesColumns - Columns to aggregate with their aggregation functions
      * @param groupByColumns - Additional columns to group by for pivoting
+     * @param sortOnlyDimensions - Pivot-column dims that are hidden from display
+     *   but still need to pass through the GROUP BY so they're available for
+     *   column ORDER BY (sortOnlyDimensions in PivotConfiguration).
      * @returns SQL for the group_by_query CTE
      */
     private getGroupByQuerySQL(
         indexColumns: ReturnType<typeof normalizeIndexColumns>,
         valuesColumns: PivotConfiguration['valuesColumns'],
         groupByColumns: PivotConfiguration['groupByColumns'],
+        sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
         const groupBySelectDimensions = [
             ...(groupByColumns || []).map((col) => `${q}${col.reference}${q}`),
+            // Sort-only pivot dimensions must be in GROUP BY so their values
+            // are available for column ORDER BY downstream. They are not
+            // pivot-spread columns (not in groupByColumns), but they still
+            // need to survive the aggregation pipeline.
+            ...(sortOnlyDimensions || []).map(
+                (col) => `${q}${col.reference}${q}`,
+            ),
             ...indexColumns.map((col) => `${q}${col.reference}${q}`),
         ];
 
@@ -473,6 +487,9 @@ export class PivotQueryBuilder {
      * @param sortBy - Sort configuration for columns
      * @param metricFirstValueQueries - Map of CTE names to their definitions
      * @param q - Quote character for field names
+     * @param sortOnlyDimensions - Hidden pivot-column dims that drive column ORDER BY
+     *   but are not pivot-spread columns. They participate in ORDER BY the same way
+     *   as groupByColumns but are not included in the groupByColumns DISTINCT SELECT.
      * @returns ORDER BY clause string for groupBy columns
      */
     private buildGroupByOrderBy(
@@ -484,8 +501,16 @@ export class PivotQueryBuilder {
             { cteName: string; sql: string }
         >,
         q: string,
+        sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): string {
         const orderByParts: string[] = [];
+
+        // All dimension columns that can appear in the ORDER BY:
+        // visible groupByColumns + hidden sortOnlyDimensions
+        const allOrderableDims = [
+            ...groupByColumns,
+            ...(sortOnlyDimensions || []),
+        ];
 
         if (sortBy) {
             const isValueColumn = (sort: VizSortBy | undefined) =>
@@ -493,10 +518,8 @@ export class PivotQueryBuilder {
                     (valCol) => valCol.reference === sort?.reference,
                 );
 
-            const isGroupByColumn = ({ reference }: VizSortBy) =>
-                groupByColumns.some(
-                    (groupCol) => groupCol.reference === reference,
-                );
+            const isOrderableDim = ({ reference }: VizSortBy) =>
+                allOrderableDims.some((col) => col.reference === reference);
 
             // Create values order parts
             const valuesOrderByParts = sortBy
@@ -520,8 +543,10 @@ export class PivotQueryBuilder {
                     return acc;
                 }, []);
 
-            // Create groups order parts. Note that groups parts should follow the groupsByColumns order rather than sortBy order.
-            const groupsOrderByParts = groupByColumns.map((col) => {
+            // Create groups order parts following allOrderableDims order (visible groupByColumns
+            // first, then sortOnlyDimensions). Note that groups parts should follow the
+            // groupsByColumns order rather than sortBy order.
+            const groupsOrderByParts = allOrderableDims.map((col) => {
                 const sort = sortBy.find((s) => s.reference === col.reference);
                 const sortExpr = this.resolveSortField(
                     col.reference,
@@ -537,7 +562,7 @@ export class PivotQueryBuilder {
 
             // Order parts cannot have values and groups interleaved. We have to ensure they are together by type
             const sortByValuesFirst = isValueColumn(
-                sortBy.find((s) => isValueColumn(s) || isGroupByColumn(s)),
+                sortBy.find((s) => isValueColumn(s) || isOrderableDim(s)),
             );
             if (sortByValuesFirst) {
                 orderByParts.push(...valuesOrderByParts, ...groupsOrderByParts);
@@ -545,8 +570,8 @@ export class PivotQueryBuilder {
                 orderByParts.push(...groupsOrderByParts, ...valuesOrderByParts);
             }
         } else {
-            // Default to all groupBy columns with ASC direction
-            groupByColumns.forEach((col) => {
+            // Default to all orderable dim columns with ASC direction
+            allOrderableDims.forEach((col) => {
                 orderByParts.push(`g.${q}${col.reference}${q} ASC`);
             });
         }
@@ -706,10 +731,13 @@ export class PivotQueryBuilder {
      * Generates the column_ranking CTE that computes column_index for each distinct groupBy combination.
      * This is needed to identify the anchor column (column_index = 1) for row sorting.
      *
-     * @param groupByColumns - Group by columns
+     * @param groupByColumns - Group by columns (visible pivot-column dims)
      * @param valuesColumns - Value columns configuration
      * @param sortBy - Sort configuration
      * @param columnAnchorCTEs - Column anchor CTEs for metric-based column sorting
+     * @param sortOnlyDimensions - Hidden pivot-column dims available in group_by_query
+     *   that should influence the ORDER BY of column_ranking (and thus column order)
+     *   but should NOT appear in the DISTINCT SELECT (so they don't create extra groups).
      * @returns SQL for the column_ranking CTE
      */
     private getColumnRankingSQL(
@@ -717,20 +745,28 @@ export class PivotQueryBuilder {
         valuesColumns: PivotConfiguration['valuesColumns'],
         sortBy: PivotConfiguration['sortBy'],
         columnAnchorCTEs: Record<string, { cteName: string; sql: string }>,
+        sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
+        // DISTINCT SELECT contains only visible groupBy columns so that each
+        // pivot column header combination maps to exactly one col_idx.
+        // sortOnlyDimensions are NOT included here — they are helper dims that
+        // only drive the ORDER BY, not the column identity.
         const groupByRefs = groupByColumns
             .map((col) => `g.${q}${col.reference}${q}`)
             .join(', ');
 
-        // Build ORDER BY clause for column_index (same logic as buildGroupByOrderBy)
+        // Build ORDER BY clause for column_index.
+        // sortOnlyDimensions participate in the ORDER BY so they influence which
+        // groupBy combination gets col_idx = 1, 2, 3, …
         const groupByOrderBy = this.buildGroupByOrderBy(
             groupByColumns,
             valuesColumns,
             sortBy,
             columnAnchorCTEs,
             q,
+            sortOnlyDimensions,
         );
 
         // Build JOINs for column anchor CTEs
@@ -965,8 +1001,9 @@ export class PivotQueryBuilder {
      *
      * @param indexColumns - Normalized index columns
      * @param valuesColumns - Value columns configuration
-     * @param groupByColumns - Group by columns
+     * @param groupByColumns - Group by columns (visible pivot-column dims)
      * @param sortBy - Sort configuration
+     * @param sortOnlyDimensions - Hidden pivot-column dims that influence column ORDER BY
      * @returns Object containing all anchor-related CTEs and the combined metricFirstValueQueries map
      */
     private getMetricAnchorCTEs(
@@ -974,6 +1011,7 @@ export class PivotQueryBuilder {
         valuesColumns: PivotConfiguration['valuesColumns'],
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         sortBy: PivotConfiguration['sortBy'],
+        sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): {
         columnAnchorCTEs: string[];
         columnRankingCTE: string | null;
@@ -1007,6 +1045,16 @@ export class PivotQueryBuilder {
         const hasMetricSort = valuesColumns?.some((valCol) =>
             sortBy?.some((sort) => sort.reference === valCol.reference),
         );
+        // A sort-only dimension also drives the column ORDER BY, which means
+        // we need column_ranking (for the precomputed ranking path) even when
+        // there is no metric sort. This keeps Databricks/Spark from emitting
+        // inline Window functions that reference cross-CTE columns.
+        const hasDimSort =
+            (sortOnlyDimensions?.length ?? 0) > 0 &&
+            sortOnlyDimensions?.some((dim) =>
+                sortBy?.some((sort) => sort.reference === dim.reference),
+            );
+        const needsColumnRanking = hasMetricSort || hasDimSort;
         const needsRowAnchor = hasMetricSort && indexColumns.length > 0;
 
         let columnRankingCTE: string | null = null;
@@ -1015,12 +1063,13 @@ export class PivotQueryBuilder {
         let rowAnchorQueries: Record<string, { cteName: string; sql: string }> =
             {};
 
-        if (hasMetricSort) {
+        if (needsColumnRanking) {
             const columnRankingSQL = this.getColumnRankingSQL(
                 groupByColumns,
                 valuesColumns,
                 sortBy,
                 columnAnchorQueries,
+                sortOnlyDimensions,
             );
             columnRankingCTE = `column_ranking AS (${columnRankingSQL})`;
 
@@ -1163,6 +1212,7 @@ export class PivotQueryBuilder {
             { cteName: string; sql: string }
         >,
         usePrecomputedRankings: boolean = false,
+        sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
@@ -1280,6 +1330,7 @@ export class PivotQueryBuilder {
             sortBy,
             metricFirstValueQueries,
             q,
+            sortOnlyDimensions,
         );
 
         // If there are no index columns, use a constant for row_index (all rows have same index)
@@ -1400,9 +1451,10 @@ export class PivotQueryBuilder {
      * @param groupByQuery - GROUP BY query SQL
      * @param indexColumns - Index columns for row identification
      * @param valuesColumns - Value columns to aggregate
-     * @param groupByColumns - Columns to pivot across
+     * @param groupByColumns - Columns to pivot across (visible pivot-column dims)
      * @param sortBy - Sort configuration
      * @param columnLimit - Maximum number of columns to return
+     * @param sortOnlyDimensions - Hidden pivot-column dims that drive column ORDER BY
      * @returns Complete SQL with CTEs for pivoting with grouping
      */
     private getFullPivotSQL(
@@ -1413,6 +1465,7 @@ export class PivotQueryBuilder {
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         sortBy: PivotConfiguration['sortBy'],
         columnLimit: number | undefined,
+        sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const rowLimit = this.limit ?? DEFAULT_PIVOT_ROW_LIMIT;
@@ -1434,6 +1487,7 @@ export class PivotQueryBuilder {
             valuesColumnsWithoutPivotTableCalculations,
             groupByColumns,
             sortBy,
+            sortOnlyDimensions,
         );
 
         // When metric sorting is active, compute rankings in separate CTEs
@@ -1469,6 +1523,7 @@ export class PivotQueryBuilder {
             sortBy,
             metricFirstValueQueries,
             needsPrecomputedRankings,
+            sortOnlyDimensions,
         );
 
         let maxColumnsPerValueColumnSql = '';
@@ -1584,6 +1639,7 @@ export class PivotQueryBuilder {
             groupByColumns,
             sortBy,
             sortOnlyColumns,
+            sortOnlyDimensions,
         } = this.pivotConfiguration;
 
         // Merge sort-only columns into valuesColumns for SQL generation.
@@ -1615,6 +1671,7 @@ export class PivotQueryBuilder {
             indexColumns,
             valuesColumns,
             groupByColumns,
+            sortOnlyDimensions,
         );
 
         let finalSql: string;
@@ -1629,6 +1686,7 @@ export class PivotQueryBuilder {
                 groupByColumns,
                 sortBy,
                 columnLimit,
+                sortOnlyDimensions,
             );
         } else {
             finalSql = this.getSimpleQuerySQL(baseSql, groupByQuery, sortBy);

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -1050,10 +1050,9 @@ export class PivotQueryBuilder {
         // there is no metric sort. This keeps Databricks/Spark from emitting
         // inline Window functions that reference cross-CTE columns.
         const hasDimSort =
-            (sortOnlyDimensions?.length ?? 0) > 0 &&
             sortOnlyDimensions?.some((dim) =>
                 sortBy?.some((sort) => sort.reference === dim.reference),
-            );
+            ) ?? false;
         const needsColumnRanking = hasMetricSort || hasDimSort;
         const needsRowAnchor = hasMetricSort && indexColumns.length > 0;
 

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -1305,6 +1305,214 @@ describe('derivePivotConfigurationFromChart', () => {
         });
     });
 
+    describe('sort-only pivot-column dimensions (hidden pivot dims) for Table charts', () => {
+        // orders_status_priority is a helper dim that the user adds as a pivot column
+        // purely to drive column sort order. It is hidden so users see only orders_status
+        // as the pivot header, but the helper value still determines the column order.
+        const itemsWithPriority: ItemsMap = {
+            ...mockItems,
+            orders_status_priority: {
+                sql: '${TABLE}.status_priority',
+                name: 'status_priority',
+                type: DimensionType.NUMBER,
+                index: 5,
+                label: 'Status priority',
+                table: 'orders',
+                groups: [],
+                hidden: false, // not hidden in the explore — hidden in the chart config
+                fieldType: FieldType.DIMENSION,
+                tableLabel: 'Orders',
+            },
+        };
+
+        it('routes a hidden pivot-column dim with a sort entry to sortOnlyDimensions (not groupByColumns)', () => {
+            const chartConfig = {
+                type: ChartType.TABLE,
+                config: {
+                    columns: { orders_status_priority: { visible: false } },
+                    pivotDimensions: [
+                        'orders_status',
+                        'orders_status_priority',
+                    ],
+                    showSubtotals: false,
+                },
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig,
+                pivotConfig: {
+                    columns: ['orders_status', 'orders_status_priority'],
+                },
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                dimensions: [
+                    'payments_payment_method',
+                    'orders_status',
+                    'orders_status_priority',
+                ],
+                metrics: ['payments_total_revenue'],
+                sorts: [
+                    { fieldId: 'orders_status_priority', descending: false },
+                ],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                itemsWithPriority,
+            );
+
+            expect(result).toBeDefined();
+
+            // orders_status_priority should NOT be in groupByColumns
+            expect(
+                result?.groupByColumns?.some(
+                    (c) => c.reference === 'orders_status_priority',
+                ),
+            ).toBe(false);
+
+            // orders_status SHOULD still be in groupByColumns
+            expect(
+                result?.groupByColumns?.some(
+                    (c) => c.reference === 'orders_status',
+                ),
+            ).toBe(true);
+
+            // orders_status_priority SHOULD be in sortOnlyDimensions
+            expect(
+                result?.sortOnlyDimensions?.some(
+                    (c) => c.reference === 'orders_status_priority',
+                ),
+            ).toBe(true);
+
+            // sortBy should still include orders_status_priority
+            expect(
+                result?.sortBy?.some(
+                    (s) => s.reference === 'orders_status_priority',
+                ),
+            ).toBe(true);
+        });
+
+        it('drops a hidden pivot-column dim entirely when it is not in sorts', () => {
+            const chartConfig = {
+                type: ChartType.TABLE,
+                config: {
+                    columns: { orders_status_priority: { visible: false } },
+                    pivotDimensions: [
+                        'orders_status',
+                        'orders_status_priority',
+                    ],
+                    showSubtotals: false,
+                },
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig,
+                pivotConfig: {
+                    columns: ['orders_status', 'orders_status_priority'],
+                },
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                dimensions: [
+                    'payments_payment_method',
+                    'orders_status',
+                    'orders_status_priority',
+                ],
+                metrics: ['payments_total_revenue'],
+                sorts: [], // no sort on the hidden dim
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                itemsWithPriority,
+            );
+
+            expect(result).toBeDefined();
+
+            // orders_status_priority should NOT be in groupByColumns
+            expect(
+                result?.groupByColumns?.some(
+                    (c) => c.reference === 'orders_status_priority',
+                ),
+            ).toBe(false);
+
+            // sortOnlyDimensions should be empty (no sort on hidden pivot dim)
+            expect(result?.sortOnlyDimensions ?? []).toEqual([]);
+        });
+
+        it('does not affect non-hidden pivot-column dims', () => {
+            // Both pivot dims are visible — neither should go to sortOnlyDimensions
+            const chartConfig = {
+                type: ChartType.TABLE,
+                config: {
+                    columns: {}, // no hidden columns
+                    pivotDimensions: [
+                        'orders_status',
+                        'orders_status_priority',
+                    ],
+                    showSubtotals: false,
+                },
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig,
+                pivotConfig: {
+                    columns: ['orders_status', 'orders_status_priority'],
+                },
+            };
+
+            const mq: MetricQuery = {
+                ...mockMetricQuery,
+                dimensions: [
+                    'payments_payment_method',
+                    'orders_status',
+                    'orders_status_priority',
+                ],
+                metrics: ['payments_total_revenue'],
+                sorts: [
+                    { fieldId: 'orders_status_priority', descending: false },
+                ],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                mq,
+                itemsWithPriority,
+            );
+
+            expect(result).toBeDefined();
+
+            // Both dims should be in groupByColumns
+            expect(
+                result?.groupByColumns?.some(
+                    (c) => c.reference === 'orders_status',
+                ),
+            ).toBe(true);
+            expect(
+                result?.groupByColumns?.some(
+                    (c) => c.reference === 'orders_status_priority',
+                ),
+            ).toBe(true);
+
+            // sortOnlyDimensions should be empty (dim is visible)
+            expect(result?.sortOnlyDimensions ?? []).toEqual([]);
+        });
+    });
+
     describe('sort-only dimensions for Table charts', () => {
         it('puts a hidden helper dimension in sortOnlyColumns instead of indexColumn', () => {
             // orders_status is hidden (visible: false) but used for sort order.

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -34,8 +34,13 @@ function getSortByForPivotConfiguration(
     partialPivot: Omit<PivotConfiguration, 'sortBy'>,
     metricQuery: MetricQuery,
 ): NonNullable<PivotConfiguration['sortBy']> | undefined {
-    const { groupByColumns, indexColumn, valuesColumns, sortOnlyColumns } =
-        partialPivot;
+    const {
+        groupByColumns,
+        indexColumn,
+        valuesColumns,
+        sortOnlyColumns,
+        sortOnlyDimensions,
+    } = partialPivot;
 
     const sortBy = metricQuery.sorts
         .map<NonNullable<PivotConfiguration['sortBy']>[number] | undefined>(
@@ -56,12 +61,17 @@ function getSortByForPivotConfiguration(
                     (col) => col.reference === sort.fieldId,
                 );
 
+                const isSortOnlyDimension = sortOnlyDimensions?.some(
+                    (col) => col.reference === sort.fieldId,
+                );
+
                 // Include sort if the field is present in any part of the pivot configuration
                 if (
                     isGroupByColumn ||
                     isIndexColumn ||
                     isValueColumn ||
-                    isSortOnlyColumn
+                    isSortOnlyColumn ||
+                    isSortOnlyDimension
                 ) {
                     return {
                         reference: sort.fieldId,
@@ -203,31 +213,54 @@ function getTablePivotConfiguration(
 
     const pivotColumns = pivotConfig.columns || [];
 
-    // Group by columns are the pivot dimensions
-    const groupByColumns = pivotColumns
+    // Identify hidden dimensions (visible: false in columnProperties).
+    // ANY hidden dim is excluded from indexColumn / groupByColumns.
+    // Among hidden dims, those that also appear in sorts participate in SQL
+    // for sort ordering but do not render as visible columns.
+    // Hidden dims that are NOT sorted are simply dropped entirely.
+    const hiddenFieldIds = getHiddenTableFields(chartConfig);
+    const sortFieldIds = new Set(metricQuery.sorts.map((s) => s.fieldId));
+
+    // Group by columns are the pivot dimensions — exclude hidden ones.
+    // Hidden pivot-column dims are either routed to sortOnlyDimensions (if sorted)
+    // or dropped entirely (if not sorted).
+    const allPivotGroupByColumns = pivotColumns
         .map((col: string) => ({
             reference: col,
         }))
         .filter((col) => metricQuery.dimensions.includes(col.reference));
 
-    // Identify hidden dimensions (visible: false in columnProperties).
-    // ANY hidden dim is excluded from indexColumn / groupByColumns.
-    // Among hidden dims, those that also appear in sorts become sortOnlyColumns —
-    // they drive sort order in the SQL but do not render as row-index columns.
-    // Hidden dims that are NOT sorted are simply dropped entirely.
-    const hiddenFieldIds = getHiddenTableFields(chartConfig);
-    const groupByRefs = new Set(groupByColumns.map((c) => c.reference));
-    const sortFieldIds = new Set(metricQuery.sorts.map((s) => s.fieldId));
+    const groupByColumns = allPivotGroupByColumns.filter(
+        (col) => !hiddenFieldIds.includes(col.reference),
+    );
 
-    // All hidden dims (regardless of sort status) — used to exclude from indexColumn.
+    // Hidden pivot-column dims that are also sorted → kept for column ORDER BY
+    // via sortOnlyDimensions. They drive column sort order but are not spread
+    // as pivot column headers.
+    const sortOnlyPivotDimensions = allPivotGroupByColumns
+        .filter(
+            (col) =>
+                hiddenFieldIds.includes(col.reference) &&
+                sortFieldIds.has(col.reference),
+        )
+        .map((col) => ({ reference: col.reference }));
+
+    const groupByRefs = new Set([
+        ...groupByColumns.map((c) => c.reference),
+        ...sortOnlyPivotDimensions.map((c) => c.reference),
+    ]);
+
+    // All hidden dims that are NOT pivot-column dims (i.e., row-index dims).
+    // These are excluded from indexColumn.
     const allHiddenDimRefs = new Set(
         metricQuery.dimensions.filter(
             (d) => hiddenFieldIds.includes(d) && !groupByRefs.has(d),
         ),
     );
 
-    // Subset of hidden dims that are also sorted → participate in SQL via sortOnlyColumns.
-    const sortOnlyDimensions = metricQuery.dimensions
+    // Subset of hidden row-index dims that are also sorted → participate in SQL
+    // via sortOnlyColumns (merged into valuesColumns for the group_by_query).
+    const sortOnlyRowDimensions = metricQuery.dimensions
         .filter((d) => allHiddenDimRefs.has(d) && sortFieldIds.has(d))
         .map((d) => ({
             reference: d,
@@ -247,9 +280,16 @@ function getTablePivotConfiguration(
         ...hiddenDimPlaceholders,
     ];
 
+    // Also exclude hidden pivot-column dims from indexColumn by treating them as
+    // group-by columns from getIndexColumn's perspective.
+    const allGroupByColumnsForIndex = [
+        ...groupByColumns,
+        ...sortOnlyPivotDimensions,
+    ];
+
     // Find columns that are not groupBy or value columns (these become index columns)
     const indexColumn = getIndexColumn(
-        groupByColumns,
+        allGroupByColumnsForIndex,
         allValuesColumnsForIndex,
         fields,
         metricQuery,
@@ -259,8 +299,11 @@ function getTablePivotConfiguration(
         indexColumn,
         valuesColumns,
         groupByColumns,
-        ...(sortOnlyDimensions.length > 0 && {
-            sortOnlyColumns: sortOnlyDimensions,
+        ...(sortOnlyRowDimensions.length > 0 && {
+            sortOnlyColumns: sortOnlyRowDimensions,
+        }),
+        ...(sortOnlyPivotDimensions.length > 0 && {
+            sortOnlyDimensions: sortOnlyPivotDimensions,
         }),
     };
 

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1068,6 +1068,11 @@ export const convertSqlPivotedRowsToPivotData = ({
         .filter((field, index, self) => self.indexOf(field) === index)
         .sort((a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b));
 
+    // pivotDetails.groupByColumns comes from PivotConfiguration.groupByColumns,
+    // which only contains VISIBLE pivot-column dims. Hidden pivot-column dims
+    // that drive sort order (sortOnlyDimensions in PivotConfiguration) are
+    // deliberately excluded from groupByColumns before this point, so they
+    // never appear as column header rows here. No extra filtering needed.
     const headerValueTypes = getHeaderValueTypes({
         metricsAsRows: pivotConfig.metricsAsRows,
         pivotDimensionNames: (pivotDetails.groupByColumns ?? []).map(

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -40,6 +40,14 @@ export type PivotConfiguration = {
      * but excluded from pivotDetails so they don't appear as chart series.
      */
     sortOnlyColumns?: ValuesColumn[];
+    /**
+     * Dimensions referenced by ORDER BY but NOT spread into pivot columns.
+     * Used when a user hides a dim that's part of `pivotConfig.columns` and has
+     * a sort entry on it: the dim still ranks column order via the GROUP BY /
+     * ORDER BY pipeline, but it doesn't become a pivot column header level.
+     * Mirrors `sortOnlyColumns` (which serves the same purpose for metrics).
+     */
+    sortOnlyDimensions?: GroupByColumn[];
 };
 
 type Field =


### PR DESCRIPTION
Related to: PROD-2108

### Description:

Adds support for **sort-only pivot-column dimensions** — hidden pivot dimensions that drive column sort order without appearing as visible pivot column headers.

Previously, all dimensions listed in `pivotConfig.columns` were treated as visible pivot column headers (`groupByColumns`). This change introduces a new `sortOnlyDimensions` field on `PivotConfiguration` to handle the case where a user hides a pivot-column dimension (e.g. `orders_status_priority`) but still wants it to control the order in which pivot columns appear.

**How it works:**

- A pivot-column dimension that is marked hidden (`visible: false`) and has a sort entry is routed to `sortOnlyDimensions` instead of `groupByColumns` in `derivePivotConfigurationFromChart`.
- Hidden pivot-column dims with no sort entry are dropped entirely (no change from before for that case).
- In `PivotQueryBuilder`, `sortOnlyDimensions` are included in the `group_by_query` SELECT and GROUP BY so their values survive the aggregation pipeline, but they are **not** included in the `column_ranking` DISTINCT SELECT — preventing them from creating extra pivot column header groups.
- The `column_ranking` ORDER BY incorporates `sortOnlyDimensions` so they influence which column combination receives `col_idx = 1, 2, 3, …`, producing the desired column order.
- `column_ranking` is now emitted whenever a `sortOnlyDimension` has a matching sort entry (`hasDimSort`), not only when a metric sort is present.
- `convertSqlPivotedRowsToPivotData` requires no changes since `groupByColumns` already contains only visible pivot-column dims by the time it is called.