### PR TITLE
fix: custom Vega-Lite charts export as blank images

### DIFF
--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -1,6 +1,14 @@
 import { Anchor, Text, useMantineColorScheme } from '@mantine-8/core';
 import { IconGraphOff } from '@tabler/icons-react';
-import { lazy, Suspense, useEffect, useMemo, useRef, type FC } from 'react';
+import {
+    lazy,
+    Suspense,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    type FC,
+} from 'react';
 import { dark as vegaDarkTheme } from 'vega-themes';
 import { type CustomVisualizationConfigAndData } from '../../hooks/useCustomVisualizationConfig';
 import LoadingChart from '../common/LoadingChart';
@@ -48,14 +56,17 @@ const CustomVisualization: FC<Props> = ({
         [isDarkMode],
     );
 
-    useEffect(() => {
+    const handleVegaEmbed = useCallback(() => {
         if (hasSignaledScreenshotReady.current) return;
-        if (!onScreenshotReady && !onScreenshotError) return;
-        if (!isLoading) {
-            onScreenshotReady?.();
-            hasSignaledScreenshotReady.current = true;
-        }
-    }, [isLoading, visualizationConfig, onScreenshotReady, onScreenshotError]);
+        onScreenshotReady?.();
+        hasSignaledScreenshotReady.current = true;
+    }, [onScreenshotReady]);
+
+    const handleVegaError = useCallback(() => {
+        if (hasSignaledScreenshotReady.current) return;
+        onScreenshotError?.();
+        hasSignaledScreenshotReady.current = true;
+    }, [onScreenshotError]);
 
     useEffect(() => {
         // Load all the rows
@@ -117,6 +128,14 @@ const CustomVisualization: FC<Props> = ({
 
     const data = { values: visProps.series };
 
+    // Vega-Embed measures the container synchronously when the spec is embedded.
+    // useElementSize() reports 0 until ResizeObserver fires, so mounting VegaEmbed
+    // before the container has been measured produces an SVG locked at 0x0 that
+    // never recovers. Wait for a real measurement before handing the spec to Vega.
+    if (!containerWidth || !containerHeight) {
+        return <LoadingChart />;
+    }
+
     return (
         <div
             className={props.className}
@@ -142,9 +161,9 @@ const CustomVisualization: FC<Props> = ({
                     spec={{
                         ...spec,
                         // @ts-ignore, see above
-                        width: 'container',
+                        width: containerWidth,
                         // @ts-ignore, see above
-                        height: 'container',
+                        height: containerHeight,
                         // @ts-ignore, see above
                         data: data,
                         // Merge configs: our defaults first, then user's config overrides
@@ -156,6 +175,8 @@ const CustomVisualization: FC<Props> = ({
                     options={{
                         actions: false,
                     }}
+                    onEmbed={handleVegaEmbed}
+                    onError={handleVegaError}
                 />
             </Suspense>
         </div>

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -1,6 +1,14 @@
+import { ChartType } from '@lightdash/common';
 import { Box, MantineProvider, type MantineThemeOverride } from '@mantine/core';
-import { useElementSize } from '@mantine/hooks';
-import { memo, useEffect, useMemo, useRef, useState, type FC } from 'react';
+import {
+    memo,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
 import ScreenshotProgressIndicator from '../components/common/ScreenshotProgressIndicator';
@@ -18,6 +26,7 @@ import {
 } from '../features/explorer/store';
 import { useExplorerQuery } from '../hooks/useExplorerQuery';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
+import { useResizeObserver } from '../hooks/useResizeObserver';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
 import { ExplorerSection } from '../providers/Explorer/types';
@@ -40,11 +49,12 @@ const MinimalExplorerContent = memo(() => {
 
     const { health } = useApp();
 
-    const {
-        ref: measureRef,
-        width: containerWidth,
-        height: containerHeight,
-    } = useElementSize();
+    // The in-repo useResizeObserver tracks ref changes via setState (unlike
+    // @mantine/hooks' useElementSize, whose [ref.current] effect dep doesn't
+    // re-run on ref attachment). Without this, containerWidth/containerHeight
+    // stay at 0 and Vega-Lite charts render at 0x0 in the minimal/export view.
+    const [measureRef, { width: containerWidth, height: containerHeight }] =
+        useResizeObserver<HTMLDivElement>();
 
     // Get query state from hook
     const { query, queryResults, explore } = useExplorerQuery();
@@ -71,7 +81,23 @@ const MinimalExplorerContent = memo(() => {
     const hasQueryError = !!query.error || !!queryResults.error;
 
     const [isScreenshotReady, setIsScreenshotReady] = useState(false);
+    const [chartHasPainted, setChartHasPainted] = useState(false);
     const hasSignaledReady = useRef(false);
+
+    // Custom (Vega-Lite) charts render asynchronously: react-vega is lazy-imported,
+    // then Vega compiles the spec and constructs its view before the chart paints.
+    // For this type we wait for the chart's own paint signal — gating only on
+    // data-loaded fires the screenshot indicator before Vega has rendered, which
+    // produces blank export PNGs.
+    const needsPaintSignal = savedChart?.chartConfig.type === ChartType.CUSTOM;
+
+    const handleChartScreenshotReady = useCallback(() => {
+        setChartHasPainted(true);
+    }, []);
+
+    const handleChartScreenshotError = useCallback(() => {
+        setChartHasPainted(true);
+    }, []);
 
     useEffect(() => {
         if (hasSignaledReady.current) return;
@@ -79,6 +105,10 @@ const MinimalExplorerContent = memo(() => {
 
         const isSuccessfullyLoaded = savedChart && !isLoadingQueryResults;
         if (!isSuccessfullyLoaded && !hasQueryError) {
+            return;
+        }
+
+        if (needsPaintSignal && !hasQueryError && !chartHasPainted) {
             return;
         }
 
@@ -90,6 +120,8 @@ const MinimalExplorerContent = memo(() => {
         hasQueryError,
         health.isInitialLoading,
         health.data,
+        needsPaintSignal,
+        chartHasPainted,
     ]);
 
     if (!savedChart || health.isInitialLoading || !health.data) {
@@ -126,6 +158,8 @@ const MinimalExplorerContent = memo(() => {
                             // get rid of the classNames once you remove analytics providers
                             className="sentry-block ph-no-capture"
                             data-testid="visualization"
+                            onScreenshotReady={handleChartScreenshotReady}
+                            onScreenshotError={handleChartScreenshotError}
                         />
                     </Box>
                 </MantineProvider>


### PR DESCRIPTION
Closes #23385

## Summary

Custom (Vega-Lite) chart image exports (`lightdash export-chart-image`, scheduled deliveries, Slack/unfurl previews) produced blank PNGs. Two issues in the minimal/export render path combined to cause it:

1. **Container size never measured.** `MinimalSavedExplorer` measured the chart container with `@mantine/hooks`' `useElementSize`, whose underlying `ResizeObserver` effect depends on `[ref.current]`. React doesn't track mutable ref changes as dependencies, so when the ref attaches across the `LightdashVisualization` `forwardRef` boundary the observer is never wired up and `width`/`height` stay `0`. Vega-Lite then rendered its SVG at `0×0` — present in the DOM but invisible. Switched to the in-repo `useResizeObserver` (which tracks the node via `setState`), pass the measured dimensions into the spec explicitly instead of relying on Vega's `'container'` sizing, and skip mounting `VegaEmbed` until a real measurement exists.

2. **Screenshot fired before paint.** The screenshot-ready indicator was gated on data-loaded, not chart-painted. Because `react-vega` is lazy-imported and compiles its view asynchronously, the headless browser could capture before the chart painted. `CustomVisualization` now signals readiness via `VegaEmbed`'s `onEmbed`/`onError`, and `MinimalSavedExplorer` waits for that paint signal for custom charts before marking the screenshot ready.

## Test plan

- [x] `pnpm -F frontend typecheck` — clean
- [x] `pnpm -F frontend lint` — no new errors
- [x] Manually exported a custom Vega-Lite chart locally — chart renders fully in the PNG (title, axes, bars, labels) where it was previously blank
- [x] Verified the chart still renders in the in-app explorer/minimal view
- [ ] Reviewer: confirm native chart types (cartesian/pie/table/etc.) still export correctly — their screenshot-ready path is unchanged (the new paint-signal gate only applies to `ChartType.CUSTOM`)

## Notes

There are other call sites of `@mantine/hooks`' `useElementSize` / `useResizeObserver` in the frontend that may have the same latent zero-size behaviour under React 19 across `forwardRef` boundaries. Out of scope here, but worth a follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)