### PR TITLE
feat(data-apps): duplicate an existing data app into a personal copy

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1337,6 +1337,18 @@ export type DataAppVersionRestoredEvent = BaseTrack & {
     };
 };
 
+export type DataAppDuplicatedEvent = BaseTrack & {
+    event: 'data_app.duplicated';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        duplicatedFromAppUuid: string;
+        duplicatedFromVersion: number;
+    };
+};
+
 export type DataAppEvent =
     | DataAppCreatedEvent
     | DataAppIteratedEvent
@@ -1345,7 +1357,8 @@ export type DataAppEvent =
     | DataAppVersionFailedEvent
     | DataAppImageUploadedEvent
     | DataAppViewedEvent
-    | DataAppVersionRestoredEvent;
+    | DataAppVersionRestoredEvent
+    | DataAppDuplicatedEvent;
 
 export type CommentsEvent = BaseTrack & {
     event: 'comment.created' | 'comment.deleted' | 'comment.resolved';

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -10,6 +10,7 @@ import {
     type ApiClarifyAppResponse,
     type ApiCreateAppSchedulerResponse,
     type ApiDeleteAppResponse,
+    type ApiDuplicateAppResponse,
     type ApiGenerateAppResponse,
     type ApiGetAppResponse,
     type ApiMyAppsResponse,
@@ -272,6 +273,33 @@ export class AppGenerateController extends BaseController {
             projectUuid,
             appUuid,
             version,
+        );
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: result,
+        };
+    }
+
+    /**
+     * Duplicate an existing app into a new personal app owned by the
+     * requester. Latest ready version is copied; no sandbox is created.
+     * @summary Duplicate app
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{appUuid}/duplicate')
+    @OperationId('duplicateApp')
+    async duplicateApp(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+    ): Promise<ApiDuplicateAppResponse> {
+        assertRegisteredAccount(req.account);
+        const result = await this.getAppGenerateService().duplicateApp(
+            toSessionUser(req.account),
+            projectUuid,
+            appUuid,
         );
         this.setStatus(200);
         return {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -3203,9 +3203,8 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         const copiedKeys = await AppGenerateService.copyVersionS3Prefix(
             s3Client,
             bucket,
-            appUuid,
-            sourceVersion,
-            newVersion,
+            { appUuid, version: sourceVersion },
+            { appUuid, version: newVersion },
         );
 
         // 2. Resync the running sandbox so the next iteration sees the
@@ -3292,20 +3291,19 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     }
 
     /**
-     * Server-side copy every object under
-     * `apps/{appUuid}/versions/{sourceVersion}/` into
-     * `apps/{appUuid}/versions/{newVersion}/`. Returns the list of
-     * destination keys so the caller can roll back on later failure.
+     * Server-side copy every object under the source version's S3 prefix
+     * into the target version's S3 prefix. Supports both same-app (restore)
+     * and cross-app (duplicate) copies. Returns the list of destination keys
+     * so the caller can roll back on later failure.
      */
     private static async copyVersionS3Prefix(
         s3Client: S3Client,
         bucket: string,
-        appUuid: string,
-        sourceVersion: number,
-        newVersion: number,
+        source: { appUuid: string; version: number },
+        target: { appUuid: string; version: number },
     ): Promise<string[]> {
-        const sourcePrefix = `apps/${appUuid}/versions/${sourceVersion}/`;
-        const destinationPrefix = `apps/${appUuid}/versions/${newVersion}/`;
+        const sourcePrefix = `apps/${source.appUuid}/versions/${source.version}/`;
+        const destinationPrefix = `apps/${target.appUuid}/versions/${target.version}/`;
         const copiedKeys: string[] = [];
 
         let continuationToken: string | undefined;
@@ -3520,6 +3518,135 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 `App ${appUuid}: failed to clean up ${keys.length} orphaned restore object(s): ${getErrorMessage(cleanupError)}`,
             );
         }
