### PR TITLE
feat(mcp): expose built-in skill resources

### DIFF
--- a/packages/api-tests/tests/mcpServer.test.ts
+++ b/packages/api-tests/tests/mcpServer.test.ts
@@ -48,6 +48,9 @@ describe('MCP server', () => {
             'Lightdash MCP Server',
         );
         expect(response.body.result.serverInfo).toHaveProperty('version');
+        expect(response.body.result.capabilities).toMatchObject({
+            resources: { listChanged: true },
+        });
     });
 
     it('should list available tools', async () => {
@@ -85,12 +88,176 @@ describe('MCP server', () => {
         expect(versionTool).toHaveProperty('inputSchema');
     });
 
+    it('should list the analyst prompt without skill prompts', async () => {
+        const response = await admin.post<
+            McpResponse<{
+                prompts: Array<{
+                    name: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 3,
+                method: 'prompts/list',
+                params: {},
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.jsonrpc).toBe('2.0');
+        expect(response.body.id).toBe(3);
+
+        const promptNames = response.body.result.prompts.map(
+            (prompt) => prompt.name,
+        );
+        expect(promptNames).toContain('lightdash-analyst');
+        expect(
+            promptNames.some((name) => name.startsWith('lightdash-skill-')),
+        ).toBe(false);
+    });
+
+    it('should list built-in skill resources', async () => {
+        const response = await admin.post<
+            McpResponse<{
+                resources: Array<{
+                    uri: string;
+                    name: string;
+                    title: string;
+                    mimeType?: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 4,
+                method: 'resources/list',
+                params: {},
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.jsonrpc).toBe('2.0');
+        expect(response.body.id).toBe(4);
+
+        const overviewResource = response.body.result.resources.find(
+            (resource) =>
+                resource.uri === 'lightdash://skills/developing-in-lightdash',
+        );
+        const nestedResource = response.body.result.resources.find((resource) =>
+            resource.uri.startsWith(
+                'lightdash://skills/developing-in-lightdash/resources/',
+            ),
+        );
+
+        expect(overviewResource).toMatchObject({
+            uri: 'lightdash://skills/developing-in-lightdash',
+            name: 'developing-in-lightdash',
+            title: 'Developing in Lightdash',
+            mimeType: 'text/markdown',
+        });
+        expect(nestedResource).toMatchObject({
+            mimeType: 'text/markdown',
+        });
+        expect(nestedResource?.name).toMatch(
+            /^developing-in-lightdash\/[^/]+$/,
+        );
+        expect(nestedResource?.title).toMatch(/^Developing in Lightdash \/ /);
+    });
+
+    it('should read a listed skill resource', async () => {
+        const listResponse = await admin.post<
+            McpResponse<{
+                resources: Array<{
+                    uri: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 5,
+                method: 'resources/list',
+                params: {},
+            },
+            { headers: mcpHeaders },
+        );
+
+        const nestedResource = listResponse.body.result.resources.find(
+            (resource) =>
+                resource.uri.startsWith(
+                    'lightdash://skills/developing-in-lightdash/resources/',
+                ),
+        );
+
+        expect(nestedResource).toBeDefined();
+
+        const readResponse = await admin.post<
+            McpResponse<{
+                contents: Array<{
+                    uri: string;
+                    mimeType?: string;
+                    text: string;
+                }>;
+            }>
+        >(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 6,
+                method: 'resources/read',
+                params: {
+                    uri: nestedResource!.uri,
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(readResponse.status).toBe(200);
+        expect(readResponse.body.result.contents).toHaveLength(1);
+        expect(readResponse.body.result.contents[0]).toMatchObject({
+            uri: nestedResource!.uri,
+            mimeType: 'text/markdown',
+        });
+        expect(
+            readResponse.body.result.contents[0].text.length,
+        ).toBeGreaterThan(0);
+    });
+
+    it('should return an MCP error for an unknown skill resource', async () => {
+        const response = await admin.post<{
+            jsonrpc: string;
+            id: number;
+            error?: { code?: number };
+        }>(
+            '/api/v1/mcp',
+            {
+                jsonrpc: '2.0',
+                id: 7,
+                method: 'resources/read',
+                params: {
+                    uri: 'lightdash://skills/developing-in-lightdash/resources/does-not-exist',
+                },
+            },
+            { headers: mcpHeaders },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.jsonrpc).toBe('2.0');
+        expect(response.body.id).toBe(7);
+        expect(response.body.error?.code).toBe(-32602);
+    });
+
     it('should handle ping request', async () => {
         const response = await admin.post<McpResponse>(
             '/api/v1/mcp',
             {
                 jsonrpc: '2.0',
-                id: 4,
+                id: 8,
                 method: 'ping',
                 params: {},
             },
@@ -98,7 +265,7 @@ describe('MCP server', () => {
         );
         expect(response.status).toBe(200);
         expect(response.body.jsonrpc).toBe('2.0');
-        expect(response.body.id).toBe(4);
+        expect(response.body.id).toBe(8);
         expect(response.body.result).toEqual({});
     });
 });

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -87,6 +87,7 @@ import {
     MCP_ANALYST_PROMPT,
 } from '../ai/prompts/mcpAnalyst';
 import { NO_RESULTS_RETRY_PROMPT } from '../ai/prompts/noResultsRetry';
+import { BuiltInSkills } from '../ai/skills/builtInSkills';
 import { getFindContent } from '../ai/tools/findContent';
 import { getFindExplores } from '../ai/tools/findExplores';
 import { getFindFields } from '../ai/tools/findFields';
@@ -135,6 +136,8 @@ export enum McpToolName {
     SEARCH_FIELD_VALUES = 'search_field_values',
     LIST_VERIFIED_CONTENT = 'list_verified_content',
 }
+
+const MCP_SKILL_RESOURCE_MIME_TYPE = 'text/markdown';
 
 type McpServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -1527,7 +1530,7 @@ export class McpService extends BaseService {
             {
                 title: 'Lightdash Data Analyst',
                 description:
-                    'Guidelines for querying Lightdash data using MCP tools. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.',
+                    'Guidelines for querying Lightdash data using MCP tools. Includes explore selection, query building, visualization rules, active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.',
                 argsSchema: {},
             },
             async (_args, extra) => {
@@ -1572,6 +1575,48 @@ export class McpService extends BaseService {
                 };
             },
         );
+
+        this.setupSkillResourceHandlers();
+    }
+
+    private setupSkillResourceHandlers(): void {
+        BuiltInSkills.listMcpResources().forEach((resource) => {
+            this.mcpServer.registerResource(
+                resource.name,
+                resource.uri,
+                {
+                    title: resource.title,
+                    description: resource.description,
+                    mimeType: MCP_SKILL_RESOURCE_MIME_TYPE,
+                },
+                async () => {
+                    const text = resource.resourceName
+                        ? await BuiltInSkills.getMcpSkillResourceBody(
+                              resource.skillName,
+                              resource.resourceName,
+                          )
+                        : await BuiltInSkills.getMcpSkillBody(
+                              resource.skillName,
+                          );
+
+                    if (!text) {
+                        throw new NotFoundError(
+                            `Resource "${resource.uri}" was not found`,
+                        );
+                    }
+
+                    return {
+                        contents: [
+                            {
+                                uri: resource.uri,
+                                mimeType: MCP_SKILL_RESOURCE_MIME_TYPE,
+                                text,
+                            },
+                        ],
+                    };
+                },
+            );
+        });
     }
 
     private async pollSqlJobToCompletion(

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.ts
@@ -1,4 +1,5 @@
 import { ParameterError } from '@lightdash/common';
+import * as fsSync from 'fs';
 import * as fs from 'fs/promises';
 import matter from 'gray-matter';
 import * as path from 'path';
@@ -13,18 +14,49 @@ type MarkdownMetadata = {
     description: string;
 };
 
+export type BuiltInSkillMcpResource = {
+    uri: string;
+    name: string;
+    title: string;
+    description: string;
+    skillName: string;
+    resourceName?: string;
+};
+
 export class BuiltInSkills {
     private static readonly SKILLS_DIR = path.join(__dirname, 'builtInSkills');
+
+    private static readonly TITLE_CASE_LOWER_WORDS = new Set([
+        'a',
+        'an',
+        'and',
+        'as',
+        'at',
+        'but',
+        'by',
+        'for',
+        'in',
+        'nor',
+        'of',
+        'on',
+        'or',
+        'the',
+        'to',
+        'with',
+    ]);
 
     private static skills: AiAgentSkill[] = [];
 
     private static skillsPromise: Promise<AiAgentSkill[]> | undefined;
 
-    private static async parseMarkdownFile(
+    private static mcpResources: BuiltInSkillMcpResource[] | undefined;
+
+    private static skillNames: string[] | undefined;
+
+    private static getMarkdownMetadata(
         filePath: string,
-    ): Promise<MarkdownMetadata & { content: string }> {
-        const fileContents = await fs.readFile(filePath, 'utf8');
-        const { content, data } = matter(fileContents);
+        data: unknown,
+    ): MarkdownMetadata {
         const { name, description } = data as Partial<MarkdownMetadata>;
 
         if (!name || !description) {
@@ -33,11 +65,82 @@ export class BuiltInSkills {
             );
         }
 
+        return { name, description };
+    }
+
+    private static async parseMarkdownFile(
+        filePath: string,
+    ): Promise<MarkdownMetadata & { content: string }> {
+        const fileContents = await fs.readFile(filePath, 'utf8');
+        const { content, data } = matter(fileContents);
+
         return {
-            name,
-            description,
+            ...this.getMarkdownMetadata(filePath, data),
             content,
         };
+    }
+
+    private static parseMarkdownFileSync(filePath: string): MarkdownMetadata {
+        const fileContents = fsSync.readFileSync(filePath, 'utf8');
+        const { data } = matter(fileContents);
+
+        return this.getMarkdownMetadata(filePath, data);
+    }
+
+    private static getSkillDirectory(skillName: string): string {
+        return path.join(this.SKILLS_DIR, skillName);
+    }
+
+    private static getBuiltInSkillNames(): string[] {
+        if (this.skillNames) {
+            return this.skillNames;
+        }
+
+        this.skillNames = fsSync
+            .readdirSync(this.SKILLS_DIR, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => entry.name)
+            .sort();
+
+        return this.skillNames;
+    }
+
+    private static getSkillFilePath(skillName: string): string {
+        return path.join(this.getSkillDirectory(skillName), 'SKILL.md');
+    }
+
+    private static getSkillResourcesDirectory(skillName: string): string {
+        return path.join(this.getSkillDirectory(skillName), 'resources');
+    }
+
+    private static getSkillResourceUri(
+        skillName: string,
+        resourceName?: string,
+    ): string {
+        return resourceName
+            ? `lightdash://skills/${skillName}/resources/${resourceName}`
+            : `lightdash://skills/${skillName}`;
+    }
+
+    private static formatResourceTitleSegment(segment: string): string {
+        return segment
+            .split('-')
+            .map((word, index, words) => {
+                const normalizedWord = word.toLowerCase();
+                if (
+                    index > 0 &&
+                    index < words.length - 1 &&
+                    this.TITLE_CASE_LOWER_WORDS.has(normalizedWord)
+                ) {
+                    return normalizedWord;
+                }
+
+                return (
+                    normalizedWord.charAt(0).toUpperCase() +
+                    normalizedWord.slice(1)
+                );
+            })
+            .join(' ');
     }
 
     private static async loadSkillResources(
@@ -86,6 +189,36 @@ export class BuiltInSkills {
         };
     }
 
+    private static listMcpSkillResourcesForSkill(
+        skillName: string,
+    ): BuiltInSkillMcpResource[] {
+        const resourcesDir = this.getSkillResourcesDirectory(skillName);
+
+        if (!fsSync.existsSync(resourcesDir)) {
+            return [];
+        }
+
+        return fsSync
+            .readdirSync(resourcesDir)
+            .filter((fileName) => fileName.endsWith('.md'))
+            .sort()
+            .map((fileName) => {
+                const resourceName = path.basename(fileName, '.md');
+                const resource = this.parseMarkdownFileSync(
+                    path.join(resourcesDir, fileName),
+                );
+
+                return {
+                    uri: this.getSkillResourceUri(skillName, resourceName),
+                    name: `${skillName}/${resourceName}`,
+                    title: `${this.formatResourceTitleSegment(skillName)} / ${this.formatResourceTitleSegment(resourceName)}`,
+                    description: resource.description,
+                    skillName,
+                    resourceName,
+                };
+            });
+    }
+
     private static async getBuiltInSkills(): Promise<AiAgentSkill[]> {
         if (this.skills.length > 0) {
             return this.skills;
@@ -97,11 +230,12 @@ export class BuiltInSkills {
 
         this.skillsPromise = (async () => {
             try {
-                const skillPromises = [
-                    this.loadSkillFromDirectory(
-                        path.join(this.SKILLS_DIR, 'developing-in-lightdash'),
-                    ),
-                ];
+                const skillPromises = this.getBuiltInSkillNames().map(
+                    (skillName) =>
+                        this.loadSkillFromDirectory(
+                            path.join(this.SKILLS_DIR, skillName),
+                        ),
+                );
                 const skills = await Promise.all(skillPromises);
 
                 this.skills = skills;
@@ -139,5 +273,70 @@ export class BuiltInSkills {
         return (await this.getBuiltInSkills()).find(
             (skill) => skill.name.toLowerCase() === name.trim().toLowerCase(),
         );
+    }
+
+    static listMcpResources(): BuiltInSkillMcpResource[] {
+        if (this.mcpResources) {
+            return this.mcpResources;
+        }
+
+        this.mcpResources = this.getBuiltInSkillNames().flatMap((skillName) => {
+            const skill = this.parseMarkdownFileSync(
+                this.getSkillFilePath(skillName),
+            );
+
+            return [
+                {
+                    uri: this.getSkillResourceUri(skillName),
+                    name: skill.name,
+                    title: this.formatResourceTitleSegment(skillName),
+                    description: skill.description,
+                    skillName,
+                },
+                ...this.listMcpSkillResourcesForSkill(skillName),
+            ];
+        });
+
+        return this.mcpResources;
+    }
+
+    static async getMcpSkillBody(
+        skillName: string,
+    ): Promise<string | undefined> {
+        if (!this.getBuiltInSkillNames().includes(skillName)) {
+            return undefined;
+        }
+
+        const skill = await this.parseMarkdownFile(
+            this.getSkillFilePath(skillName),
+        );
+
+        return skill.content;
+    }
+
+    static async getMcpSkillResourceBody(
+        skillName: string,
+        resourceName: string,
+    ): Promise<string | undefined> {
+        if (!this.getBuiltInSkillNames().includes(skillName)) {
+            return undefined;
+        }
+
+        try {
+            const resource = await this.parseMarkdownFile(
+                path.join(
+                    this.getSkillResourcesDirectory(skillName),
+                    `${resourceName}.md`,
+                ),
+            );
+
+            return resource.content;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                return undefined;
+            }
+
+            throw error;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Expose built-in skill markdown as MCP resources so MCP clients can list and read them via the standard `resources/list` and `resources/read` methods.

- Each skill yields an overview resource at `lightdash://skills/<skill>` plus one nested resource per file under `resources/`.
- `BuiltInSkills` now lazily enumerates every subdirectory under `builtInSkills/` instead of hardcoding `developing-in-lightdash`.
- Resource titles and descriptions come from frontmatter (`title`, `description`).
- Resource list/read handlers are async and registered once at server creation; capability advertises `resources.listChanged: false` since the catalogue is static.
- Unknown resource URIs return a JSON-RPC `-32602` error.