### PR TITLE
fix: dashboard version comparison crashes on previous version

### DIFF
--- a/packages/frontend/src/components/common/ContentTable/useContentTable.test.tsx
+++ b/packages/frontend/src/components/common/ContentTable/useContentTable.test.tsx
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { type ContentTableColumnDef } from './types';
+import { useContentTable } from './useContentTable';
+
+type Row = { name: string; createdAt: string };
+
+const data: Row[] = [
+    { name: 'b', createdAt: '2024-01-02T00:00:00Z' },
+    { name: 'a', createdAt: '2024-01-01T00:00:00Z' },
+];
+
+describe('useContentTable', () => {
+    test('builds an accessorFn column that has a string header but no id without throwing', () => {
+        const columns: ContentTableColumnDef<Row>[] = [
+            {
+                accessorFn: (row) => row.createdAt,
+                header: 'Current Version',
+            },
+        ];
+
+        const { result } = renderHook(() =>
+            useContentTable<Row>({ columns, data }),
+        );
+
+        const column = result.current
+            .getAllLeafColumns()
+            .find((c) => c.columnDef.header !== undefined && !c.getIsGrouped());
+
+        expect(column).toBeDefined();
+        expect(column?.id).toBe('Current Version');
+    });
+
+    test('sorts an accessorFn column that has no explicit sortingFn without throwing', () => {
+        const columns: ContentTableColumnDef<Row>[] = [
+            {
+                accessorFn: (row) => row.createdAt,
+                id: 'createdAt',
+                header: 'Current Version',
+            },
+        ];
+
+        const { result } = renderHook(() =>
+            useContentTable<Row>({
+                columns,
+                data,
+                initialState: { sorting: [{ id: 'createdAt', desc: false }] },
+            }),
+        );
+
+        const sortedRows = result.current.getSortedRowModel().rows;
+
+        expect(sortedRows.map((r) => r.original.name)).toEqual(['a', 'b']);
+    });
+});

--- a/packages/frontend/src/components/common/ContentTable/useContentTable.tsx
+++ b/packages/frontend/src/components/common/ContentTable/useContentTable.tsx
@@ -47,7 +47,10 @@ const resolveNextState = <TValue,>(
 
 const getColumnId = <TData extends RowData>(
     column: ContentTableColumnDef<TData>,
-) => column.id ?? column.accessorKey;
+) =>
+    column.id ??
+    column.accessorKey ??
+    (typeof column.header === 'string' ? column.header : undefined);
 
 const DEFAULT_COLUMN_SIZE = 180;
 const DEFAULT_COLUMN_MIN_SIZE = 40;
@@ -100,7 +103,7 @@ const toTanStackColumn = <TData extends RowData>(
         maxSize: getDataColumnMaxSize(column, defaultColumn),
         minSize: getDataColumnMinSize(column, defaultColumn),
         size: getDataColumnSize(column, defaultColumn),
-        sortingFn: column.sortingFn,
+        ...(column.sortingFn ? { sortingFn: column.sortingFn } : {}),
         meta: {
             ...column.meta,
             lightdashColumnDef: column,

--- a/packages/frontend/src/pages/DashboardVersionComparison.tsx
+++ b/packages/frontend/src/pages/DashboardVersionComparison.tsx
@@ -471,6 +471,7 @@ const ChartsTable = ({
             },
             {
                 accessorFn: (row) => row.currentVersion?.createdAt,
+                id: 'currentVersion',
                 header: 'Current Version',
                 size: 200,
                 Cell: ({ row }) => (
@@ -499,6 +500,7 @@ const ChartsTable = ({
             },
             {
                 accessorFn: (row) => row.selectedVersion?.createdAt,
+                id: 'selectedVersion',
                 header: 'Selected Version',
                 size: 200,
                 Cell: ({ row }) => (
@@ -661,6 +663,7 @@ const FiltersTable = ({ data }: { data: any[] }) => {
         () => [
             {
                 accessorFn: (row) => row.currentFilter?.label || '-',
+                id: 'currentVersion',
                 header: 'Current Version',
                 size: 300,
                 Cell: ({ row }) => (
@@ -674,6 +677,7 @@ const FiltersTable = ({ data }: { data: any[] }) => {
             },
             {
                 accessorFn: (row) => row.versionFilter?.label || '-',
+                id: 'selectedVersion',
                 header: 'Selected Version',
                 size: 300,
                 Cell: ({ row }) => (


### PR DESCRIPTION
Closes #23399

## Problem

Selecting a previous (non-current) version in a dashboard's version history crashed the comparison panel into the global error boundary ("Something went wrong."), blocking the in-product rollback flow. In production the error had no message; in dev it read `Columns require an id when using an accessorFn`.

## Root cause

The comparison tables render through the shared `ContentTable`/TanStack wrapper. Two issues in `useContentTable.tsx` combined:

1. `toTanStackColumn` always wraps a column's `header` in a function, defeating TanStack's built-in "derive `id` from a string header" fallback. With `getColumnId = column.id ?? column.accessorKey`, any `accessorFn` column without an explicit `id`/`accessorKey` resolved to `id: undefined` → TanStack throws.
2. The wrapper unconditionally set `sortingFn: column.sortingFn`, overwriting TanStack's `'auto'` default with `undefined`. Once a table sorted, `getSortingFn()` returned `undefined` → `TypeError: columnInfo.sortingFn is not a function`. This second crash was previously masked by the `id` error.

Both regressed when the comparison tables were migrated from mantine-react-table (which tolerated a missing `id`) to the `ContentTable`/TanStack wrapper.

## Fix

- `getColumnId` now falls back to a string `header`, mirroring TanStack's own id derivation — closing this class of bug for **any** table using the wrapper.
- `sortingFn` is only set when defined, preserving TanStack's `'auto'` default.
- Added explicit `id`s to the four affected comparison columns (Charts + Filters "Current Version"/"Selected Version"), matching the existing `rollbackAction` pattern.

## Testing

- Added a regression test (`useContentTable.test.tsx`) covering both crashes. Verified it **fails** against the pre-fix wrapper (reproducing `Columns require an id…` and `sortingFn is not a function`) and **passes** with the fix.
- Manually verified in the running app: selecting a previous version now renders the Version Comparison panel (Tiles / Charts / Filters), the Charts comparison table shows data, and sorting by a column header works without crashing.
- `frontend` typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
