### PR TITLE
fix: align filter dropdowns inline so Apply button stays visible (PROD-2395)

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -208,7 +208,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                 )}
 
                 {(showValueInput || filterRule.required) && (
-                    <Group spacing="xs" noWrap align="center">
+                    <Group spacing="xs" noWrap align="flex-start">
                         <Box style={{ flex: 1 }}>
                             <FilterInputComponent
                                 popoverProps={popoverProps}
@@ -243,6 +243,7 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                                         variant="subtle"
                                         color="gray"
                                         size="sm"
+                                        mt={4}
                                         disabled={
                                             filterRule.disabled ||
                                             (filterRule.values?.length ?? 0) ===

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -364,7 +364,17 @@ const FilterConfiguration: FC<Props> = ({
         : 'Filter field and value required';
 
     return (
-        <Stack>
+        // Make inline dropdowns flow in the panel (instead of absolute), so the
+        // panel grows with them and Apply stays visible — PROD-2395 sketch.
+        <Stack
+            sx={{
+                '.mantine-Select-dropdown, .mantine-MultiSelect-dropdown': {
+                    position: 'static',
+                    width: '100%',
+                    marginTop: 4,
+                },
+            }}
+        >
             <Tabs
                 value={selectedTabId}
                 onTabChange={(tabId: FilterTabs) => setSelectedTabId(tabId)}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-2395/i-want-to-see-the-apply-button-for-dashboard-filters-after-ive

Implemented Priyanka suggestion: https://lightdash.slack.com/archives/C04E1CCKN64/p1779284098823409?thread_ts=1779281854.224939&cid=C04E1CCKN64


Before
<img width="423" height="498" alt="CleanShot 2026-05-21 at 13 07 42" src="https://github.com/user-attachments/assets/9afba11c-e88f-456e-a78f-fe7d4f89d41d" />

After

<img width="413" height="502" alt="CleanShot 2026-05-21 at 13 39 26" src="https://github.com/user-attachments/assets/ca154c46-280d-4e39-a0c4-a146fe516cbd" />

### Description:

Fixes an issue in the dashboard filter configuration panel where dropdown menus (for filter field and value selectors) were rendering with absolute positioning, causing them to overflow outside the panel and obscure the "Apply" button.

Dropdowns inside the filter configuration panel are now rendered inline (static positioning) so the panel expands to accommodate them, keeping the Apply button visible and accessible. Additionally, the filter input group alignment has been adjusted to `flex-start` to properly handle multi-line content.