### PR TITLE
fix(warehouse-credentials): delete old BigQuery credentials before re…

### DIFF
--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2324,6 +2324,12 @@ export class UserService extends BaseService {
         user: SessionUser,
         refreshToken: string,
     ) {
+        // Remove old BigQuery credentials to prevent duplicates on re-authentication
+        await this.userWarehouseCredentialsModel.deleteAllByUserAndWarehouseType(
+            user.userUuid,
+            WarehouseTypes.BIGQUERY,
+        );
+
         const bigqueryCredentials: UpsertUserWarehouseCredentials = {
             name: 'Default',
             credentials: {


### PR DESCRIPTION
…-auth

Add deduplication logic to createBigqueryWarehouseCredentials() to delete existing credentials before creating new ones. This matches the behavior of Snowflake credentials and prevents credential accumulation on re-authentication.

Fixes #23364

https://claude.ai/code/session_01Tnc6knPV5TJhDt72Sh1zQX

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
