### PR TITLE
feat: block query execution for trial orgs

### DIFF
--- a/packages/backend/src/routers/organizationRouter.ts
+++ b/packages/backend/src/routers/organizationRouter.ts
@@ -13,6 +13,26 @@ import {
 
 export const organizationRouter: Router = express.Router();
 
+organizationRouter.get(
+    '/access',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const results = await req.services
+                .getOrganizationAccessService()
+                .getOrganizationAccess(req.account);
+
+            res.json({
+                status: 'ok',
+                results,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
+
 organizationRouter.post(
     '/projects/precompiled',
     allowApiKeyAuthentication,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -63,6 +63,7 @@ import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CacheHitCacheResult, MissCacheResult } from '../CacheService/types';
+import type { OrganizationAccessService } from '../OrganizationAccessService/OrganizationAccessService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
@@ -165,6 +166,10 @@ const userAttributesModel = {
     getAttributeValuesForOrgMember: jest.fn(async () => ({})),
 };
 
+const organizationAccessService = {
+    assertQueryAccess: jest.fn(async () => undefined),
+};
+
 const getMockedAsyncQueryService = (
     lightdashConfig: LightdashConfig,
     overrides: Partial<AsyncQueryService> = {},
@@ -172,6 +177,8 @@ const getMockedAsyncQueryService = (
     new AsyncQueryService({
         lightdashConfig,
         analytics: analyticsMock,
+        organizationAccessService:
+            organizationAccessService as unknown as OrganizationAccessService,
         projectModel: projectModel as unknown as ProjectModel,
         preAggregateModel: {} as PreAggregateModel,
         onboardingModel: onboardingModel as unknown as OnboardingModel,
@@ -322,6 +329,41 @@ describe('AsyncQueryService', () => {
                         expiresAt: undefined,
                     }) satisfies MissCacheResult,
             );
+        });
+
+        test('blocks query execution when organization access is blocked', async () => {
+            organizationAccessService.assertQueryAccess.mockRejectedValueOnce(
+                new ForbiddenError(
+                    'Your Lightdash trial has expired. Contact sales to restore query access.',
+                ),
+            );
+
+            await expect(
+                serviceWithCache.executeAsyncQuery(
+                    {
+                        account: sessionAccount,
+                        projectUuid,
+                        metricQuery: metricQueryMock,
+                        context: QueryExecutionContext.EXPLORE,
+                        dateZoom: undefined,
+                        queryTags: {
+                            query_context: QueryExecutionContext.EXPLORE,
+                        },
+                        explore: validExplore,
+                        invalidateCache: false,
+                        sql: 'SELECT * FROM test',
+                        fields: {},
+                        missingParameterReferences: [],
+                        displayTimezone: null,
+                        useTimezoneAwareDateTrunc: false,
+                    },
+                    { query: metricQueryMock },
+                ),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(
+                serviceWithCache.queryHistoryModel.create,
+            ).not.toHaveBeenCalled();
         });
 
         test('Cache Hit - Complete Flow', async () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -153,6 +153,7 @@ import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
 import { CsvService } from '../CsvService/CsvService';
 import { ExcelService } from '../ExcelService/ExcelService';
+import { OrganizationAccessService } from '../OrganizationAccessService/OrganizationAccessService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
@@ -246,6 +247,7 @@ type AsyncQueryExecutionPlan =
       };
 
 type AsyncQueryServiceArguments = ProjectServiceArguments & {
+    organizationAccessService: OrganizationAccessService;
     queryHistoryModel: QueryHistoryModel;
     downloadAuditModel: DownloadAuditModel;
     cacheService?: ICacheService;
@@ -285,10 +287,13 @@ export class AsyncQueryService extends ProjectService {
 
     persistentDownloadFileService: PersistentDownloadFileService;
 
+    organizationAccessService: OrganizationAccessService;
+
     protected readonly preAggregateStrategy: PreAggregateStrategy;
 
     constructor(args: AsyncQueryServiceArguments) {
         super(args);
+        this.organizationAccessService = args.organizationAccessService;
         this.queryHistoryModel = args.queryHistoryModel;
         this.downloadAuditModel = args.downloadAuditModel;
         this.cacheService = args.cacheService;
@@ -3579,6 +3584,7 @@ export class AsyncQueryService extends ProjectService {
         requestParameters: ExecuteAsyncQueryRequestParams,
     ): Promise<ExecuteAsyncQueryReturn> {
         assertIsAccountWithOrg(args.account);
+        await this.organizationAccessService.assertQueryAccess(args.account);
 
         const { organizationUuid } = await this.projectModel.getSummary(
             args.projectUuid,

--- a/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.test.ts
+++ b/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.test.ts
@@ -1,5 +1,6 @@
 import {
     FeatureFlags,
+    ForbiddenError,
     OrganizationAccessStatus,
     type Account,
 } from '@lightdash/common';
@@ -16,6 +17,13 @@ const account = {
     },
     authentication: {
         type: 'session',
+    },
+} as Account;
+
+const apiAccount = {
+    ...account,
+    authentication: {
+        type: 'pat',
     },
 } as Account;
 
@@ -50,5 +58,53 @@ describe('OrganizationAccessService', () => {
         const access = await service.getOrganizationAccess(account);
 
         expect(access.status).toBe(OrganizationAccessStatus.TRIAL_WARNING);
+    });
+
+    it('gives blocked precedence over warning', async () => {
+        const service = buildService(
+            new Set([
+                FeatureFlags.OrganizationTrialWarning,
+                FeatureFlags.OrganizationTrialBlocked,
+            ]),
+        );
+
+        const access = await service.getOrganizationAccess(account);
+
+        expect(access.status).toBe(OrganizationAccessStatus.TRIAL_BLOCKED);
+    });
+
+    it('blocks query access for trial-blocked orgs', async () => {
+        const service = buildService(
+            new Set([FeatureFlags.OrganizationTrialBlocked]),
+        );
+
+        await expect(service.assertQueryAccess(account)).rejects.toThrow(
+            ForbiddenError,
+        );
+    });
+
+    it('allows API/CLI query access during grace period', async () => {
+        const service = buildService(
+            new Set([FeatureFlags.OrganizationTrialBlocked]),
+        );
+
+        await expect(service.assertQueryAccess(apiAccount)).resolves.toEqual(
+            expect.objectContaining({
+                status: OrganizationAccessStatus.TRIAL_BLOCKED,
+            }),
+        );
+    });
+
+    it('blocks API/CLI query access after grace period flag is enabled', async () => {
+        const service = buildService(
+            new Set([
+                FeatureFlags.OrganizationTrialBlocked,
+                FeatureFlags.OrganizationTrialApiCliBlocked,
+            ]),
+        );
+
+        await expect(service.assertQueryAccess(apiAccount)).rejects.toThrow(
+            ForbiddenError,
+        );
     });
 });

--- a/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.test.ts
+++ b/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.test.ts
@@ -1,0 +1,54 @@
+import {
+    FeatureFlags,
+    OrganizationAccessStatus,
+    type Account,
+} from '@lightdash/common';
+import { type FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
+import { OrganizationAccessService } from './OrganizationAccessService';
+
+const account = {
+    organization: {
+        organizationUuid: 'org-uuid',
+        name: 'Acme',
+    },
+    user: {
+        id: 'user-uuid',
+    },
+    authentication: {
+        type: 'session',
+    },
+} as Account;
+
+const buildService = (enabledFlags: Set<string>) => {
+    const featureFlagService = {
+        get: jest.fn(async ({ featureFlagId }: { featureFlagId: string }) => ({
+            id: featureFlagId,
+            enabled: enabledFlags.has(featureFlagId),
+        })),
+    } as unknown as FeatureFlagService;
+
+    return new OrganizationAccessService({
+        featureFlagService,
+        cacheTtlMs: 0,
+    });
+};
+
+describe('OrganizationAccessService', () => {
+    it('returns active when no trial flags are enabled', async () => {
+        const service = buildService(new Set());
+
+        await expect(service.getOrganizationAccess(account)).resolves.toEqual({
+            status: OrganizationAccessStatus.ACTIVE,
+        });
+    });
+
+    it('returns trial warning when the warning flag is enabled', async () => {
+        const service = buildService(
+            new Set([FeatureFlags.OrganizationTrialWarning]),
+        );
+
+        const access = await service.getOrganizationAccess(account);
+
+        expect(access.status).toBe(OrganizationAccessStatus.TRIAL_WARNING);
+    });
+});

--- a/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.ts
+++ b/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.ts
@@ -1,5 +1,6 @@
 import {
     FeatureFlags,
+    ForbiddenError,
     OrganizationAccessStatus,
     type Account,
     type OrganizationAccess,
@@ -8,6 +9,10 @@ import { BaseService } from '../BaseService';
 import { type FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 
 const DEFAULT_CACHE_TTL_MS = 60 * 1000;
+const TRIAL_BLOCKED_MESSAGE =
+    'Your Lightdash trial has expired. Contact sales to restore query access.';
+const TRIAL_API_CLI_BLOCKED_MESSAGE =
+    'Your Lightdash trial has expired. API and CLI query access is blocked.';
 
 type OrganizationAccessServiceArguments = {
     featureFlagService: FeatureFlagService;
@@ -18,6 +23,11 @@ type CacheEntry = {
     access: OrganizationAccess;
     expiresAt: number;
 };
+
+const isApiCliAccount = (account?: Account) =>
+    account?.authentication.type === 'pat' ||
+    account?.authentication.type === 'oauth' ||
+    account?.authentication.type === 'service-account';
 
 export class OrganizationAccessService extends BaseService {
     private readonly featureFlagService: FeatureFlagService;
@@ -30,6 +40,23 @@ export class OrganizationAccessService extends BaseService {
         super();
         this.featureFlagService = args.featureFlagService;
         this.cacheTtlMs = args.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    }
+
+    async assertQueryAccess(account?: Account): Promise<OrganizationAccess> {
+        const access = await this.getOrganizationAccess(account);
+        if (access.status !== OrganizationAccessStatus.TRIAL_BLOCKED) {
+            return access;
+        }
+
+        if (isApiCliAccount(account) && !access.apiCliBlocked) {
+            return access;
+        }
+
+        throw new ForbiddenError(
+            isApiCliAccount(account)
+                ? TRIAL_API_CLI_BLOCKED_MESSAGE
+                : TRIAL_BLOCKED_MESSAGE,
+        );
     }
 
     async getOrganizationAccess(
@@ -70,10 +97,27 @@ export class OrganizationAccessService extends BaseService {
             organizationName: account.organization.name,
         };
 
-        const isWarning = await this.featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.OrganizationTrialWarning,
-        });
+        const [isBlocked, isWarning, isApiCliBlocked] = await Promise.all([
+            this.featureFlagService.get({
+                user,
+                featureFlagId: FeatureFlags.OrganizationTrialBlocked,
+            }),
+            this.featureFlagService.get({
+                user,
+                featureFlagId: FeatureFlags.OrganizationTrialWarning,
+            }),
+            this.featureFlagService.get({
+                user,
+                featureFlagId: FeatureFlags.OrganizationTrialApiCliBlocked,
+            }),
+        ]);
+
+        if (isBlocked.enabled) {
+            return {
+                status: OrganizationAccessStatus.TRIAL_BLOCKED,
+                apiCliBlocked: isApiCliBlocked.enabled,
+            };
+        }
 
         if (isWarning.enabled) {
             return {

--- a/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.ts
+++ b/packages/backend/src/services/OrganizationAccessService/OrganizationAccessService.ts
@@ -1,0 +1,86 @@
+import {
+    FeatureFlags,
+    OrganizationAccessStatus,
+    type Account,
+    type OrganizationAccess,
+} from '@lightdash/common';
+import { BaseService } from '../BaseService';
+import { type FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
+
+const DEFAULT_CACHE_TTL_MS = 60 * 1000;
+
+type OrganizationAccessServiceArguments = {
+    featureFlagService: FeatureFlagService;
+    cacheTtlMs?: number;
+};
+
+type CacheEntry = {
+    access: OrganizationAccess;
+    expiresAt: number;
+};
+
+export class OrganizationAccessService extends BaseService {
+    private readonly featureFlagService: FeatureFlagService;
+
+    private readonly cacheTtlMs: number;
+
+    private readonly cache = new Map<string, CacheEntry>();
+
+    constructor(args: OrganizationAccessServiceArguments) {
+        super();
+        this.featureFlagService = args.featureFlagService;
+        this.cacheTtlMs = args.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    }
+
+    async getOrganizationAccess(
+        account?: Account,
+    ): Promise<OrganizationAccess> {
+        const organizationUuid = account?.organization.organizationUuid;
+        if (!organizationUuid) {
+            return { status: OrganizationAccessStatus.ACTIVE };
+        }
+
+        const cached = this.cache.get(organizationUuid);
+        if (cached && cached.expiresAt > Date.now()) {
+            return cached.access;
+        }
+
+        const access = await this.resolveOrganizationAccess(account);
+        this.cache.set(organizationUuid, {
+            access,
+            expiresAt: Date.now() + this.cacheTtlMs,
+        });
+        return access;
+    }
+
+    clearCache(organizationUuid?: string) {
+        if (organizationUuid) {
+            this.cache.delete(organizationUuid);
+            return;
+        }
+        this.cache.clear();
+    }
+
+    private async resolveOrganizationAccess(
+        account: Account,
+    ): Promise<OrganizationAccess> {
+        const user = {
+            userUuid: account.user.id,
+            organizationUuid: account.organization.organizationUuid,
+            organizationName: account.organization.name,
+        };
+
+        const isWarning = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.OrganizationTrialWarning,
+        });
+
+        if (isWarning.enabled) {
+            return {
+                status: OrganizationAccessStatus.TRIAL_WARNING,
+            };
+        }
+
+        return { status: OrganizationAccessStatus.ACTIVE };
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -700,6 +700,8 @@ export class ServiceRepository
                 new AsyncQueryService({
                     lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
+                    organizationAccessService:
+                        this.getOrganizationAccessService(),
                     projectModel: this.models.getProjectModel(),
                     preAggregateModel: this.models.getPreAggregateModel(),
                     onboardingModel: this.models.getOnboardingModel(),

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -35,6 +35,7 @@ import { LightdashAnalyticsService } from './LightdashAnalyticsService/Lightdash
 import { MetricsExplorerService } from './MetricsExplorerService/MetricsExplorerService';
 import { NotificationsService } from './NotificationsService/NotificationsService';
 import { OAuthService } from './OAuthService/OAuthService';
+import { OrganizationAccessService } from './OrganizationAccessService/OrganizationAccessService';
 import { OrganizationService } from './OrganizationService/OrganizationService';
 import { OrganizationSsoService } from './OrganizationSsoService/OrganizationSsoService';
 import { PermissionsService } from './PermissionsService/PermissionsService';
@@ -88,6 +89,7 @@ interface ServiceManifest {
 
     organizationService: OrganizationService;
     organizationSsoService: OrganizationSsoService;
+    organizationAccessService: OrganizationAccessService;
     preAggregateMaterializationService: PreAggregateMaterializationService;
     persistentDownloadFileService: PersistentDownloadFileService;
     personalAccessTokenService: PersonalAccessTokenService;
@@ -527,6 +529,16 @@ export class ServiceRepository
                         this.models.getOrganizationAllowedEmailDomainsModel(),
                     groupsModel: this.models.getGroupsModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
+                }),
+        );
+    }
+
+    public getOrganizationAccessService(): OrganizationAccessService {
+        return this.getService(
+            'organizationAccessService',
+            () =>
+                new OrganizationAccessService({
+                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -132,6 +132,7 @@ export * from './types/notifications';
 export * from './types/oauth';
 export * from './types/openIdIdentity';
 export * from './types/organization';
+export * from './types/organizationAccess';
 export * from './types/organizationMemberProfile';
 export * from './types/organizationSso';
 export * from './types/organizationWarehouseCredentials';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -140,6 +140,7 @@ import {
     type OrganizationProject,
     type UpdateAllowedEmailDomains,
 } from './organization';
+import { type OrganizationAccess } from './organizationAccess';
 import {
     type ApiOrganizationMemberProfiles,
     type OrganizationMemberProfile,
@@ -882,6 +883,7 @@ type ApiResults =
     | ApiRefreshResults
     | ApiCreatePreviewResults
     | ApiHealthResults
+    | OrganizationAccess
     | Organization
     | LightdashUser
     | LoginOptions

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -199,6 +199,17 @@ export enum FeatureFlags {
      * instances. This does not block product access.
      */
     OrganizationTrialWarning = 'organization-trial-warning',
+
+    /**
+     * Block query execution for an organization whose trial has expired.
+     */
+    OrganizationTrialBlocked = 'organization-trial-blocked',
+
+    /**
+     * Block API/CLI-style query execution after the agreed grace period has
+     * elapsed for a trial-blocked organization.
+     */
+    OrganizationTrialApiCliBlocked = 'organization-trial-api-cli-blocked',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -193,6 +193,12 @@ export enum FeatureFlags {
      * Enable AI thread context compaction for streamed web-app conversations.
      */
     AiContextCompaction = 'ai-context-compaction',
+
+    /**
+     * Show a persistent trial warning banner for an organization on shared
+     * instances. This does not block product access.
+     */
+    OrganizationTrialWarning = 'organization-trial-warning',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/organizationAccess.ts
+++ b/packages/common/src/types/organizationAccess.ts
@@ -1,6 +1,7 @@
 export enum OrganizationAccessStatus {
     ACTIVE = 'active',
     TRIAL_WARNING = 'trial_warning',
+    TRIAL_BLOCKED = 'trial_blocked',
 }
 
 export type OrganizationAccess =
@@ -9,6 +10,10 @@ export type OrganizationAccess =
       }
     | {
           status: OrganizationAccessStatus.TRIAL_WARNING;
+      }
+    | {
+          status: OrganizationAccessStatus.TRIAL_BLOCKED;
+          apiCliBlocked: boolean;
       };
 
 export type ApiOrganizationAccessResponse = {

--- a/packages/common/src/types/organizationAccess.ts
+++ b/packages/common/src/types/organizationAccess.ts
@@ -1,0 +1,17 @@
+export enum OrganizationAccessStatus {
+    ACTIVE = 'active',
+    TRIAL_WARNING = 'trial_warning',
+}
+
+export type OrganizationAccess =
+    | {
+          status: OrganizationAccessStatus.ACTIVE;
+      }
+    | {
+          status: OrganizationAccessStatus.TRIAL_WARNING;
+      };
+
+export type ApiOrganizationAccessResponse = {
+    status: 'ok';
+    results: OrganizationAccess;
+};

--- a/packages/frontend/src/components/NavBar/TrialWarningBanner.module.css
+++ b/packages/frontend/src/components/NavBar/TrialWarningBanner.module.css
@@ -1,0 +1,3 @@
+.banner {
+    z-index: var(--mantine-z-index-app);
+}

--- a/packages/frontend/src/components/NavBar/TrialWarningBanner.tsx
+++ b/packages/frontend/src/components/NavBar/TrialWarningBanner.tsx
@@ -1,0 +1,33 @@
+import {
+    OrganizationAccessStatus,
+    type OrganizationAccess,
+} from '@lightdash/common';
+import { Center, Text } from '@mantine-8/core';
+import { BANNER_HEIGHT } from '../common/Page/constants';
+import classes from './TrialWarningBanner.module.css';
+
+type Props = {
+    access: OrganizationAccess;
+};
+
+export const TrialWarningBanner = ({ access }: Props) => {
+    if (access.status !== OrganizationAccessStatus.TRIAL_WARNING) {
+        return null;
+    }
+
+    return (
+        <Center
+            pos="fixed"
+            top={0}
+            w="100%"
+            h={BANNER_HEIGHT}
+            px="md"
+            bg="yellow.7"
+            className={classes.banner}
+        >
+            <Text c="gray.9" size="sm" fw={700} truncate>
+                Your Lightdash trial has expired. Contact sales@lightdash.com
+            </Text>
+        </Center>
+    );
+};

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -1,9 +1,10 @@
-import { ProjectType } from '@lightdash/common';
+import { OrganizationAccessStatus, ProjectType } from '@lightdash/common';
 import { Box } from '@mantine-8/core';
 import { clsx } from '@mantine/core';
 import { memo } from 'react';
 import { useParams } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import { useOrganizationAccess } from '../../hooks/organization/useOrganizationAccess';
 import { useActiveProjectUuid } from '../../hooks/useActiveProject';
 import { useProject } from '../../hooks/useProject';
 import { useImpersonation } from '../../hooks/user/useImpersonation';
@@ -15,6 +16,7 @@ import { ImpersonationBanner } from './ImpersonationBanner';
 import classes from './index.module.css';
 import { MainNavBarContent } from './MainNavBarContent';
 import { PreviewBanner } from './PreviewBanner';
+import { TrialWarningBanner } from './TrialWarningBanner';
 
 enum NavBarMode {
     DEFAULT = 'default',
@@ -69,12 +71,19 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
 
     const isCurrentProjectPreview = project?.type === ProjectType.PREVIEW;
     const { isImpersonating } = useImpersonation();
+    const { data: organizationAccess } = useOrganizationAccess();
 
     const { navBarMode } = useNavBarMode();
 
-    const hasBanner = isImpersonating || isCurrentProjectPreview;
+    const showTrialWarning =
+        !isImpersonating &&
+        !isCurrentProjectPreview &&
+        organizationAccess?.status === OrganizationAccessStatus.TRIAL_WARNING;
 
-    // Calculate placeholder height: navbar + banner (if preview or impersonating)
+    const hasBanner =
+        isImpersonating || isCurrentProjectPreview || showTrialWarning;
+
+    // Calculate placeholder height: navbar + banner.
     const headerContainerHeight =
         NAVBAR_HEIGHT + (hasBanner ? BANNER_HEIGHT : 0);
 
@@ -91,9 +100,11 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
             >
                 {isImpersonating ? (
                     <ImpersonationBanner />
+                ) : isCurrentProjectPreview ? (
+                    <PreviewBanner expiresAt={project?.expiresAt ?? null} />
                 ) : (
-                    isCurrentProjectPreview && (
-                        <PreviewBanner expiresAt={project?.expiresAt ?? null} />
+                    organizationAccess && (
+                        <TrialWarningBanner access={organizationAccess} />
                     )
                 )}
                 <Box

--- a/packages/frontend/src/hooks/organization/useOrganizationAccess.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationAccess.ts
@@ -1,0 +1,20 @@
+import { type ApiError, type OrganizationAccess } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+
+const getOrganizationAccess = async (): Promise<OrganizationAccess> => {
+    return lightdashApi<OrganizationAccess>({
+        url: '/org/access',
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useOrganizationAccess = (enabled: boolean = true) =>
+    useQuery<OrganizationAccess, ApiError>({
+        queryKey: ['organization-access'],
+        queryFn: getOrganizationAccess,
+        enabled,
+        retry: false,
+        refetchOnMount: false,
+    });


### PR DESCRIPTION
## Summary
- add trial-blocked feature flags on top of the banner status model
- block query execution at the AsyncQueryService boundary with a trial-expired error
- keep API/CLI query access available until the API/CLI grace flag is enabled

## Stack
- Base PR: #23249

## Validation
- pnpm -F common build
- pnpm -F backend test -- OrganizationAccessService.test.ts AsyncQueryService.test.ts
- pnpm -F common typecheck
- pnpm -F backend linter src/services/AsyncQueryService/AsyncQueryService.ts src/services/AsyncQueryService/AsyncQueryService.test.ts src/services/OrganizationAccessService/OrganizationAccessService.ts src/services/OrganizationAccessService/OrganizationAccessService.test.ts src/services/ServiceRepository.ts
