### PR TITLE
feat: add `showSubtotalsExpanded` option to default subtotals to expanded

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -424,6 +424,8 @@ export type TableChart = {
     showResultsTotal?: boolean;
     /** Show subtotal rows */
     showSubtotals?: boolean;
+    /** Default subtotal rows to expanded (vs. collapsed). Only meaningful when showSubtotals is true. */
+    showSubtotalsExpanded?: boolean;
     /** Column-specific configuration */
     columns?: Record<string, ColumnProperties>;
     /** Conditional formatting rules */

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -231,6 +231,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
         getField,
         showResultsTotal,
         showSubtotals,
+        showSubtotalsExpanded,
         updateColumnProperty,
     } = visualizationConfig.chartConfig;
 
@@ -306,6 +307,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 getField={getField}
                                 hideRowNumbers={hideRowNumbers}
                                 showSubtotals={showSubtotals}
+                                showSubtotalsExpanded={showSubtotalsExpanded}
                                 columnProperties={
                                     visualizationConfig.chartConfig
                                         .columnProperties
@@ -326,6 +328,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 getField={getField}
                                 hideRowNumbers={hideRowNumbers}
                                 showSubtotals={showSubtotals}
+                                showSubtotalsExpanded={showSubtotalsExpanded}
                                 columnProperties={
                                     visualizationConfig.chartConfig
                                         .columnProperties
@@ -369,6 +372,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 hideRowNumbers={hideRowNumbers}
                 showColumnCalculation={showColumnCalculation}
                 showSubtotals={showSubtotals}
+                showSubtotalsExpanded={showSubtotalsExpanded}
                 conditionalFormattings={conditionalFormattings}
                 minMaxMap={minMaxMap}
                 onColumnWidthChange={onColumnWidthChange}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -330,12 +330,7 @@ const GeneralSettings: FC = () => {
                 <Checkbox
                     ml="lg"
                     label="Expand subtotals by default"
-                    checked={
-                        canUseSubtotals &&
-                        !metricsAsRows &&
-                        showSubtotals &&
-                        showSubtotalsExpanded
-                    }
+                    checked={showSubtotalsExpanded ?? false}
                     onChange={() => {
                         setShowSubtotalsExpanded(!showSubtotalsExpanded);
                     }}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -157,11 +157,13 @@ const GeneralSettings: FC = () => {
         setShowResultsTotal,
         setShowRowCalculation,
         setShowSubtotals,
+        setShowSubtotalsExpanded,
         setShowTableNames,
         showColumnCalculation,
         showResultsTotal,
         showRowCalculation,
         showSubtotals,
+        showSubtotalsExpanded,
         showTableNames,
         rowLimit,
         setRowLimit,
@@ -325,6 +327,22 @@ const GeneralSettings: FC = () => {
                         />
                     </Box>
                 </Tooltip>
+                <Checkbox
+                    ml="lg"
+                    label="Expand subtotals by default"
+                    checked={
+                        canUseSubtotals &&
+                        !metricsAsRows &&
+                        showSubtotals &&
+                        showSubtotalsExpanded
+                    }
+                    onChange={() => {
+                        setShowSubtotalsExpanded(!showSubtotalsExpanded);
+                    }}
+                    disabled={
+                        !canUseSubtotals || metricsAsRows || !showSubtotals
+                    }
+                />
             </Config.Section>
         </Stack>
     );

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -162,6 +162,7 @@ type PivotTableProps = BoxProps & // TODO: remove this
         getFieldLabel: (fieldId: string) => string | undefined;
         getField: (fieldId: string) => ItemsMap[string] | undefined;
         showSubtotals?: boolean;
+        showSubtotalsExpanded?: boolean;
         columnProperties?: Record<string, ColumnProperties>;
         isMinimal: boolean;
         isDashboard?: boolean;
@@ -191,6 +192,7 @@ const PivotTable: FC<PivotTableProps> = ({
     getField,
     className,
     showSubtotals = false,
+    showSubtotalsExpanded = false,
     columnProperties = {},
     isMinimal = false,
     isDashboard = false,
@@ -592,6 +594,9 @@ const PivotTable: FC<PivotTableProps> = ({
             columnPinning: {
                 left: [ROW_NUMBER_COLUMN_ID],
             },
+        },
+        initialState: {
+            expanded: showSubtotalsExpanded ? true : {},
         },
         onGroupingChange: setGrouping,
         getExpandedRowModel: getExpandedRowModel(),

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -37,6 +37,7 @@ import {
     getCoreRowModel,
     getExpandedRowModel,
     useReactTable,
+    type ExpandedState,
     type GroupingState,
     type Row,
 } from '@tanstack/react-table';
@@ -205,6 +206,15 @@ const PivotTable: FC<PivotTableProps> = ({
     const { colorScheme } = useMantineColorScheme();
     const containerRef = useRef<HTMLDivElement>(null);
     const [grouping, setGrouping] = React.useState<GroupingState>([]);
+    const [expanded, setExpanded] = React.useState<ExpandedState>(
+        showSubtotalsExpanded ? true : {},
+    );
+    const [prevShowSubtotalsExpanded, setPrevShowSubtotalsExpanded] =
+        React.useState(showSubtotalsExpanded);
+    if (showSubtotalsExpanded !== prevShowSubtotalsExpanded) {
+        setPrevShowSubtotalsExpanded(showSubtotalsExpanded);
+        setExpanded(showSubtotalsExpanded ? true : {});
+    }
 
     const { handleResizeStart, resizeHandleClassName } = useColumnResize({
         onColumnWidthChange,
@@ -590,15 +600,14 @@ const PivotTable: FC<PivotTableProps> = ({
         columns: columns,
         state: {
             grouping,
+            expanded,
             columnOrder: columnOrder,
             columnPinning: {
                 left: [ROW_NUMBER_COLUMN_ID],
             },
         },
-        initialState: {
-            expanded: showSubtotalsExpanded ? true : {},
-        },
         onGroupingChange: setGrouping,
+        onExpandedChange: setExpanded,
         getExpandedRowModel: getExpandedRowModel(),
         getGroupedRowModel: getGroupedRowModelLightdash(),
         getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -46,6 +46,7 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
     hideRowNumbers,
     showColumnCalculation,
     showSubtotals,
+    showSubtotalsExpanded,
     children,
     ...rest
 }) => {
@@ -178,6 +179,9 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
                 ],
             },
             pagination: paginationState,
+        },
+        initialState: {
+            expanded: showSubtotalsExpanded ? true : {},
         },
         meta: {
             columnProperties,

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -3,6 +3,7 @@ import {
     getExpandedRowModel,
     useReactTable,
     type ColumnOrderState,
+    type ExpandedState,
     type GroupingState,
 } from '@tanstack/react-table';
 import React, { useEffect, useMemo, useState, type FC } from 'react';
@@ -61,7 +62,18 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
         minMaxMap,
     } = rest;
     const [grouping, setGrouping] = useState<GroupingState>([]);
+    const [expanded, setExpanded] = useState<ExpandedState>(
+        showSubtotalsExpanded ? true : {},
+    );
+    const [prevShowSubtotalsExpanded, setPrevShowSubtotalsExpanded] = useState(
+        showSubtotalsExpanded,
+    );
+    if (showSubtotalsExpanded !== prevShowSubtotalsExpanded) {
+        setPrevShowSubtotalsExpanded(showSubtotalsExpanded);
+        setExpanded(showSubtotalsExpanded ? true : {});
+    }
     const [columnVisibility, setColumnVisibility] = useState({});
+
     const [isInfiniteScrollEnabled, setIsInfiniteScrollEnabled] = useState(
         !pagination?.show || !!pagination?.defaultScroll,
     );
@@ -170,6 +182,7 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
         columns: visibleColumns,
         state: {
             grouping,
+            expanded,
             columnVisibility,
             columnOrder: tempColumnOrder,
             columnPinning: {
@@ -180,9 +193,7 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
             },
             pagination: paginationState,
         },
-        initialState: {
-            expanded: showSubtotalsExpanded ? true : {},
-        },
+        onExpandedChange: setExpanded,
         meta: {
             columnProperties,
             minMaxMap,

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -68,6 +68,7 @@ export type ProviderProps = {
         showResultsTotal?: boolean;
     };
     showSubtotals?: boolean;
+    showSubtotalsExpanded?: boolean;
     hideRowNumbers?: boolean;
     showColumnCalculation?: boolean;
     conditionalFormattings?: ConditionalFormattingConfig[];

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -77,6 +77,9 @@ const useTableConfig = (
     const [showSubtotals, setShowSubtotals] = useState<boolean>(
         tableChartConfig?.showSubtotals ?? false,
     );
+    const [showSubtotalsExpanded, setShowSubtotalsExpanded] = useState<boolean>(
+        tableChartConfig?.showSubtotalsExpanded ?? false,
+    );
     const [hideRowNumbers, setHideRowNumbers] = useState<boolean>(
         tableChartConfig?.hideRowNumbers === undefined
             ? false
@@ -653,6 +656,7 @@ const useTableConfig = (
             showTableNames,
             showResultsTotal,
             showSubtotals,
+            showSubtotalsExpanded,
             columns: columnProperties,
             hideRowNumbers,
             conditionalFormattings,
@@ -666,6 +670,7 @@ const useTableConfig = (
             showTableNames,
             showResultsTotal,
             showSubtotals,
+            showSubtotalsExpanded,
             columnProperties,
             conditionalFormattings,
             metricsAsRows,
@@ -690,6 +695,8 @@ const useTableConfig = (
             setShowResultsTotal,
             showSubtotals,
             setShowSubtotals,
+            showSubtotalsExpanded,
+            setShowSubtotalsExpanded,
 
             columnProperties: exposedColumnProperties,
             setColumnProperties,
@@ -729,6 +736,8 @@ const useTableConfig = (
             setShowResultsTotal,
             showSubtotals,
             setShowSubtotals,
+            showSubtotalsExpanded,
+            setShowSubtotalsExpanded,
 
             exposedColumnProperties,
             setColumnProperties,


### PR DESCRIPTION
Closes: PROD-5789

### Description:

Adds a new "Expand subtotals by default" option to the table visualization configuration. When subtotals are enabled, users can now choose whether subtotal rows render in an expanded or collapsed state by default.

A new `showSubtotalsExpanded` field has been added to the `TableChart` type and wired through the table config hook, general settings panel, and both the `PivotTable` and `TableProvider` components. The expanded state is initialized based on this setting and updates reactively when the setting changes.

The checkbox in the general settings panel is disabled when subtotals are not available (e.g., when metrics-as-rows mode is active or subtotals are turned off).