### PR TITLE
feat(ai-agents): show MCP icons in tool calls

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -180,6 +180,7 @@ export type DbAiAgentToolCall = {
     tool_call_id: string;
     tool_name: string;
     tool_args: object;
+    ai_mcp_server_uuid: string | null;
     parent_tool_call_id: string | null;
     created_at: Date;
 };
@@ -192,6 +193,7 @@ export type AiAgentToolCallTable = Knex.CompositeTableType<
         | 'tool_call_id'
         | 'tool_name'
         | 'tool_args'
+        | 'ai_mcp_server_uuid'
         | 'parent_tool_call_id'
     >,
     never

--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -159,6 +159,7 @@ export type DbAiMcpServer = {
     project_uuid: string;
     name: string;
     url: string;
+    icon_url: string | null;
     auth_type: 'none' | 'bearer' | 'oauth';
     connection_status:
         | 'not_connected'

--- a/packages/backend/src/ee/database/migrations/20260521140500_add_icon_and_mcp_server_to_ai_tool_calls.ts
+++ b/packages/backend/src/ee/database/migrations/20260521140500_add_icon_and_mcp_server_to_ai_tool_calls.ts
@@ -1,0 +1,56 @@
+import { Knex } from 'knex';
+
+const AI_MCP_SERVER_TABLE = 'ai_mcp_server';
+const AI_AGENT_TOOL_CALL_TABLE = 'ai_agent_tool_call';
+
+export async function up(knex: Knex): Promise<void> {
+    const hasIconUrl = await knex.schema.hasColumn(
+        AI_MCP_SERVER_TABLE,
+        'icon_url',
+    );
+    const hasMcpServerUuid = await knex.schema.hasColumn(
+        AI_AGENT_TOOL_CALL_TABLE,
+        'ai_mcp_server_uuid',
+    );
+
+    await knex.schema.alterTable(AI_MCP_SERVER_TABLE, (table) => {
+        if (!hasIconUrl) {
+            table.text('icon_url').nullable();
+        }
+    });
+
+    await knex.schema.alterTable(AI_AGENT_TOOL_CALL_TABLE, (table) => {
+        if (!hasMcpServerUuid) {
+            table
+                .uuid('ai_mcp_server_uuid')
+                .nullable()
+                .references('ai_mcp_server_uuid')
+                .inTable(AI_MCP_SERVER_TABLE)
+                .onDelete('SET NULL');
+            table.index(['ai_mcp_server_uuid']);
+        }
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    const hasMcpServerUuid = await knex.schema.hasColumn(
+        AI_AGENT_TOOL_CALL_TABLE,
+        'ai_mcp_server_uuid',
+    );
+    const hasIconUrl = await knex.schema.hasColumn(
+        AI_MCP_SERVER_TABLE,
+        'icon_url',
+    );
+
+    await knex.schema.alterTable(AI_AGENT_TOOL_CALL_TABLE, (table) => {
+        if (hasMcpServerUuid) {
+            table.dropColumn('ai_mcp_server_uuid');
+        }
+    });
+
+    await knex.schema.alterTable(AI_MCP_SERVER_TABLE, (table) => {
+        if (hasIconUrl) {
+            table.dropColumn('icon_url');
+        }
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -18,6 +18,7 @@ import {
     AiAgentSummary,
     AiAgentThreadSummary,
     AiAgentToolCall,
+    AiAgentToolCallMcpServer,
     AiAgentToolResult,
     AiAgentUser,
     AiAgentUserPreferences,
@@ -209,6 +210,12 @@ export type AiMcpCredential = {
 export type AiMcpServerWithSensitiveData = AiMcpServer & {
     resolvedCredential: AiMcpCredentialPayload | null;
     resolvedCredentialScope: AiMcpCredentialScope | null;
+};
+
+type DbAiAgentToolCallWithMcpServer = DbAiAgentToolCall & {
+    mcp_server_uuid: string | null;
+    mcp_server_name: string | null;
+    mcp_server_icon_url: string | null;
 };
 
 export class AiAgentModel {
@@ -648,6 +655,7 @@ export class AiAgentModel {
             projectUuid: row.project_uuid,
             name: row.name,
             url: row.url,
+            iconUrl: row.icon_url,
             authType: row.auth_type,
             ...credentialStatus,
             createdAt: row.created_at,
@@ -747,6 +755,7 @@ export class AiAgentModel {
                 project_uuid: `${AiMcpServerTableName}.project_uuid`,
                 name: `${AiMcpServerTableName}.name`,
                 url: `${AiMcpServerTableName}.url`,
+                icon_url: `${AiMcpServerTableName}.icon_url`,
                 auth_type: `${AiMcpServerTableName}.auth_type`,
                 connection_status: `${AiMcpServerTableName}.connection_status`,
                 error: `${AiMcpServerTableName}.error`,
@@ -799,6 +808,7 @@ export class AiAgentModel {
                 project_uuid: `${AiMcpServerTableName}.project_uuid`,
                 name: `${AiMcpServerTableName}.name`,
                 url: `${AiMcpServerTableName}.url`,
+                icon_url: `${AiMcpServerTableName}.icon_url`,
                 auth_type: `${AiMcpServerTableName}.auth_type`,
                 connection_status: `${AiMcpServerTableName}.connection_status`,
                 error: `${AiMcpServerTableName}.error`,
@@ -940,6 +950,7 @@ export class AiAgentModel {
         projectUuid: string;
         name: string;
         url: string;
+        iconUrl?: string | null;
         authType: ApiCreateAiMcpServer['authType'];
         credentialScope: AiMcpCredentialScope;
         credentials: ApiCreateAiMcpServer['credentials'];
@@ -951,6 +962,7 @@ export class AiAgentModel {
                     project_uuid: args.projectUuid,
                     name: args.name,
                     url: args.url,
+                    icon_url: args.iconUrl ?? null,
                     auth_type: args.authType,
                     connection_status:
                         args.authType === 'oauth' ? null : 'connected',
@@ -984,6 +996,7 @@ export class AiAgentModel {
         serverUuid: string;
         connectionStatus: AiMcpServerConnectionStatus;
         error: string | null;
+        iconUrl?: string | null;
         actorUserUuid?: string | null;
         trx?: Knex;
     }): Promise<void> {
@@ -1000,6 +1013,15 @@ export class AiAgentModel {
         }
 
         if (row.auth_type === 'oauth') {
+            if (args.iconUrl !== undefined) {
+                await trx(AiMcpServerTableName)
+                    .where('ai_mcp_server_uuid', args.serverUuid)
+                    .update({
+                        icon_url: args.iconUrl,
+                        updated_at: trx.fn.now(),
+                    });
+            }
+
             const credential = await this.getCredential(
                 args.serverUuid,
                 'shared',
@@ -1037,6 +1059,9 @@ export class AiAgentModel {
             .update({
                 connection_status: args.connectionStatus,
                 error: args.error,
+                ...(args.iconUrl !== undefined
+                    ? { icon_url: args.iconUrl }
+                    : {}),
                 updated_at: trx.fn.now(),
             });
     }
@@ -1507,6 +1532,7 @@ export class AiAgentModel {
                 project_uuid: `${AiMcpServerTableName}.project_uuid`,
                 name: `${AiMcpServerTableName}.name`,
                 url: `${AiMcpServerTableName}.url`,
+                icon_url: `${AiMcpServerTableName}.icon_url`,
                 auth_type: `${AiMcpServerTableName}.auth_type`,
                 connection_status: `${AiMcpServerTableName}.connection_status`,
                 error: `${AiMcpServerTableName}.error`,
@@ -1565,6 +1591,7 @@ export class AiAgentModel {
                 project_uuid: `${AiMcpServerTableName}.project_uuid`,
                 name: `${AiMcpServerTableName}.name`,
                 url: `${AiMcpServerTableName}.url`,
+                icon_url: `${AiMcpServerTableName}.icon_url`,
                 auth_type: `${AiMcpServerTableName}.auth_type`,
                 connection_status: `${AiMcpServerTableName}.connection_status`,
                 error: `${AiMcpServerTableName}.error`,
@@ -1612,6 +1639,7 @@ export class AiAgentModel {
                 project_uuid: `${AiMcpServerTableName}.project_uuid`,
                 name: `${AiMcpServerTableName}.name`,
                 url: `${AiMcpServerTableName}.url`,
+                icon_url: `${AiMcpServerTableName}.icon_url`,
                 auth_type: `${AiMcpServerTableName}.auth_type`,
                 connection_status: `${AiMcpServerTableName}.connection_status`,
                 error: `${AiMcpServerTableName}.error`,
@@ -4025,6 +4053,7 @@ export class AiAgentModel {
         toolCallId: string;
         toolName: string;
         toolArgs: object;
+        mcpServerUuid?: string | null;
         parentToolCallId: string | null;
     }): Promise<string> {
         const [toolCall] = await this.database(AiAgentToolCallTableName)
@@ -4033,6 +4062,7 @@ export class AiAgentModel {
                 tool_call_id: data.toolCallId,
                 tool_name: data.toolName,
                 tool_args: data.toolArgs,
+                ai_mcp_server_uuid: data.mcpServerUuid ?? null,
                 parent_tool_call_id: data.parentToolCallId,
             })
             .returning('ai_agent_tool_call_uuid');
@@ -4041,7 +4071,27 @@ export class AiAgentModel {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    private parseToolCall(row: DbAiAgentToolCall): AiAgentToolCall {
+    private parseMcpServerForToolCall(
+        row: DbAiAgentToolCall | DbAiAgentToolCallWithMcpServer,
+    ): AiAgentToolCallMcpServer | null {
+        if (!row.ai_mcp_server_uuid) {
+            return null;
+        }
+
+        return {
+            uuid: row.ai_mcp_server_uuid,
+            name:
+                'mcp_server_name' in row && row.mcp_server_name
+                    ? row.mcp_server_name
+                    : 'MCP',
+            iconUrl:
+                'mcp_server_icon_url' in row ? row.mcp_server_icon_url : null,
+        };
+    }
+
+    private parseToolCall(
+        row: DbAiAgentToolCall | DbAiAgentToolCallWithMcpServer,
+    ): AiAgentToolCall {
         const parsedToolName = ToolNameSchema.safeParse(row.tool_name);
 
         if (parsedToolName.success) {
@@ -4066,6 +4116,7 @@ export class AiAgentModel {
                 createdAt: row.created_at,
                 toolType: 'mcp',
                 toolName: row.tool_name,
+                mcpServer: this.parseMcpServerForToolCall(row),
                 toolArgs: row.tool_args,
             };
         }
@@ -4182,10 +4233,21 @@ export class AiAgentModel {
 
     async getToolCallsForPrompt(
         promptUuid: string,
-    ): Promise<DbAiAgentToolCall[]> {
+    ): Promise<DbAiAgentToolCallWithMcpServer[]> {
         return this.database(AiAgentToolCallTableName)
-            .where('ai_prompt_uuid', promptUuid)
-            .orderBy('created_at', 'asc');
+            .leftJoin(
+                AiMcpServerTableName,
+                `${AiAgentToolCallTableName}.ai_mcp_server_uuid`,
+                `${AiMcpServerTableName}.ai_mcp_server_uuid`,
+            )
+            .select<DbAiAgentToolCallWithMcpServer[]>(
+                `${AiAgentToolCallTableName}.*`,
+                `${AiMcpServerTableName}.ai_mcp_server_uuid as mcp_server_uuid`,
+                `${AiMcpServerTableName}.name as mcp_server_name`,
+                `${AiMcpServerTableName}.icon_url as mcp_server_icon_url`,
+            )
+            .where(`${AiAgentToolCallTableName}.ai_prompt_uuid`, promptUuid)
+            .orderBy(`${AiAgentToolCallTableName}.created_at`, 'asc');
     }
 
     async findSqlApprovalContext(toolCallId: string): Promise<
@@ -5719,6 +5781,7 @@ export class AiAgentModel {
                         'tool_call_id',
                         'tool_name',
                         'tool_args',
+                        'ai_mcp_server_uuid',
                         'parent_tool_call_id',
                         'created_at',
                     )
@@ -5729,6 +5792,7 @@ export class AiAgentModel {
                     tool_call_id: toolCall.tool_call_id,
                     tool_name: toolCall.tool_name,
                     tool_args: toolCall.tool_args,
+                    ai_mcp_server_uuid: toolCall.ai_mcp_server_uuid,
                     parent_tool_call_id: toolCall.parent_tool_call_id,
                 }));
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -39,6 +39,12 @@ describe('AiAgentService MCP support', () => {
             const server = new McpServer({
                 name: 'test-mcp-server',
                 version: '1.0.0',
+                icons: [
+                    {
+                        src: '/mcp-icon.svg',
+                        mimeType: 'image/svg+xml',
+                    },
+                ],
             });
 
             const transport = new StreamableHTTPServerTransport({
@@ -123,6 +129,9 @@ describe('AiAgentService MCP support', () => {
         );
 
         expect(mcpServer.hasCredentials).toBe(true);
+        expect(mcpServer.iconUrl).toBe(
+            new URL('/mcp-icon.svg', mcpServerUrl).toString(),
+        );
         expect(mcpServer).not.toHaveProperty('credentials');
 
         const listedMcpServers = await services.aiAgentService.listMcpServers(
@@ -136,6 +145,7 @@ describe('AiAgentService MCP support', () => {
             uuid: mcpServer.uuid,
             name: `Docs MCP ${suffix}`,
             authType: 'bearer',
+            iconUrl: new URL('/mcp-icon.svg', mcpServerUrl).toString(),
             hasCredentials: true,
         });
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1988,20 +1988,23 @@ export class AiAgentService extends BaseService {
                   }
                 : null;
 
+        let mcpConnectionMetadata: { iconUrl: string | null } | null = null;
+
         try {
             if (body.authType !== 'oauth') {
-                await this.aiAgentMcpRuntimeClient.testConnection({
-                    name,
-                    url: normalizedUrl,
-                    authType: body.authType,
-                    bearerToken: credentials?.bearerToken,
-                    onUncaughtError: (error) => {
-                        Logger.error(
-                            `[AiAgent][MCP][${name}] Uncaught MCP client error while validating connection`,
-                            error,
-                        );
-                    },
-                });
+                mcpConnectionMetadata =
+                    await this.aiAgentMcpRuntimeClient.testConnection({
+                        name,
+                        url: normalizedUrl,
+                        authType: body.authType,
+                        bearerToken: credentials?.bearerToken,
+                        onUncaughtError: (error) => {
+                            Logger.error(
+                                `[AiAgent][MCP][${name}] Uncaught MCP client error while validating connection`,
+                                error,
+                            );
+                        },
+                    });
             }
         } catch (error) {
             throw new ParameterError(
@@ -2015,6 +2018,7 @@ export class AiAgentService extends BaseService {
             projectUuid,
             name,
             url: normalizedUrl,
+            iconUrl: mcpConnectionMetadata?.iconUrl ?? null,
             authType: body.authType,
             credentialScope: credentialScope ?? 'shared',
             credentials,

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
@@ -22,6 +22,7 @@ const getMcpServer = (
     projectUuid: 'project-uuid',
     name: 'Docs MCP',
     url: 'https://docs.example.com/mcp',
+    iconUrl: null,
     authType: 'none',
     hasCredentials: false,
     credentialScope: null,
@@ -76,6 +77,15 @@ describe('resolveMcpTools', () => {
                 }
 
                 return {
+                    serverInfo: {
+                        name: 'Docs MCP',
+                        version: '1.0.0',
+                        icons: [
+                            {
+                                src: '/docs-icon.svg',
+                            },
+                        ],
+                    },
                     tools: async () => ({
                         search: { description: 'search tool' },
                     }),
@@ -90,6 +100,9 @@ describe('resolveMcpTools', () => {
         });
 
         expect(Object.keys(result.tools)).toEqual(['mcp_docs_mcp__search']);
+        expect(result.mcpToolNameToServerUuid).toEqual({
+            mcp_docs_mcp__search: healthyServer.uuid,
+        });
         expect(result.unavailableMcpServers).toEqual([
             {
                 serverUuid: 'broken-server',
@@ -103,11 +116,48 @@ describe('resolveMcpTools', () => {
             serverUuid: healthyServer.uuid,
             connectionStatus: 'connected',
             error: null,
+            iconUrl: 'https://docs.example.com/docs-icon.svg',
         });
         expect(aiAgentModel.updateMcpServerRuntimeState).toHaveBeenCalledWith({
             serverUuid: 'broken-server',
             connectionStatus: 'error',
             error: 'We could not connect to the MCP server. Check that it is available and try again.',
+        });
+
+        await result.closeMcpClients();
+        expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects non-image data URI MCP icons', async () => {
+        const close = jest.fn().mockResolvedValue(undefined);
+        const mcpServer = getMcpServer({ name: 'Docs MCP' });
+
+        createHttpMcpClientSpy.mockResolvedValue({
+            serverInfo: {
+                name: 'Docs MCP',
+                version: '1.0.0',
+                icons: [
+                    {
+                        src: 'data:text/html,<script>alert(1)</script>',
+                    },
+                ],
+            },
+            tools: async () => ({
+                search: { description: 'search tool' },
+            }),
+            close,
+        } as unknown as MCPClient);
+
+        const result = await runtimeClient.resolveTools({
+            mcpServers: [mcpServer],
+            debugLoggingEnabled: false,
+        });
+
+        expect(aiAgentModel.updateMcpServerRuntimeState).toHaveBeenCalledWith({
+            serverUuid: mcpServer.uuid,
+            connectionStatus: 'connected',
+            error: null,
+            iconUrl: null,
         });
 
         await result.closeMcpClients();

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -1,4 +1,8 @@
-import { createMCPClient, type MCPClient } from '@ai-sdk/mcp';
+import {
+    createMCPClient,
+    type Configuration,
+    type MCPClient,
+} from '@ai-sdk/mcp';
 import {
     assertUnreachable,
     type AiMcpCredentialScope,
@@ -37,8 +41,25 @@ type Dependencies = {
 
 export type ResolvedMcpTools = {
     tools: ToolSet;
+    mcpToolNameToServerUuid: Record<string, string>;
     unavailableMcpServers: UnavailableMcpServer[];
     closeMcpClients: () => Promise<void>;
+};
+
+export type McpConnectionMetadata = {
+    iconUrl: string | null;
+};
+
+type McpServerIcon = {
+    src: string;
+    mimeType?: string;
+    sizes?: string[];
+    theme?: 'light' | 'dark';
+};
+
+type McpServerInfoWithIcons = Configuration & {
+    icons?: McpServerIcon[];
+    websiteUrl?: string;
 };
 
 const buildDefaultClientMetadata = (
@@ -80,6 +101,49 @@ const fromSdkTokens = (
     tokenType: tokens.token_type,
     scope: tokens.scope,
 });
+
+const resolveMcpIconUrl = (
+    icon: McpServerIcon | undefined,
+    serverUrl: string,
+): string | null => {
+    if (!icon?.src) {
+        return null;
+    }
+
+    if (icon.src.startsWith('data:image/')) {
+        return icon.src;
+    }
+
+    try {
+        const iconUrl = new URL(icon.src, serverUrl);
+        if (!['http:', 'https:'].includes(iconUrl.protocol)) {
+            return null;
+        }
+
+        return iconUrl.toString();
+    } catch {
+        return null;
+    }
+};
+
+const getMcpServerIconUrl = (
+    serverInfo: Configuration,
+    serverUrl: string,
+): string | null => {
+    const { icons, websiteUrl } = serverInfo as McpServerInfoWithIcons;
+
+    if (icons?.length) {
+        const preferredIcon =
+            icons.find((icon) => icon.theme !== 'dark') ?? icons[0];
+        return resolveMcpIconUrl(preferredIcon, serverUrl);
+    }
+
+    try {
+        return new URL('/favicon.svg', websiteUrl ?? serverUrl).toString();
+    } catch {
+        return null;
+    }
+};
 
 export class McpAuthorizationRequiredError extends Error {
     constructor(
@@ -468,11 +532,14 @@ export const createHttpMcpClient = async (
 export const testMcpConnection = async (
     mcpServer: McpServerConnectionArgs,
     onUncaughtError?: (error: unknown) => void,
-): Promise<void> => {
+): Promise<McpConnectionMetadata> => {
     const client = await createHttpMcpClient(mcpServer, onUncaughtError);
 
     try {
         await client.tools();
+        return {
+            iconUrl: getMcpServerIconUrl(client.serverInfo, mcpServer.url),
+        };
     } catch (error) {
         throw normalizeMcpError(mcpServer, error);
     } finally {
@@ -494,6 +561,7 @@ export class AiAgentMcpRuntimeClient {
         serverUuid: string;
         connectionStatus: AiMcpServerConnectionStatus;
         error: string | null;
+        iconUrl?: string | null;
     }) {
         try {
             await this.aiAgentModel.updateMcpServerRuntimeState(args);
@@ -550,8 +618,8 @@ export class AiAgentMcpRuntimeClient {
         authType: 'none' | 'bearer';
         bearerToken?: string;
         onUncaughtError?: (error: unknown) => void;
-    }): Promise<void> {
-        await testMcpConnection(
+    }): Promise<McpConnectionMetadata> {
+        return testMcpConnection(
             {
                 uuid: 'create-mcp-server-validation',
                 name: args.name,
@@ -694,6 +762,7 @@ export class AiAgentMcpRuntimeClient {
         if (args.mcpServers.length === 0) {
             return {
                 tools: {},
+                mcpToolNameToServerUuid: {},
                 unavailableMcpServers: [],
                 closeMcpClients: async () => undefined,
             };
@@ -702,6 +771,7 @@ export class AiAgentMcpRuntimeClient {
         const connectedClients: MCPClient[] = [];
         const usedToolNames = new Set<string>();
         const resolvedTools: ToolSet = {};
+        const mcpToolNameToServerUuid: Record<string, string> = {};
         const unavailableMcpServers: UnavailableMcpServer[] = [];
 
         const serverResults = await Promise.all(
@@ -725,6 +795,10 @@ export class AiAgentMcpRuntimeClient {
                         serverUuid: mcpServer.uuid,
                         connectionStatus: 'connected',
                         error: null,
+                        iconUrl: getMcpServerIconUrl(
+                            mcpClient.serverInfo,
+                            mcpServer.url,
+                        ),
                     });
 
                     return {
@@ -799,6 +873,8 @@ export class AiAgentMcpRuntimeClient {
                     }
 
                     usedToolNames.add(namespacedToolName);
+                    mcpToolNameToServerUuid[namespacedToolName] =
+                        serverResult.mcpServer.uuid;
                     resolvedTools[namespacedToolName] =
                         toolDefinition as ToolSet[string];
                 }
@@ -807,6 +883,7 @@ export class AiAgentMcpRuntimeClient {
 
         return {
             tools: resolvedTools,
+            mcpToolNameToServerUuid,
             unavailableMcpServers,
             closeMcpClients: async () => {
                 const results = await Promise.allSettled(

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -73,6 +73,7 @@ const withToolHints = (
 
 export type AgentMcpToolSetup = {
     tools: ToolSet;
+    mcpToolNameToServerUuid: Record<string, string>;
     unavailableMcpServers: UnavailableMcpServer[];
     closeMcpClients: () => Promise<void>;
 };
@@ -415,6 +416,10 @@ export const generateAgentResponse = async ({
                                     toolCallId: toolCall.toolCallId,
                                     toolName: toolCall.toolName,
                                     toolArgs: toolCall.input as object,
+                                    mcpServerUuid:
+                                        mcpToolSetup.mcpToolNameToServerUuid[
+                                            toolCall.toolName
+                                        ] ?? null,
                                     parentToolCallId: null,
                                 });
                             }
@@ -626,6 +631,10 @@ export const streamAgentResponse = async ({
                                 toolCallId: event.chunk.toolCallId,
                                 toolName: event.chunk.toolName,
                                 toolArgs: event.chunk.input as object,
+                                mcpServerUuid:
+                                    mcpToolSetup.mcpToolNameToServerUuid[
+                                        event.chunk.toolName
+                                    ] ?? null,
                                 parentToolCallId: null,
                             })
                             .catch((error) => {

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -171,6 +171,7 @@ export type StoreToolCallFn = (data: {
     toolCallId: string;
     toolName: string;
     toolArgs: object;
+    mcpServerUuid?: string | null;
     parentToolCallId: string | null;
 }) => Promise<void>;
 

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -53,6 +53,7 @@ export type AiMcpServer = {
     projectUuid: string;
     name: string;
     url: string;
+    iconUrl: string | null;
     authType: AiMcpServerAuthType;
     hasCredentials: boolean;
     credentialScope: AiMcpCredentialScope | null;
@@ -445,6 +446,11 @@ export type AiAgentMcpToolName = string;
 export type AiAgentToolType = 'built-in' | 'mcp';
 export type AiAgentToolName = ToolName | AiAgentMcpToolName;
 
+export type AiAgentToolCallMcpServer = Pick<
+    AiMcpServer,
+    'uuid' | 'name' | 'iconUrl'
+>;
+
 export const isAiAgentMcpToolName = (
     toolName: string,
 ): toolName is AiAgentMcpToolName => toolName.startsWith('mcp_');
@@ -474,6 +480,7 @@ export type AiAgentToolCall = AiAgentBaseToolCall &
         | {
               toolType: 'mcp';
               toolName: AiAgentMcpToolName;
+              mcpServer: AiAgentToolCallMcpServer | null;
           }
     );
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -1,6 +1,7 @@
 import {
     type AiAgentToolName,
     type AiAgentMessageAssistant,
+    type AiMcpServer,
     isToolProposeChangeResult,
     type ToolProposeChangeArgs,
 } from '@lightdash/common';
@@ -299,7 +300,8 @@ const AssistantBubbleContent: FC<{
     message: AiAgentMessageAssistant;
     projectUuid: string;
     agentUuid: string;
-}> = ({ message, projectUuid, agentUuid }) => {
+    mcpServers?: AiMcpServer[];
+}> = ({ message, projectUuid, agentUuid, mcpServers }) => {
     const canManageAgents = useAiAgentPermission({
         action: 'manage',
         projectUuid,
@@ -639,6 +641,7 @@ const AssistantBubbleContent: FC<{
                                     isLive={isStreaming}
                                     toolResults={message.toolResults}
                                     toolCalls={message.toolCalls}
+                                    mcpServers={mcpServers}
                                     pendingContent={pendingApprovalContent}
                                 />
                             )}
@@ -680,6 +683,7 @@ const AssistantBubbleContent: FC<{
                                 isLive={isStreaming || isPending}
                                 toolResults={message.toolResults}
                                 toolCalls={message.toolCalls}
+                                mcpServers={mcpServers}
                             />
                         )}
                         {message.reasoning && message.reasoning.length > 0 && (
@@ -768,6 +772,7 @@ type Props = {
     onAddToEvals?: (promptUuid: string) => void;
     renderArtifactsInline?: boolean;
     showAddToEvalsButton?: boolean;
+    mcpServers?: AiMcpServer[];
 };
 
 export const AssistantBubble: FC<Props> = memo(
@@ -780,6 +785,7 @@ export const AssistantBubble: FC<Props> = memo(
         onAddToEvals,
         renderArtifactsInline = false,
         showAddToEvalsButton = false,
+        mcpServers,
     }) => {
         const artifact = useAiAgentStoreSelector(
             (state) => state.aiArtifact.artifact,
@@ -872,6 +878,7 @@ export const AssistantBubble: FC<Props> = memo(
                     message={message}
                     projectUuid={projectUuid}
                     agentUuid={agentUuid}
+                    mcpServers={mcpServers}
                 />
 
                 {isArtifactAvailable && projectUuid && agentUuid && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -17,6 +17,7 @@ import {
     type PropsWithChildren,
 } from 'react';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
+import { useAgentAiMcpServers } from '../../hooks/useProjectAiMcpServers';
 import { AddToEvalModal } from '../Admin/AddToEvalModal';
 import { AssistantBubble } from './AgentChatAssistantBubble';
 import styles from './AgentChatDisplay.module.css';
@@ -97,6 +98,9 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
     showAddToEvalsButton = false,
 }) => {
     const viewport = useRef<HTMLDivElement>(null);
+    const { data: mcpServers } = useAgentAiMcpServers(projectUuid, agentUuid, {
+        enabled: !!projectUuid && !!agentUuid,
+    });
     const [addToEvalsPromptUuid, setAddToEvalsPromptUuid] = useState<
         string | null
     >(null);
@@ -167,6 +171,7 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                                 showAddToEvalsButton={
                                                     showAddToEvalsButton
                                                 }
+                                                mcpServers={mcpServers}
                                                 renderArtifactsInline={
                                                     renderArtifactsInline
                                                 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.module.css
@@ -132,6 +132,41 @@
     animation: livePulse 1.8s ease-in-out infinite;
 }
 
+.mcpSummaryIconStack {
+    flex-shrink: 0;
+    margin-left: 2px;
+}
+
+.mcpSummaryIcon {
+    position: relative;
+    z-index: var(--mcp-summary-icon-z-index);
+    width: 15px;
+    height: 15px;
+    min-width: 15px;
+    margin-left: -4px;
+}
+
+.mcpSummaryIcon:first-child {
+    margin-left: 0;
+}
+
+.mcpSummaryOverflow {
+    position: relative;
+    z-index: 0;
+    display: inline-flex;
+    align-items: center;
+    height: 15px;
+    margin-left: -3px;
+    padding: 0 3px 0 5px;
+    border-radius: 999px;
+    background-color: var(--mantine-color-ldGray-1);
+    color: var(--mantine-color-ldGray-6);
+    box-shadow: inset 0 0 0 0.5px var(--mantine-color-ldGray-3);
+    font-size: 9px;
+    font-weight: 600;
+    line-height: 1;
+}
+
 .latestMcpLabel {
     min-width: 0;
     animation: labelSettle 260ms ease-out;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -4,7 +4,7 @@ import {
     type AiAgentToolCall,
     type AiAgentToolName,
     type AiAgentToolResult,
-    friendlyName,
+    type AiMcpServer,
     isToolName,
 } from '@lightdash/common';
 import {
@@ -26,9 +26,14 @@ import { ToolCallDescription } from './descriptions/ToolCallDescription';
 import { DiscoverFieldsTrace, type TraceEntry } from './DiscoverFieldsTrace';
 import styles from './LiveActivityCard.module.css';
 import { ToolCallChip } from './ToolCallChip';
+import { ToolCallIcon } from './ToolCallIcon';
 import { ToolCallRow } from './ToolCallRow';
 import { getActivityTitle } from './utils/getActivityTitle';
 import { getToolCallChipLabel } from './utils/getToolCallChipLabel';
+import {
+    getMcpServerForToolName,
+    getMcpToolDisplayMetadata,
+} from './utils/mcpToolDisplay';
 import { stripMarkdown } from './utils/stripMarkdown';
 import { getToolIcon } from './utils/toolIcons';
 import { type ToolCallSummary } from './utils/types';
@@ -50,6 +55,7 @@ type Props = {
     toolResults?: AiAgentToolResult[];
     /** All tool calls for the message. Used to resolve subagent children via parentToolCallId. */
     toolCalls?: AiAgentToolCall[];
+    mcpServers?: AiMcpServer[];
     /**
      * Pending interactive content (e.g. SqlApprovalCard awaiting user
      * decision). When present, the card auto-expands and renders this in the
@@ -68,10 +74,64 @@ const TOOLS_WITHOUT_PREVIEW = new Set<string>([
     'runSavedChart',
 ]);
 
-const getMcpDisplayName = (toolName: string) => {
-    const maybeServerName = toolName.replace(/^mcp_/, '').split('__')[0];
+const MCP_SUMMARY_ICON_LIMIT = 4;
 
-    return maybeServerName ? friendlyName(maybeServerName) : 'Tool';
+const getMcpSummaryIcons = (
+    toolGroups: LiveActivityToolGroup[],
+    mcpServers?: AiMcpServer[],
+) => {
+    const seen = new Set<string>();
+
+    return toolGroups.flatMap((group) => {
+        if (isToolName(group.toolName)) return [];
+
+        const linkedMcpServer =
+            group.calls.find((toolCall) => toolCall.mcpServer)?.mcpServer ??
+            undefined;
+        const mcpServer =
+            linkedMcpServer ??
+            getMcpServerForToolName(group.toolName, mcpServers);
+        const metadata = getMcpToolDisplayMetadata(group.toolName, mcpServer);
+        const key = mcpServer?.uuid ?? metadata.label;
+
+        if (seen.has(key)) return [];
+        seen.add(key);
+
+        return [{ toolName: group.toolName, mcpServer, key }];
+    });
+};
+
+const McpSummaryIconStack: FC<{
+    toolGroups: LiveActivityToolGroup[];
+    mcpServers?: AiMcpServer[];
+}> = ({ toolGroups, mcpServers }) => {
+    const icons = getMcpSummaryIcons(toolGroups, mcpServers);
+    if (icons.length === 0) return null;
+
+    const visibleIcons = icons.slice(0, MCP_SUMMARY_ICON_LIMIT);
+    const overflow = icons.length - visibleIcons.length;
+
+    return (
+        <Group gap={0} wrap="nowrap" className={styles.mcpSummaryIconStack}>
+            {visibleIcons.map((icon, idx) => (
+                <ToolCallIcon
+                    key={icon.key}
+                    toolName={icon.toolName}
+                    mcpServer={icon.mcpServer}
+                    className={styles.mcpSummaryIcon}
+                    style={
+                        {
+                            '--mcp-summary-icon-z-index':
+                                visibleIcons.length - idx,
+                        } as React.CSSProperties
+                    }
+                />
+            ))}
+            {overflow > 0 && (
+                <Box className={styles.mcpSummaryOverflow}>+{overflow}</Box>
+            )}
+        </Group>
+    );
 };
 
 export const ReasoningHistoryRow: FC<{
@@ -137,9 +197,7 @@ export const ReasoningHistoryRow: FC<{
                         icon={IconChevronRight}
                         size={11}
                         stroke={1.6}
-                        className={`${styles.chevron} ${
-                            open ? styles.chevronOpen : ''
-                        }`}
+                        className={`${styles.chevron} ${open ? styles.chevronOpen : ''}`}
                     />
                 </Group>
             </UnstyledButton>
@@ -169,12 +227,22 @@ export const ReasoningHistoryRow: FC<{
     );
 };
 
-const LatestRow: FC<{ group: LiveActivityToolGroup; isLive: boolean }> = ({
-    group,
-    isLive,
-}) => {
-    const Icon = getToolIcon(group.toolName);
+const LatestRow: FC<{
+    group: LiveActivityToolGroup;
+    isLive: boolean;
+    mcpServers?: AiMcpServer[];
+}> = ({ group, isLive, mcpServers }) => {
     const builtInToolName = isToolName(group.toolName) ? group.toolName : null;
+    const linkedMcpServer =
+        group.calls.find((toolCall) => toolCall.mcpServer)?.mcpServer ??
+        undefined;
+    const mcpServer = builtInToolName
+        ? undefined
+        : (linkedMcpServer ??
+          getMcpServerForToolName(group.toolName, mcpServers));
+    const mcpDisplayMetadata = builtInToolName
+        ? undefined
+        : getMcpToolDisplayMetadata(group.toolName, mcpServer);
     const label = builtInToolName
         ? isLive
             ? TOOL_DISPLAY_MESSAGES[builtInToolName]
@@ -205,11 +273,12 @@ const LatestRow: FC<{ group: LiveActivityToolGroup; isLive: boolean }> = ({
                     className={styles.iconChip}
                     data-live={isLive ? 'true' : 'false'}
                 >
-                    <MantineIcon
-                        icon={Icon}
+                    <ToolCallIcon
+                        toolName={group.toolName}
                         size={12}
                         stroke={1.7}
                         className={styles.latestIcon}
+                        mcpServer={mcpServer}
                         data-live={isLive ? 'true' : 'false'}
                     />
                 </Box>
@@ -230,7 +299,7 @@ const LatestRow: FC<{ group: LiveActivityToolGroup; isLive: boolean }> = ({
                     key={`label-${group.toolName}-${isLive ? 'live' : 'done'}`}
                 >
                     <Text size="xs" className={styles.latestLabel}>
-                        Using MCP {getMcpDisplayName(group.toolName)}:
+                        Using MCP {mcpDisplayMetadata?.label ?? 'MCP'}:
                     </Text>
                     <ToolCallChip
                         maxWidth={260}
@@ -399,6 +468,7 @@ export const LiveActivityCard: FC<Props> = ({
     isLive,
     toolResults,
     toolCalls,
+    mcpServers,
     pendingContent,
 }) => {
     const [userExpanded, setUserExpanded] = useState(false);
@@ -489,11 +559,19 @@ export const LiveActivityCard: FC<Props> = ({
                                         >
                                             {summary.title}
                                         </Text>
+                                        <McpSummaryIconStack
+                                            toolGroups={toolGroups}
+                                            mcpServers={mcpServers}
+                                        />
                                     </Group>
                                 );
                             })()
                         ) : latest ? (
-                            <LatestRow group={latest} isLive={isLive} />
+                            <LatestRow
+                                group={latest}
+                                isLive={isLive}
+                                mcpServers={mcpServers}
+                            />
                         ) : hasPending ? (
                             <Group
                                 gap={8}
@@ -646,6 +724,7 @@ export const LiveActivityCard: FC<Props> = ({
                                             toolCalls={group.calls}
                                             status="done"
                                             toolResults={toolResults}
+                                            mcpServers={mcpServers}
                                             extraBody={
                                                 groupTrace ? (
                                                     <DiscoverFieldsTrace

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallIcon.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallIcon.module.css
@@ -1,0 +1,44 @@
+.mcpIcon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    min-width: 16px;
+    box-sizing: border-box;
+    border-radius: 4px;
+    background-color: var(--mcp-icon-bg, var(--mantine-color-ldGray-7));
+    color: var(--mcp-icon-color, var(--mantine-color-white));
+    border: 1px solid var(--mcp-icon-border, transparent);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+    font-size: 7px;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    flex-shrink: 0;
+}
+
+.mcpIcon[data-has-image='true'] {
+    padding: 2px;
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-ldGray-1)
+    );
+    border-color: transparent;
+    box-shadow:
+        inset 0 0 0 0.5px
+            light-dark(
+                var(--mantine-color-ldGray-3),
+                var(--mantine-color-ldGray-4)
+            ),
+        0 1px 2px light-dark(rgba(15, 23, 42, 0.07), rgba(0, 0, 0, 0.28));
+}
+
+.mcpFavicon {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 3px;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallIcon.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallIcon.tsx
@@ -1,0 +1,74 @@
+import { isToolName, type AiAgentToolName } from '@lightdash/common';
+import { Box } from '@mantine-8/core';
+import { useState, type CSSProperties, type FC } from 'react';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
+import styles from './ToolCallIcon.module.css';
+import {
+    getMcpToolDisplayMetadata,
+    type McpDisplayServer,
+} from './utils/mcpToolDisplay';
+import { getToolIcon } from './utils/toolIcons';
+
+type Props = {
+    toolName: AiAgentToolName;
+    size?: number;
+    stroke?: number;
+    className?: string;
+    style?: CSSProperties;
+    mcpServer?: McpDisplayServer;
+    'data-live'?: 'true' | 'false';
+    'data-status'?: string;
+};
+
+export const ToolCallIcon: FC<Props> = ({
+    toolName,
+    size = 13,
+    stroke = 1.6,
+    className,
+    style,
+    mcpServer,
+    ...dataAttributes
+}) => {
+    const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
+
+    if (isToolName(toolName)) {
+        const Icon = getToolIcon(toolName);
+        return (
+            <MantineIcon
+                icon={Icon}
+                size={size}
+                stroke={stroke}
+                className={className}
+                {...dataAttributes}
+            />
+        );
+    }
+
+    const displayMetadata = getMcpToolDisplayMetadata(toolName, mcpServer);
+    const shouldShowFavicon =
+        displayMetadata.iconUrl && displayMetadata.iconUrl !== failedIconUrl;
+
+    return (
+        <Box
+            component="span"
+            aria-hidden
+            className={`${styles.mcpIcon} ${className ?? ''}`}
+            style={style}
+            data-provider={displayMetadata.kind}
+            data-has-image={shouldShowFavicon ? 'true' : 'false'}
+            {...dataAttributes}
+        >
+            {shouldShowFavicon ? (
+                <Box
+                    component="img"
+                    src={displayMetadata.iconUrl!}
+                    alt=""
+                    className={styles.mcpFavicon}
+                    onError={() => setFailedIconUrl(displayMetadata.iconUrl)}
+                />
+            ) : (
+                displayMetadata.shortLabel
+            )}
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
@@ -3,7 +3,7 @@ import {
     TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL,
     type AiAgentToolResult,
     type AiAgentToolName,
-    friendlyName,
+    type AiMcpServer,
     isToolName,
     type ToolName,
 } from '@lightdash/common';
@@ -20,9 +20,13 @@ import { useState, type FC } from 'react';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { ToolCallDescription } from './descriptions/ToolCallDescription';
 import { ToolCallChip } from './ToolCallChip';
+import { ToolCallIcon } from './ToolCallIcon';
 import styles from './ToolCallRow.module.css';
 import { getToolCallChipLabel } from './utils/getToolCallChipLabel';
-import { getToolIcon } from './utils/toolIcons';
+import {
+    getMcpServerForToolName,
+    getMcpToolDisplayMetadata,
+} from './utils/mcpToolDisplay';
 import { type ToolCallSummary } from './utils/types';
 
 const TOOLS_WITHOUT_DESCRIPTION = new Set<ToolName>([
@@ -39,18 +43,13 @@ const HIDE_INLINE_PREVIEW = new Set<ToolName>(['runSql']);
 // Max chips shown inline when collapsed before "+N more".
 const MAX_CHIPS_COLLAPSED = 3;
 
-const getMcpDisplayName = (toolName: string) => {
-    const maybeServerName = toolName.replace(/^mcp_/, '').split('__')[0];
-
-    return maybeServerName ? friendlyName(maybeServerName) : 'Tool';
-};
-
 export type ToolCallRowStatus = 'running' | 'done' | 'error';
 
 type Props = {
     toolName: AiAgentToolName;
     toolCalls: ToolCallSummary[];
     status?: ToolCallRowStatus;
+    mcpServers?: AiMcpServer[];
     /**
      * Optional extra content rendered inside the expanded body, below the
      * per-call descriptions. Used to surface things like the discoverFields
@@ -64,11 +63,20 @@ export const ToolCallRow: FC<Props> = ({
     toolName,
     toolCalls,
     status = 'done',
+    mcpServers,
     extraBody,
     toolResults,
 }) => {
-    const Icon = getToolIcon(toolName);
     const builtInToolName = isToolName(toolName) ? toolName : null;
+    const linkedMcpServer =
+        toolCalls.find((toolCall) => toolCall.mcpServer)?.mcpServer ??
+        undefined;
+    const mcpServer = builtInToolName
+        ? undefined
+        : (linkedMcpServer ?? getMcpServerForToolName(toolName, mcpServers));
+    const mcpDisplayMetadata = builtInToolName
+        ? undefined
+        : getMcpToolDisplayMetadata(toolName, mcpServer);
     const label = builtInToolName
         ? status === 'running'
             ? TOOL_DISPLAY_MESSAGES[builtInToolName]
@@ -145,11 +153,12 @@ export const ToolCallRow: FC<Props> = ({
 
     const head = (
         <Group gap={8} align="center" wrap="nowrap" className={styles.head}>
-            <MantineIcon
-                icon={Icon}
+            <ToolCallIcon
+                toolName={toolName}
                 size={13}
                 stroke={1.6}
                 className={styles.icon}
+                mcpServer={mcpServer}
                 data-status={status}
             />
             {label ? (
@@ -158,7 +167,7 @@ export const ToolCallRow: FC<Props> = ({
                 </Text>
             ) : (
                 <Text size="xs" className={styles.label}>
-                    Used MCP {getMcpDisplayName(toolName)}:{' '}
+                    Used MCP {mcpDisplayMetadata?.label ?? 'MCP'}:{' '}
                     <ToolCallChip maxWidth={260} className={styles.mcpToolChip}>
                         {toolName}
                     </ToolCallChip>
@@ -173,9 +182,7 @@ export const ToolCallRow: FC<Props> = ({
                     icon={IconChevronRight}
                     size={11}
                     stroke={1.6}
-                    className={`${styles.chevron} ${
-                        expanded ? styles.chevronOpen : ''
-                    }`}
+                    className={`${styles.chevron} ${expanded ? styles.chevronOpen : ''}`}
                 />
             )}
         </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getActivityTitle.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getActivityTitle.ts
@@ -1,8 +1,8 @@
 import {
     IconChartLine,
     IconLayoutDashboard,
+    IconRoute,
     IconSearch,
-    IconSparkles,
     type TablerIconsProps,
 } from '@tabler/icons-react';
 import type { JSX } from 'react';
@@ -41,7 +41,7 @@ export const getActivityTitle = (
     toolGroups: LiveActivityToolGroup[],
 ): ActivityTitle => {
     if (toolGroups.length === 0) {
-        return { title: 'Steps taken', icon: IconSparkles };
+        return { title: 'Steps taken', icon: IconRoute };
     }
     const toolNames = toolGroups.map((g) => g.toolName);
     const hasDashboard = toolNames.includes('generateDashboard');
@@ -65,5 +65,5 @@ export const getActivityTitle = (
     if (onlySearches) {
         return { title: 'Research steps', icon: IconSearch };
     }
-    return { title: 'Steps taken', icon: IconSparkles };
+    return { title: 'Steps taken', icon: IconRoute };
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getMcpProviderMetadata,
+    getMcpServerDisplayName,
+    getMcpServerForToolName,
+    getMcpToolParts,
+    getMcpToolDisplayMetadata,
+    sanitizeMcpToolKeyPart,
+} from './mcpToolDisplay';
+
+describe('mcpToolDisplay', () => {
+    it('extracts the MCP server and tool key from namespaced tool names', () => {
+        expect(getMcpToolParts('mcp_github__create_issue')).toEqual({
+            serverKey: 'github',
+            toolKey: 'create_issue',
+        });
+    });
+
+    it('falls back to a readable server display name', () => {
+        expect(getMcpProviderMetadata('mcp_github__search_repos')).toEqual({
+            kind: 'generic',
+            label: 'Github',
+            shortLabel: 'G',
+        });
+
+        expect(getMcpServerDisplayName('mcp_internal_tools__lookup')).toBe(
+            'Internal tools',
+        );
+    });
+
+    it('uses the same server name sanitization as backend MCP tool names', () => {
+        expect(sanitizeMcpToolKeyPart('Acme Docs MCP')).toBe('acme_docs_mcp');
+    });
+
+    it('matches tool calls to attached MCP servers and uses the stored icon URL', () => {
+        const mcpServer = {
+            uuid: 'server-1',
+            projectUuid: 'project-1',
+            name: 'Acme Docs MCP',
+            url: 'https://docs.example.com/mcp',
+            iconUrl: 'https://docs.example.com/icon.svg',
+            authType: 'oauth',
+            hasCredentials: true,
+            credentialScope: 'shared',
+            connectionStatus: 'connected',
+            error: null,
+            connectedByUserUuid: 'user-1',
+            createdAt: new Date('2026-01-01T00:00:00Z'),
+            updatedAt: new Date('2026-01-01T00:00:00Z'),
+        } as const;
+
+        expect(
+            getMcpServerForToolName('mcp_acme_docs_mcp__search', [mcpServer]),
+        ).toBe(mcpServer);
+
+        expect(
+            getMcpToolDisplayMetadata('mcp_acme_docs_mcp__search', mcpServer),
+        ).toMatchObject({
+            kind: 'generic',
+            label: 'Acme Docs MCP',
+            iconUrl: 'https://docs.example.com/icon.svg',
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.ts
@@ -1,0 +1,113 @@
+import {
+    friendlyName,
+    type AiAgentToolCallMcpServer,
+    type AiMcpServer,
+} from '@lightdash/common';
+
+export type McpProviderKind = 'generic';
+
+export type McpProviderMetadata = {
+    kind: McpProviderKind;
+    label: string;
+    shortLabel: string;
+    fallbackIconUrl?: string;
+};
+
+export type McpToolDisplayMetadata = McpProviderMetadata & {
+    iconUrl: string | null;
+};
+
+export type McpDisplayServer =
+    | AiMcpServer
+    | AiAgentToolCallMcpServer
+    | undefined;
+
+export const getMcpToolParts = (toolName: string) => {
+    if (!toolName.startsWith('mcp_')) {
+        return null;
+    }
+
+    const withoutPrefix = toolName.replace(/^mcp_/, '');
+    const [serverKey, toolKey] = withoutPrefix.split('__');
+
+    return {
+        serverKey: serverKey || 'tool',
+        toolKey: toolKey || null,
+    };
+};
+
+export const sanitizeMcpToolKeyPart = (value: string) => {
+    const sanitized = value
+        .replace(/[^a-zA-Z0-9_]+/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_+/, '')
+        .replace(/_+$/, '');
+    return sanitized.length > 0 ? sanitized.toLowerCase() : 'tool';
+};
+
+const getShortLabel = (label: string) =>
+    label
+        .split(/\s+/)
+        .map((part) => part[0])
+        .join('')
+        .slice(0, 2) || 'M';
+
+export const getMcpProviderMetadata = (
+    toolName: string,
+): McpProviderMetadata => {
+    const parts = getMcpToolParts(toolName);
+    if (!parts) {
+        return {
+            kind: 'generic',
+            label: 'MCP',
+            shortLabel: 'M',
+        };
+    }
+
+    const fallbackLabel = friendlyName(parts.serverKey);
+    const label = fallbackLabel || 'MCP';
+
+    return {
+        kind: 'generic',
+        label,
+        shortLabel: getShortLabel(label),
+    };
+};
+
+export const getMcpServerDisplayName = (toolName: string) =>
+    getMcpProviderMetadata(toolName).label;
+
+export const getMcpServerForToolName = (
+    toolName: string,
+    mcpServers: AiMcpServer[] | undefined,
+) => {
+    const parts = getMcpToolParts(toolName);
+    if (!parts || !mcpServers?.length) {
+        return undefined;
+    }
+
+    return mcpServers.find(
+        (server) => sanitizeMcpToolKeyPart(server.name) === parts.serverKey,
+    );
+};
+
+const getConfiguredIconUrl = (mcpServer: McpDisplayServer) => {
+    if (!mcpServer) {
+        return null;
+    }
+
+    return mcpServer.iconUrl ?? null;
+};
+
+export const getMcpToolDisplayMetadata = (
+    toolName: string,
+    mcpServer: McpDisplayServer,
+): McpToolDisplayMetadata => {
+    const provider = getMcpProviderMetadata(toolName);
+    return {
+        ...provider,
+        label: mcpServer?.name ?? provider.label,
+        iconUrl:
+            getConfiguredIconUrl(mcpServer) ?? provider.fallbackIconUrl ?? null,
+    };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/types.ts
@@ -1,9 +1,13 @@
-import { type AiAgentToolName } from '@lightdash/common';
+import {
+    type AiAgentToolCallMcpServer,
+    type AiAgentToolName,
+} from '@lightdash/common';
 
 export type ToolCallSummary = {
     toolCallId: string;
     toolName: AiAgentToolName;
     toolArgs: unknown;
+    mcpServer?: AiAgentToolCallMcpServer | null;
     /**
      * The tool's output once it has resolved. Populated for live streaming
      * (preliminary) updates and for the final result. `undefined` while the


### PR DESCRIPTION
## Summary
- Persist MCP server icons and link MCP tool calls back to their source MCP server
- Show MCP favicons/brand icons in live and completed tool-call rows
- Add a compact stacked MCP icon summary to the collapsed activity header

## Validation
- `pnpm -F common build`
- `pnpm -F frontend exec oxlint src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallIcon.tsx src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getActivityTitle.ts src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.ts src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.test.ts`
- `pnpm -F frontend test -- mcpToolDisplay.test.ts`
- `pnpm -F backend test -- src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts`
- `git diff --check`
