### PR TITLE
fix(embed): generate 32-char secret to satisfy HS256 minimum

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -265,7 +265,7 @@ export class EmbedService extends BaseService {
             throw new ForbiddenError();
         }
 
-        const secret = nanoidGenerator();
+        const secret = nanoidGenerator(32);
         const encodedSecret = this.encryptionUtil.encrypt(secret);
         await this.embedModel.save(
             projectUuid,


### PR DESCRIPTION
## Summary

Closes PROD-7848

`POST /api/v1/embed/:projectUuid/secret` was producing 21-character (168-bit) embed secrets — below the RFC 7518 §3.2 minimum of 256 bits for HS256. Recent JWT libraries (driven by CVE-2025-45769) refuse to sign with a key that short, so customers integrating with current `firebase/php-jwt`, PyJWT, or java-jwt could not generate embed JWTs and their embedded dashboards stopped working.

## Root cause

Embed secrets are minted in `EmbedService.updateEmbedConfig` via `nanoid()` with no length argument — that default is 21 characters:

```ts
const secret = nanoidGenerator();
const encodedSecret = this.encryptionUtil.encrypt(secret);
```

21 ASCII characters = 21 bytes = 168 bits. HS256 requires a key at least the size of the hash output (32 bytes / 256 bits), and the new generation of JWT libraries enforces that minimum on the signing side. Lightdash's verify path uses `jsonwebtoken.verify()`, which does not enforce the minimum — so the short keys went unnoticed on our side while breaking spec-compliant clients on theirs.

## Fix

Pass `32` to `nanoid` so newly minted secrets are 32 ASCII bytes (256 bits), clearing the HS256 floor. Cryptographic entropy of a 32-char nanoid is ~192 bits — well above any practical brute-force threshold.

- `packages/backend/src/ee/services/EmbedService/EmbedService.ts` — `nanoidGenerator()` → `nanoidGenerator(32)` in `updateEmbedConfig`.
- No DB migration. No change to the verify path. No change to the encrypted storage column.

## Old vs new behaviour

```
Old secret:  21 chars · 168 bits · rejected by spec-compliant HS256 signers
                  └── e.g. "V1StGXR8_Z5jdHi6B-myT"

New secret:  32 chars · 256 bits · accepted by all RFC 7518 HS256 signers
                  └── e.g. "V1StGXR8_Z5jdHi6B-myTpQGZ_d8AzXk"
```

- **Existing customers (unaffected):** their 21-char secrets stay in `embed.encodedSecret` and continue to verify on Lightdash's side. If their JWT library still tolerates the short key, nothing changes for them.
- **Existing customers blocked by strict libraries:** click *Generate new secret* on the embed settings page to mint a 32-char secret and unblock signing. Same one-click flow that already exists; just produces a longer key.
- **New embed configs:** start at 32 chars by default.

## Test plan

- [x] `pnpm -F backend typecheck && pnpm -F backend lint`
- [x] Manual: in the embed settings page, click *Generate new secret*; confirm the new secret is 32 characters.
- [ ] Manual: sign an embed JWT with the new 32-char secret using `firebase/php-jwt` (current version) — confirm the library accepts the key and the resulting token verifies via the embed endpoint.
- [ ] Manual: verify a previously-issued JWT signed with a legacy 21-char secret still validates against the stored secret (no change to the verify path).