### PR TITLE
fix: detect parameter refs inside liquid {% %} tags

### DIFF
--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -2,7 +2,7 @@ import {
     DimensionType,
     FieldType,
     FilterOperator,
-    getParameterReferencesFromSqlAndFormat,
+    getParameterReferences,
     MetricType,
     SupportedDbtAdapter,
     TimeFrames,
@@ -43,8 +43,7 @@ const makeDimension = ({
     hidden: false,
     compiledSql: compiledSql ?? sql ?? '"orders".id',
     parameterReferences:
-        parameterReferences ??
-        getParameterReferencesFromSqlAndFormat(sql ?? '${TABLE}.id'),
+        parameterReferences ?? getParameterReferences(sql ?? '${TABLE}.id'),
     tablesReferences: [table],
     ...(compilationError ? { compilationError } : {}),
 });
@@ -80,8 +79,7 @@ const makeMetric = ({
     hidden: false,
     compiledSql: compiledSql ?? sql ?? 'count(*)',
     parameterReferences:
-        parameterReferences ??
-        getParameterReferencesFromSqlAndFormat(sql ?? 'count(*)'),
+        parameterReferences ?? getParameterReferences(sql ?? 'count(*)'),
     tablesReferences: [table],
     ...(filters ? { filters } : {}),
     ...(compilationError ? { compilationError } : {}),

--- a/packages/backend/src/utils/QueryBuilder/parameters.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.ts
@@ -1,4 +1,5 @@
 import {
+    getParameterReferences,
     parameterRegex,
     renderLiquidSql,
     UnexpectedServerError,
@@ -189,6 +190,14 @@ export const safeReplaceParametersWithTypes = ({
         escapeString: sqlBuilder.escapeString.bind(sqlBuilder),
         quoteChar: sqlBuilder.getStringQuoteChar(),
         wrapChar,
+    });
+
+    // Liquid blocks (e.g. `{% if ld.parameters.x == "y" %}...{% endif %}`) reference parameters
+    // but are evaluated and consumed by `renderLiquidSql` before the `${...}` regex scan above,
+    // so their parameter references would otherwise be lost. Scan the pre-render SQL for
+    // liquid-style references and merge them into the references set.
+    getParameterReferences(sql).forEach((ref) => {
+        allParametersResult.references.add(ref);
     });
 
     // If no parameter definitions are provided, use the standard replacement

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -44,7 +44,6 @@ import {
     getAvailableParameterNames,
     getAvailableParametersFromTables,
     getParameterReferences,
-    getParameterReferencesFromSqlAndFormat,
     validateParameterConfiguration,
     validateParameterNames,
     validateParameterReferences,
@@ -902,7 +901,7 @@ export class ExploreCompiler {
         const compiledSql = compiledMetric.sql;
 
         // Extract parameter references from both SQL and format string
-        const parameterReferences = getParameterReferencesFromSqlAndFormat(
+        const parameterReferences = getParameterReferences(
             compiledSql,
             typeof metric.format === 'string' ? metric.format : undefined,
         );
@@ -1210,7 +1209,7 @@ export class ExploreCompiler {
         const compiledSql = compiledDimension.sql;
 
         // Extract parameter references from both SQL and format string
-        const parameterReferences = getParameterReferencesFromSqlAndFormat(
+        const parameterReferences = getParameterReferences(
             compiledSql,
             typeof dimension.format === 'string' ? dimension.format : undefined,
         );

--- a/packages/common/src/compiler/parameters.test.ts
+++ b/packages/common/src/compiler/parameters.test.ts
@@ -99,6 +99,129 @@ describe('getParameterReferences', () => {
         });
     });
 
+    describe('Liquid template references', () => {
+        it('should extract parameters from {% if %} liquid tags', () => {
+            const sql =
+                '{% if ld.parameters.source_schema == "jaffle" %}jaffle.orders{% else %}public.orders{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual(['source_schema']);
+        });
+
+        it('should extract parameters from {% elsif %} branches', () => {
+            const sql =
+                '{% if ld.parameters.grain == "day" %}d' +
+                '{% elsif ld.parameters.fallback == "week" %}w' +
+                '{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toContain('grain');
+            expect(result).toContain('fallback');
+            expect(result.length).toBe(2);
+        });
+
+        it('should extract parameters from {% case %} / {% when %} blocks', () => {
+            const sql =
+                '{% case ld.parameters.region %}{% when "EU" %}eu{% when "US" %}us{% endcase %}';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual(['region']);
+        });
+
+        it('should extract parameters from {% assign %} tags', () => {
+            const sql = '{% assign foo = ld.parameters.bar %}SELECT {{ foo }}';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual(['bar']);
+        });
+
+        it('should extract parameters used with liquid operators (contains)', () => {
+            const sql =
+                '{% if ld.parameters.tags contains "premium" %}premium{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual(['tags']);
+        });
+
+        it('should extract parameters from lightdash.parameters in liquid tags', () => {
+            const sql =
+                '{% if lightdash.parameters.grain == "day" %}day{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual(['grain']);
+        });
+
+        it('should extract model-scoped parameters from liquid tags', () => {
+            const sql =
+                '{% if ld.parameters.orders.status == "active" %}active{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual(['orders.status']);
+        });
+
+        it('should NOT detect ld.query.fields as a parameter', () => {
+            const sql =
+                '{% if ld.query.fields contains "orders.id" %}has_id{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual([]);
+        });
+
+        it('should extract both ${} and liquid-bare references in the same string', () => {
+            const sql =
+                '{% if ld.parameters.region == "EU" %}SELECT * FROM eu_orders{% else %}SELECT * FROM ${ld.parameters.fallback_table}{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toContain('region');
+            expect(result).toContain('fallback_table');
+            expect(result.length).toBe(2);
+        });
+
+        it('should accept multiple sources and dedupe', () => {
+            const sql = '${ld.parameters.x}';
+            const format = '${ld.parameters.x}${ld.parameters.y}';
+            const result = getParameterReferences(sql, format);
+            expect(result).toContain('x');
+            expect(result).toContain('y');
+            expect(result.length).toBe(2);
+        });
+
+        it('should ignore undefined sources', () => {
+            const result = getParameterReferences(
+                '${ld.parameters.x}',
+                undefined,
+            );
+            expect(result).toEqual(['x']);
+        });
+    });
+
+    describe('Negative cases — false-positive guards', () => {
+        it('should not match bare ld.parameters.X when no liquid tags are present', () => {
+            // Without {%, the broad scan never fires — only ${...} is matched.
+            const sql =
+                'SELECT * FROM tbl -- ld.parameters.fake_ref in a comment';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual([]);
+        });
+
+        it('should not match suffixed identifiers like myld.parameters.x in liquid SQL', () => {
+            // Left boundary in the broad regex prevents matching after a word/dot char.
+            const sql =
+                '{% if ld.parameters.real == 1 %}SELECT myld.parameters.fake{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual(['real']);
+        });
+
+        it('should not match if the left boundary is another dot (e.g. table.ld.parameters.x)', () => {
+            const sql =
+                '{% if ld.parameters.real == 1 %}SELECT t.ld.parameters.fake{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toEqual(['real']);
+        });
+
+        it('limitation: a quoted SQL identifier "ld.parameters.fake" inside liquid SQL IS still matched', () => {
+            // Documented behavior: column names with literal `ld.parameters.X` are
+            // exceedingly rare (warehouses require quoting for dots in identifiers)
+            // and a false-positive in detection is harmless (UI shows extra param).
+            const sql =
+                'SELECT "ld.parameters.fake" FROM t WHERE {% if ld.parameters.real %}1{% endif %}';
+            const result = getParameterReferences(sql);
+            expect(result).toContain('real');
+            expect(result).toContain('fake');
+        });
+    });
+
     describe('Edge cases and validation', () => {
         it('should return empty array when no parameter references exist', () => {
             const sql = 'SELECT * FROM users WHERE status = "active"';

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -10,73 +10,57 @@ import { CompileError } from '../types/errors';
 import type { CompiledTable, Table } from '../types/explore';
 import type { LightdashProjectParameter } from '../types/lightdashProjectConfig';
 
-// Regex for SQL parameter replacement - requires full ${} syntax
+// Regex for SQL parameter substitution - requires the full ${...} syntax.
+// Used by `replaceLightdashValues` to find substitution sites.
 export const parameterRegex =
     /\$\{(?:lightdash|ld)\.parameters\.(\w+(?:\.\w+)?)\}/g;
 
-// Regex for extracting parameter references - works with format strings, ternary expressions,
-// and Liquid template blocks like {% if ld.parameters.grain == "day" %}
+// Broader regex that also matches bare `ld.parameters.X` references — used to catch
+// references inside Liquid template tags (e.g. `{% if ld.parameters.grain == "day" %}`),
+// format strings, and ternary expressions. The lookbehind requires a non-word,
+// non-dot boundary before `ld`/`lightdash` so identifiers like `myld.parameters.x`
+// don't false-match.
 const parameterReferencePattern =
-    /(?:lightdash|ld)\.parameters\.(\w+(?:\.\w+)?)/g;
+    /(?<![\w.])(?:lightdash|ld)\.parameters\.(\w+(?:\.\w+)?)/g;
 
 export enum LightdashParameters {
     PREFIX = 'lightdash.parameters',
     PREFIX_SHORT = 'ld.parameters',
 }
 
-/**
- * Extracts parameter references from SQL strings or format strings
- * @param sql - The SQL or format string to extract parameter references from
- * @returns An array of unique parameter names referenced in the string
- */
-export const getParameterReferences = (
-    sql: string,
-    regex = parameterRegex,
-): string[] => {
-    const matches = sql.match(regex);
-
-    if (!matches) {
-        return [];
-    }
-
-    // Extract parameter names using the regex capture group and remove duplicates
-    const parameterNames = matches.map((match) => match.replace(regex, '$1'));
-
-    // Return unique parameter names
-    return [...new Set(parameterNames)];
+const matchAll = (input: string, regex: RegExp): string[] => {
+    const matches = input.match(regex);
+    if (!matches) return [];
+    return matches.map((match) => match.replace(regex, '$1'));
 };
 
 /**
- * Extracts and combines parameter references from both SQL and format strings
- * @param compiledSql - The compiled SQL to extract parameters from
- * @param format - Optional format string to extract parameters from
- * @returns An array of unique parameter names from both sources
+ * Single source of truth for extracting parameter references from a templated SQL or
+ * format string. Detects both `${ld.parameters.X}` substitution sites and bare
+ * `ld.parameters.X` references inside Liquid template blocks (only when `{%` is present,
+ * to avoid false positives in plain SQL).
+ *
+ * @param sources - One or more strings to scan (e.g. compiled SQL, sql_from, format string).
+ * @returns A deduplicated array of parameter names.
  */
-export const getParameterReferencesFromSqlAndFormat = (
-    compiledSql: string,
-    format?: string,
+export const getParameterReferences = (
+    ...sources: (string | undefined)[]
 ): string[] => {
-    const sqlParameterReferences = getParameterReferences(compiledSql);
-
-    // Also extract parameter references from Liquid template blocks
-    // e.g., {% if ld.parameters.grain == "day" %}
-    const liquidParameterReferences = compiledSql.includes('{%')
-        ? getParameterReferences(compiledSql, parameterReferencePattern)
-        : [];
-
-    const formatParameterReferences =
-        format && typeof format === 'string'
-            ? getParameterReferences(format, parameterReferencePattern)
-            : [];
-
-    // Combine and deduplicate parameter references from all sources
-    return Array.from(
-        new Set([
-            ...sqlParameterReferences,
-            ...liquidParameterReferences,
-            ...formatParameterReferences,
-        ]),
-    );
+    const references = new Set<string>();
+    sources.forEach((source) => {
+        if (!source || typeof source !== 'string') return;
+        // Always match ${...} substitution sites.
+        matchAll(source, parameterRegex).forEach((name) =>
+            references.add(name),
+        );
+        // If the source contains Liquid tags, also match bare references inside them.
+        if (source.includes('{%')) {
+            matchAll(source, parameterReferencePattern).forEach((name) =>
+                references.add(name),
+            );
+        }
+    });
+    return [...references];
 };
 
 export const validateParameterReferences = (

--- a/packages/common/src/ee/preAggregates/dimensionEligibility.test.ts
+++ b/packages/common/src/ee/preAggregates/dimensionEligibility.test.ts
@@ -1,4 +1,4 @@
-import { getParameterReferencesFromSqlAndFormat } from '../../compiler/parameters';
+import { getParameterReferences } from '../../compiler/parameters';
 import type { CompiledTable } from '../../types/explore';
 import {
     DimensionType,
@@ -25,7 +25,7 @@ const makeDimension = (
     compiledSql: overrides.compiledSql ?? overrides.sql ?? '"orders".id',
     parameterReferences:
         overrides.parameterReferences ??
-        getParameterReferencesFromSqlAndFormat(overrides.sql ?? '${TABLE}.id'),
+        getParameterReferences(overrides.sql ?? '${TABLE}.id'),
     tablesReferences: overrides.tablesReferences ?? ['orders'],
     hidden: overrides.hidden ?? false,
 });

--- a/packages/common/src/ee/preAggregates/metricEligibility.test.ts
+++ b/packages/common/src/ee/preAggregates/metricEligibility.test.ts
@@ -1,4 +1,4 @@
-import { getParameterReferencesFromSqlAndFormat } from '../../compiler/parameters';
+import { getParameterReferences } from '../../compiler/parameters';
 import type { CompiledTable } from '../../types/explore';
 import {
     DimensionType,
@@ -29,9 +29,7 @@ const makeDimension = (
     compiledSql: overrides.compiledSql ?? overrides.sql ?? '"orders".amount',
     parameterReferences:
         overrides.parameterReferences ??
-        getParameterReferencesFromSqlAndFormat(
-            overrides.sql ?? '${TABLE}.amount',
-        ),
+        getParameterReferences(overrides.sql ?? '${TABLE}.amount'),
     tablesReferences: overrides.tablesReferences ?? ['orders'],
     hidden: overrides.hidden ?? false,
 });
@@ -51,9 +49,7 @@ const makeMetric = (
         overrides.compiledSql ?? overrides.sql ?? 'SUM("orders".amount)',
     parameterReferences:
         overrides.parameterReferences ??
-        getParameterReferencesFromSqlAndFormat(
-            overrides.sql ?? 'sum(${TABLE}.amount)',
-        ),
+        getParameterReferences(overrides.sql ?? 'sum(${TABLE}.amount)'),
     tablesReferences: overrides.tablesReferences ?? ['orders'],
     hidden: overrides.hidden ?? false,
 });

--- a/packages/common/src/templating/CLAUDE.md
+++ b/packages/common/src/templating/CLAUDE.md
@@ -74,7 +74,7 @@ When a query runs:
 
 ### Parameter Detection for UI
 
-`getParameterReferencesFromSqlAndFormat()` in `compiler/parameters.ts` extracts parameter names from both `${ld.parameters.x}` syntax and `{% if ld.parameters.x %}` syntax, so the UI shows the parameter selector.
+`getParameterReferences()` in `compiler/parameters.ts` extracts parameter names from both `${ld.parameters.x}` syntax and `{% if ld.parameters.x %}` syntax, so the UI shows the parameter selector.
 
 ## Safety Mechanisms
 


### PR DESCRIPTION
## Summary

Closes: [PROD-7476](https://linear.app/lightdash/issue/PROD-7476/required-parameters-and-decouple-parameters-from-dimensions)

The UI uses parameter detection to know which parameter selectors to show for an explore. The detection regex only matched `${ld.parameters.X}` substitution sites, so a model whose `sql_from` uses a Liquid conditional like `{% if ld.parameters.source_schema == \"jaffle\" %}...{% endif %}` would not surface the parameter — the value is consumed by the Liquid render before the regex scan sees it.

- **Consolidates** the two detection helpers (`getParameterReferences` + `getParameterReferencesFromSqlAndFormat`) into a single variadic `getParameterReferences(...sources)` that always scans both the strict `${...}` form and bare `ld.parameters.X` inside Liquid blocks (guarded by the presence of `{%` to avoid false positives in plain SQL).
- **Tightens** the broad regex with a left-boundary lookbehind so identifiers like `myld.parameters.x` or `t.ld.parameters.x` don't false-match.
- **Adds a runtime fix** in `QueryBuilder/parameters.ts` so the parameter-references set returned by `safeReplaceParametersWithTypes` includes Liquid-only references — those get consumed by `renderLiquidSql` before the post-render substitution scan would see them.

## Test plan

- [x] `parameters.test.ts` — 50 tests pass, including 15 new tests covering Liquid `{% if %}` / `{% elsif %}` / `{% case %}` / `{% assign %}` / `contains`, model-scoped params in Liquid, `ld.query.fields` not falsely detected, multi-source dedup, and negative cases (no `{%` → no broad scan; `myld.parameters.x` not matched).
- [x] `exploreCompiler.test.ts`, `dimensionEligibility.test.ts`, `metricEligibility.test.ts` — 182 tests pass after rename.
- [x] `QueryBuilder/parameters.test.ts` — 22 tests pass (existing SQL-injection escape coverage intact).
- [x] Manual: loading a model with `sql_from: "{% if ld.parameters.X %}A{% else %}B{% endif %}"` now shows the parameter in the explorer's Parameters tab.