### PR TITLE
feat: add MCP tool discovery, persistence, and per-agent enable/disable controls

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -230,3 +230,61 @@ export type AiAgentMcpServerTable = Knex.CompositeTableType<
         >
     >
 >;
+
+export const AiMcpServerToolTableName = 'ai_mcp_server_tool';
+
+export type DbAiMcpServerTool = {
+    ai_mcp_server_tool_uuid: string;
+    ai_mcp_server_uuid: string;
+    tool_name: string;
+    title: string | null;
+    description: string | null;
+    input_schema: unknown;
+    annotations: unknown | null;
+    meta: unknown | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiMcpServerToolTable = Knex.CompositeTableType<
+    DbAiMcpServerTool,
+    Omit<
+        DbAiMcpServerTool,
+        'ai_mcp_server_tool_uuid' | 'created_at' | 'updated_at'
+    >,
+    Partial<
+        Omit<
+            DbAiMcpServerTool,
+            'ai_mcp_server_tool_uuid' | 'created_at' | 'updated_at'
+        >
+    > & {
+        updated_at: Knex.Raw;
+    }
+>;
+
+export const AiAgentMcpServerToolTableName = 'ai_agent_mcp_server_tool';
+
+export type DbAiAgentMcpServerTool = {
+    ai_agent_uuid: string;
+    ai_mcp_server_uuid: string;
+    ai_mcp_server_tool_uuid: string;
+    enabled: boolean;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiAgentMcpServerToolTable = Knex.CompositeTableType<
+    DbAiAgentMcpServerTool,
+    Omit<DbAiAgentMcpServerTool, 'created_at' | 'updated_at'>,
+    Partial<
+        Omit<
+            DbAiAgentMcpServerTool,
+            | 'ai_agent_uuid'
+            | 'ai_mcp_server_uuid'
+            | 'ai_mcp_server_tool_uuid'
+            | 'created_at'
+        >
+    > & {
+        updated_at: Knex.Raw;
+    }
+>;

--- a/packages/backend/src/ee/database/migrations/20260520103000_add_ai_mcp_server_tools.ts
+++ b/packages/backend/src/ee/database/migrations/20260520103000_add_ai_mcp_server_tools.ts
@@ -1,0 +1,87 @@
+import { Knex } from 'knex';
+
+const AiAgentMcpServerTableName = 'ai_agent_mcp_server';
+const AiAgentMcpServerToolTableName = 'ai_agent_mcp_server_tool';
+const AiMcpServerTableName = 'ai_mcp_server';
+const AiMcpServerToolTableName = 'ai_mcp_server_tool';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiMcpServerToolTableName))) {
+        await knex.schema.createTable(AiMcpServerToolTableName, (table) => {
+            table
+                .uuid('ai_mcp_server_tool_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+
+            table
+                .uuid('ai_mcp_server_uuid')
+                .notNullable()
+                .references('ai_mcp_server_uuid')
+                .inTable(AiMcpServerTableName)
+                .onDelete('CASCADE');
+
+            table.text('tool_name').notNullable();
+            table.text('title').nullable();
+            table.text('description').nullable();
+            table.jsonb('input_schema').notNullable();
+            table.jsonb('annotations').nullable();
+            table.jsonb('meta').nullable();
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .timestamp('updated_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+
+            table.unique(['ai_mcp_server_uuid', 'tool_name']);
+            table.unique(['ai_mcp_server_uuid', 'ai_mcp_server_tool_uuid']);
+            table.index(['ai_mcp_server_uuid']);
+        });
+    }
+
+    if (!(await knex.schema.hasTable(AiAgentMcpServerToolTableName))) {
+        await knex.schema.createTable(
+            AiAgentMcpServerToolTableName,
+            (table) => {
+                table.uuid('ai_agent_uuid').notNullable();
+                table.uuid('ai_mcp_server_uuid').notNullable();
+                table.uuid('ai_mcp_server_tool_uuid').notNullable();
+                table.boolean('enabled').notNullable();
+                table
+                    .timestamp('created_at', { useTz: false })
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+                table
+                    .timestamp('updated_at', { useTz: false })
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+
+                table.primary([
+                    'ai_agent_uuid',
+                    'ai_mcp_server_uuid',
+                    'ai_mcp_server_tool_uuid',
+                ]);
+                table
+                    .foreign(['ai_agent_uuid', 'ai_mcp_server_uuid'])
+                    .references(['ai_agent_uuid', 'ai_mcp_server_uuid'])
+                    .inTable(AiAgentMcpServerTableName)
+                    .onDelete('CASCADE');
+                table
+                    .foreign(['ai_mcp_server_uuid', 'ai_mcp_server_tool_uuid'])
+                    .references([
+                        'ai_mcp_server_uuid',
+                        'ai_mcp_server_tool_uuid',
+                    ])
+                    .inTable(AiMcpServerToolTableName)
+                    .onDelete('CASCADE');
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AiAgentMcpServerToolTableName);
+    await knex.schema.dropTableIfExists(AiMcpServerToolTableName);
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -9,6 +9,8 @@ import {
     AiAgentEvaluationRunResult,
     AiAgentEvaluationRunSummary,
     AiAgentEvaluationSummary,
+    AiAgentMcpServerTool,
+    AiAgentMcpServerToolUpdate,
     AiAgentMessage,
     AiAgentMessageAssistant,
     AiAgentMessageAssistantArtifact,
@@ -27,6 +29,8 @@ import {
     AiMcpCredentialScope,
     AiMcpServer,
     AiMcpServerConnectionStatus,
+    AiMcpServerTool,
+    AiMcpServerToolInput,
     AiPromptContext,
     AiPromptContextInput,
     AiPromptContextItem,
@@ -117,18 +121,22 @@ import {
     AiAgentInstructionVersionsTableName,
     AiAgentIntegrationTableName,
     AiAgentMcpServerTableName,
+    AiAgentMcpServerToolTableName,
     AiAgentSlackIntegrationTableName,
     AiAgentSpaceAccessTableName,
     AiAgentTableName,
     AiAgentUserAccessTableName,
     AiMcpServerCredentialTableName,
     AiMcpServerTableName,
+    AiMcpServerToolTableName,
     DbAiAgent,
     DbAiAgentIntegration,
     DbAiAgentMcpServer,
+    DbAiAgentMcpServerTool,
     DbAiAgentSlackIntegration,
     DbAiMcpServer,
     DbAiMcpServerCredential,
+    DbAiMcpServerTool,
 } from '../database/entities/aiAgent';
 import { AiAgentUserPreferencesTableName } from '../database/entities/aiAgentUserPreferences';
 import {
@@ -711,6 +719,85 @@ export class AiAgentModel {
         };
     }
 
+    private static toAiMcpServerTool(row: DbAiMcpServerTool): AiMcpServerTool {
+        return {
+            uuid: row.ai_mcp_server_tool_uuid,
+            mcpServerUuid: row.ai_mcp_server_uuid,
+            toolName: row.tool_name,
+            title: row.title,
+            description: row.description,
+            inputSchema: row.input_schema,
+            annotations: row.annotations,
+            meta: row.meta,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+        };
+    }
+
+    private static toAiAgentMcpServerTool(args: {
+        agentUuid: string;
+        tool: DbAiMcpServerTool;
+        setting?: DbAiAgentMcpServerTool;
+    }): AiAgentMcpServerTool {
+        return {
+            ...AiAgentModel.toAiMcpServerTool(args.tool),
+            agentUuid: args.agentUuid,
+            enabled: args.setting?.enabled ?? false,
+        };
+    }
+
+    private static getMcpServerToolSelect(trx: Knex | Knex.Transaction) {
+        return {
+            ai_mcp_server_tool_uuid: `${AiMcpServerToolTableName}.ai_mcp_server_tool_uuid`,
+            ai_mcp_server_uuid: `${AiMcpServerToolTableName}.ai_mcp_server_uuid`,
+            tool_name: `${AiMcpServerToolTableName}.tool_name`,
+            title: `${AiMcpServerToolTableName}.title`,
+            description: `${AiMcpServerToolTableName}.description`,
+            input_schema: `${AiMcpServerToolTableName}.input_schema`,
+            annotations: `${AiMcpServerToolTableName}.annotations`,
+            meta: `${AiMcpServerToolTableName}.meta`,
+            created_at: `${AiMcpServerToolTableName}.created_at`,
+            updated_at: `${AiMcpServerToolTableName}.updated_at`,
+        } satisfies Record<keyof DbAiMcpServerTool, Knex.Value>;
+    }
+
+    private static getAgentMcpServerToolSelect(trx: Knex | Knex.Transaction) {
+        return {
+            ai_agent_uuid: `${AiAgentMcpServerToolTableName}.ai_agent_uuid`,
+            ai_mcp_server_uuid: `${AiAgentMcpServerToolTableName}.ai_mcp_server_uuid`,
+            ai_mcp_server_tool_uuid: `${AiAgentMcpServerToolTableName}.ai_mcp_server_tool_uuid`,
+            enabled: `${AiAgentMcpServerToolTableName}.enabled`,
+            created_at: `${AiAgentMcpServerToolTableName}.created_at`,
+            updated_at: `${AiAgentMcpServerToolTableName}.updated_at`,
+        } satisfies Record<keyof DbAiAgentMcpServerTool, Knex.Value>;
+    }
+
+    private static getAgentMcpServerAttachmentSelect(
+        trx: Knex | Knex.Transaction,
+    ) {
+        return {
+            ai_agent_uuid: `${AiAgentMcpServerTableName}.ai_agent_uuid`,
+            ai_mcp_server_uuid: `${AiAgentMcpServerTableName}.ai_mcp_server_uuid`,
+            created_at: `${AiAgentMcpServerTableName}.created_at`,
+        } satisfies Record<keyof DbAiAgentMcpServer, Knex.Value>;
+    }
+
+    private async getAgentMcpServerAttachment(args: {
+        agentUuid: string;
+        serverUuid: string;
+        trx?: Knex;
+    }): Promise<DbAiAgentMcpServer | undefined> {
+        const trx = args.trx ?? this.database;
+
+        return trx(AiAgentMcpServerTableName)
+            .select<DbAiAgentMcpServer[]>(
+                AiAgentModel.getAgentMcpServerAttachmentSelect(trx),
+            )
+            .where('ai_agent_uuid', args.agentUuid)
+            .andWhere('ai_mcp_server_uuid', args.serverUuid)
+            .first();
+    }
+
     private encryptMcpCredentialPayload(
         credential: AiMcpCredentialPayload,
     ): Buffer {
@@ -827,6 +914,353 @@ export class AiAgentModel {
         });
 
         return AiAgentModel.toAiMcpServer(row, credential ?? null);
+    }
+
+    async listMcpServerTools(args: {
+        projectUuid: string;
+        serverUuid: string;
+        trx?: Knex;
+    }): Promise<AiMcpServerTool[]> {
+        const trx = args.trx ?? this.database;
+
+        const server = await trx(AiMcpServerTableName)
+            .select('ai_mcp_server_uuid')
+            .where('ai_mcp_server_uuid', args.serverUuid)
+            .andWhere('project_uuid', args.projectUuid)
+            .first();
+
+        if (!server) {
+            throw new NotFoundError('MCP server not found for this project');
+        }
+
+        const rows = await trx(AiMcpServerToolTableName)
+            .select<DbAiMcpServerTool[]>(
+                AiAgentModel.getMcpServerToolSelect(trx),
+            )
+            .where('ai_mcp_server_uuid', args.serverUuid)
+            .orderBy('tool_name', 'asc');
+
+        return rows.map(AiAgentModel.toAiMcpServerTool);
+    }
+
+    async upsertDiscoveredMcpServerTools(args: {
+        serverUuid: string;
+        tools: AiMcpServerToolInput[];
+        defaultEnabledForExistingAttachments?: boolean;
+        trx?: Knex;
+    }): Promise<AiMcpServerTool[]> {
+        const trx = args.trx ?? this.database;
+        const toolMap = new Map(
+            args.tools.map((tool) => [tool.toolName, tool] as const),
+        );
+        const tools = [...toolMap.values()];
+        const toolNames = tools.map((tool) => tool.toolName);
+
+        const server = await trx(AiMcpServerTableName)
+            .select('ai_mcp_server_uuid', 'project_uuid')
+            .where('ai_mcp_server_uuid', args.serverUuid)
+            .first();
+
+        if (!server) {
+            throw new NotFoundError('MCP server not found');
+        }
+
+        if (tools.length > 0) {
+            await trx(AiMcpServerToolTableName)
+                .insert(
+                    tools.map((tool) => ({
+                        ai_mcp_server_uuid: args.serverUuid,
+                        tool_name: tool.toolName,
+                        title: tool.title,
+                        description: tool.description,
+                        input_schema: tool.inputSchema,
+                        annotations: tool.annotations,
+                        meta: tool.meta,
+                        created_at: trx.fn.now(),
+                        updated_at: trx.fn.now(),
+                    })),
+                )
+                .onConflict(['ai_mcp_server_uuid', 'tool_name'])
+                .merge({
+                    title: trx.raw('excluded.title'),
+                    description: trx.raw('excluded.description'),
+                    input_schema: trx.raw('excluded.input_schema'),
+                    annotations: trx.raw('excluded.annotations'),
+                    meta: trx.raw('excluded.meta'),
+                    updated_at: trx.fn.now(),
+                });
+        }
+
+        const removedToolsQuery = trx(AiMcpServerToolTableName).where(
+            'ai_mcp_server_uuid',
+            args.serverUuid,
+        );
+
+        if (toolNames.length > 0) {
+            void removedToolsQuery.whereNotIn('tool_name', toolNames);
+        }
+
+        await removedToolsQuery.delete();
+
+        if (toolNames.length > 0) {
+            const discoveredToolRows = await trx(AiMcpServerToolTableName)
+                .select<DbAiMcpServerTool[]>(
+                    AiAgentModel.getMcpServerToolSelect(trx),
+                )
+                .where('ai_mcp_server_uuid', args.serverUuid)
+                .whereIn('tool_name', toolNames);
+
+            const attachmentRows = await trx(AiAgentMcpServerTableName)
+                .select<DbAiAgentMcpServer[]>(
+                    AiAgentModel.getAgentMcpServerAttachmentSelect(trx),
+                )
+                .where('ai_mcp_server_uuid', args.serverUuid);
+
+            if (attachmentRows.length > 0 && discoveredToolRows.length > 0) {
+                await trx(AiAgentMcpServerToolTableName)
+                    .insert(
+                        attachmentRows.flatMap((row) =>
+                            discoveredToolRows.map((tool) => ({
+                                ai_agent_uuid: row.ai_agent_uuid,
+                                ai_mcp_server_uuid: row.ai_mcp_server_uuid,
+                                ai_mcp_server_tool_uuid:
+                                    tool.ai_mcp_server_tool_uuid,
+                                enabled:
+                                    args.defaultEnabledForExistingAttachments ??
+                                    false,
+                                created_at: trx.fn.now(),
+                                updated_at: trx.fn.now(),
+                            })),
+                        ),
+                    )
+                    .onConflict([
+                        'ai_agent_uuid',
+                        'ai_mcp_server_uuid',
+                        'ai_mcp_server_tool_uuid',
+                    ])
+                    .ignore();
+            }
+        }
+
+        return this.listMcpServerTools({
+            projectUuid: server.project_uuid,
+            serverUuid: args.serverUuid,
+            trx,
+        });
+    }
+
+    async listAgentMcpServerTools(args: {
+        agentUuid: string;
+        serverUuid: string;
+        trx?: Knex;
+    }): Promise<AiAgentMcpServerTool[]> {
+        const trx = args.trx ?? this.database;
+
+        const attachment = await this.getAgentMcpServerAttachment({
+            agentUuid: args.agentUuid,
+            serverUuid: args.serverUuid,
+            trx,
+        });
+
+        if (!attachment) {
+            throw new NotFoundError('MCP server is not attached to this agent');
+        }
+
+        const toolRows = await trx(AiMcpServerToolTableName)
+            .select<DbAiMcpServerTool[]>(
+                AiAgentModel.getMcpServerToolSelect(trx),
+            )
+            .where('ai_mcp_server_uuid', args.serverUuid)
+            .orderBy('tool_name', 'asc');
+
+        const settingRows = await trx(AiAgentMcpServerToolTableName)
+            .select<DbAiAgentMcpServerTool[]>(
+                AiAgentModel.getAgentMcpServerToolSelect(trx),
+            )
+            .where('ai_agent_uuid', attachment.ai_agent_uuid)
+            .andWhere('ai_mcp_server_uuid', attachment.ai_mcp_server_uuid)
+            .whereIn(
+                'ai_mcp_server_tool_uuid',
+                toolRows.map((tool) => tool.ai_mcp_server_tool_uuid),
+            );
+
+        const settingMap = new Map(
+            settingRows.map(
+                (row) => [row.ai_mcp_server_tool_uuid, row] as const,
+            ),
+        );
+
+        return toolRows.map((tool) =>
+            AiAgentModel.toAiAgentMcpServerTool({
+                agentUuid: args.agentUuid,
+                tool,
+                setting: settingMap.get(tool.ai_mcp_server_tool_uuid),
+            }),
+        );
+    }
+
+    async upsertAgentMcpServerToolSettings(args: {
+        agentUuid: string;
+        serverUuid: string;
+        toolSettings: AiAgentMcpServerToolUpdate[];
+        trx?: Knex;
+    }): Promise<AiAgentMcpServerTool[]> {
+        const trx = args.trx ?? this.database;
+        const settingMap = new Map(
+            args.toolSettings.map((tool) => [tool.toolName, tool] as const),
+        );
+        const toolSettings = [...settingMap.values()];
+
+        const attachment = await this.getAgentMcpServerAttachment({
+            agentUuid: args.agentUuid,
+            serverUuid: args.serverUuid,
+            trx,
+        });
+
+        if (!attachment) {
+            throw new NotFoundError('MCP server is not attached to this agent');
+        }
+
+        if (toolSettings.length === 0) {
+            return this.listAgentMcpServerTools({
+                agentUuid: args.agentUuid,
+                serverUuid: args.serverUuid,
+                trx,
+            });
+        }
+
+        const toolNames = toolSettings.map((tool) => tool.toolName);
+        const existingTools = await trx(AiMcpServerToolTableName)
+            .select<DbAiMcpServerTool[]>(
+                AiAgentModel.getMcpServerToolSelect(trx),
+            )
+            .where('ai_mcp_server_uuid', args.serverUuid)
+            .whereIn('tool_name', toolNames);
+
+        if (existingTools.length !== toolNames.length) {
+            throw new NotFoundError('One or more MCP tools were not found');
+        }
+
+        const toolUuidByName = new Map(
+            existingTools.map(
+                (tool) =>
+                    [tool.tool_name, tool.ai_mcp_server_tool_uuid] as const,
+            ),
+        );
+
+        await trx(AiAgentMcpServerToolTableName)
+            .insert(
+                toolSettings.map((tool) => ({
+                    ai_agent_uuid: attachment.ai_agent_uuid,
+                    ai_mcp_server_uuid: attachment.ai_mcp_server_uuid,
+                    ai_mcp_server_tool_uuid: toolUuidByName.get(tool.toolName)!,
+                    enabled: tool.enabled,
+                    created_at: trx.fn.now(),
+                    updated_at: trx.fn.now(),
+                })),
+            )
+            .onConflict([
+                'ai_agent_uuid',
+                'ai_mcp_server_uuid',
+                'ai_mcp_server_tool_uuid',
+            ])
+            .merge({
+                enabled: trx.raw('excluded.enabled'),
+                updated_at: trx.fn.now(),
+            });
+
+        return this.listAgentMcpServerTools({
+            agentUuid: args.agentUuid,
+            serverUuid: args.serverUuid,
+            trx,
+        });
+    }
+
+    async initializeAgentMcpServerToolSettings(args: {
+        agentUuid: string;
+        serverUuid: string;
+        enabled: boolean;
+        trx?: Knex;
+    }): Promise<void> {
+        const trx = args.trx ?? this.database;
+        const attachment = await this.getAgentMcpServerAttachment({
+            agentUuid: args.agentUuid,
+            serverUuid: args.serverUuid,
+            trx,
+        });
+
+        if (!attachment) {
+            throw new NotFoundError('MCP server is not attached to this agent');
+        }
+
+        const tools = await trx(AiMcpServerToolTableName)
+            .select<DbAiMcpServerTool[]>(
+                AiAgentModel.getMcpServerToolSelect(trx),
+            )
+            .where('ai_mcp_server_uuid', args.serverUuid);
+
+        if (tools.length === 0) {
+            return;
+        }
+
+        await trx(AiAgentMcpServerToolTableName)
+            .insert(
+                tools.map((tool) => ({
+                    ai_agent_uuid: attachment.ai_agent_uuid,
+                    ai_mcp_server_uuid: attachment.ai_mcp_server_uuid,
+                    ai_mcp_server_tool_uuid: tool.ai_mcp_server_tool_uuid,
+                    enabled: args.enabled,
+                    created_at: trx.fn.now(),
+                    updated_at: trx.fn.now(),
+                })),
+            )
+            .onConflict([
+                'ai_agent_uuid',
+                'ai_mcp_server_uuid',
+                'ai_mcp_server_tool_uuid',
+            ])
+            .ignore();
+    }
+
+    async getEnabledMcpServerToolNames(args: {
+        agentUuid: string;
+        serverUuid: string;
+        trx?: Knex;
+    }): Promise<string[]> {
+        const trx = args.trx ?? this.database;
+        const attachment = await this.getAgentMcpServerAttachment({
+            agentUuid: args.agentUuid,
+            serverUuid: args.serverUuid,
+            trx,
+        });
+
+        if (!attachment) {
+            throw new NotFoundError('MCP server is not attached to this agent');
+        }
+
+        const rows = await trx(AiAgentMcpServerToolTableName)
+            .innerJoin(AiMcpServerToolTableName, function joinMcpToolRows() {
+                this.on(
+                    `${AiAgentMcpServerToolTableName}.ai_mcp_server_tool_uuid`,
+                    '=',
+                    `${AiMcpServerToolTableName}.ai_mcp_server_tool_uuid`,
+                );
+            })
+            .select<{ tool_name: string }[]>({
+                tool_name: `${AiMcpServerToolTableName}.tool_name`,
+            })
+            .where(
+                `${AiAgentMcpServerToolTableName}.ai_agent_uuid`,
+                attachment.ai_agent_uuid,
+            )
+            .andWhere(
+                `${AiAgentMcpServerToolTableName}.ai_mcp_server_uuid`,
+                attachment.ai_mcp_server_uuid,
+            )
+            .andWhere(`${AiAgentMcpServerToolTableName}.enabled`, true)
+            .orderBy(`${AiMcpServerToolTableName}.tool_name`, 'asc');
+
+        return rows.map((row) => row.tool_name);
     }
 
     async getCredential(
@@ -1623,13 +2057,12 @@ export class AiAgentModel {
         mcpServerUuids: string[],
         { trx = this.database }: { trx?: Knex } = {},
     ): Promise<AiMcpServer[]> {
-        await trx(AiAgentMcpServerTableName)
-            .where('ai_agent_uuid', agentUuid)
-            .delete();
-
         const uniqueMcpServerUuids = [...new Set(mcpServerUuids)];
 
         if (uniqueMcpServerUuids.length === 0) {
+            await trx(AiAgentMcpServerTableName)
+                .where('ai_agent_uuid', agentUuid)
+                .delete();
             return [];
         }
 
@@ -1655,12 +2088,50 @@ export class AiAgentModel {
             );
         }
 
-        await trx(AiAgentMcpServerTableName).insert(
-            uniqueMcpServerUuids.map((mcpServerUuid) => ({
-                ai_agent_uuid: agentUuid,
-                ai_mcp_server_uuid: mcpServerUuid,
-            })),
+        const existingRows = await trx(AiAgentMcpServerTableName)
+            .select<DbAiAgentMcpServer[]>(
+                AiAgentModel.getAgentMcpServerAttachmentSelect(trx),
+            )
+            .where('ai_agent_uuid', agentUuid);
+
+        const existingServerUuids = new Set(
+            existingRows.map((row) => row.ai_mcp_server_uuid),
         );
+        const nextServerUuids = new Set(uniqueMcpServerUuids);
+
+        const serverUuidsToDetach = [...existingServerUuids].filter(
+            (serverUuid) => !nextServerUuids.has(serverUuid),
+        );
+        const serverUuidsToAttach = uniqueMcpServerUuids.filter(
+            (serverUuid) => !existingServerUuids.has(serverUuid),
+        );
+
+        if (serverUuidsToDetach.length > 0) {
+            await trx(AiAgentMcpServerTableName)
+                .where('ai_agent_uuid', agentUuid)
+                .whereIn('ai_mcp_server_uuid', serverUuidsToDetach)
+                .delete();
+        }
+
+        if (serverUuidsToAttach.length > 0) {
+            await trx(AiAgentMcpServerTableName).insert(
+                serverUuidsToAttach.map((mcpServerUuid) => ({
+                    ai_agent_uuid: agentUuid,
+                    ai_mcp_server_uuid: mcpServerUuid,
+                })),
+            );
+
+            await Promise.all(
+                serverUuidsToAttach.map((serverUuid) =>
+                    this.initializeAgentMcpServerToolSettings({
+                        agentUuid,
+                        serverUuid,
+                        enabled: true,
+                        trx,
+                    }),
+                ),
+            );
+        }
 
         const rowMap = new Map(
             rows.map((row) => [row.ai_mcp_server_uuid, row]),

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -149,6 +149,25 @@ describe('AiAgentService MCP support', () => {
             hasCredentials: true,
         });
 
+        await models.aiAgentModel.upsertDiscoveredMcpServerTools({
+            serverUuid: mcpServer.uuid,
+            tools: [
+                {
+                    toolName: 'search',
+                    title: 'Search docs',
+                    description: 'Search documentation',
+                    inputSchema: {
+                        type: 'object',
+                        properties: {
+                            query: { type: 'string' },
+                        },
+                    },
+                    annotations: null,
+                    meta: null,
+                },
+            ],
+        });
+
         const agent = await services.aiAgentService.createAgent(
             context.testUser,
             {
@@ -180,6 +199,134 @@ describe('AiAgentService MCP support', () => {
             mcpServer.uuid,
         ]);
         expect(agentMcpServers[0]).not.toHaveProperty('credentials');
+
+        const initialAgentToolSettings =
+            await models.aiAgentModel.listAgentMcpServerTools({
+                agentUuid: agent.uuid,
+                serverUuid: mcpServer.uuid,
+            });
+
+        expect(
+            initialAgentToolSettings.map((tool) => ({
+                toolName: tool.toolName,
+                enabled: tool.enabled,
+            })),
+        ).toEqual([
+            {
+                toolName: 'search',
+                enabled: true,
+            },
+        ]);
+        await expect(
+            models.aiAgentModel.getEnabledMcpServerToolNames({
+                agentUuid: agent.uuid,
+                serverUuid: mcpServer.uuid,
+            }),
+        ).resolves.toEqual(['search']);
+
+        await models.aiAgentModel.upsertDiscoveredMcpServerTools({
+            serverUuid: mcpServer.uuid,
+            tools: [
+                {
+                    toolName: 'search',
+                    title: 'Search docs',
+                    description: 'Search documentation',
+                    inputSchema: {
+                        type: 'object',
+                        properties: {
+                            query: { type: 'string' },
+                        },
+                    },
+                    annotations: null,
+                    meta: null,
+                },
+                {
+                    toolName: 'lookup',
+                    title: 'Lookup doc',
+                    description: 'Lookup a single document',
+                    inputSchema: {
+                        type: 'object',
+                        properties: {
+                            id: { type: 'string' },
+                        },
+                    },
+                    annotations: null,
+                    meta: null,
+                },
+            ],
+        });
+
+        await expect(
+            models.aiAgentModel.listAgentMcpServerTools({
+                agentUuid: agent.uuid,
+                serverUuid: mcpServer.uuid,
+            }),
+        ).resolves.toMatchObject([
+            {
+                toolName: 'lookup',
+                enabled: false,
+            },
+            {
+                toolName: 'search',
+                enabled: true,
+            },
+        ]);
+
+        await models.aiAgentModel.upsertAgentMcpServerToolSettings({
+            agentUuid: agent.uuid,
+            serverUuid: mcpServer.uuid,
+            toolSettings: [{ toolName: 'lookup', enabled: true }],
+        });
+
+        await expect(
+            models.aiAgentModel.getEnabledMcpServerToolNames({
+                agentUuid: agent.uuid,
+                serverUuid: mcpServer.uuid,
+            }),
+        ).resolves.toEqual(['lookup', 'search']);
+
+        await models.aiAgentModel.upsertDiscoveredMcpServerTools({
+            serverUuid: mcpServer.uuid,
+            tools: [
+                {
+                    toolName: 'lookup',
+                    title: 'Lookup doc',
+                    description: 'Lookup a single document',
+                    inputSchema: {
+                        type: 'object',
+                        properties: {
+                            id: { type: 'string' },
+                        },
+                    },
+                    annotations: null,
+                    meta: null,
+                },
+            ],
+        });
+
+        const refreshedAgentToolSettings =
+            await models.aiAgentModel.listAgentMcpServerTools({
+                agentUuid: agent.uuid,
+                serverUuid: mcpServer.uuid,
+            });
+
+        expect(
+            refreshedAgentToolSettings.map((tool) => ({
+                toolName: tool.toolName,
+                enabled: tool.enabled,
+            })),
+        ).toEqual([
+            {
+                toolName: 'lookup',
+                enabled: true,
+            },
+        ]);
+        await expect(
+            models.aiAgentModel.getEnabledMcpServerToolNames({
+                agentUuid: agent.uuid,
+                serverUuid: mcpServer.uuid,
+            }),
+        ).resolves.toEqual(['lookup']);
 
         const sensitiveMcpServers =
             await models.aiAgentModel.getAgentMcpServersWithSensitiveData(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10221,6 +10221,14 @@ const models: TsoaRoute.Models = {
                 },
                 hasCredentials: { dataType: 'boolean', required: true },
                 authType: { ref: 'AiMcpServerAuthType', required: true },
+                iconUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 url: { dataType: 'string', required: true },
                 name: { dataType: 'string', required: true },
                 projectUuid: { dataType: 'string', required: true },
@@ -11362,6 +11370,34 @@ const models: TsoaRoute.Models = {
         type: { dataType: 'string', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiMcpServer.uuid-or-name-or-iconUrl_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+                iconUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentToolCallMcpServer: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AiMcpServer.uuid-or-name-or-iconUrl_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentToolCall: {
         dataType: 'refAlias',
         type: {
@@ -11388,6 +11424,14 @@ const models: TsoaRoute.Models = {
                         {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
+                                mcpServer: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { ref: 'AiAgentToolCallMcpServer' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
                                 toolName: {
                                     ref: 'AiAgentMcpToolName',
                                     required: true,
@@ -11477,11 +11521,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -11539,11 +11583,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11807,6 +11807,10 @@
                     "authType": {
                         "$ref": "#/components/schemas/AiMcpServerAuthType"
                     },
+                    "iconUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "url": {
                         "type": "string"
                     },
@@ -11829,6 +11833,7 @@
                     "credentialScope",
                     "hasCredentials",
                     "authType",
+                    "iconUrl",
                     "url",
                     "name",
                     "projectUuid",
@@ -12974,6 +12979,26 @@
             "AiAgentMcpToolName": {
                 "type": "string"
             },
+            "Pick_AiMcpServer.uuid-or-name-or-iconUrl_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "iconUrl": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["name", "uuid", "iconUrl"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "AiAgentToolCallMcpServer": {
+                "$ref": "#/components/schemas/Pick_AiMcpServer.uuid-or-name-or-iconUrl_"
+            },
             "AiAgentToolCall": {
                 "allOf": [
                     {
@@ -12997,6 +13022,14 @@
                             },
                             {
                                 "properties": {
+                                    "mcpServer": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/AiAgentToolCallMcpServer"
+                                            }
+                                        ],
+                                        "nullable": true
+                                    },
                                     "toolName": {
                                         "$ref": "#/components/schemas/AiAgentMcpToolName"
                                     },
@@ -13006,7 +13039,11 @@
                                         "nullable": false
                                     }
                                 },
-                                "required": ["toolName", "toolType"],
+                                "required": [
+                                    "mcpServer",
+                                    "toolName",
+                                    "toolType"
+                                ],
                                 "type": "object"
                             }
                         ]
@@ -13086,8 +13123,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13145,8 +13182,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -33798,7 +33835,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3001.1",
+        "version": "0.3002.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -64,6 +64,39 @@ export type AiMcpServer = {
     updatedAt: Date;
 };
 
+export type AiMcpServerTool = {
+    uuid: string;
+    mcpServerUuid: string;
+    toolName: string;
+    title: string | null;
+    description: string | null;
+    inputSchema: unknown;
+    annotations: unknown | null;
+    meta: unknown | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type AiMcpServerToolInput = Pick<
+    AiMcpServerTool,
+    | 'toolName'
+    | 'title'
+    | 'description'
+    | 'inputSchema'
+    | 'annotations'
+    | 'meta'
+>;
+
+export type AiAgentMcpServerTool = AiMcpServerTool & {
+    agentUuid: string;
+    enabled: boolean;
+};
+
+export type AiAgentMcpServerToolUpdate = Pick<
+    AiAgentMcpServerTool,
+    'toolName' | 'enabled'
+>;
+
 export type AiAgentIntegration = {
     type: 'slack';
     channelId: string;


### PR DESCRIPTION


### Description:

Adds the foundational data model and persistence layer for MCP tool discovery and per-agent tool enable/disable controls.

A new `ai_mcp_server_tool` table stores the discovered tool catalog per MCP server, and a new `ai_agent_mcp_server_tool` table stores per-attachment enabled/disabled state keyed by the `ai_agent_mcp_server_uuid` introduced in this PR. The `ai_agent_mcp_server` table gains a dedicated UUID column to support these foreign key relationships.

New model methods on `AiAgentModel` cover:

- Upserting discovered tools from a refresh, removing tools no longer present upstream, and initializing attachment-scoped tool settings for all existing agent/server attachments
- Listing server tools and agent-scoped tool settings
- Updating enabled state per tool per attachment
- Fetching only the enabled tool names for a given agent/server pair at runtime

When a server is newly attached to an agent, tool settings are initialized from the current catalog with `enabled: true`. When a refresh adds new tools to an already-attached server, those new tools default to `enabled: false` to avoid silently expanding the tool surface.

Common types `AiMcpServerTool`, `AiMcpServerToolInput`, `AiAgentMcpServerTool`, and `AiAgentMcpServerToolUpdate` are added to support the model and future service/controller/frontend layers.

Integration tests cover the full lifecycle: initial attach with tool initialization, refresh adding new tools defaulting to disabled, explicit toggle updates, and refresh removing tools that are no longer upstream.