### PR TITLE
feat(impersonation): add warehouse credentials disclaimer

### DIFF
--- a/packages/frontend/src/components/UserSettings/ImpersonationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ImpersonationPanel/index.tsx
@@ -4,6 +4,7 @@ import {
     useImpersonationSettings,
     useUpdateImpersonationSettings,
 } from '../../../hooks/user/useImpersonation';
+import Callout from '../../common/Callout';
 
 const ImpersonationPanel: FC = () => {
     const { data: settings, isLoading } = useImpersonationSettings();
@@ -11,26 +12,38 @@ const ImpersonationPanel: FC = () => {
         useUpdateImpersonationSettings();
 
     return (
-        <Group justify="space-between" wrap="nowrap">
-            <Stack gap="xxs">
-                <Text fw={500} fz="sm">
-                    Enable user impersonation
+        <Stack gap="sm">
+            <Group justify="space-between" wrap="nowrap">
+                <Stack gap="xxs">
+                    <Text fw={500} fz="sm">
+                        Enable user impersonation
+                    </Text>
+                    <Text fz="xs" c="ldGray.6">
+                        Allow organization admins to impersonate other users to
+                        see Lightdash from their perspective.
+                    </Text>
+                </Stack>
+                <Switch
+                    checked={settings?.impersonationEnabled ?? false}
+                    disabled={isLoading || isUpdating}
+                    onChange={(event) => {
+                        updateSettings({
+                            impersonationEnabled: event.currentTarget.checked,
+                        });
+                    }}
+                />
+            </Group>
+            <Callout variant="warning">
+                <Text fz="xs">
+                    If the project requires users to provide their own warehouse
+                    credentials, queries run with the impersonated user's{' '}
+                    <Text span inherit fw={700}>
+                        personal warehouse credentials
+                    </Text>{' '}
+                    (including SSO-backed credentials).
                 </Text>
-                <Text fz="xs" c="ldGray.6">
-                    Allow organization admins to impersonate other users to see
-                    Lightdash from their perspective.
-                </Text>
-            </Stack>
-            <Switch
-                checked={settings?.impersonationEnabled ?? false}
-                disabled={isLoading || isUpdating}
-                onChange={(event) => {
-                    updateSettings({
-                        impersonationEnabled: event.currentTarget.checked,
-                    });
-                }}
-            />
-        </Group>
+            </Callout>
+        </Stack>
     );
 };
 


### PR DESCRIPTION
Closes: [GLITCH-345](https://linear.app/lightdash/issue/GLITCH-345/add-disclaimer-on-impersonation-org-setting-about-warehouse)

## Screenshot

<img width="1866" height="484" alt="CleanShot 2026-05-21 at 14 23 44@2x" src="https://github.com/user-attachments/assets/68dbd734-f915-434a-93aa-a8e8b8bce5cd" />

## Description

Adds a warning callout below the **Enable user impersonation** toggle on the organization settings page. The callout makes it clear that — when a project uses per-user warehouse credentials (including SSO-backed ones) — queries run as the impersonated user use *their* personal warehouse credentials. This is a known caveat we want admins to see before enabling impersonation as we move it toward GA.

No behaviour change — copy only.

```
Organization settings → User impersonation
┌───────────────────────────────────────────────────────────────┐
│ Enable user impersonation                              [ ●─ ] │
│ Allow organization admins to impersonate other users …        │
├───────────────────────────────────────────────────────────────┤
│ ⚠ If the project requires users to provide their own          │
│   warehouse credentials, queries run with the impersonated    │
│   user's personal warehouse credentials (including            │
│   SSO-backed credentials).                                    │
└───────────────────────────────────────────────────────────────┘
```

## Test plan

- [ ] Org settings → User impersonation: callout appears below the toggle with yellow warning styling, matches other callouts in the app
- [ ] Verify on light and dark themes