### PR TITLE
fix(explorer): stop 404s when scrolling fields of joined aliased tables

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -35,6 +35,7 @@ import {
     explorerActions,
     selectIsFieldActive,
     selectIsFieldFiltered,
+    selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
     type ExplorerStoreState,
@@ -148,8 +149,12 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
     );
     const isSelected = useExplorerSelector(selectIsActive, (a, b) => a === b);
 
-    const exploreTableName = useTableTree((context) => context.tableName);
-    const { data: exploreData } = useExplore(exploreTableName);
+    // Use the active explore name (base table) rather than the section's
+    // table name — for sections that represent joined tables, the section
+    // name is the join alias, which is not a valid explore identifier and
+    // would 404 the /explores/{name} endpoint.
+    const activeTableName = useExplorerSelector(selectTableName);
+    const { data: exploreData } = useExplore(activeTableName);
 
     const metricInfo = useMemo(() => {
         if (isCompiledMetric(item)) {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7817

## Summary

When an explore has a joined table with an `alias`, browsing the field tree fires a stream of `GET /api/v1/projects/{uuid}/explores/{alias}` requests, all 404, surfacing `Explore "{alias}" does not exist` errors. Queries still run correctly — the bug is purely in the sidebar's field-loading path.

## Root cause

`TreeSingleNode` is rendered once per visible field in the sidebar. It reads the *section's* table name from the tree context (which is the join alias for joined sections) and feeds it to `useExplore`:

```tsx
const exploreTableName = useTableTree((context) => context.tableName);
const { data: exploreData } = useExplore(exploreTableName);
```

The `/explores/{name}` endpoint is keyed by base explore name, not by join alias, so every aliased section 404s. The data is only used to resolve `baseDimension` for additional-metric hover previews — and `exploreData.tables` already contains every joined table keyed by name. The per-section fetch was never needed.

## Fix

Use the active explore name from the explorer store instead of the section's table name. React Query dedupes this to the same cached entry already populated by the page-level `useExplore`, so the per-row request goes away entirely (not just for joined sections).

- `packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx` — read `selectTableName` from the explorer store; drop the alias-keyed fetch.

## Network trace (jaffle shop, `fanouts_accounts_bridged_fanout` with aliased joins `fanouts_industry_sales_targets` + `fanouts_segment_sales_targets`)

```
Before — expand an aliased join section, scroll the fields
  GET /explores/fanouts_accounts_bridged_fanout     200
  GET /explores/fanouts_industry_sales_targets      404  <- alias
  GET /explores/fanouts_industry_sales_targets      404  <- on re-mount
  GET /explores/fanouts_segment_sales_targets       404  <- alias
  GET /explores/fanouts_segment_sales_targets       404  <- on re-mount
  ...

After
  GET /explores/fanouts_accounts_bridged_fanout     200
  (no further /explores/ requests)
```

## Test plan

- [x] `pnpm -F frontend lint` on the changed file — clean
- [x] Manual repro: open `…/tables/fanouts_accounts_bridged_fanout` in jaffle shop, expand `Fanouts industry sales targets` (an aliased join), confirm the network tab shows zero requests to `/explores/fanouts_industry_sales_targets`
- [ ] Manual: confirm additional-metric hover previews still render the aggregated SQL with the correct base dimension on a regular (non-joined) field
- [ ] Manual: same hover-preview check on a field belonging to an aliased joined table

🤖 Generated with [Claude Code](https://claude.com/claude-code)