### PR TITLE
fix: set filter string autocomplete dropdown position to top

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -11,7 +11,14 @@ import DefaultFilterInputs from './DefaultFilterInputs';
 const BooleanFilterInputs = <T extends BaseFilterRule>(
     props: FilterInputsProps<T>,
 ) => {
-    const { rule, onChange, disabled, filterType, popoverProps } = props;
+    const {
+        rule,
+        onChange,
+        disabled,
+        filterType,
+        popoverProps,
+        valuesDropdownPosition,
+    } = props;
 
     const isFilterRuleDisabled = isFilterRule(rule) && rule.disabled;
 
@@ -33,6 +40,7 @@ const BooleanFilterInputs = <T extends BaseFilterRule>(
                     withinPortal={popoverProps?.withinPortal}
                     onDropdownOpen={popoverProps?.onOpen}
                     onDropdownClose={popoverProps?.onClose}
+                    dropdownPosition={valuesDropdownPosition}
                     disabled={disabled}
                     data-autofocus
                     initiallyOpened={currentValue === null && !disabled}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -25,6 +25,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
     disabled,
     onChange,
     popoverProps,
+    valuesDropdownPosition,
 }: FilterInputsProps<T>) => {
     const { getField } = useFiltersContext();
     const suggestions = isFilterRule(rule)
@@ -85,6 +86,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             withinPortal={popoverProps?.withinPortal}
                             onDropdownOpen={popoverProps?.onOpen}
                             onDropdownClose={popoverProps?.onClose}
+                            dropdownPosition={valuesDropdownPosition}
                             values={(rule.values || []).filter(isString)}
                             singleValue={isSingleValue}
                             onChange={(values) =>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
@@ -16,6 +16,7 @@ export type FilterInputsProps<T extends BaseFilterRule> = {
     onChange: (value: T) => void;
     disabled?: boolean;
     popoverProps?: Omit<PopoverProps, 'children'>;
+    valuesDropdownPosition?: 'top' | 'bottom' | 'flip';
 };
 
 const FilterInputComponent = <T extends BaseFilterRule>(

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -215,6 +215,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                                 filterType={filterType}
                                 field={field}
                                 rule={filterRule}
+                                valuesDropdownPosition="top"
                                 onChange={(newFilterRule) =>
                                     onChangeFilterRule(
                                         newFilterRule as DashboardFilterRule,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-2395/i-want-to-see-the-apply-button-for-dashboard-filters-after-ive

most simple , self contained fix. 

<img width="423" height="347" alt="CleanShot 2026-05-21 at 10 20 10" src="https://github.com/user-attachments/assets/8922de61-4243-4900-8552-9f64b5566532" />


### Description:
The dropdown for the filter string autocomplete multi-select input now opens upward (`dropdownPosition="top"`) instead of the default downward direction, preventing the dropdown from being obscured when the filter input is near the bottom of the screen.