### PR TITLE
docs(skills): document nested spaceSlug syntax

### DIFF
--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -259,6 +259,16 @@ version: 1
 
 **Chart scoping:** Use `spaceSlug` only for shared charts. Add `dashboardSlug` to scope a chart to a specific dashboard (it won't appear in the space).
 
+**Nested spaces:** Spaces can be nested. In YAML, `spaceSlug` uses `parent/child` syntax to address a sub-space — the `/` denotes hierarchy. Examples:
+
+```yaml
+spaceSlug: sales              # Top-level space "sales"
+spaceSlug: sales/maps         # Sub-space "maps" inside "sales"
+spaceSlug: sales/eu/forecasts # Deeper nesting works the same way
+```
+
+Each path segment must be the slug of an existing (or to-be-created) space at that level. A bare slug like `sales-maps` is a flat top-level space, NOT a sub-space — the slash is the only thing that creates the hierarchy.
+
 ### Choosing the Right Chart Type
 
 | Data Pattern | Recommended Chart | Why |

--- a/skills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/skills/developing-in-lightdash/resources/dashboard-reference.md
@@ -44,6 +44,8 @@ tiles:
 
 **Chart scoping:** Charts can be scoped to a dashboard (via `dashboardSlug` on the chart YAML) or live independently in a space. See [Chart Types](../SKILL.md#chart-types) for guidance.
 
+**Nested `spaceSlug`:** Use `parent/child` syntax to put a dashboard in a sub-space, e.g. `spaceSlug: sales/forecasts`. A bare slug is a flat top-level space; the slash is what creates the hierarchy.
+
 ### SQL Chart Tile
 
 Display a SQL-based chart:


### PR DESCRIPTION
## Summary

- Adds an explicit "Nested spaces" subsection to the `developing-in-lightdash` skill explaining that `spaceSlug` uses `parent/child` syntax (e.g. `spaceSlug: sales/maps`) to address a sub-space
- Mirrors a one-line note in the dashboard reference page since `spaceSlug` shows up there too
- Calls out that a bare slug like `sales-maps` is a flat top-level space, not a sub-space — the slash is the only thing that creates hierarchy

The convention was previously only implicit in a few examples in `map-chart-reference.md` (`spaceSlug: sales/maps`) with no explanation, so an LLM consuming the skill couldn't reliably reproduce it.

## Test plan

- [ ] Read [SKILL.md](https://github.com/lightdash/lightdash/blob/claude/focused-sanderson-0c803a/skills/developing-in-lightdash/SKILL.md#chart-types) and confirm the "Nested spaces" subsection renders correctly
- [ ] Read [dashboard-reference.md](https://github.com/lightdash/lightdash/blob/claude/focused-sanderson-0c803a/skills/developing-in-lightdash/resources/dashboard-reference.md) and confirm the inline note renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)