### PR TITLE
fix(ai-copilot): use iconUrl src instead of favicon fallback for MCP server icon

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -766,7 +766,7 @@ export const AiAgentMcpServersInput = ({
                                                     )}
                                                     name={mcpServer.name}
                                                     size={40}
-                                                    url={mcpServer.url}
+                                                    src={mcpServer.iconUrl}
                                                 />
                                                 <Stack gap={2}>
                                                     <Text fw={600}>
@@ -832,6 +832,9 @@ export const AiAgentMcpServersInput = ({
                                                 background: 'transparent',
                                                 border: 0,
                                                 cursor: 'pointer',
+                                                font: 'inherit',
+                                                color: 'inherit',
+                                                textAlign: 'inherit',
                                             }}
                                         >
                                             <Group

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiMcpServerIcon.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiMcpServerIcon.tsx
@@ -1,6 +1,6 @@
 import { Avatar, type MantineColor } from '@mantine-8/core';
 import { IconPlugConnected } from '@tabler/icons-react';
-import { useMemo, type FC } from 'react';
+import { type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 
 type Props = {
@@ -8,37 +8,18 @@ type Props = {
     name: string;
     size?: number;
     src?: string | null;
-    url: string;
 };
 
-export const AiMcpServerIcon: FC<Props> = ({
-    color,
-    name,
-    size = 40,
-    src,
-    url,
-}) => {
-    const fallbackFaviconUrl = useMemo(() => {
-        try {
-            return new URL('/favicon.ico', url).toString();
-        } catch {
-            return undefined;
-        }
-    }, [url]);
-
-    const imageSrc = src ?? fallbackFaviconUrl;
-
-    return (
-        <Avatar
-            src={imageSrc}
-            alt={`${name} favicon`}
-            radius="md"
-            size={size}
-            variant="light"
-            color={color}
-            imageProps={{ referrerPolicy: 'no-referrer' }}
-        >
-            <MantineIcon icon={IconPlugConnected} size="md" />
-        </Avatar>
-    );
-};
+export const AiMcpServerIcon: FC<Props> = ({ color, name, size = 40, src }) => (
+    <Avatar
+        src={src ?? undefined}
+        alt={`${name} icon`}
+        radius="md"
+        size={size}
+        variant="light"
+        color={color}
+        imageProps={{ referrerPolicy: 'no-referrer' }}
+    >
+        <MantineIcon icon={IconPlugConnected} size="md" />
+    </Avatar>
+);


### PR DESCRIPTION
Closes:

### Description:
Removes the automatic favicon fallback logic from `AiMcpServerIcon` that previously derived an icon URL from the MCP server's `url` property. The component now only renders an icon when an explicit `src` is provided, falling back to the plug icon otherwise. The `url` prop has been removed from the component, and the call site now passes `mcpServer.iconUrl` directly as `src`.