### PR TITLE
feat: add MCP server tool listing, refresh, and per-agent tool enable/disable APIs

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -9,6 +9,7 @@ import {
     ApiAiAgentEvaluationRunSummaryListResponse,
     ApiAiAgentEvaluationSummaryListResponse,
     ApiAiAgentExploreAccessSummaryResponse,
+    ApiAiAgentMcpServerToolListResponse,
     ApiAiAgentModelOptionsResponse,
     ApiAiAgentResponse,
     ApiAiAgentSqlApprovalRequest,
@@ -28,6 +29,7 @@ import {
     ApiAiAgentVerifiedQuestionsResponse,
     ApiAiMcpServerListResponse,
     ApiAiMcpServerResponse,
+    ApiAiMcpServerToolListResponse,
     ApiAppendEvaluationRequest,
     ApiAppendInstructionRequest,
     ApiAppendInstructionResponse,
@@ -44,6 +46,7 @@ import {
     ApiStartAiMcpOAuthResponse,
     ApiSuccessEmpty,
     ApiUpdateAiAgent,
+    ApiUpdateAiAgentMcpServerToolsRequest,
     ApiUpdateEvaluationRequest,
     ApiUpdateUserAgentPreferences,
     ApiUpdateUserAgentPreferencesResponse,
@@ -208,6 +211,52 @@ export class AiAgentController extends BaseController {
         };
     }
 
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/mcpServers/{mcpServerUuid}/tools')
+    @OperationId('listMcpServerTools')
+    async listMcpServerTools(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() mcpServerUuid: string,
+    ): Promise<ApiAiMcpServerToolListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().listMcpServerTools(
+                toSessionUser(req.account),
+                projectUuid,
+                mcpServerUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/mcpServers/{mcpServerUuid}/tools/refresh')
+    @OperationId('refreshMcpServerTools')
+    async refreshMcpServerTools(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() mcpServerUuid: string,
+    ): Promise<ApiAiMcpServerToolListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().refreshMcpServerTools(
+                toSessionUser(req.account),
+                projectUuid,
+                mcpServerUuid,
+            ),
+        };
+    }
+
     @Middlewares([
         allowApiKeyAuthentication,
         isAuthenticated,
@@ -301,6 +350,58 @@ export class AiAgentController extends BaseController {
                 toSessionUser(req.account),
                 projectUuid,
                 agentUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentUuid}/mcpServers/{mcpServerUuid}/tools')
+    @OperationId('listAgentMcpServerTools')
+    async listAgentMcpServerTools(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() mcpServerUuid: string,
+    ): Promise<ApiAiAgentMcpServerToolListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().listAgentMcpServerTools(
+                toSessionUser(req.account),
+                projectUuid,
+                agentUuid,
+                mcpServerUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{agentUuid}/mcpServers/{mcpServerUuid}/tools')
+    @OperationId('updateAgentMcpServerTools')
+    async updateAgentMcpServerTools(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() mcpServerUuid: string,
+        @Body() body: ApiUpdateAiAgentMcpServerToolsRequest,
+    ): Promise<ApiAiAgentMcpServerToolListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().updateAgentMcpServerTools(
+                toSessionUser(req.account),
+                projectUuid,
+                agentUuid,
+                mcpServerUuid,
+                body,
             ),
         };
     }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import {
     getModels,
     getServices,
@@ -16,12 +17,19 @@ describe('AiAgentService MCP support', () => {
     let context: IntegrationTestContext;
     let mcpServerUrl: string;
     let httpServer: Server;
+    let availableTools: {
+        name: string;
+        title: string;
+        description: string;
+        inputSchema: Record<string, z.ZodTypeAny>;
+    }[];
 
     beforeAll(async () => {
         context = getTestContext();
 
         const expectedBearerToken = 'secret-token-for-test-server';
         const app = createMcpExpressApp();
+        availableTools = [];
 
         app.post('/mcp', async (req, res) => {
             if (req.headers.authorization !== `Bearer ${expectedBearerToken}`) {
@@ -45,6 +53,25 @@ describe('AiAgentService MCP support', () => {
                         mimeType: 'image/svg+xml',
                     },
                 ],
+            });
+
+            availableTools.forEach((tool) => {
+                server.registerTool(
+                    tool.name,
+                    {
+                        title: tool.title,
+                        description: tool.description,
+                        inputSchema: tool.inputSchema,
+                    },
+                    async () => ({
+                        content: [
+                            {
+                                type: 'text',
+                                text: `Ran ${tool.name}`,
+                            },
+                        ],
+                    }),
+                );
             });
 
             const transport = new StreamableHTTPServerTransport({
@@ -114,6 +141,16 @@ describe('AiAgentService MCP support', () => {
         const models = getModels(context.app);
         const suffix = crypto.randomUUID().slice(0, 8);
         const expectedBearerToken = 'secret-token-for-test-server';
+        availableTools = [
+            {
+                name: 'search',
+                title: 'Search docs',
+                description: 'Search documentation',
+                inputSchema: {
+                    query: z.string(),
+                },
+            },
+        ];
 
         const mcpServer = await services.aiAgentService.createMcpServer(
             context.testUser,
@@ -149,24 +186,18 @@ describe('AiAgentService MCP support', () => {
             hasCredentials: true,
         });
 
-        await models.aiAgentModel.upsertDiscoveredMcpServerTools({
-            serverUuid: mcpServer.uuid,
-            tools: [
-                {
-                    toolName: 'search',
-                    title: 'Search docs',
-                    description: 'Search documentation',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            query: { type: 'string' },
-                        },
-                    },
-                    annotations: null,
-                    meta: null,
-                },
-            ],
-        });
+        await expect(
+            services.aiAgentService.listMcpServerTools(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                mcpServer.uuid,
+            ),
+        ).resolves.toMatchObject([
+            {
+                toolName: 'search',
+                title: 'Search docs',
+            },
+        ]);
 
         const agent = await services.aiAgentService.createAgent(
             context.testUser,
@@ -201,10 +232,12 @@ describe('AiAgentService MCP support', () => {
         expect(agentMcpServers[0]).not.toHaveProperty('credentials');
 
         const initialAgentToolSettings =
-            await models.aiAgentModel.listAgentMcpServerTools({
-                agentUuid: agent.uuid,
-                serverUuid: mcpServer.uuid,
-            });
+            await services.aiAgentService.listAgentMcpServerTools(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agent.uuid,
+                mcpServer.uuid,
+            );
 
         expect(
             initialAgentToolSettings.map((tool) => ({
@@ -224,43 +257,38 @@ describe('AiAgentService MCP support', () => {
             }),
         ).resolves.toEqual(['search']);
 
-        await models.aiAgentModel.upsertDiscoveredMcpServerTools({
-            serverUuid: mcpServer.uuid,
-            tools: [
-                {
-                    toolName: 'search',
-                    title: 'Search docs',
-                    description: 'Search documentation',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            query: { type: 'string' },
-                        },
-                    },
-                    annotations: null,
-                    meta: null,
+        availableTools = [
+            {
+                name: 'search',
+                title: 'Search docs',
+                description: 'Search documentation',
+                inputSchema: {
+                    query: z.string(),
                 },
-                {
-                    toolName: 'lookup',
-                    title: 'Lookup doc',
-                    description: 'Lookup a single document',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            id: { type: 'string' },
-                        },
-                    },
-                    annotations: null,
-                    meta: null,
+            },
+            {
+                name: 'lookup',
+                title: 'Lookup doc',
+                description: 'Lookup a single document',
+                inputSchema: {
+                    id: z.string(),
                 },
-            ],
-        });
+            },
+        ];
+
+        await services.aiAgentService.refreshMcpServerTools(
+            context.testUser,
+            SEED_PROJECT.project_uuid,
+            mcpServer.uuid,
+        );
 
         await expect(
-            models.aiAgentModel.listAgentMcpServerTools({
-                agentUuid: agent.uuid,
-                serverUuid: mcpServer.uuid,
-            }),
+            services.aiAgentService.listAgentMcpServerTools(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agent.uuid,
+                mcpServer.uuid,
+            ),
         ).resolves.toMatchObject([
             {
                 toolName: 'lookup',
@@ -272,11 +300,15 @@ describe('AiAgentService MCP support', () => {
             },
         ]);
 
-        await models.aiAgentModel.upsertAgentMcpServerToolSettings({
-            agentUuid: agent.uuid,
-            serverUuid: mcpServer.uuid,
-            toolSettings: [{ toolName: 'lookup', enabled: true }],
-        });
+        await services.aiAgentService.updateAgentMcpServerTools(
+            context.testUser,
+            SEED_PROJECT.project_uuid,
+            agent.uuid,
+            mcpServer.uuid,
+            {
+                toolSettings: [{ toolName: 'lookup', enabled: true }],
+            },
+        );
 
         await expect(
             models.aiAgentModel.getEnabledMcpServerToolNames({
@@ -285,30 +317,30 @@ describe('AiAgentService MCP support', () => {
             }),
         ).resolves.toEqual(['lookup', 'search']);
 
-        await models.aiAgentModel.upsertDiscoveredMcpServerTools({
-            serverUuid: mcpServer.uuid,
-            tools: [
-                {
-                    toolName: 'lookup',
-                    title: 'Lookup doc',
-                    description: 'Lookup a single document',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            id: { type: 'string' },
-                        },
-                    },
-                    annotations: null,
-                    meta: null,
+        availableTools = [
+            {
+                name: 'lookup',
+                title: 'Lookup doc',
+                description: 'Lookup a single document',
+                inputSchema: {
+                    id: z.string(),
                 },
-            ],
-        });
+            },
+        ];
+
+        await services.aiAgentService.refreshMcpServerTools(
+            context.testUser,
+            SEED_PROJECT.project_uuid,
+            mcpServer.uuid,
+        );
 
         const refreshedAgentToolSettings =
-            await models.aiAgentModel.listAgentMcpServerTools({
-                agentUuid: agent.uuid,
-                serverUuid: mcpServer.uuid,
-            });
+            await services.aiAgentService.listAgentMcpServerTools(
+                context.testUser,
+                SEED_PROJECT.project_uuid,
+                agent.uuid,
+                mcpServer.uuid,
+            );
 
         expect(
             refreshedAgentToolSettings.map((tool) => ({

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7,6 +7,7 @@ import {
     AiAgentEvalRunJobPayload,
     AiAgentEvaluationRun,
     AiAgentEvaluationSummary,
+    AiAgentMcpServerToolUpdate,
     AiAgentNotFoundError,
     AiAgentSummary,
     AiAgentThread,
@@ -31,6 +32,7 @@ import {
     ApiCreateAiMcpServer,
     ApiCreateEvaluationRequest,
     ApiUpdateAiAgent,
+    ApiUpdateAiAgentMcpServerToolsRequest,
     ApiUpdateEvaluationRequest,
     ApiUpdateUserAgentPreferences,
     assertUnreachable,
@@ -1886,9 +1888,111 @@ export class AiAgentService extends BaseService {
         return server;
     }
 
+    private async assertCanManageAgent(
+        user: SessionUser,
+        agentUuid: string,
+        projectUuid?: string,
+    ): Promise<AiAgent> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        const agent = await this.getAgent(user, agentUuid, projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid: agent.organizationUuid,
+                    projectUuid: agent.projectUuid,
+                    metadata: {
+                        agentUuid: agent.uuid,
+                        agentName: agent.name,
+                    },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        return agent;
+    }
+
+    private async discoverMcpServerTools(args: {
+        projectUuid: string;
+        mcpServerUuid: string;
+        actorUserUuid?: string;
+        defaultEnabledForExistingAttachments?: boolean;
+    }) {
+        const server = await this.getProjectMcpServerOrThrow(
+            args.projectUuid,
+            args.mcpServerUuid,
+        );
+        const credential = await this.aiAgentModel.getCredential(
+            args.mcpServerUuid,
+            'shared',
+            {
+                userUuid: args.actorUserUuid,
+            },
+        );
+
+        const tools = await this.aiAgentMcpRuntimeClient.listTools({
+            projectUuid: args.projectUuid,
+            mcpServer: {
+                ...server,
+                resolvedCredential: credential?.credentials ?? null,
+                resolvedCredentialScope: credential?.credentialScope ?? null,
+            },
+        });
+
+        return this.aiAgentModel.upsertDiscoveredMcpServerTools({
+            serverUuid: args.mcpServerUuid,
+            tools,
+            defaultEnabledForExistingAttachments:
+                args.defaultEnabledForExistingAttachments,
+        });
+    }
+
     public async listMcpServers(user: SessionUser, projectUuid: string) {
         await this.assertCanManageMcpServers(user, projectUuid);
         return this.aiAgentModel.listMcpServers(projectUuid);
+    }
+
+    public async listMcpServerTools(
+        user: SessionUser,
+        projectUuid: string,
+        mcpServerUuid: string,
+    ) {
+        await this.assertCanManageMcpServers(user, projectUuid);
+
+        return this.aiAgentModel.listMcpServerTools({
+            projectUuid,
+            serverUuid: mcpServerUuid,
+        });
+    }
+
+    public async refreshMcpServerTools(
+        user: SessionUser,
+        projectUuid: string,
+        mcpServerUuid: string,
+    ) {
+        await this.assertCanManageMcpServers(user, projectUuid);
+
+        try {
+            return await this.discoverMcpServerTools({
+                projectUuid,
+                mcpServerUuid,
+                actorUserUuid: user.userUuid,
+            });
+        } catch (error) {
+            throw new ParameterError(
+                `We couldn't refresh this MCP server's tools. Check the connection and authentication settings, then try again. Details: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
     }
 
     public async listAgentMcpServers(
@@ -1914,6 +2018,49 @@ export class AiAgentService extends BaseService {
                     }) => server,
                 ),
             );
+    }
+
+    public async listAgentMcpServerTools(
+        user: SessionUser,
+        projectUuid: string,
+        agentUuid: string,
+        mcpServerUuid: string,
+    ) {
+        await this.assertCanManageAgent(user, agentUuid, projectUuid);
+        await this.getProjectMcpServerOrThrow(projectUuid, mcpServerUuid);
+
+        return this.aiAgentModel.listAgentMcpServerTools({
+            agentUuid,
+            serverUuid: mcpServerUuid,
+        });
+    }
+
+    public async updateAgentMcpServerTools(
+        user: SessionUser,
+        projectUuid: string,
+        agentUuid: string,
+        mcpServerUuid: string,
+        body: ApiUpdateAiAgentMcpServerToolsRequest,
+    ) {
+        await this.assertCanManageAgent(user, agentUuid, projectUuid);
+        await this.getProjectMcpServerOrThrow(projectUuid, mcpServerUuid);
+
+        const toolSettings: AiAgentMcpServerToolUpdate[] = [
+            ...new Map<string, AiAgentMcpServerToolUpdate>(
+                body.toolSettings.map(
+                    (tool): [string, AiAgentMcpServerToolUpdate] => [
+                        tool.toolName,
+                        tool,
+                    ],
+                ),
+            ).values(),
+        ];
+
+        return this.aiAgentModel.upsertAgentMcpServerToolSettings({
+            agentUuid,
+            serverUuid: mcpServerUuid,
+            toolSettings,
+        });
     }
 
     public async createMcpServer(
@@ -2014,7 +2161,7 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        return this.aiAgentModel.createMcpServer({
+        const server = await this.aiAgentModel.createMcpServer({
             projectUuid,
             name,
             url: normalizedUrl,
@@ -2024,6 +2171,21 @@ export class AiAgentService extends BaseService {
             credentials,
             actorUserUuid: user.userUuid,
         });
+
+        if (body.authType !== 'oauth') {
+            await this.discoverMcpServerTools({
+                projectUuid,
+                mcpServerUuid: server.uuid,
+                actorUserUuid: user.userUuid,
+            }).catch((error) => {
+                Logger.error(
+                    `[AiAgent][MCP][${server.name}] Failed to discover tools after MCP server creation`,
+                    error,
+                );
+            });
+        }
+
+        return server;
     }
 
     public async startMcpOAuthConnection(
@@ -2099,6 +2261,17 @@ export class AiAgentService extends BaseService {
             serverUrl: server.url,
             code: args.code,
             credential,
+        });
+
+        await this.discoverMcpServerTools({
+            projectUuid: args.projectUuid,
+            mcpServerUuid: args.mcpServerUuid,
+            defaultEnabledForExistingAttachments: true,
+        }).catch((error) => {
+            Logger.error(
+                `[AiAgent][MCP][${server.name}] Failed to discover tools after OAuth connection completed`,
+                error,
+            );
         });
     }
 
@@ -4885,14 +5058,24 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 agentUuid: agentSettings.uuid,
                 projectUuid: prompt.projectUuid,
             });
+        const agentMcpServersWithSensitiveData =
+            await this.aiAgentModel.getAgentMcpServersWithSensitiveData(
+                agentSettings.uuid,
+                user.userUuid,
+            );
         const mcpServers = this.aiAgentMcpRuntimeClient.attachRuntimeProviders({
             projectUuid: prompt.projectUuid,
             userUuid: user.userUuid,
-            mcpServers:
-                await this.aiAgentModel.getAgentMcpServersWithSensitiveData(
-                    agentSettings.uuid,
-                    user.userUuid,
-                ),
+            mcpServers: await Promise.all(
+                agentMcpServersWithSensitiveData.map(async (mcpServer) => ({
+                    ...mcpServer,
+                    enabledToolNames:
+                        await this.aiAgentModel.getEnabledMcpServerToolNames({
+                            agentUuid: agentSettings.uuid,
+                            serverUuid: mcpServer.uuid,
+                        }),
+                })),
+            ),
         });
         const { enabled: agentRevampEnabled } =
             await this.featureFlagService.get({

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
@@ -164,6 +164,40 @@ describe('resolveMcpTools', () => {
         expect(close).toHaveBeenCalledTimes(1);
     });
 
+    it('filters out disabled MCP tools', async () => {
+        const close = jest.fn().mockResolvedValue(undefined);
+        const server = getMcpServer({
+            name: 'Lightdash Docs',
+            enabledToolNames: ['search_lightdash'],
+        });
+
+        createHttpMcpClientSpy.mockResolvedValue({
+            serverInfo: {
+                name: 'Lightdash Docs',
+                version: '1.0.0',
+            },
+            tools: async () => ({
+                search_lightdash: { description: 'search tool' },
+                query_docs_filesystem_lightdash: {
+                    description: 'query tool',
+                },
+            }),
+            close,
+        } as unknown as MCPClient);
+
+        const result = await runtimeClient.resolveTools({
+            mcpServers: [server],
+            debugLoggingEnabled: false,
+        });
+
+        expect(Object.keys(result.tools)).toEqual([
+            'mcp_lightdash_docs__search_lightdash',
+        ]);
+
+        await result.closeMcpClients();
+        expect(close).toHaveBeenCalledTimes(1);
+    });
+
     it('preserves not_connected for authorization-required OAuth servers', async () => {
         const oauthServer = getMcpServer({
             uuid: 'oauth-server',

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -1,6 +1,7 @@
 import {
     createMCPClient,
     type Configuration,
+    type ListToolsResult,
     type MCPClient,
 } from '@ai-sdk/mcp';
 import {
@@ -8,6 +9,7 @@ import {
     type AiMcpCredentialScope,
     type AiMcpServerAuthType,
     type AiMcpServerConnectionStatus,
+    type AiMcpServerToolInput,
 } from '@lightdash/common';
 /* eslint-disable import/extensions */
 import {
@@ -547,6 +549,18 @@ export const testMcpConnection = async (
     }
 };
 
+const toMcpServerToolInputs = (
+    result: ListToolsResult,
+): AiMcpServerToolInput[] =>
+    result.tools.map((tool) => ({
+        toolName: tool.name,
+        title: tool.title ?? null,
+        description: tool.description ?? null,
+        inputSchema: tool.inputSchema,
+        annotations: tool.annotations ?? null,
+        meta: tool._meta ?? null,
+    }));
+
 export class AiAgentMcpRuntimeClient {
     private readonly aiAgentModel: AiAgentModel;
 
@@ -749,6 +763,70 @@ export class AiAgentMcpRuntimeClient {
         }));
     }
 
+    async listTools(args: {
+        projectUuid: string;
+        mcpServer: AiMcpServerWithSensitiveData;
+    }): Promise<AiMcpServerToolInput[]> {
+        let mcpClient: MCPClient | undefined;
+
+        try {
+            mcpClient = await createHttpMcpClient(
+                {
+                    ...args.mcpServer,
+                    oauthProvider:
+                        args.mcpServer.authType === 'oauth'
+                            ? this.createSharedMcpOAuthProvider({
+                                  projectUuid: args.projectUuid,
+                                  mcpServerUuid: args.mcpServer.uuid,
+                              })
+                            : undefined,
+                },
+                (error) => {
+                    Logger.error(
+                        `[AiAgent][MCP][${args.mcpServer.name}] Uncaught MCP client error during tool discovery`,
+                        error,
+                    );
+                },
+            );
+
+            const tools = await mcpClient.listTools();
+
+            await this.persistRuntimeState({
+                serverUuid: args.mcpServer.uuid,
+                connectionStatus: 'connected',
+                error: null,
+            });
+
+            return toMcpServerToolInputs(tools);
+        } catch (error) {
+            const normalizedError =
+                error instanceof Error ? error : new Error(String(error));
+            const userFacingErrorMessage =
+                getMcpUserFacingErrorMessage(normalizedError);
+            const status = getUnavailableMcpStatus(
+                args.mcpServer as AiAgentMcpServer,
+                normalizedError,
+            );
+
+            await this.persistRuntimeState({
+                serverUuid: args.mcpServer.uuid,
+                connectionStatus: status,
+                error: userFacingErrorMessage,
+            });
+
+            throw normalizedError;
+        } finally {
+            if (mcpClient) {
+                await mcpClient.close().catch((closeError) => {
+                    Logger.error(
+                        `[AiAgent][MCP][${args.mcpServer.name}] Failed to close MCP client after tool discovery`,
+                        closeError,
+                    );
+                });
+            }
+        }
+    }
+
     async resolveTools(args: {
         mcpServers: AiAgentMcpServer[];
         debugLoggingEnabled: boolean;
@@ -858,10 +936,21 @@ export class AiAgentMcpRuntimeClient {
                 const serverPrefix = sanitizeMcpToolKeyPart(
                     serverResult.mcpServer.name,
                 );
+                const enabledToolNames = new Set(
+                    serverResult.mcpServer.enabledToolNames ?? [],
+                );
 
                 for (const [toolName, toolDefinition] of Object.entries(
                     serverResult.tools,
                 )) {
+                    if (
+                        serverResult.mcpServer.enabledToolNames &&
+                        !enabledToolNames.has(toolName)
+                    ) {
+                        // eslint-disable-next-line no-continue
+                        continue;
+                    }
+
                     const toolSuffix = sanitizeMcpToolKeyPart(toolName);
                     const baseToolName = `mcp_${serverPrefix}__${toolSuffix}`;
                     let namespacedToolName = baseToolName;

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -52,6 +52,7 @@ export type AiAgentMcpServer = AiMcpServer & {
     resolvedCredential: AiMcpCredentialPayload | null;
     resolvedCredentialScope: 'shared' | 'user' | null;
     oauthProvider?: OAuthClientProvider;
+    enabledToolNames?: string[];
 };
 
 export type UnavailableMcpServer = {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10313,6 +10313,75 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiMcpServerTool: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                meta: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'any' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                annotations: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'any' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                inputSchema: { dataType: 'any', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                toolName: { dataType: 'string', required: true },
+                mcpServerUuid: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiMcpServerTool-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiMcpServerTool' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiMcpServerToolListResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiMcpServerTool-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess__authorizationUrl-string__': {
         dataType: 'refAlias',
         type: {
@@ -10445,6 +10514,86 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 results: { ref: 'AiAgent', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentMcpServerTool: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'AiMcpServerTool' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        enabled: { dataType: 'boolean', required: true },
+                        agentUuid: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiAgentMcpServerTool-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentMcpServerTool',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentMcpServerToolListResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiAgentMcpServerTool-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiAgentMcpServerTool.toolName-or-enabled_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                toolName: { dataType: 'string', required: true },
+                enabled: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentMcpServerToolUpdate: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AiAgentMcpServerTool.toolName-or-enabled_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateAiAgentMcpServerToolsRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                toolSettings: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentMcpServerToolUpdate',
+                    },
+                    required: true,
+                },
             },
             validators: {},
         },
@@ -38414,6 +38563,136 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_listMcpServerTools: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        mcpServerUuid: {
+            in: 'path',
+            name: 'mcpServerUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/mcpServers/:mcpServerUuid/tools',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.listMcpServerTools,
+        ),
+
+        async function AiAgentController_listMcpServerTools(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_listMcpServerTools,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listMcpServerTools',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_refreshMcpServerTools: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        mcpServerUuid: {
+            in: 'path',
+            name: 'mcpServerUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/mcpServers/:mcpServerUuid/tools/refresh',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.refreshMcpServerTools,
+        ),
+
+        async function AiAgentController_refreshMcpServerTools(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_refreshMcpServerTools,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'refreshMcpServerTools',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsAiAgentController_startMcpOAuthConnection: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -38662,6 +38941,154 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'listAgentMcpServers',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_listAgentMcpServerTools: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        mcpServerUuid: {
+            in: 'path',
+            name: 'mcpServerUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/mcpServers/:mcpServerUuid/tools',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.listAgentMcpServerTools,
+        ),
+
+        async function AiAgentController_listAgentMcpServerTools(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_listAgentMcpServerTools,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listAgentMcpServerTools',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_updateAgentMcpServerTools: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        mcpServerUuid: {
+            in: 'path',
+            name: 'mcpServerUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiUpdateAiAgentMcpServerToolsRequest',
+        },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/mcpServers/:mcpServerUuid/tools',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.updateAgentMcpServerTools,
+        ),
+
+        async function AiAgentController_updateAgentMcpServerTools(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_updateAgentMcpServerTools,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateAgentMcpServerTools',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11909,6 +11909,75 @@
                 "required": ["authType", "url", "name"],
                 "type": "object"
             },
+            "AiMcpServerTool": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "meta": {
+                        "nullable": true
+                    },
+                    "annotations": {
+                        "nullable": true
+                    },
+                    "inputSchema": {},
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "toolName": {
+                        "type": "string"
+                    },
+                    "mcpServerUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "createdAt",
+                    "meta",
+                    "annotations",
+                    "inputSchema",
+                    "description",
+                    "title",
+                    "toolName",
+                    "mcpServerUuid",
+                    "uuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiMcpServerTool-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiMcpServerTool"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiMcpServerToolListResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiMcpServerTool-Array_"
+            },
             "ApiSuccess__authorizationUrl-string__": {
                 "properties": {
                     "results": {
@@ -12056,6 +12125,73 @@
                     }
                 },
                 "required": ["results", "status"],
+                "type": "object"
+            },
+            "AiAgentMcpServerTool": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AiMcpServerTool"
+                    },
+                    {
+                        "properties": {
+                            "enabled": {
+                                "type": "boolean"
+                            },
+                            "agentUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["enabled", "agentUuid"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiSuccess_AiAgentMcpServerTool-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentMcpServerTool"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentMcpServerToolListResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentMcpServerTool-Array_"
+            },
+            "Pick_AiAgentMcpServerTool.toolName-or-enabled_": {
+                "properties": {
+                    "toolName": {
+                        "type": "string"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["toolName", "enabled"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "AiAgentMcpServerToolUpdate": {
+                "$ref": "#/components/schemas/Pick_AiAgentMcpServerTool.toolName-or-enabled_"
+            },
+            "ApiUpdateAiAgentMcpServerToolsRequest": {
+                "properties": {
+                    "toolSettings": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentMcpServerToolUpdate"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["toolSettings"],
                 "type": "object"
             },
             "AiModelOption": {
@@ -35626,6 +35762,98 @@
                 }
             }
         },
+        "/api/v1/projects/{projectUuid}/aiAgents/mcpServers/{mcpServerUuid}/tools": {
+            "get": {
+                "operationId": "listMcpServerTools",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiMcpServerToolListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "mcpServerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/mcpServers/{mcpServerUuid}/tools/refresh": {
+            "post": {
+                "operationId": "refreshMcpServerTools",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiMcpServerToolListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "mcpServerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
         "/api/v1/projects/{projectUuid}/aiAgents/mcpServers/{mcpServerUuid}/oauth/start": {
             "post": {
                 "operationId": "startMcpOAuthConnection",
@@ -35906,6 +36134,122 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/mcpServers/{mcpServerUuid}/tools": {
+            "get": {
+                "operationId": "listAgentMcpServerTools",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentMcpServerToolListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "agentUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "mcpServerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "updateAgentMcpServerTools",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentMcpServerToolListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "agentUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "mcpServerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiUpdateAiAgentMcpServerToolsRequest"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/models": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -341,6 +341,13 @@ export type ApiCreateAiMcpServer = {
 
 export type ApiAiMcpServerListResponse = ApiSuccess<AiMcpServer[]>;
 export type ApiAiMcpServerResponse = ApiSuccess<AiMcpServer>;
+export type ApiAiMcpServerToolListResponse = ApiSuccess<AiMcpServerTool[]>;
+export type ApiAiAgentMcpServerToolListResponse = ApiSuccess<
+    AiAgentMcpServerTool[]
+>;
+export type ApiUpdateAiAgentMcpServerToolsRequest = {
+    toolSettings: AiAgentMcpServerToolUpdate[];
+};
 export type ApiStartAiMcpOAuthResponse = ApiSuccess<{
     authorizationUrl: string;
 }>;


### PR DESCRIPTION
Closes:

### Description:

Adds API endpoints and service methods for managing MCP server tools within the AI Agent system.

**New endpoints:**
- `GET /api/v1/projects/:projectUuid/aiAgents/mcpServers/:mcpServerUuid/tools` — lists discovered tools for an MCP server
- `POST /api/v1/projects/:projectUuid/aiAgents/mcpServers/:mcpServerUuid/tools/refresh` — re-connects to the MCP server to discover and update its available tools
- `GET /api/v1/projects/:projectUuid/aiAgents/:agentUuid/mcpServers/:mcpServerUuid/tools` — lists tools for a specific agent's MCP server attachment, including per-tool enabled/disabled state
- `PATCH /api/v1/projects/:projectUuid/aiAgents/:agentUuid/mcpServers/:mcpServerUuid/tools` — updates which tools are enabled for a specific agent's MCP server

**Behaviour changes:**
- When a non-OAuth MCP server is created, tool discovery is automatically attempted and any failures are logged without blocking the creation response.
- When an OAuth connection is completed, tool discovery is triggered automatically with newly discovered tools defaulting to enabled for existing agent attachments.
- When an agent runs, only tools explicitly enabled for that agent's MCP server attachment are passed to the runtime client, filtering out any disabled tools.

**Integration tests** have been updated to exercise these flows through the service layer rather than calling model methods directly, and the test MCP server now dynamically registers tools based on a configurable `availableTools` array.