### PR TITLE
fix: prevent dashboard filter popover from dismissing on child popup interaction

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -410,7 +410,7 @@ const FilterConfiguration: FC<Props> = ({
                     </Tabs.List>
                 ) : null}
 
-                <Tabs.Panel value={FilterTabs.SETTINGS} miw={350} maw={520}>
+                <Tabs.Panel value={FilterTabs.SETTINGS} w={400}>
                     <Stack spacing="sm">
                         {isCreatingNew ? (
                             !!fields && fields.length > 0 ? (
@@ -567,9 +567,14 @@ const FilterConfiguration: FC<Props> = ({
                             disabled={
                                 isApplyDisabled || isLockedRequiredMissingValue
                             }
-                            onClick={() => {
+                            // We use onMouseDown instead of onClick: when an
+                            // inline dropdown (Select/MultiSelect) is open,
+                            // Mantine's click-outside detector fires on
+                            // mousedown and the subsequent click event never
+                            // reaches the Apply button — so a real-user click
+                            // would otherwise need two presses to apply.
+                            onMouseDown={() => {
                                 setSelectedTabId(FilterTabs.SETTINGS);
-
                                 if (!!draftFilterRule) onSave(draftFilterRule);
                             }}
                         >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

See thread  https://lightdash.slack.com/archives/C01788UVBUG/p1779365281928669
<img width="608" height="480" alt="Area" src="https://github.com/user-attachments/assets/cbd03d60-88d5-4d85-b6c5-cf15a894e5b9" />




### Description:
 Bug 1: Panel grew horizontally when adding values

  Symptom: Selecting multiple values in a multi-select pushed pills onto the same row, expanding the popover panel width from ~350px up to ~520px.

  Cause: Tabs.Panel value={FilterTabs.SETTINGS} had miw={350} maw={520} — a flexible range that grew with content.

  Fix: Pinned to fixed width.
  -<Tabs.Panel value={FilterTabs.SETTINGS} miw={350} maw={520}>
  +<Tabs.Panel value={FilterTabs.SETTINGS} w={400}>
  Pills now wrap to a new line instead of widening the panel.

  ---
  Bug 2: Apply needed two clicks when a dropdown was open

  Symptom: With an inline dropdown (operator / values / boolean) open, the first click on Apply only closed the dropdown — a second click was needed
  to actually apply and close the popover.

  Cause: Mantine v6's useClickOutside fires on mousedown to close the dropdown, and the subsequent click event on the Apply button never fires (likely
   because the re-render or focus shift swallows it).

  Fix: Switch Apply from onClick to onMouseDown, which fires before Mantine's outside-click detector runs.
  -onClick={() => {
  +onMouseDown={() => {
       setSelectedTabId(FilterTabs.SETTINGS);
       if (!!draftFilterRule) onSave(draftFilterRule);
   }}

