### PR TITLE
feat: add content validation for AI agent patch operations

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -27,6 +27,7 @@ import { enhanceExploresForPreAggregates } from './preAggregates/enhanceExplores
 import { preAggregatePostProcessor } from './preAggregates/postProcessor';
 import { CommercialSchedulerClient } from './scheduler/SchedulerClient';
 import { CommercialSchedulerWorker } from './scheduler/SchedulerWorker';
+import { AiAgentContentValidation } from './services/ai/utils/AiAgentContentValidation';
 import { AiAgentAdminService } from './services/AiAgentAdminService';
 import { AiAgentService } from './services/AiAgentService/AiAgentService';
 import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
@@ -160,6 +161,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiOrganizationSettingsService:
                         repository.getAiOrganizationSettingsService(),
                     shareService: repository.getShareService(),
+                    aiAgentContentValidation: new AiAgentContentValidation(),
                     prometheusMetrics,
                 }),
             aiAgentAdminService: ({ models, context }) =>

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -202,6 +202,7 @@ import {
     UpdateProgressFn,
     UpdateSlackMessageFn,
 } from '../ai/types/aiAgentDependencies';
+import { AiAgentContentValidation } from '../ai/utils/AiAgentContentValidation';
 import { getUserFacingErrorMessage } from '../ai/utils/errorMessages';
 import {
     getAgentConfirmationBlocks,
@@ -266,6 +267,7 @@ type AiAgentServiceDependencies = {
     savedChartService: SavedChartService;
     aiOrganizationSettingsService: AiOrganizationSettingsService;
     shareService: ShareService;
+    aiAgentContentValidation: AiAgentContentValidation;
     prometheusMetrics?: PrometheusMetrics;
 };
 
@@ -443,6 +445,8 @@ export class AiAgentService extends BaseService {
 
     private readonly shareService: ShareService;
 
+    private readonly aiAgentContentValidation: AiAgentContentValidation;
+
     private readonly aiAgentMcpRuntimeClient: AiAgentMcpRuntimeClient;
 
     private static getPinnedContextAnalyticsProperties(
@@ -496,6 +500,7 @@ export class AiAgentService extends BaseService {
         this.aiOrganizationSettingsService =
             dependencies.aiOrganizationSettingsService;
         this.shareService = dependencies.shareService;
+        this.aiAgentContentValidation = dependencies.aiAgentContentValidation;
         this.aiAgentMcpRuntimeClient = new AiAgentMcpRuntimeClient({
             aiAgentModel: this.aiAgentModel,
             lightdashConfig: this.lightdashConfig,
@@ -4172,12 +4177,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             'Patch must be an RFC6902 patch array',
                         );
                     }
+                    this.aiAgentContentValidation.validatePatch(type, patch);
 
                     const currentContent = await readContent({ slug, type });
                     const patchedContent = JsonPatch.applyPatch(
                         structuredClone(currentContent.content),
                         patch,
                     ).newDocument;
+                    this.aiAgentContentValidation.validateContent(
+                        type,
+                        patchedContent,
+                    );
 
                     const patchedSlug =
                         typeof patchedContent.slug === 'string' &&

--- a/packages/backend/src/ee/services/ai/utils/AiAgentContentValidation.ts
+++ b/packages/backend/src/ee/services/ai/utils/AiAgentContentValidation.ts
@@ -1,0 +1,290 @@
+import {
+    chartAsCodeSchema,
+    dashboardAsCodeSchema,
+    ParameterError,
+} from '@lightdash/common';
+import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
+import { compact, get, set, uniq } from 'lodash';
+
+type ContentType = 'dashboard' | 'chart';
+
+type PatchOperation = {
+    path?: unknown;
+    from?: unknown;
+};
+
+const BANNED_PATHS: Record<
+    ContentType,
+    Array<{
+        path: string;
+        reason: string;
+    }>
+> = {
+    chart: [
+        { path: '/slug', reason: 'slug is read-only' },
+        { path: '/spaceSlug', reason: 'spaceSlug is read-only' },
+        { path: '/updatedAt', reason: 'updatedAt is read-only' },
+        { path: '/downloadedAt', reason: 'downloadedAt is read-only' },
+        {
+            path: '/verified',
+            reason: 'verified cannot be edited with editContent',
+        },
+        { path: '/verification', reason: 'verification is read-only' },
+    ],
+    dashboard: [
+        { path: '/slug', reason: 'slug is read-only' },
+        { path: '/spaceSlug', reason: 'spaceSlug is read-only' },
+        { path: '/updatedAt', reason: 'updatedAt is read-only' },
+        { path: '/downloadedAt', reason: 'downloadedAt is read-only' },
+        {
+            path: '/verified',
+            reason: 'verified cannot be edited with editContent',
+        },
+        { path: '/verification', reason: 'verification is read-only' },
+    ],
+};
+
+const TIMESTAMP_FIELDS: Record<ContentType, string[]> = {
+    chart: ['/updatedAt', '/downloadedAt', '/verification/verifiedAt'],
+    dashboard: ['/updatedAt', '/downloadedAt', '/verification/verifiedAt'],
+};
+
+const CHART_CONFIG_SUPPORTED_TYPES = [
+    'big_number',
+    'cartesian',
+    'custom',
+    'pie',
+    'funnel',
+    'table',
+    'treemap',
+    'gauge',
+    'map',
+    'sankey',
+] as const;
+
+export class AiAgentContentValidation {
+    private readonly ajv: Ajv;
+
+    private readonly bannedPaths = BANNED_PATHS;
+
+    private readonly timestampFields = TIMESTAMP_FIELDS;
+
+    private validators:
+        | {
+              chart: ValidateFunction;
+              dashboard: ValidateFunction;
+          }
+        | undefined;
+
+    constructor() {
+        this.ajv = new Ajv({
+            coerceTypes: true,
+            allErrors: true,
+            allowUnionTypes: true,
+            discriminator: true,
+        });
+        addFormats(this.ajv);
+    }
+
+    validatePatch(type: ContentType, patch: unknown[]): void {
+        const errors = patch.flatMap((operation, index) => {
+            const op = operation as PatchOperation;
+            return compact([
+                typeof op.path === 'string'
+                    ? AiAgentContentValidation.formatBannedPathError(
+                          index,
+                          'path',
+                          this.getBannedPathError(type, op.path),
+                      )
+                    : undefined,
+                typeof op.from === 'string'
+                    ? AiAgentContentValidation.formatBannedPathError(
+                          index,
+                          'from',
+                          this.getBannedPathError(type, op.from),
+                      )
+                    : undefined,
+            ]);
+        });
+
+        if (errors.length > 0) {
+            throw new ParameterError(
+                `Patch contains disallowed paths:\n${errors
+                    .map((error) => `- ${error}`)
+                    .join('\n')}`,
+                { validationErrors: errors },
+            );
+        }
+    }
+
+    validateContent(type: ContentType, content: unknown): void {
+        const validator = this.getValidator(type);
+        const normalizedContent = this.normalizeTimestampFields(type, content);
+        const valid = validator(normalizedContent);
+
+        if (valid) {
+            return;
+        }
+
+        const validationErrors = AiAgentContentValidation.formatErrors(
+            validator.errors ?? [],
+        );
+
+        throw new ParameterError(
+            `Edited ${type} is invalid:\n${validationErrors
+                .map((error) => `- ${error}`)
+                .join('\n')}`,
+            { validationErrors },
+        );
+    }
+
+    private getValidator(type: ContentType): ValidateFunction {
+        const validators = this.getValidators();
+        return type === 'chart' ? validators.chart : validators.dashboard;
+    }
+
+    private getValidators(): {
+        chart: ValidateFunction;
+        dashboard: ValidateFunction;
+    } {
+        if (this.validators) {
+            return this.validators;
+        }
+
+        this.validators = {
+            chart: this.ajv.compile(chartAsCodeSchema),
+            dashboard: this.ajv.compile(dashboardAsCodeSchema),
+        };
+
+        return this.validators;
+    }
+
+    private getBannedPathError(
+        type: ContentType,
+        path: string,
+    ): string | undefined {
+        const banned = this.bannedPaths[type].find(
+            (entry) => path === entry.path || path.startsWith(`${entry.path}/`),
+        );
+
+        if (!banned) {
+            return undefined;
+        }
+
+        return `Patch path "${path}" is not allowed: ${banned.reason}`;
+    }
+
+    private static formatBannedPathError(
+        index: number,
+        source: 'path' | 'from',
+        error: string | undefined,
+    ): string | undefined {
+        return error ? `patch[${index}].${source}: ${error}` : undefined;
+    }
+
+    private normalizeTimestampFields(
+        type: ContentType,
+        content: unknown,
+    ): unknown {
+        const cloned = structuredClone(content);
+        if (typeof cloned !== 'object' || cloned === null) {
+            return cloned;
+        }
+
+        for (const path of this.timestampFields[type]) {
+            const pathSegments = path.split('/').filter(Boolean);
+            const value = get(cloned, pathSegments);
+
+            if (value instanceof Date) {
+                set(cloned, pathSegments, value.toISOString());
+            }
+        }
+
+        return cloned;
+    }
+
+    private static formatErrors(errors: ErrorObject[]): string[] {
+        const specificErrors = errors.filter(
+            (error) =>
+                !['oneOf', 'anyOf', 'allOf', 'if'].includes(error.keyword),
+        );
+        const selectedErrors =
+            specificErrors.length > 0 ? specificErrors : errors;
+
+        const formatted = selectedErrors.map((error) =>
+            AiAgentContentValidation.formatError(error),
+        );
+
+        return uniq(formatted);
+    }
+
+    private static formatError(error: ErrorObject): string {
+        const path = error.instancePath || '/';
+
+        switch (error.keyword) {
+            case 'required': {
+                const property = String(
+                    (
+                        error.params as {
+                            missingProperty?: string;
+                        }
+                    ).missingProperty ?? 'unknown',
+                );
+                return `${path} is missing required property "${property}"`;
+            }
+            case 'additionalProperties': {
+                const property = String(
+                    (
+                        error.params as {
+                            additionalProperty?: string;
+                        }
+                    ).additionalProperty ?? 'unknown',
+                );
+                return `${path} has unexpected property "${property}"`;
+            }
+            case 'type': {
+                const expectedType = String(
+                    (error.params as { type?: string }).type ??
+                        'the expected type',
+                );
+                return `${path} must be ${expectedType}`;
+            }
+            case 'enum': {
+                const { allowedValues } = error.params as {
+                    allowedValues?: unknown[];
+                };
+                if (Array.isArray(allowedValues) && allowedValues.length > 0) {
+                    return `${path} must be one of: ${allowedValues
+                        .map((value) => JSON.stringify(value))
+                        .join(', ')}`;
+                }
+                return `${path} has an invalid value`;
+            }
+            case 'discriminator': {
+                const { tag, tagValue } = error.params as {
+                    tag?: string;
+                    tagValue?: unknown;
+                };
+
+                if (typeof tag === 'string') {
+                    const tagPath = path === '/' ? `/${tag}` : `${path}/${tag}`;
+                    if (tagPath === '/chartConfig/type') {
+                        return `${tagPath} must be one of: ${CHART_CONFIG_SUPPORTED_TYPES.map(
+                            (value) => JSON.stringify(value),
+                        ).join(', ')}; got ${JSON.stringify(tagValue)}`;
+                    }
+                    return `${tagPath} must be a supported value, got ${JSON.stringify(
+                        tagValue,
+                    )}`;
+                }
+
+                return `${path} has an invalid discriminator value`;
+            }
+            case 'const':
+                return `${path} must match the required value`;
+            default:
+                return `${path} ${error.message ?? 'is invalid'}`;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AiAgentContentValidation` to validate AI agent content edits before upsert
- block read-only JSON patch paths and normalize timestamp fields before schema validation
- improve validation errors for chart config discriminator mismatches and supported values

## Testing
- pnpm -F backend typecheck
- pnpm -F backend run linter src/ee/services/ai/utils/AiAgentContentValidation.ts src/ee/services/AiAgentService/AiAgentService.ts src/ee/index.ts
- validated failing `editContent` tool calls in the app and confirmed stored tool results in Postgres

Closes: https://linear.app/lightdash/issue/ZAP-415/add-linting-and-verification-for-ai-agent-content-edits
