### PR TITLE
fix(warehouse-credentials): dedup BigQuery personal credentials on re-auth

### DIFF
--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2324,6 +2324,12 @@ export class UserService extends BaseService {
         user: SessionUser,
         refreshToken: string,
     ) {
+        // Remove old BigQuery credentials to prevent duplicates on re-authentication
+        await this.userWarehouseCredentialsModel.deleteAllByUserAndWarehouseType(
+            user.userUuid,
+            WarehouseTypes.BIGQUERY,
+        );
+
         const bigqueryCredentials: UpsertUserWarehouseCredentials = {
             name: 'Default',
             credentials: {


### PR DESCRIPTION
Closes [PROD-7838](https://linear.app/lightdash/issue/PROD-7838/bigquery-personal-warehouse-credentials-accumulate-on-re).

## Summary

Re-authenticating with Google OAuth for a BigQuery personal warehouse credential inserts a new row every time. The user's "My warehouse connections" list grows unbounded, with no UI signal to tell duplicates apart. Only the BigQuery SSO path is affected — Snowflake (delete-all + insert) and Databricks (find-and-update) already dedup.

## Root cause

`createBigqueryWarehouseCredentials()` in `UserService.ts` calls `createWarehouseCredentials()` directly with no prior cleanup:

```ts
async createBigqueryWarehouseCredentials(user, refreshToken) {
    const bigqueryCredentials = { name: 'Default', credentials: { /* ... */ } };
    await this.createWarehouseCredentials(user, bigqueryCredentials);  // new row every call
}
```

Compare with `createSnowflakeWarehouseCredentials()` two functions below, which calls `deleteAllByUserAndWarehouseType()` first — `// Remove old Snowflake credentials to prevent duplicates on re-authentication`. BigQuery is the only personal-credential entry point that skipped this step.

## Fix

Add the same `deleteAllByUserAndWarehouseType()` call before the insert. This deletes every BigQuery row for that user (regardless of how the row was created) and then inserts a single fresh row — identical scope to the existing Snowflake behaviour.

- `packages/backend/src/services/UserService.ts` — call `deleteAllByUserAndWarehouseType(userUuid, BIGQUERY)` before inserting.
- One-off cleanup of *existing* duplicate rows for affected customers is intentionally out of scope; users can delete extras under Settings → My warehouse connections.

## Behaviour by warehouse

```
Snowflake personal SSO   delete-all + insert     (unchanged)
Databricks personal U2M  find-and-update         (unchanged)
BigQuery personal SSO    insert-only             →   delete-all + insert
```

## Caveat

`createBigqueryWarehouseCredentials` is only invoked from the Google OAuth strategy with a hardcoded `name: 'Default'` — there is no UI for a manual BigQuery credential (BigQuery is in `ssoOnlyTypes` in `CreateCredentialsModal.tsx`). A direct `POST /api/v1/user/warehouseCredentials` with a custom BigQuery body is possible via API but not surfaced in the UI; any such row will be wiped on the next SSO re-auth. Same as Snowflake today — established pattern, not a new concern from this PR.

If we ever need per-host or per-project personal BigQuery credentials, we'd switch to the Databricks find-and-update pattern instead.

## Test plan

- [x] `npx jest UserService.test` — 41 tests pass
- [x] Manual: in a project with "Require users to provide their own credentials" + BigQuery, authenticate twice via Google OAuth; confirm exactly one row appears in Settings → My warehouse connections
- [ ] Manual: confirm Snowflake and Databricks personal re-auth flows still behave as before (regression check on the two adjacent functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)