### PR TITLE
fix(data-apps): add `allow-popups` to sandbox

### DIFF
--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -168,7 +168,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
                 src={src}
                 style={{ width: '100%', height: '100%', border: 'none' }}
                 title="App preview"
-                sandbox="allow-scripts allow-modals"
+                sandbox="allow-scripts allow-modals allow-popups"
                 allow=""
                 onLoad={handleLoad}
             />


### PR DESCRIPTION
### Description:
Reported (and confirmed) by a user, links inside a data app that open in a new tab (`target="_blank"`) aren't working without the `allow-popups` permission.

What allow-popups grants
- The iframe can call `window.open()` to navigate a new tab/window.
- The popup is still gated by a user gesture (browsers block programmatic popup spam), so a malicious or buggy generated app can't drive-by spam tabs.
- The popup inherits the same sandbox flags as the parent iframe (unlike `allow-popups-to-escape-sandbox`), no allow-same-origin, no cookie/storage access, no parent DOM access. The popup is just as defanged as the iframe itself.
