### PR TITLE
fix(backend): move Express Request augmentation to ambient .d.ts

### DIFF
--- a/packages/backend/src/@types/express.d.ts
+++ b/packages/backend/src/@types/express.d.ts
@@ -1,0 +1,25 @@
+import {
+    Account,
+    Project,
+    ServiceAccount,
+    SessionUser,
+} from '@lightdash/common';
+import { ClientRepository } from '../clients/ClientRepository';
+import { ServiceRepository } from '../services/ServiceRepository';
+
+declare global {
+    namespace Express {
+        interface Request {
+            services: ServiceRepository;
+            serviceAccount?: Pick<ServiceAccount, 'organizationUuid'>;
+            project?: Pick<Project, 'projectUuid'>;
+            /**
+             * @deprecated Clients should be used inside services. This will be removed soon.
+             */
+            clients: ClientRepository;
+            account?: Account;
+        }
+
+        interface User extends SessionUser {}
+    }
+}

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -1,6 +1,5 @@
 import './sentry'; // Sentry has to be initialized before anything else
 import {
-    Account,
     AnyType,
     ApiError,
     getErrorMessage,
@@ -9,9 +8,6 @@ import {
     LightdashVersionHeader,
     MissingConfigError,
     OauthAuthenticationError,
-    Project,
-    ServiceAccount,
-    SessionUser,
     UnexpectedServerError,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -85,29 +81,9 @@ import {
 import { UtilProviderMap, UtilRepository } from './utils/UtilRepository';
 import { VERSION } from './version';
 
-// We need to override this interface to have our user typing
-declare global {
-    namespace Express {
-        /**
-         * There's potentially a good case for NOT including this under the top-level of the Request,
-         * but instead under `locals` - I've yet to see a good reasoning on -why-, so for now I'm
-         * opting for the keystrokes saved through omitting `.locals`.
-         */
-        interface Request {
-            services: ServiceRepository;
-            serviceAccount?: Pick<ServiceAccount, 'organizationUuid'>;
-            // The project associated with this request
-            project?: Pick<Project, 'projectUuid'>;
-            /**
-             * @deprecated Clients should be used inside services. This will be removed soon.
-             */
-            clients: ClientRepository;
-            account?: Account;
-        }
-
-        interface User extends SessionUser {}
-    }
-}
+// Express Request/User type augmentations live in src/@types/express.d.ts
+// so they're picked up as ambient declarations regardless of which file is
+// the compilation entry point (e.g. knex seed/migrate via ts-node).
 
 const schedulerWorkerFactory = (context: {
     lightdashConfig: LightdashConfig;

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -22,7 +22,7 @@
         "skipLibCheck": true,
         "types": ["node", "jest", "passport", "express-session"]
     },
-    "files": ["src/@types/express-session.d.ts"],
+    "files": ["src/@types/express-session.d.ts", "src/@types/express.d.ts"],
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
     "exclude": ["dist", "node_modules", "src/ee/services/McpService/mcp-chart-app"],
     "references": [


### PR DESCRIPTION
### Description:
The Express Request/User type augmentation lived inside App.ts as a regular module. ts-node only picks up augmentations from files in the entry point's import graph, so running knex seed/migrate (which never imports App.ts) failed to typecheck winston.ts after it started reading req.account in #23250. Moving the declare global block to src/@types/express.d.ts makes it ambient and ensures it loads regardless of entry point.
