### PR TITLE
fix(snowflake): avoid warehouse resume on session setup

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -500,17 +500,20 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         }
 
         const timezoneQuery = options?.timezone || 'UTC';
+        console.debug(`Setting Snowflake session timezone to ${timezoneQuery}`);
         sessionParams.push(`TIMEZONE = '${timezoneQuery}'`);
 
         // Force FALSE to avoid casing inconsistencies between Snowflake and Lightdash.
+        console.debug(
+            'Setting Snowflake session QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE',
+        );
         sessionParams.push(`QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE`);
 
         const timeoutSeconds = this.credentials.timeoutSeconds ?? 300;
-        sessionParams.push(`STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`);
-
         console.debug(
-            `Setting Snowflake session params: ${sessionParams.join(', ')}`,
+            `Setting Snowflake session STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`,
         );
+        sessionParams.push(`STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`);
 
         await this.executeStatements(
             connection,

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -476,62 +476,45 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             tags?: Record<string, string>;
         },
     ) {
-        const sqlStatements: string[] = [];
-
+        // MULTI_STATEMENT routes through Snowflake's stored-procedure path and resumes the warehouse, so send each statement individually to keep ALTER SESSION on the cloud-services layer.
         if (this.connectionOptions.warehouse) {
-            // eslint-disable-next-line no-console
             console.debug(
                 `Running snowflake query on warehouse: ${this.connectionOptions.warehouse}`,
             );
-            sqlStatements.push(
+            await this.executeStatements(
+                connection,
                 `USE WAREHOUSE ${this.connectionOptions.warehouse};`,
             );
         }
 
+        const sessionParams: string[] = [];
+
         const startOfWeek = this.getStartOfWeek();
         if (isWeekDay(startOfWeek)) {
-            const snowflakeStartOfWeekIndex = startOfWeek + 1; // 1 (Monday) to 7 (Sunday):
-            sqlStatements.push(
-                `ALTER SESSION SET WEEK_START = ${snowflakeStartOfWeekIndex};`,
-            );
+            const snowflakeStartOfWeekIndex = startOfWeek + 1; // 1 (Monday) to 7 (Sunday)
+            sessionParams.push(`WEEK_START = ${snowflakeStartOfWeekIndex}`);
         }
 
         if (options?.tags) {
-            sqlStatements.push(
-                `ALTER SESSION SET QUERY_TAG = '${JSON.stringify(
-                    options?.tags,
-                )}';`,
-            );
+            sessionParams.push(`QUERY_TAG = '${JSON.stringify(options.tags)}'`);
         }
 
         const timezoneQuery = options?.timezone || 'UTC';
-        console.debug(`Setting Snowflake session timezone to ${timezoneQuery}`);
-        sqlStatements.push(`ALTER SESSION SET TIMEZONE = '${timezoneQuery}';`);
+        sessionParams.push(`TIMEZONE = '${timezoneQuery}'`);
 
-        /**
-         * Force QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE to avoid casing inconsistencies
-         * between Snowflake <> Lightdash
-         */
-        console.debug(
-            'Setting Snowflake session QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE',
-        );
-        sqlStatements.push(
-            `ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;`,
-        );
+        // Force FALSE to avoid casing inconsistencies between Snowflake and Lightdash.
+        sessionParams.push(`QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE`);
 
-        // Default timeout to 300 seconds if not specified
         const timeoutSeconds = this.credentials.timeoutSeconds ?? 300;
+        sessionParams.push(`STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`);
+
         console.debug(
-            `Setting Snowflake session STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`,
-        );
-        sqlStatements.push(
-            `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds};`,
+            `Setting Snowflake session params: ${sessionParams.join(', ')}`,
         );
 
         await this.executeStatements(
             connection,
-            sqlStatements.join('\n'),
-            sqlStatements.length,
+            `ALTER SESSION SET ${sessionParams.join(', ')};`,
         );
     }
 

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -476,8 +476,8 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             tags?: Record<string, string>;
         },
     ) {
-        // MULTI_STATEMENT routes through Snowflake's stored-procedure path and resumes the warehouse, so send each statement individually to keep ALTER SESSION on the cloud-services layer.
         if (this.connectionOptions.warehouse) {
+            // eslint-disable-next-line no-console
             console.debug(
                 `Running snowflake query on warehouse: ${this.connectionOptions.warehouse}`,
             );
@@ -491,7 +491,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
 
         const startOfWeek = this.getStartOfWeek();
         if (isWeekDay(startOfWeek)) {
-            const snowflakeStartOfWeekIndex = startOfWeek + 1; // 1 (Monday) to 7 (Sunday)
+            const snowflakeStartOfWeekIndex = startOfWeek + 1; // 1 (Monday) to 7 (Sunday):
             sessionParams.push(`WEEK_START = ${snowflakeStartOfWeekIndex}`);
         }
 
@@ -503,12 +503,16 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         console.debug(`Setting Snowflake session timezone to ${timezoneQuery}`);
         sessionParams.push(`TIMEZONE = '${timezoneQuery}'`);
 
-        // Force FALSE to avoid casing inconsistencies between Snowflake and Lightdash.
+        /**
+         * Force QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE to avoid casing inconsistencies
+         * between Snowflake <> Lightdash
+         */
         console.debug(
             'Setting Snowflake session QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE',
         );
         sessionParams.push(`QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE`);
 
+        // Default timeout to 300 seconds if not specified
         const timeoutSeconds = this.credentials.timeoutSeconds ?? 300;
         console.debug(
             `Setting Snowflake session STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7820

## Summary

Every Snowflake query was resuming the warehouse purely for session setup — including queries whose `SELECT` would have been served entirely by Snowflake's Result Cache. Dashboard interactions on suspended warehouses paid an unnecessary resume cost on every load.

Affects all Snowflake projects regardless of auth type. Other warehouses are untouched.

## Root cause

`prepareWarehouse()` bundled `USE WAREHOUSE` and 3–5 `ALTER SESSION SET …` statements into a single `connection.execute()` call with `MULTI_STATEMENT_COUNT`. Per Snowflake support, MULTI_STATEMENT requests share the stored-procedure execution path, which **resumes the warehouse unconditionally** — even when every bundled statement is session-level only and would otherwise stay on the cloud-services layer.

```ts
// Old prepareWarehouse: 4–6 statements bundled, MULTI_STATEMENT_COUNT set
await this.executeStatements(
    connection,
    sqlStatements.join('\n'),
    sqlStatements.length, // → MULTI_STATEMENT_COUNT > 1
);
```

```
Before:
  prepareWarehouse()
    └─► executeStatements(USE WAREHOUSE; ALTER SESSION …×N, count=N)
          └─► MULTI_STATEMENT_COUNT=N
                └─► stored-procedure path  ──►  warehouse RESUME (billed)

After:
  prepareWarehouse()
    ├─► executeStatements("USE WAREHOUSE …")              ──► cloud services (free, no resume)
    └─► executeStatements("ALTER SESSION SET a, b, c, …") ──► cloud services (free, no resume)
```

Each `ALTER SESSION` on its own runs on the cloud-services layer (free unless it exceeds 10% of compute usage). `USE WAREHOUSE` only sets the session's current warehouse — it does not resume.

Sibling ticket [AE-55](https://linear.app/lightdash/issue/AE-55/reduce-amount-of-statements-in-snowflake) tracked the query-history clutter from the same bundle; collapsing the `ALTER SESSION`s into one statement cleans that up as a side effect.

## Fix

Send `USE WAREHOUSE` and the session params as two ordinary single-statement requests; collapse all `ALTER SESSION SET` params into one comma-separated statement so neither call needs `MULTI_STATEMENT_COUNT`.

- `packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts` — `prepareWarehouse()` now issues `USE WAREHOUSE` and a single combined `ALTER SESSION SET` instead of a bundled MULTI_STATEMENT request.
- `executeStatements()` signature is unchanged — `createProgrammaticAccessToken()` still uses it.
- Not in scope: moving `QUERY_TAG` to the SDK's connection-level `queryTag` option (the value is per-call and the `EXTERNAL_BROWSER` cached-connection path would complicate it); upstream gap for connection-time `TIMEZONE`/`WEEK_START`/etc. tracked by [snowflakedb/snowflake-connector-nodejs#61](https://github.com/snowflakedb/snowflake-connector-nodejs/issues/61).

## Before

Single SQL string sent with `parameters: { MULTI_STATEMENT_COUNT: 5 }`:

```sql
USE WAREHOUSE compute_wh;
ALTER SESSION SET WEEK_START = 1;
ALTER SESSION SET QUERY_TAG = '{"…"}';
ALTER SESSION SET TIMEZONE = 'UTC';
ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;
ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = 300;
```

## After

Two ordinary statements, no `MULTI_STATEMENT_COUNT`:

```sql
-- call 1
USE WAREHOUSE compute_wh;

-- call 2
ALTER SESSION SET WEEK_START = 1, QUERY_TAG = '{"…"}', TIMEZONE = 'UTC', QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE, STATEMENT_TIMEOUT_IN_SECONDS = 300;
```

## Test plan

- [x] `pnpm -F warehouses typecheck && pnpm -F warehouses lint`
- [x] `pnpm -F warehouses test` — 145 tests pass; existing `SnowflakeWarehouseClient` suite covers `runQuery` / `getCatalog` paths through the updated `prepareWarehouse`.
- [ ] Manual on a real Snowflake account: suspend the warehouse, load a dashboard whose SELECT is a Result Cache hit, confirm in Snowflake query history that no warehouse resume event is logged for the session-setup statements.
- [ ] Manual: confirm `TIMEZONE`, `WEEK_START`, `QUERY_TAG`, `STATEMENT_TIMEOUT_IN_SECONDS`, and `QUOTED_IDENTIFIERS_IGNORE_CASE` are all applied to the session (verify with `SHOW PARAMETERS IN SESSION`).