### PR TITLE
feat: add `theme` prop to SDK components for light/dark mode support

### DIFF
--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -31,6 +31,7 @@ const LIGHTDASH_SDK_VERSION_LOCAL_STORAGE_KEY = '__lightdash_sdk_version';
 type BaseProps = {
     instanceUrl: string;
     token: Promise<string> | string;
+    theme?: 'light' | 'dark';
     styles?: {
         backgroundColor?: string;
         fontFamily?: string;
@@ -83,8 +84,9 @@ const persistInstanceUrl = (instanceUrl: string) => {
 const SdkProviders: FC<
     PropsWithChildren<{
         styles?: { backgroundColor?: string; fontFamily?: string };
+        theme?: 'light' | 'dark';
     }>
-> = ({ children, styles }) => {
+> = ({ children, styles, theme }) => {
     const themeOverride = {
         fontFamily: styles?.fontFamily,
         other: {
@@ -101,8 +103,12 @@ const SdkProviders: FC<
                 withCSSVariables
                 themeOverride={themeOverride}
                 notificationsLimit={0}
+                forceColorScheme={theme}
             >
-                <Mantine8Provider themeOverride={themeOverride}>
+                <Mantine8Provider
+                    themeOverride={themeOverride}
+                    forceColorScheme={theme}
+                >
                     <ModalsProvider>
                         <AppProvider>
                             <FullscreenProvider enabled={false}>
@@ -134,6 +140,7 @@ const Dashboard: FC<DashboardProps> = ({
     token: tokenOrTokenPromise,
     instanceUrl,
     styles,
+    theme,
     filters,
     contentOverrides,
     onExplore,
@@ -179,7 +186,7 @@ const Dashboard: FC<DashboardProps> = ({
     }
 
     return (
-        <SdkProviders styles={styles}>
+        <SdkProviders styles={styles} theme={theme}>
             <EmbedProvider
                 embedToken={token}
                 projectUuid={projectUuid}
@@ -194,7 +201,11 @@ const Dashboard: FC<DashboardProps> = ({
                         height: '100%',
                         position: 'relative',
                         overflow: 'auto',
-                        backgroundColor: styles?.backgroundColor,
+                        backgroundColor:
+                            styles?.backgroundColor ??
+                            (theme
+                                ? 'var(--mantine-color-body)'
+                                : undefined),
                     }}
                 />
             </EmbedProvider>
@@ -206,6 +217,7 @@ const Explore: FC<BaseProps & { exploreId: string; savedChart: SavedChart }> = (
     token: tokenOrTokenPromise,
     instanceUrl,
     styles,
+    theme,
     filters,
     contentOverrides,
     onExplore,
@@ -252,7 +264,7 @@ const Explore: FC<BaseProps & { exploreId: string; savedChart: SavedChart }> = (
     }
 
     return (
-        <SdkProviders styles={styles}>
+        <SdkProviders styles={styles} theme={theme}>
             <EmbedProvider
                 embedToken={token}
                 projectUuid={projectUuid}
@@ -268,7 +280,11 @@ const Explore: FC<BaseProps & { exploreId: string; savedChart: SavedChart }> = (
                         height: '100%',
                         position: 'relative',
                         overflow: 'auto',
-                        backgroundColor: styles?.backgroundColor,
+                        backgroundColor:
+                            styles?.backgroundColor ??
+                            (theme
+                                ? 'var(--mantine-color-body)'
+                                : undefined),
                     }}
                 />
             </EmbedProvider>
@@ -280,6 +296,7 @@ const Chart: FC<Omit<BaseProps, 'filters' | 'onExplore'> & { id: string }> = ({
     token: tokenOrTokenPromise,
     instanceUrl,
     styles,
+    theme,
     contentOverrides,
     id,
 }) => {
@@ -323,7 +340,7 @@ const Chart: FC<Omit<BaseProps, 'filters' | 'onExplore'> & { id: string }> = ({
     }
 
     return (
-        <SdkProviders styles={styles}>
+        <SdkProviders styles={styles} theme={theme}>
             <EmbedProvider
                 embedToken={token}
                 projectUuid={projectUuid}
@@ -336,7 +353,11 @@ const Chart: FC<Omit<BaseProps, 'filters' | 'onExplore'> & { id: string }> = ({
                         height: '100%',
                         position: 'relative',
                         overflow: 'auto',
-                        backgroundColor: styles?.backgroundColor,
+                        backgroundColor:
+                            styles?.backgroundColor ??
+                            (theme
+                                ? 'var(--mantine-color-body)'
+                                : undefined),
                     }}
                 />
             </EmbedProvider>

--- a/packages/frontend/src/providers/MantineProvider.tsx
+++ b/packages/frontend/src/providers/MantineProvider.tsx
@@ -17,6 +17,7 @@ type Props = {
     theme?: MantineThemeOverride;
     themeOverride?: MantineThemeOverride;
     notificationsLimit?: number;
+    forceColorScheme?: ColorScheme;
 };
 
 const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
@@ -27,11 +28,14 @@ const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
 
     themeOverride = {},
     notificationsLimit,
+    forceColorScheme,
 }) => {
-    const [colorScheme, setColorScheme] = useLocalStorage<ColorScheme>({
+    const [storedColorScheme, setColorScheme] = useLocalStorage<ColorScheme>({
         key: 'color-scheme',
         defaultValue: 'light',
     });
+
+    const colorScheme = forceColorScheme ?? storedColorScheme;
 
     const theme = useMemo(
         () => getMantineThemeOverride(colorScheme),
@@ -39,6 +43,7 @@ const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
     );
 
     const toggleColorScheme = (value?: ColorScheme) => {
+        if (forceColorScheme) return;
         setColorScheme(value || (colorScheme === 'dark' ? 'light' : 'dark'));
     };
 

--- a/packages/sdk-test-app/src/examples/ThemeExamplePage.tsx
+++ b/packages/sdk-test-app/src/examples/ThemeExamplePage.tsx
@@ -1,0 +1,102 @@
+import Lightdash from '@lightdash/sdk';
+import { useState } from 'react';
+import { ExampleLayout } from '../components/ExampleLayout';
+import { ExampleSelect } from '../components/ExampleSelect';
+import type { EmbedConfigState } from '../hooks/useEmbedConfig';
+import { getRepoSourceUrl } from '../lib/repo';
+import { emptyStateBoxStyle, emptyStateStyle } from '../styles';
+import {
+    dashboardContainerStyle,
+    filterPanelGridStyle,
+    infoBoxStyle,
+    panelLabelStyle,
+    sectionDescStyle,
+    sectionTitleStyle,
+} from './PaletteUuidExamplePage.styles';
+
+type ThemeExamplePageProps = {
+    embedConfig: EmbedConfigState;
+};
+
+const THEME_OPTIONS = [
+    { value: 'light', label: 'Light' },
+    { value: 'dark', label: 'Dark' },
+] as const;
+
+const sourceUrl = getRepoSourceUrl(
+    'packages/sdk-test-app/src/examples/ThemeExamplePage.tsx',
+);
+
+export function ThemeExamplePage({ embedConfig }: ThemeExamplePageProps) {
+    const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+    return (
+        <ExampleLayout
+            embedConfig={embedConfig}
+            sourceUrl={sourceUrl}
+            title="Theme demo"
+            description={
+                <>
+                    This example shows how to switch the embedded{' '}
+                    <code>Lightdash.Dashboard</code> between light and dark mode
+                    via the <code>theme</code> prop. The host app picks the
+                    value — typically based on its own theme state — and the
+                    SDK applies the matching Mantine color scheme.
+                </>
+            }
+        >
+            {embedConfig.instanceUrl && embedConfig.token ? (
+                <>
+                    <section>
+                        <h3 style={sectionTitleStyle}>Theme selector</h3>
+
+                        <div style={filterPanelGridStyle}>
+                            <div>
+                                <ExampleSelect
+                                    label="Theme"
+                                    value={theme}
+                                    onChange={(value) =>
+                                        setTheme(value as 'light' | 'dark')
+                                    }
+                                    options={[...THEME_OPTIONS]}
+                                    helperText="In a real host app, this would match the parent app's light/dark setting."
+                                />
+                            </div>
+
+                            <div>
+                                <label style={panelLabelStyle}>
+                                    Current dashboard prop
+                                </label>
+                                <pre style={infoBoxStyle}>
+                                    {JSON.stringify({ theme }, null, 2)}
+                                </pre>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section>
+                        <h3 style={sectionTitleStyle}>Dashboard</h3>
+                        <p style={sectionDescStyle}>
+                            The embedded dashboard below re-renders when the
+                            theme changes.
+                        </p>
+                        <div style={dashboardContainerStyle}>
+                            <Lightdash.Dashboard
+                                key={`${embedConfig.remountKey}:${theme}`}
+                                instanceUrl={embedConfig.instanceUrl}
+                                token={embedConfig.token}
+                                theme={theme}
+                            />
+                        </div>
+                    </section>
+                </>
+            ) : (
+                <div style={emptyStateStyle}>
+                    <div style={emptyStateBoxStyle}>
+                        Click <strong>Config</strong> to add your embed URL
+                    </div>
+                </div>
+            )}
+        </ExampleLayout>
+    );
+}

--- a/packages/sdk-test-app/src/examples/examples.tsx
+++ b/packages/sdk-test-app/src/examples/examples.tsx
@@ -3,6 +3,7 @@ import type { EmbedConfigState } from '../hooks/useEmbedConfig';
 import { FiltersExamplePage } from './FiltersExamplePage';
 import { I18nExamplePage } from './I18nExamplePage';
 import { PaletteUuidExamplePage } from './PaletteUuidExamplePage';
+import { ThemeExamplePage } from './ThemeExamplePage';
 
 export type ExampleDefinition = {
     component: ComponentType<{ embedConfig: EmbedConfigState }>;
@@ -41,6 +42,15 @@ export const examples: ExampleDefinition[] = [
         sourcePath:
             'packages/sdk-test-app/src/examples/PaletteUuidExamplePage.tsx',
         component: PaletteUuidExamplePage,
+    },
+    {
+        slug: 'theme',
+        path: '/examples/theme',
+        title: 'Theme demo',
+        description:
+            'Switch the embedded dashboard between light and dark mode via the `theme` prop.',
+        sourcePath: 'packages/sdk-test-app/src/examples/ThemeExamplePage.tsx',
+        component: ThemeExamplePage,
     },
     // Future examples:
     // {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7845/add-theme-prop-lightdark-mode-to-react-sdk-components

<img width="1003" height="618" alt="CleanShot 2026-05-21 at 17 05 16" src="https://github.com/user-attachments/assets/8214c597-61ee-4c07-b723-476a2c538396" />

<img width="1006" height="607" alt="CleanShot 2026-05-21 at 17 30 15" src="https://github.com/user-attachments/assets/28c7a400-d3fa-4a11-9c40-dfa838be7123" />


### Out of scope

- System theme, for now this should be captured by the parent website, and passed as theme (light/dark)

### Description:

Adds a `theme` prop (`'light' | 'dark'`) to the SDK's `Dashboard`, `Explore`, and `Chart` components, allowing host applications to explicitly control the color scheme of embedded content.

When `theme` is provided, it is passed down to both Mantine providers via `forceColorScheme`, overriding the locally stored color scheme preference and disabling the ability to toggle it. When a `theme` is set but no explicit `backgroundColor` is provided in `styles`, the background automatically falls back to `var(--mantine-color-body)` to match the forced color scheme.

A new `ThemeExamplePage` has been added to the SDK test app demonstrating how to switch an embedded dashboard between light and dark mode using the `theme` prop.