### PR TITLE
feat: add MCP server tool permissions panel with expand/collapse and auto-refresh

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -79,11 +79,15 @@ export const AiAgentFormSetup = ({
     form,
     projectUuid,
     agentUuid,
+    isSavingAgent,
+    persistedMcpServerUuids,
 }: {
     mode: 'create' | 'edit';
     form: ReturnType<typeof useForm<z.infer<typeof formSchema>>>;
     projectUuid: string;
-    agentUuid: string;
+    agentUuid?: string;
+    isSavingAgent?: boolean;
+    persistedMcpServerUuids?: string[];
 }) => {
     const { data: project } = useProject(projectUuid);
     const exploreAccessSummaryQuery = useGetAgentExploreAccessSummary(
@@ -281,10 +285,12 @@ export const AiAgentFormSetup = ({
                                     they work.
                                 </Text>
                             </Stack>
-                            <AiAgentKnowledgeFilesSection
-                                agentUuid={agentUuid}
-                                projectUuid={projectUuid}
-                            />
+                            {agentUuid && (
+                                <AiAgentKnowledgeFilesSection
+                                    agentUuid={agentUuid}
+                                    projectUuid={projectUuid}
+                                />
+                            )}
                             <Stack gap="sm">
                                 <Box>
                                     <Title
@@ -402,6 +408,9 @@ export const AiAgentFormSetup = ({
                     </Paper>
 
                     <AiAgentMcpServersInput
+                        agentUuid={agentUuid}
+                        isSavingAgent={isSavingAgent}
+                        persistedMcpServerUuids={persistedMcpServerUuids}
                         projectUuid={projectUuid}
                         value={form.values.mcpServerUuids}
                         onChange={(value) => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServerToolsPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServerToolsPanel.tsx
@@ -1,0 +1,417 @@
+import type { AiMcpServer } from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Button,
+    Checkbox,
+    Group,
+    Stack,
+    Text,
+    useMantineColorScheme,
+} from '@mantine-8/core';
+import {
+    IconAlertTriangle,
+    IconInfoCircle,
+    IconRefresh,
+    IconTools,
+} from '@tabler/icons-react';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import { useEffect, useState, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+import {
+    rehypeRemoveHeaderLinks,
+    useMdEditorStyle,
+} from '../../../../utils/markdownUtils';
+import {
+    useAgentAiMcpServerTools,
+    useRefreshAiMcpServerToolsMutation,
+    useUpdateAgentAiMcpServerToolsMutation,
+} from '../hooks/useProjectAiMcpServers';
+
+type Props = {
+    agentUuid?: string;
+    projectUuid: string;
+    mcpServer: AiMcpServer;
+    isPersistedAttachment: boolean;
+    isSavingAgent?: boolean;
+    opened: boolean;
+    showHeader?: boolean;
+};
+
+const shouldBlockTools = (mcpServer: AiMcpServer) =>
+    mcpServer.authType === 'oauth' &&
+    mcpServer.connectionStatus !== 'connected';
+
+const ToolDescriptionModal = ({
+    opened,
+    onClose,
+    title,
+    toolName,
+    source,
+}: {
+    opened: boolean;
+    onClose: () => void;
+    title: string;
+    toolName: string;
+    source: string;
+}) => {
+    const { colorScheme } = useMantineColorScheme();
+    const markdownStyle = useMdEditorStyle();
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title={title}
+            size="lg"
+            icon={IconTools}
+            cancelLabel={false}
+            actions={false}
+        >
+            <Stack gap="md">
+                <Box>
+                    <Text size="xs" fw={700} c="dimmed" tt="uppercase">
+                        Tool name
+                    </Text>
+                    <Text size="sm">{toolName}</Text>
+                </Box>
+                <Box>
+                    <Text size="xs" fw={700} c="dimmed" tt="uppercase" mb="xs">
+                        Description
+                    </Text>
+                    <Box data-color-mode={colorScheme}>
+                        <MarkdownPreview
+                            source={source}
+                            rehypeRewrite={rehypeRemoveHeaderLinks}
+                            style={{
+                                ...markdownStyle,
+                                color: 'var(--mantine-color-text)',
+                            }}
+                            components={{
+                                p: ({ children }) => (
+                                    <p style={{ margin: 0, fontWeight: 400 }}>
+                                        {children}
+                                    </p>
+                                ),
+                                ul: ({ children }) => (
+                                    <ul
+                                        style={{
+                                            margin: '4px 0 0',
+                                            paddingLeft: 18,
+                                        }}
+                                    >
+                                        {children}
+                                    </ul>
+                                ),
+                                ol: ({ children }) => (
+                                    <ol
+                                        style={{
+                                            margin: '4px 0 0',
+                                            paddingLeft: 18,
+                                        }}
+                                    >
+                                        {children}
+                                    </ol>
+                                ),
+                            }}
+                        />
+                    </Box>
+                </Box>
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export const AiAgentMcpServerToolsPanel: FC<Props> = ({
+    agentUuid,
+    projectUuid,
+    mcpServer,
+    isPersistedAttachment,
+    isSavingAgent = false,
+    opened,
+    showHeader = true,
+}) => {
+    const [hasRequestedInitialRefresh, setHasRequestedInitialRefresh] =
+        useState(false);
+    const [selectedToolForDescription, setSelectedToolForDescription] =
+        useState<{
+            title: string;
+            toolName: string;
+            description: string;
+        } | null>(null);
+    const canConfigureTools =
+        !!agentUuid && isPersistedAttachment && !isSavingAgent;
+    const isConnectionRequired = shouldBlockTools(mcpServer);
+
+    const toolsQuery = useAgentAiMcpServerTools(
+        projectUuid,
+        agentUuid,
+        mcpServer.uuid,
+        {
+            enabled: canConfigureTools && opened,
+        },
+    );
+
+    const { mutateAsync: refreshTools, isLoading: isRefreshingTools } =
+        useRefreshAiMcpServerToolsMutation(projectUuid);
+    const {
+        mutateAsync: updateTools,
+        isLoading: isUpdatingTools,
+        variables: updateVariables,
+    } = useUpdateAgentAiMcpServerToolsMutation(
+        projectUuid,
+        agentUuid ?? '',
+        mcpServer.uuid,
+    );
+
+    const tools = toolsQuery.data ?? [];
+
+    useEffect(() => {
+        if (
+            !canConfigureTools ||
+            !opened ||
+            isConnectionRequired ||
+            hasRequestedInitialRefresh ||
+            isRefreshingTools ||
+            toolsQuery.isLoading ||
+            tools.length > 0
+        ) {
+            return;
+        }
+
+        setHasRequestedInitialRefresh(true);
+        void refreshTools({
+            mcpServerUuid: mcpServer.uuid,
+            agentUuid,
+            showSuccessToast: false,
+        });
+    }, [
+        agentUuid,
+        canConfigureTools,
+        hasRequestedInitialRefresh,
+        isConnectionRequired,
+        isRefreshingTools,
+        mcpServer.uuid,
+        opened,
+        refreshTools,
+        tools.length,
+        toolsQuery.isLoading,
+    ]);
+
+    if (!agentUuid || !isPersistedAttachment) {
+        return (
+            <Box py="sm">
+                <Text size="sm" c="dimmed">
+                    Save this agent before configuring MCP tools.
+                </Text>
+            </Box>
+        );
+    }
+
+    if (isSavingAgent) {
+        return null;
+    }
+
+    if (isConnectionRequired) {
+        return (
+            <Box py="sm">
+                <Group gap="xs" wrap="nowrap">
+                    <MantineIcon icon={IconAlertTriangle} color="orange" />
+                    <Text size="sm" c="dimmed">
+                        Connect this MCP account to load tools.
+                    </Text>
+                </Group>
+            </Box>
+        );
+    }
+
+    const enabledCount = tools.filter((tool) => tool.enabled).length;
+    const allToolsEnabled = tools.length > 0 && enabledCount === tools.length;
+    const hasMixedToolSelection =
+        enabledCount > 0 && enabledCount < tools.length;
+    const isInitialLoading = toolsQuery.isLoading && tools.length === 0;
+
+    return (
+        <Box py="sm">
+            <Stack gap="md">
+                <Stack gap={2}>
+                    <Group justify="space-between" gap="sm" align="center">
+                        {showHeader ? (
+                            <Group gap="xs">
+                                <MantineIcon
+                                    icon={IconTools}
+                                    color="var(--mantine-color-ldGray-7)"
+                                />
+                                <Text size="sm" fw={600}>
+                                    Tools
+                                </Text>
+                                {!isInitialLoading && tools.length > 0 && (
+                                    <Text size="xs" c="dimmed">
+                                        {enabledCount}/{tools.length} enabled
+                                    </Text>
+                                )}
+                            </Group>
+                        ) : (
+                            <Text size="xs" c="dimmed">
+                                Changes save automatically.
+                            </Text>
+                        )}
+                        <Group gap={4}>
+                            <Button
+                                variant="subtle"
+                                size="compact-xs"
+                                leftSection={
+                                    <MantineIcon icon={IconRefresh} size="sm" />
+                                }
+                                loading={isRefreshingTools}
+                                onClick={() =>
+                                    refreshTools({
+                                        mcpServerUuid: mcpServer.uuid,
+                                        agentUuid,
+                                        showSuccessToast: true,
+                                    })
+                                }
+                            >
+                                Refresh tools from this MCP
+                            </Button>
+                        </Group>
+                    </Group>
+                    {showHeader && (
+                        <Text size="xs" c="dimmed">
+                            Changes save automatically.
+                        </Text>
+                    )}
+                </Stack>
+
+                {isInitialLoading ? (
+                    <Group gap="xs">
+                        <Text size="sm" c="dimmed">
+                            Loading tools...
+                        </Text>
+                    </Group>
+                ) : tools.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                        No tools found for this MCP server yet.
+                    </Text>
+                ) : (
+                    <Stack gap="xs">
+                        <Checkbox
+                            label={
+                                <Text size="sm" fw={600} c="ldGray.9">
+                                    Enable all
+                                </Text>
+                            }
+                            checked={allToolsEnabled}
+                            indeterminate={hasMixedToolSelection}
+                            disabled={isRefreshingTools || isUpdatingTools}
+                            onChange={(event) =>
+                                void updateTools({
+                                    toolSettings: tools.map((tool) => ({
+                                        toolName: tool.toolName,
+                                        enabled: event.currentTarget.checked,
+                                    })),
+                                })
+                            }
+                        />
+                        {tools.map((tool) => {
+                            const isUpdating =
+                                isUpdatingTools &&
+                                (updateVariables?.toolSettings.some(
+                                    (setting) =>
+                                        setting.toolName === tool.toolName,
+                                ) ??
+                                    false);
+                            const checkboxId = `mcp-tool-${tool.uuid}`;
+
+                            return (
+                                <Box key={tool.uuid} py={2} pl="lg">
+                                    <Group
+                                        align="center"
+                                        gap="xs"
+                                        wrap="nowrap"
+                                    >
+                                        <Checkbox
+                                            id={checkboxId}
+                                            checked={tool.enabled}
+                                            disabled={isUpdating}
+                                            aria-label={`Toggle ${tool.title || tool.toolName}`}
+                                            onChange={(event) =>
+                                                void updateTools({
+                                                    toolSettings: [
+                                                        {
+                                                            toolName:
+                                                                tool.toolName,
+                                                            enabled:
+                                                                event
+                                                                    .currentTarget
+                                                                    .checked,
+                                                        },
+                                                    ],
+                                                })
+                                            }
+                                        />
+                                        <Box flex={1}>
+                                            <Group gap={6} wrap="nowrap">
+                                                <Text
+                                                    component="label"
+                                                    htmlFor={checkboxId}
+                                                    size="sm"
+                                                    fw={700}
+                                                    c="ldGray.9"
+                                                    style={{
+                                                        cursor: isUpdating
+                                                            ? 'not-allowed'
+                                                            : 'pointer',
+                                                    }}
+                                                >
+                                                    {tool.title ||
+                                                        tool.toolName}
+                                                </Text>
+                                                <ActionIcon
+                                                    variant="subtle"
+                                                    color="gray"
+                                                    size="sm"
+                                                    aria-label={`View description for ${tool.title || tool.toolName}`}
+                                                    onClick={() =>
+                                                        setSelectedToolForDescription(
+                                                            {
+                                                                title:
+                                                                    tool.title ||
+                                                                    tool.toolName,
+                                                                toolName:
+                                                                    tool.toolName,
+                                                                description:
+                                                                    tool.description ||
+                                                                    'No description provided',
+                                                            },
+                                                        )
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconInfoCircle}
+                                                        size="sm"
+                                                    />
+                                                </ActionIcon>
+                                            </Group>
+                                        </Box>
+                                    </Group>
+                                </Box>
+                            );
+                        })}
+                    </Stack>
+                )}
+            </Stack>
+            <ToolDescriptionModal
+                opened={!!selectedToolForDescription}
+                onClose={() => setSelectedToolForDescription(null)}
+                title={selectedToolForDescription?.title ?? 'Tool description'}
+                toolName={selectedToolForDescription?.toolName ?? ''}
+                source={
+                    selectedToolForDescription?.description ??
+                    'No description provided'
+                }
+            />
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -11,6 +11,8 @@ import {
     Button,
     Center,
     Checkbox,
+    Collapse,
+    Divider,
     Group,
     Menu,
     MultiSelect,
@@ -18,7 +20,6 @@ import {
     PasswordInput,
     SegmentedControl,
     Stack,
-    Table,
     Text,
     TextInput,
     Title,
@@ -27,7 +28,10 @@ import { useForm, zodResolver } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAlertTriangle,
+    IconChevronDown,
+    IconChevronRight,
     IconDots,
+    IconEye,
     IconPlug,
     IconPlugConnected,
     IconTrash,
@@ -39,9 +43,12 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import {
     useProjectAiMcpServers,
+    useAgentAiMcpServerTools,
     useProjectCreateAiMcpServerMutation,
     useStartMcpOAuthConnectionMutation,
 } from '../hooks/useProjectAiMcpServers';
+import { AiAgentMcpServerToolsPanel } from './AiAgentMcpServerToolsPanel';
+import { AiMcpServerIcon } from './AiMcpServerIcon';
 
 const CREATE_NEW_MCP_OPTION_VALUE = '__create_new_mcp__';
 
@@ -93,6 +100,22 @@ const getMcpConnectionStatusLabel = (
 };
 
 const getMcpConnectionStatusColor = (
+    connectionStatus: AiMcpServerConnectionStatus | null,
+) => {
+    switch (connectionStatus) {
+        case 'connected':
+            return 'green';
+        case 'connecting':
+            return 'blue';
+        case 'error':
+            return 'red';
+        case 'not_connected':
+        default:
+            return 'gray';
+    }
+};
+
+const getMcpServerIconColor = (
     connectionStatus: AiMcpServerConnectionStatus | null,
 ) => {
     switch (connectionStatus) {
@@ -342,11 +365,52 @@ const AttachMcpServersModal = ({
     );
 };
 
+const McpToolPermissionsSummary = ({
+    agentUuid,
+    isPersistedAttachment,
+    isSavingAgent,
+    mcpServerUuid,
+    projectUuid,
+}: {
+    agentUuid?: string;
+    isPersistedAttachment: boolean;
+    isSavingAgent?: boolean;
+    mcpServerUuid: string;
+    projectUuid: string;
+}) => {
+    const { data } = useAgentAiMcpServerTools(
+        projectUuid,
+        agentUuid,
+        mcpServerUuid,
+        {
+            enabled: !!agentUuid && isPersistedAttachment && !isSavingAgent,
+        },
+    );
+
+    if (!agentUuid || !isPersistedAttachment || isSavingAgent || !data) {
+        return null;
+    }
+
+    const enabledCount = data.filter((tool) => tool.enabled).length;
+
+    return (
+        <Text size="sm" c="dimmed">
+            {enabledCount}/{data.length} enabled
+        </Text>
+    );
+};
+
 export const AiAgentMcpServersInput = ({
+    agentUuid,
+    isSavingAgent = false,
+    persistedMcpServerUuids,
     projectUuid,
     value,
     onChange,
 }: {
+    agentUuid?: string;
+    isSavingAgent?: boolean;
+    persistedMcpServerUuids?: string[];
     projectUuid: string;
     value: string[];
     onChange: (value: string[]) => void;
@@ -356,6 +420,7 @@ export const AiAgentMcpServersInput = ({
     const [isAttachMcpServersModalOpen, attachMcpServersModalHandlers] =
         useDisclosure(false);
     const [attachSelection, setAttachSelection] = useState<string[]>([]);
+    const [expandedMcpServers, setExpandedMcpServers] = useState<string[]>([]);
     const { data: mcpServers, isLoading: isLoadingMcpServers } =
         useProjectAiMcpServers(projectUuid);
     const { mutateAsync: createMcpServer, isLoading: isCreatingMcpServer } =
@@ -489,8 +554,44 @@ export const AiAgentMcpServersInput = ({
             onChange(
                 value.filter((selectedUuid) => selectedUuid !== mcpServerUuid),
             );
+            setExpandedMcpServers((currentExpandedMcpServers) =>
+                currentExpandedMcpServers.filter(
+                    (expandedMcpServerUuid) =>
+                        expandedMcpServerUuid !== mcpServerUuid,
+                ),
+            );
         },
         [onChange, value],
+    );
+
+    const handleToggleExpandedMcpServer = useCallback(
+        (mcpServerUuid: string) => {
+            setExpandedMcpServers((currentExpandedMcpServers) =>
+                currentExpandedMcpServers.includes(mcpServerUuid)
+                    ? currentExpandedMcpServers.filter(
+                          (expandedMcpServerUuid) =>
+                              expandedMcpServerUuid !== mcpServerUuid,
+                      )
+                    : [...currentExpandedMcpServers, mcpServerUuid],
+            );
+        },
+        [],
+    );
+
+    const handleSetExpandedMcpServer = useCallback(
+        (mcpServerUuid: string, expanded: boolean) => {
+            setExpandedMcpServers((currentExpandedMcpServers) =>
+                expanded
+                    ? currentExpandedMcpServers.includes(mcpServerUuid)
+                        ? currentExpandedMcpServers
+                        : [...currentExpandedMcpServers, mcpServerUuid]
+                    : currentExpandedMcpServers.filter(
+                          (expandedMcpServerUuid) =>
+                              expandedMcpServerUuid !== mcpServerUuid,
+                      ),
+            );
+        },
+        [],
     );
 
     const renderMcpServerActionMenu = useCallback(
@@ -498,6 +599,7 @@ export const AiAgentMcpServersInput = ({
             mcpServer: AiMcpServer,
             connectionStatus: AiMcpServerConnectionStatus | null,
             isConnecting: boolean,
+            isExpanded: boolean,
         ) => {
             return (
                 <Menu
@@ -508,17 +610,37 @@ export const AiAgentMcpServersInput = ({
                     width={220}
                 >
                     <Menu.Target>
-                        <ActionIcon variant="subtle" color="gray">
+                        <ActionIcon
+                            type="button"
+                            variant="subtle"
+                            color="gray"
+                            onClick={(event) => event.stopPropagation()}
+                        >
                             <MantineIcon icon={IconDots} />
                         </ActionIcon>
                     </Menu.Target>
                     <Menu.Dropdown>
+                        <Menu.Item
+                            type="button"
+                            leftSection={<MantineIcon icon={IconEye} />}
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                handleSetExpandedMcpServer(
+                                    mcpServer.uuid,
+                                    !isExpanded,
+                                );
+                            }}
+                        >
+                            {isExpanded ? 'Hide tools' : 'View tools'}
+                        </Menu.Item>
                         {mcpServer.authType === 'oauth' && (
                             <Menu.Item
+                                type="button"
                                 leftSection={
                                     <MantineIcon icon={IconPlugConnected} />
                                 }
-                                onClick={() => {
+                                onClick={(event) => {
+                                    event.stopPropagation();
                                     void handleStartMcpOAuthConnection(
                                         mcpServer.uuid,
                                     );
@@ -534,10 +656,12 @@ export const AiAgentMcpServersInput = ({
                             </Menu.Item>
                         )}
                         <Menu.Item
+                            type="button"
                             leftSection={<MantineIcon icon={IconTrash} />}
-                            onClick={() =>
-                                handleRemoveMcpServer(mcpServer.uuid)
-                            }
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                handleRemoveMcpServer(mcpServer.uuid);
+                            }}
                             disabled={isConnecting}
                             color="red"
                         >
@@ -547,7 +671,11 @@ export const AiAgentMcpServersInput = ({
                 </Menu>
             );
         },
-        [handleRemoveMcpServer, handleStartMcpOAuthConnection],
+        [
+            handleRemoveMcpServer,
+            handleSetExpandedMcpServer,
+            handleStartMcpOAuthConnection,
+        ],
     );
 
     return (
@@ -598,102 +726,176 @@ export const AiAgentMcpServersInput = ({
                         </Center>
                     )}
                     {selectedMcpServers.length > 0 && (
-                        <Table.ScrollContainer minWidth={560}>
-                            <Table
-                                highlightOnHover
-                                withTableBorder
-                                withColumnBorders={false}
-                                verticalSpacing="sm"
-                                style={{
-                                    borderRadius: 'var(--mantine-radius-md)',
-                                    overflow: 'hidden',
-                                }}
-                            >
-                                <Table.Thead>
-                                    <Table.Tr>
-                                        <Table.Th>Name</Table.Th>
-                                        <Table.Th w={140}>Type</Table.Th>
-                                        <Table.Th w={160}>Status</Table.Th>
-                                        <Table.Th w={56} />
-                                    </Table.Tr>
-                                </Table.Thead>
-                                <Table.Tbody>
-                                    {selectedMcpServers.map((mcpServer) => {
-                                        const isConnecting =
-                                            mcpServer.authType === 'oauth' &&
-                                            isStartingMcpOAuthConnection &&
-                                            startingMcpOAuthConnection?.mcpServerUuid ===
-                                                mcpServer.uuid;
-                                        const connectionStatus = isConnecting
-                                            ? 'connecting'
-                                            : mcpServer.connectionStatus;
+                        <Stack gap="sm">
+                            {selectedMcpServers.map((mcpServer) => {
+                                const isConnecting =
+                                    mcpServer.authType === 'oauth' &&
+                                    isStartingMcpOAuthConnection &&
+                                    startingMcpOAuthConnection?.mcpServerUuid ===
+                                        mcpServer.uuid;
+                                const connectionStatus = isConnecting
+                                    ? 'connecting'
+                                    : mcpServer.connectionStatus;
+                                const isExpanded = expandedMcpServers.includes(
+                                    mcpServer.uuid,
+                                );
+                                const isPersistedAttachment =
+                                    persistedMcpServerUuids?.includes(
+                                        mcpServer.uuid,
+                                    ) ?? false;
 
-                                        return (
-                                            <Table.Tr key={mcpServer.uuid}>
-                                                <Table.Td>
-                                                    <Stack gap={2}>
-                                                        <Text fw={600}>
-                                                            {mcpServer.name}
-                                                        </Text>
+                                return (
+                                    <Paper
+                                        key={mcpServer.uuid}
+                                        withBorder
+                                        radius="md"
+                                        p={0}
+                                        style={{ overflow: 'hidden' }}
+                                    >
+                                        <Group
+                                            justify="space-between"
+                                            align="flex-start"
+                                            gap="md"
+                                            px="md"
+                                            py="md"
+                                        >
+                                            <Group gap="sm" align="flex-start">
+                                                <AiMcpServerIcon
+                                                    color={getMcpServerIconColor(
+                                                        connectionStatus,
+                                                    )}
+                                                    name={mcpServer.name}
+                                                    size={40}
+                                                    url={mcpServer.url}
+                                                />
+                                                <Stack gap={2}>
+                                                    <Text fw={600}>
+                                                        {mcpServer.name}
+                                                    </Text>
+                                                    <Text size="sm" c="dimmed">
+                                                        {mcpServer.url}
+                                                    </Text>
+                                                    {mcpServer.error && (
                                                         <Text
                                                             size="xs"
-                                                            c="dimmed"
+                                                            c="red.7"
                                                         >
-                                                            {mcpServer.url}
+                                                            {mcpServer.error}
                                                         </Text>
-                                                        {mcpServer.error && (
-                                                            <Text
-                                                                size="xs"
-                                                                c="red.7"
-                                                            >
-                                                                {
-                                                                    mcpServer.error
-                                                                }
-                                                            </Text>
-                                                        )}
-                                                    </Stack>
-                                                </Table.Td>
-                                                <Table.Td>
-                                                    <Text
-                                                        fw={450}
-                                                        c="ldDark.9"
+                                                    )}
+                                                </Stack>
+                                            </Group>
+                                            <Group
+                                                gap="xs"
+                                                align="center"
+                                                wrap="nowrap"
+                                            >
+                                                <Badge
+                                                    variant="default"
+                                                    color="gray"
+                                                >
+                                                    {getMcpAuthTypeLabel(
+                                                        mcpServer.authType,
+                                                    )}
+                                                </Badge>
+                                                <Badge
+                                                    variant="light"
+                                                    color={getMcpConnectionStatusColor(
+                                                        connectionStatus,
+                                                    )}
+                                                >
+                                                    {getMcpConnectionStatusLabel(
+                                                        connectionStatus,
+                                                    )}
+                                                </Badge>
+                                                {renderMcpServerActionMenu(
+                                                    mcpServer,
+                                                    connectionStatus,
+                                                    isConnecting,
+                                                    isExpanded,
+                                                )}
+                                            </Group>
+                                        </Group>
+                                        <Divider />
+                                        <Box
+                                            component="button"
+                                            type="button"
+                                            onClick={() =>
+                                                handleToggleExpandedMcpServer(
+                                                    mcpServer.uuid,
+                                                )
+                                            }
+                                            px="md"
+                                            py="sm"
+                                            style={{
+                                                width: '100%',
+                                                background: 'transparent',
+                                                border: 0,
+                                                cursor: 'pointer',
+                                            }}
+                                        >
+                                            <Group
+                                                justify="space-between"
+                                                gap="sm"
+                                            >
+                                                <Group gap="xs" wrap="nowrap">
+                                                    <MantineIcon
+                                                        icon={
+                                                            isExpanded
+                                                                ? IconChevronDown
+                                                                : IconChevronRight
+                                                        }
+                                                        color="var(--mantine-color-dimmed)"
                                                         size="sm"
-                                                    >
-                                                        {getMcpAuthTypeLabel(
-                                                            mcpServer.authType,
-                                                        )}
+                                                    />
+                                                    <Text size="sm" fw={500}>
+                                                        Tool permissions
                                                     </Text>
-                                                </Table.Td>
-                                                <Table.Td>
-                                                    <Badge
-                                                        variant="light"
-                                                        color={getMcpConnectionStatusColor(
-                                                            connectionStatus,
-                                                        )}
-                                                    >
-                                                        {getMcpConnectionStatusLabel(
-                                                            connectionStatus,
-                                                        )}
-                                                    </Badge>
-                                                </Table.Td>
-                                                <Table.Td>
-                                                    <Group
-                                                        justify="flex-end"
-                                                        wrap="nowrap"
-                                                    >
-                                                        {renderMcpServerActionMenu(
-                                                            mcpServer,
-                                                            connectionStatus,
-                                                            isConnecting,
-                                                        )}
-                                                    </Group>
-                                                </Table.Td>
-                                            </Table.Tr>
-                                        );
-                                    })}
-                                </Table.Tbody>
-                            </Table>
-                        </Table.ScrollContainer>
+                                                    <McpToolPermissionsSummary
+                                                        agentUuid={agentUuid}
+                                                        isPersistedAttachment={
+                                                            isPersistedAttachment
+                                                        }
+                                                        isSavingAgent={
+                                                            isSavingAgent
+                                                        }
+                                                        mcpServerUuid={
+                                                            mcpServer.uuid
+                                                        }
+                                                        projectUuid={
+                                                            projectUuid
+                                                        }
+                                                    />
+                                                </Group>
+                                                <Text size="sm" c="dimmed">
+                                                    {isExpanded
+                                                        ? 'Hide'
+                                                        : 'View'}
+                                                </Text>
+                                            </Group>
+                                        </Box>
+                                        <Collapse in={isExpanded}>
+                                            <Divider />
+                                            <Box px="md" py="sm">
+                                                <AiAgentMcpServerToolsPanel
+                                                    agentUuid={agentUuid}
+                                                    isSavingAgent={
+                                                        isSavingAgent
+                                                    }
+                                                    opened={isExpanded}
+                                                    projectUuid={projectUuid}
+                                                    mcpServer={mcpServer}
+                                                    isPersistedAttachment={
+                                                        isPersistedAttachment
+                                                    }
+                                                    showHeader={false}
+                                                />
+                                            </Box>
+                                        </Collapse>
+                                    </Paper>
+                                );
+                            })}
+                        </Stack>
                     )}
                 </Stack>
             </Paper>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiMcpServerIcon.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiMcpServerIcon.tsx
@@ -1,0 +1,44 @@
+import { Avatar, type MantineColor } from '@mantine-8/core';
+import { IconPlugConnected } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+
+type Props = {
+    color: MantineColor;
+    name: string;
+    size?: number;
+    src?: string | null;
+    url: string;
+};
+
+export const AiMcpServerIcon: FC<Props> = ({
+    color,
+    name,
+    size = 40,
+    src,
+    url,
+}) => {
+    const fallbackFaviconUrl = useMemo(() => {
+        try {
+            return new URL('/favicon.ico', url).toString();
+        } catch {
+            return undefined;
+        }
+    }, [url]);
+
+    const imageSrc = src ?? fallbackFaviconUrl;
+
+    return (
+        <Avatar
+            src={imageSrc}
+            alt={`${name} favicon`}
+            radius="md"
+            size={size}
+            variant="light"
+            color={color}
+            imageProps={{ referrerPolicy: 'no-referrer' }}
+        >
+            <MantineIcon icon={IconPlugConnected} size="md" />
+        </Avatar>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
@@ -1,8 +1,11 @@
 import type {
+    ApiAiAgentMcpServerToolListResponse,
     ApiAiMcpServerListResponse,
     ApiAiMcpServerResponse,
+    ApiAiMcpServerToolListResponse,
     ApiCreateAiMcpServer,
     ApiError,
+    ApiUpdateAiAgentMcpServerToolsRequest,
 } from '@lightdash/common';
 import {
     useMutation,
@@ -15,6 +18,8 @@ import useToaster from '../../../../hooks/toaster/useToaster';
 
 export const PROJECT_AI_MCP_SERVERS_KEY = 'projectAiMcpServers';
 export const AGENT_AI_MCP_SERVERS_KEY = 'agentAiMcpServers';
+const PROJECT_AI_MCP_SERVER_TOOLS_KEY = 'projectAiMcpServerTools';
+const AGENT_AI_MCP_SERVER_TOOLS_KEY = 'agentAiMcpServerTools';
 
 const listProjectAiMcpServers = async (
     projectUuid: string,
@@ -45,6 +50,42 @@ const createProjectAiMcpServer = async (
         version: 'v1',
         url: `/projects/${projectUuid}/aiAgents/mcpServers`,
         method: 'POST',
+        body: JSON.stringify(data),
+    });
+
+const listAgentAiMcpServerTools = async (
+    projectUuid: string,
+    agentUuid: string,
+    mcpServerUuid: string,
+): Promise<ApiAiAgentMcpServerToolListResponse['results']> =>
+    lightdashApi<ApiAiAgentMcpServerToolListResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/mcpServers/${mcpServerUuid}/tools`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const refreshProjectAiMcpServerTools = async (
+    projectUuid: string,
+    mcpServerUuid: string,
+): Promise<ApiAiMcpServerToolListResponse['results']> =>
+    lightdashApi<ApiAiMcpServerToolListResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/mcpServers/${mcpServerUuid}/tools/refresh`,
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+
+const updateAgentAiMcpServerTools = async (
+    projectUuid: string,
+    agentUuid: string,
+    mcpServerUuid: string,
+    data: ApiUpdateAiAgentMcpServerToolsRequest,
+): Promise<ApiAiAgentMcpServerToolListResponse['results']> =>
+    lightdashApi<ApiAiAgentMcpServerToolListResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/mcpServers/${mcpServerUuid}/tools`,
+        method: 'PATCH',
         body: JSON.stringify(data),
     });
 
@@ -199,6 +240,42 @@ export const useAgentAiMcpServers = (
     });
 };
 
+export const useAgentAiMcpServerTools = (
+    projectUuid: string | undefined,
+    agentUuid: string | undefined,
+    mcpServerUuid: string | undefined,
+    options?: UseQueryOptions<
+        ApiAiAgentMcpServerToolListResponse['results'],
+        ApiError
+    >,
+) => {
+    const { showToastApiError } = useToaster();
+
+    return useQuery<ApiAiAgentMcpServerToolListResponse['results'], ApiError>({
+        queryKey: [
+            AGENT_AI_MCP_SERVER_TOOLS_KEY,
+            projectUuid,
+            agentUuid,
+            mcpServerUuid,
+        ],
+        queryFn: () =>
+            listAgentAiMcpServerTools(projectUuid!, agentUuid!, mcpServerUuid!),
+        enabled:
+            !!projectUuid &&
+            !!agentUuid &&
+            !!mcpServerUuid &&
+            options?.enabled !== false,
+        ...options,
+        onError: (error) => {
+            showToastApiError({
+                title: 'Failed to fetch MCP tools',
+                apiError: error.error,
+            });
+            options?.onError?.(error);
+        },
+    });
+};
+
 export const useProjectCreateAiMcpServerMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
     const { showToastApiError, showToastSuccess } = useToaster();
@@ -237,6 +314,56 @@ export const useProjectCreateAiMcpServerMutation = (projectUuid: string) => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to create MCP server',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useRefreshAiMcpServerToolsMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+
+    return useMutation<
+        ApiAiMcpServerToolListResponse['results'],
+        ApiError,
+        {
+            mcpServerUuid: string;
+            agentUuid?: string;
+            showSuccessToast?: boolean;
+        }
+    >({
+        mutationFn: ({ mcpServerUuid }) =>
+            refreshProjectAiMcpServerTools(projectUuid, mcpServerUuid),
+        onSuccess: async (_, variables) => {
+            if (variables.showSuccessToast) {
+                showToastSuccess({
+                    title: 'MCP tools refreshed',
+                });
+            }
+
+            await queryClient.invalidateQueries({
+                queryKey: [
+                    PROJECT_AI_MCP_SERVER_TOOLS_KEY,
+                    projectUuid,
+                    variables.mcpServerUuid,
+                ],
+            });
+
+            if (variables.agentUuid) {
+                await queryClient.invalidateQueries({
+                    queryKey: [
+                        AGENT_AI_MCP_SERVER_TOOLS_KEY,
+                        projectUuid,
+                        variables.agentUuid,
+                        variables.mcpServerUuid,
+                    ],
+                });
+            }
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to refresh MCP tools',
                 apiError: error,
             });
         },
@@ -283,4 +410,98 @@ export const useStartMcpOAuthConnectionMutation = (projectUuid: string) => {
             });
         },
     });
+};
+
+export const useUpdateAgentAiMcpServerToolsMutation = (
+    projectUuid: string,
+    agentUuid: string,
+    mcpServerUuid: string,
+) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiAiAgentMcpServerToolListResponse['results'],
+        ApiError,
+        ApiUpdateAiAgentMcpServerToolsRequest
+    >(
+        (data) =>
+            updateAgentAiMcpServerTools(
+                projectUuid,
+                agentUuid,
+                mcpServerUuid,
+                data,
+            ),
+        {
+            onMutate: async (
+                data,
+            ): Promise<{
+                previousTools?: ApiAiAgentMcpServerToolListResponse['results'];
+            }> => {
+                const queryKey = [
+                    AGENT_AI_MCP_SERVER_TOOLS_KEY,
+                    projectUuid,
+                    agentUuid,
+                    mcpServerUuid,
+                ];
+
+                await queryClient.cancelQueries({ queryKey });
+
+                const previousTools =
+                    queryClient.getQueryData<
+                        ApiAiAgentMcpServerToolListResponse['results']
+                    >(queryKey);
+
+                queryClient.setQueryData<
+                    ApiAiAgentMcpServerToolListResponse['results']
+                >(
+                    queryKey,
+                    (currentTools) =>
+                        currentTools?.map((tool) => {
+                            const nextSetting = data.toolSettings.find(
+                                (setting) => setting.toolName === tool.toolName,
+                            );
+
+                            return nextSetting
+                                ? { ...tool, enabled: nextSetting.enabled }
+                                : tool;
+                        }) ?? currentTools,
+                );
+
+                return { previousTools };
+            },
+            onSuccess: (tools) => {
+                queryClient.setQueryData(
+                    [
+                        AGENT_AI_MCP_SERVER_TOOLS_KEY,
+                        projectUuid,
+                        agentUuid,
+                        mcpServerUuid,
+                    ],
+                    tools,
+                );
+            },
+            onError: ({ error }, _, context) => {
+                queryClient.setQueryData(
+                    [
+                        AGENT_AI_MCP_SERVER_TOOLS_KEY,
+                        projectUuid,
+                        agentUuid,
+                        mcpServerUuid,
+                    ],
+                    (
+                        context as
+                            | {
+                                  previousTools?: ApiAiAgentMcpServerToolListResponse['results'];
+                              }
+                            | undefined
+                    )?.previousTools,
+                );
+                showToastApiError({
+                    title: 'Failed to update MCP tools',
+                    apiError: error,
+                });
+            },
+        },
+    );
 };

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -400,9 +400,13 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                         <Box pt="sm" pr="sm">
                             <AiAgentFormSetup
                                 mode={isCreateMode ? 'create' : 'edit'}
-                                agentUuid={actualAgentUuid!}
+                                agentUuid={actualAgentUuid}
                                 form={form}
                                 projectUuid={projectUuid!}
+                                isSavingAgent={isUpdatingAgent}
+                                persistedMcpServerUuids={agentMcpServers?.map(
+                                    (mcpServer) => mcpServer.uuid,
+                                )}
                             />
                         </Box>
                     )}


### PR DESCRIPTION
Closes: [PROD-7825](https://linear.app/lightdash/issue/CENG-7825)

### Description:

Adds per-agent MCP tool permission configuration, allowing users to enable or disable individual tools exposed by attached MCP servers.

Key changes:

- Replaces the flat table view of attached MCP servers with an expandable card layout. Each card shows the server's favicon (via `AiMcpServerIcon`), connection status badges, and a collapsible "Tool permissions" section.
- Introduces `AiAgentMcpServerToolsPanel`, a new component that renders a checklist of tools for a given MCP server. It supports enabling/disabling individual tools or all tools at once, refreshing the tool list from the MCP server, and viewing full tool descriptions in a modal.
- Tool state changes are applied optimistically with rollback on error.
- When no tools have been fetched yet and the panel is first opened, a refresh is triggered automatically.
- The tools panel shows a prompt to save the agent first if it hasn't been persisted yet, and a warning if an OAuth-based MCP server is not yet connected.
- Adds `useAgentAiMcpServerTools`, `useRefreshAiMcpServerToolsMutation`, and `useUpdateAgentAiMcpServerToolsMutation` hooks to fetch, refresh, and update tool settings via the API.
- `AiAgentFormSetup` now accepts an optional `agentUuid` and `persistedMcpServerUuids` to distinguish between newly added and already-saved MCP server attachments, gating the knowledge files section and tool configuration on the agent being persisted.