+    }
+
+    /**
+     * Duplicate an existing app the user can view into a new personal app
+     * owned by the requester. The new app starts at v1 with the source's
+     * latest ready version's S3 artifacts (dist.tar + source.tar + any
+     * extracted assets) server-side copied into the new prefix. No sandbox
+     * is created — a fresh one spins up lazily on the first iteration via
+     * the standard restore-from-tarball path.
+     *
+     * Carried over: template, chart/dashboard resource refs (UUIDs only),
+     * claudeModel, prompt (source's latest ready version's text), and the
+     * description verbatim. Dropped: images, prior version history, prior
+     * clarifications, sandbox, pin state.
+     */
+    async duplicateApp(
+        user: SessionUser,
+        projectUuid: string,
+        sourceAppUuid: string,
+    ): Promise<GenerateAppResult> {
+        await this.assertDataAppsEnabled(user);
+
+        const sourceApp = await this.appModel.getApp(
+            sourceAppUuid,
+            projectUuid,
+        );
+        await this.assertCanViewApp(user, sourceApp);
+
+        // The duplicate lands as a personal app in the same project. We need
+        // `create:DataApp` on the project itself — viewers who can read a
+        // shared app but can't author new ones must not be able to fork it.
+        this.assertDataAppAbility(
+            user,
+            'create',
+            sourceApp.organization_uuid,
+            projectUuid,
+            'Insufficient permissions to duplicate this data app',
+        );
+
+        const sourceVersion = await this.appModel.getLatestReadyVersion(
+            sourceApp.app_id,
+        );
+        if (!sourceVersion) {
+            throw new ParameterError(
+                'Cannot duplicate an app that has no successful version',
+            );
+        }
+
+        const sourceResources = sourceVersion.resources ?? null;
+        const resources: AppVersionResources = {
+            images: [],
+            charts: sourceResources?.charts ?? [],
+            dashboardName: sourceResources?.dashboardName ?? null,
+            clarifications: [],
+            ...(sourceResources?.claudeModel
+                ? { claudeModel: sourceResources.claudeModel }
+                : {}),
+        };
+
+        const newAppUuid = uuidv4();
+        const newVersion = 1;
+        const { client: s3Client, bucket } = this.getS3Client();
+
+        const copiedKeys = await AppGenerateService.copyVersionS3Prefix(
+            s3Client,
+            bucket,
+            { appUuid: sourceApp.app_id, version: sourceVersion.version },
+            { appUuid: newAppUuid, version: newVersion },
+        );
+
+        // The user-facing chat collapses everything before the duplicate
+        // into a single v1 bubble. The original prompt would imply we're
+        // about to re-execute it; instead, frame the bubble as "copy this
+        // app" with a markdown link to the source's preview at the version
+        // we forked from, and a static assistant reply confirming success.
+        const sourceDisplayName = sourceApp.name || 'untitled app';
+        const sourcePreviewPath = `/projects/${projectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/preview`;
+        const duplicatePrompt = `Duplicate [${sourceDisplayName}](${sourcePreviewPath})`;
+
+        try {
+            await this.appModel.createWithVersion(
+                {
+                    app_id: newAppUuid,
+                    project_uuid: projectUuid,
+                    created_by_user_uuid: user.userUuid,
+                    name: `Duplicate of ${sourceDisplayName}`,
+                    description: sourceApp.description,
+                    template: sourceApp.template,
+                    space_uuid: null,
+                },
+                { version: newVersion, prompt: duplicatePrompt },
+                'ready',
+                resources,
+            );
+            await this.appModel.updateStatusMessage(
+                newAppUuid,
+                newVersion,
+                'Duplicate ready!',
+            );
+        } catch (error) {
+            // The new app row failed to insert; drop the orphaned S3 copy so
+            // we don't leak storage. Cleanup failures are swallowed (logged
+            // by the helper) — orphans are harmless.
+            await this.cleanupRestoredS3Keys(
+                s3Client,
+                bucket,
+                newAppUuid,
+                copiedKeys,
+            );
+            throw error;
+        }
+
+        this.analytics.track({
+            event: 'data_app.duplicated',
+            userId: user.userUuid,
+            properties: {
+                organizationId: user.organizationUuid!,
+                projectId: projectUuid,
+                appUuid: newAppUuid,
+                duplicatedFromAppUuid: sourceApp.app_id,
+                duplicatedFromVersion: sourceVersion.version,
+            },
+        });
+
+        this.logger.info(
+            `App ${newAppUuid}: duplicated from app ${sourceApp.app_id} v${sourceVersion.version} (user=${user.userUuid}, copied ${copiedKeys.length} S3 object(s))`,
+        );
+
+        return { appUuid: newAppUuid, version: newVersion };
     }
 
     async cancelVersion(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8515,6 +8515,14 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDuplicateAppResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess__appUuid-string--version-number__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess__appUuid-string--name-string--description-string__': {
         dataType: 'refAlias',
         type: {
@@ -10221,6 +10229,14 @@ const models: TsoaRoute.Models = {
                 },
                 hasCredentials: { dataType: 'boolean', required: true },
                 authType: { ref: 'AiMcpServerAuthType', required: true },
+                iconUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 url: { dataType: 'string', required: true },
                 name: { dataType: 'string', required: true },
                 projectUuid: { dataType: 'string', required: true },
@@ -11362,6 +11378,34 @@ const models: TsoaRoute.Models = {
         type: { dataType: 'string', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiMcpServer.uuid-or-name-or-iconUrl_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+                iconUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentToolCallMcpServer: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AiMcpServer.uuid-or-name-or-iconUrl_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentToolCall: {
         dataType: 'refAlias',
         type: {
@@ -11388,6 +11432,14 @@ const models: TsoaRoute.Models = {
                         {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
+                                mcpServer: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { ref: 'AiAgentToolCallMcpServer' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
                                 toolName: {
                                     ref: 'AiAgentMcpToolName',
                                     required: true,
@@ -11580,11 +11632,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12088,13 +12140,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -12136,11 +12188,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12182,11 +12234,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12201,11 +12253,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12220,11 +12272,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12239,11 +12291,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -36722,6 +36774,73 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'restoreAppVersion',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_duplicateApp: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/duplicate',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.duplicateApp,
+        ),
+
+        async function AppGenerateController_duplicateApp(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_duplicateApp,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'duplicateApp',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -9894,6 +9894,9 @@
             "ApiRestoreAppVersionResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__appUuid-string--version-number__"
             },
+            "ApiDuplicateAppResponse": {
+                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--version-number__"
+            },
             "ApiSuccess__appUuid-string--name-string--description-string__": {
                 "properties": {
                     "results": {
@@ -11807,6 +11810,10 @@
                     "authType": {
                         "$ref": "#/components/schemas/AiMcpServerAuthType"
                     },
+                    "iconUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "url": {
                         "type": "string"
                     },
@@ -11829,6 +11836,7 @@
                     "credentialScope",
                     "hasCredentials",
                     "authType",
+                    "iconUrl",
                     "url",
                     "name",
                     "projectUuid",
@@ -12974,6 +12982,26 @@
             "AiAgentMcpToolName": {
                 "type": "string"
             },
+            "Pick_AiMcpServer.uuid-or-name-or-iconUrl_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "iconUrl": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["name", "uuid", "iconUrl"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "AiAgentToolCallMcpServer": {
+                "$ref": "#/components/schemas/Pick_AiMcpServer.uuid-or-name-or-iconUrl_"
+            },
             "AiAgentToolCall": {
                 "allOf": [
                     {
@@ -12997,6 +13025,14 @@
                             },
                             {
                                 "properties": {
+                                    "mcpServer": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/AiAgentToolCallMcpServer"
+                                            }
+                                        ],
+                                        "nullable": true
+                                    },
                                     "toolName": {
                                         "$ref": "#/components/schemas/AiAgentMcpToolName"
                                     },
@@ -13006,7 +13042,11 @@
                                         "nullable": false
                                     }
                                 },
-                                "required": ["toolName", "toolType"],
+                                "required": [
+                                    "mcpServer",
+                                    "toolName",
+                                    "toolType"
+                                ],
                                 "type": "object"
                             }
                         ]
@@ -13170,19 +13210,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -13406,19 +13433,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -33798,7 +33825,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3001.1",
+        "version": "0.3002.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -229,6 +229,11 @@ export type ApiRestoreAppVersionResponse = ApiSuccess<{
     version: number;
 }>;
 
+export type ApiDuplicateAppResponse = ApiSuccess<{
+    appUuid: string;
+    version: number;
+}>;
+
 export type ApiDeleteAppResponse = ApiSuccessEmpty;
 
 export type ApiAppSummary = {

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -25,8 +25,9 @@ import {
     IconUsers,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useLocation, useParams } from 'react-router';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import { useDuplicateApp } from '../../../features/apps/hooks/useDuplicateApp';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
     usePromoteChartDiffMutation,
@@ -78,8 +79,10 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
 }) => {
     const { user } = useApp();
     const location = useLocation();
+    const navigate = useNavigate();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { data: project } = useProject(projectUuid);
+    const { mutate: duplicateApp } = useDuplicateApp();
     const organizationUuid = user.data?.organizationUuid;
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
     const isPinned = !!item.data.pinnedListUuid;
@@ -322,12 +325,44 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                             </Menu.Item>
 
                             {item.type === ResourceViewItemType.CHART ||
-                            item.type === ResourceViewItemType.DASHBOARD ? (
+                            item.type === ResourceViewItemType.DASHBOARD ||
+                            item.type === ResourceViewItemType.DATA_APP ? (
                                 <Menu.Item
                                     component="button"
                                     role="menuitem"
-                                    leftSection={<IconCopy size={18} />}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconCopy}
+                                            size={18}
+                                        />
+                                    }
                                     onClick={() => {
+                                        // Data apps are duplicated synchronously
+                                        // with a direct mutation; charts and
+                                        // dashboards open a modal that lets the
+                                        // user pick a name/space first.
+                                        if (
+                                            item.type ===
+                                            ResourceViewItemType.DATA_APP
+                                        ) {
+                                            if (!projectUuid) return;
+                                            duplicateApp(
+                                                {
+                                                    projectUuid,
+                                                    appUuid: item.data.uuid,
+                                                },
+                                                {
+                                                    onSuccess: ({
+                                                        appUuid: newAppUuid,
+                                                    }) => {
+                                                        void navigate(
+                                                            `/projects/${projectUuid}/apps/${newAppUuid}`,
+                                                        );
+                                                    },
+                                                },
+                                            );
+                                            return;
+                                        }
                                         onAction({
                                             type: ResourceViewItemAction.DUPLICATE,
                                             item,

--- a/packages/frontend/src/features/apps/ChatMessageContent.tsx
+++ b/packages/frontend/src/features/apps/ChatMessageContent.tsx
@@ -4,9 +4,15 @@
  * with the same styling as the input editor's mention pills. Anything
  * outside a reference renders as plain text, with newlines preserved.
  *
+ * Markdown-style links (`[text](url)`) inside the plain-text segments
+ * render as anchors — used by system-authored prompts (e.g. the v1 chat
+ * bubble of a duplicated app, which links back to the source's preview)
+ * without introducing a full markdown renderer.
+ *
  * Used in the data-app chat history so post-submit messages match the
  * pre-submit input editor visually.
  */
+import { Anchor } from '@mantine-8/core';
 import { Fragment, type FC } from 'react';
 import classes from './AppPromptEditor.module.css';
 
@@ -16,11 +22,18 @@ import classes from './AppPromptEditor.module.css';
 const REF_PATTERN =
     /\[([A-Za-z][A-Za-z0-9-]*)(?:\s+"([^"]*)")?(?:\s+@([^\]]+))?\]/g;
 
+// Markdown link: `[link text](href)`. Disallows newlines and `]`/`)`
+// inside the parts so we don't run past the intended boundaries. Element
+// refs never put `(` immediately after `]`, so the two patterns don't
+// collide.
+const MARKDOWN_LINK = /\[([^\]\n]+)\]\(([^)\s]+)\)/g;
+
 type Segment =
     | { kind: 'text'; value: string }
-    | { kind: 'ref'; tag: string; text: string; loc: string };
+    | { kind: 'ref'; tag: string; text: string; loc: string }
+    | { kind: 'link'; text: string; href: string };
 
-function parse(content: string): Segment[] {
+function parseRefs(content: string): Segment[] {
     const segments: Segment[] = [];
     let cursor = 0;
     REF_PATTERN.lastIndex = 0;
@@ -47,6 +60,38 @@ function parse(content: string): Segment[] {
     return segments;
 }
 
+function splitTextOnLinks(text: string): Segment[] {
+    const segments: Segment[] = [];
+    let cursor = 0;
+    MARKDOWN_LINK.lastIndex = 0;
+    let match: RegExpExecArray | null = MARKDOWN_LINK.exec(text);
+    while (match !== null) {
+        if (match.index > cursor) {
+            segments.push({
+                kind: 'text',
+                value: text.slice(cursor, match.index),
+            });
+        }
+        segments.push({
+            kind: 'link',
+            text: match[1] ?? '',
+            href: match[2] ?? '',
+        });
+        cursor = match.index + match[0].length;
+        match = MARKDOWN_LINK.exec(text);
+    }
+    if (cursor < text.length) {
+        segments.push({ kind: 'text', value: text.slice(cursor) });
+    }
+    return segments;
+}
+
+function parse(content: string): Segment[] {
+    return parseRefs(content).flatMap((seg) =>
+        seg.kind === 'text' ? splitTextOnLinks(seg.value) : [seg],
+    );
+}
+
 const TextWithBreaks: FC<{ value: string }> = ({ value }) => {
     const lines = value.split('\n');
     return (
@@ -69,6 +114,19 @@ const ChatMessageContent: FC<{ content: string }> = ({ content }) => {
             {segments.map((seg, i) => {
                 if (seg.kind === 'text') {
                     return <TextWithBreaks key={i} value={seg.value} />;
+                }
+                if (seg.kind === 'link') {
+                    return (
+                        <Anchor
+                            key={i}
+                            href={seg.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            inherit
+                        >
+                            {seg.text}
+                        </Anchor>
+                    );
                 }
                 const inner = seg.text
                     ? `<${seg.tag}> ${seg.text}`

--- a/packages/frontend/src/features/apps/hooks/useDuplicateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useDuplicateApp.ts
@@ -1,0 +1,37 @@
+import { type ApiDuplicateAppResponse, type ApiError } from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+type DuplicateAppParams = {
+    projectUuid: string;
+    appUuid: string;
+};
+
+type DuplicateAppResult = ApiDuplicateAppResponse['results'];
+
+const duplicateApp = ({ projectUuid, appUuid }: DuplicateAppParams) =>
+    lightdashApi<DuplicateAppResult>({
+        method: 'POST',
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/duplicate`,
+        body: undefined,
+    });
+
+export const useDuplicateApp = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<DuplicateAppResult, ApiError, DuplicateAppParams>({
+        mutationFn: duplicateApp,
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ['myApps'] });
+            void queryClient.invalidateQueries({ queryKey: ['content'] });
+            showToastSuccess({ title: 'Data app duplicated' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to duplicate app',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -34,6 +34,7 @@ import {
     IconAppsOff,
     IconAppWindow,
     IconArrowUp,
+    IconCopy,
     IconDots,
     IconExternalLink,
     IconArrowBackUp,
@@ -104,6 +105,7 @@ import type { QueryEvent } from '../features/apps/hooks/useAppSdkBridge';
 import { useBuildNotification } from '../features/apps/hooks/useBuildNotification';
 import { useCancelAppVersion } from '../features/apps/hooks/useCancelAppVersion';
 import { useClarifyApp } from '../features/apps/hooks/useClarifyApp';
+import { useDuplicateApp } from '../features/apps/hooks/useDuplicateApp';
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
@@ -550,6 +552,8 @@ const AppGenerate: FC = () => {
         useClarifyApp();
     const { mutate: cancelMutate, isLoading: isCancelling } =
         useCancelAppVersion();
+    const { mutate: duplicateMutate, isLoading: isDuplicating } =
+        useDuplicateApp();
     const {
         mutate: restoreVersionMutate,
         isLoading: isRestoringVersion,
@@ -2280,7 +2284,10 @@ const AppGenerate: FC = () => {
                                             color="ldGray.6"
                                             aria-label="App actions"
                                         >
-                                            <IconDots size={16} />
+                                            <MantineIcon
+                                                icon={IconDots}
+                                                size={16}
+                                            />
                                         </ActionIcon>
                                     </Menu.Target>
                                     <Menu.Dropdown>
@@ -2290,7 +2297,8 @@ const AppGenerate: FC = () => {
                                                 to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/preview`}
                                                 target="_blank"
                                                 leftSection={
-                                                    <IconExternalLink
+                                                    <MantineIcon
+                                                        icon={IconExternalLink}
                                                         size={14}
                                                     />
                                                 }
@@ -2301,7 +2309,41 @@ const AppGenerate: FC = () => {
                                         {previewApp && <Menu.Divider />}
                                         <Menu.Item
                                             leftSection={
-                                                <IconPencil size={14} />
+                                                <MantineIcon
+                                                    icon={IconCopy}
+                                                    size={14}
+                                                />
+                                            }
+                                            disabled={
+                                                isDuplicating || !activeAppUuid
+                                            }
+                                            onClick={() => {
+                                                if (!activeAppUuid) return;
+                                                duplicateMutate(
+                                                    {
+                                                        projectUuid,
+                                                        appUuid: activeAppUuid,
+                                                    },
+                                                    {
+                                                        onSuccess: ({
+                                                            appUuid: newAppUuid,
+                                                        }) => {
+                                                            void navigate(
+                                                                `/projects/${projectUuid}/apps/${newAppUuid}`,
+                                                            );
+                                                        },
+                                                    },
+                                                );
+                                            }}
+                                        >
+                                            Duplicate
+                                        </Menu.Item>
+                                        <Menu.Item
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconPencil}
+                                                    size={14}
+                                                />
                                             }
                                             onClick={() =>
                                                 setIsUpdateModalOpen(true)
@@ -2311,13 +2353,14 @@ const AppGenerate: FC = () => {
                                         </Menu.Item>
                                         <Menu.Item
                                             leftSection={
-                                                appSpaceUuid ? (
-                                                    <IconFolderSymlink
-                                                        size={14}
-                                                    />
-                                                ) : (
-                                                    <IconFolderPlus size={14} />
-                                                )
+                                                <MantineIcon
+                                                    icon={
+                                                        appSpaceUuid
+                                                            ? IconFolderSymlink
+                                                            : IconFolderPlus
+                                                    }
+                                                    size={14}
+                                                />
                                             }
                                             onClick={() =>
                                                 setIsMoveToSpaceOpen(true)
@@ -2331,7 +2374,10 @@ const AppGenerate: FC = () => {
                                         <Menu.Item
                                             color="red"
                                             leftSection={
-                                                <IconTrash size={14} />
+                                                <MantineIcon
+                                                    icon={IconTrash}
+                                                    size={14}
+                                                />
                                             }
                                             onClick={() =>
                                                 setIsDeleteModalOpen(true)


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7572/make-it-possible-to-duplicate-data-apps

### Description:
Adds a Duplicate action that forks any app the user can view into a new personal app owned by the requester. v1 is seeded by S3-copying the source's latest ready version (dist + source tarballs), carrying over template, claudeModel, and chart/dashboard resource refs. Images, sandbox, prior version history, and clarifications are dropped.

Permission gate is view:DataApp on the source plus create:DataApp on the project. Surfaces in both the ResourceView action menu (list/grid cards) and the chat-header overflow menu inside AppGenerate.
