### PR TITLE
fix(ai): restore artifact fields and filters

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -15,13 +15,20 @@ import {
 } from '@lightdash/common';
 import {
     Box,
+    Button,
     Center,
+    Collapse,
+    Flex,
     Group,
     Stack,
     Text,
     useMantineColorScheme,
 } from '@mantine-8/core';
-import { IconExclamationCircle } from '@tabler/icons-react';
+import {
+    IconChevronDown,
+    IconChevronUp,
+    IconExclamationCircle,
+} from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC, type ReactNode } from 'react';
 import { useParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -40,6 +47,12 @@ import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults'
 import { AgentVisualizationChartTypeSwitcher } from './AgentVisualizationChartTypeSwitcher';
 import AgentVisualizationFilters from './AgentVisualizationFilters';
 import AgentVisualizationMetricsAndDimensions from './AgentVisualizationMetricsAndDimensions';
+import {
+    getVisualizationFieldsCount,
+    getVisualizationFiltersCount,
+    shouldDisplayMetricsAndDimensions,
+    shouldDisplayVisualizationFilters,
+} from './AiVisualizationRenderer.utils';
 
 type Props = {
     vizQueryData: ApiAiAgentThreadMessageVizQuery;
@@ -91,6 +104,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
     const [echartsClickEvent, setEchartsClickEvent] =
         useState<EchartsSeriesClickEvent | null>(null);
     const [echartsSeries, setEchartsSeries] = useState<EChartsSeries[]>([]);
+    const [detailsExpanded, setDetailsExpanded] = useState(false);
 
     // Tag the cached expanded config with the chart type it was computed
     // for. Switching types makes the cached entry "for the wrong type" and
@@ -144,9 +158,17 @@ export const AiVisualizationRenderer: FC<Props> = ({
         [webAiChartConfig],
     );
 
-    const displayMetricsAndDimensions =
-        vizQueryData.type !== AiResultType.TABLE_RESULT &&
-        vizQueryData.type !== AiResultType.QUERY_RESULT;
+    const displayMetricsAndDimensions = shouldDisplayMetricsAndDimensions(
+        vizQueryData.type,
+    );
+    const displayFilters = shouldDisplayVisualizationFilters(
+        metricQuery.filters,
+    );
+    const fieldsCount = displayMetricsAndDimensions
+        ? getVisualizationFieldsCount(metricQuery)
+        : 0;
+    const filtersCount = getVisualizationFiltersCount(metricQuery.filters);
+    const displayDetails = fieldsCount > 0 || filtersCount > 0;
 
     const defaultChartType: AiAgentChartTypeOption =
         webAiChartConfig.type === AiResultType.QUERY_RESULT
@@ -213,7 +235,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
                 onChartConfigChange={handleChartConfigChange}
                 unsavedMetricQuery={metricQuery}
             >
-                <Stack gap="md" h="100%">
+                <Stack gap="md" h="100%" style={{ minHeight: 0 }}>
                     {headerContent}
                     {webAiChartConfig.type === AiResultType.QUERY_RESULT &&
                         onChartTypeChange && (
@@ -233,6 +255,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
                         )}
                     <Box
                         flex="1"
+                        mih={0}
                         style={{
                             // Scrolling for tables
                             overflow: 'auto',
@@ -258,23 +281,67 @@ export const AiVisualizationRenderer: FC<Props> = ({
                         <DrillDownModal />
                     </Box>
 
-                    <Stack gap="xs">
-                        <ErrorBoundary>
-                            {displayMetricsAndDimensions && (
-                                <AgentVisualizationMetricsAndDimensions
-                                    metricQuery={metricQuery}
-                                    fieldsMap={fields}
-                                />
-                            )}
+                    {displayDetails ? (
+                        <Stack gap="xs" style={{ flexShrink: 0 }}>
+                            <Flex align="center" justify="flex-start">
+                                <Button
+                                    size="compact-xs"
+                                    variant="subtle"
+                                    color="ldGray"
+                                    aria-expanded={detailsExpanded}
+                                    rightSection={
+                                        <MantineIcon
+                                            icon={
+                                                detailsExpanded
+                                                    ? IconChevronUp
+                                                    : IconChevronDown
+                                            }
+                                            size={12}
+                                        />
+                                    }
+                                    onClick={() =>
+                                        setDetailsExpanded((value) => !value)
+                                    }
+                                    styles={{
+                                        root: {
+                                            flexShrink: 0,
+                                            border: 'none',
+                                        },
+                                    }}
+                                >
+                                    {[
+                                        fieldsCount > 0
+                                            ? `Fields ${fieldsCount}`
+                                            : null,
+                                        filtersCount > 0
+                                            ? `Filters ${filtersCount}`
+                                            : null,
+                                    ]
+                                        .filter(Boolean)
+                                        .join(' · ')}
+                                </Button>
+                            </Flex>
+                            <Collapse in={detailsExpanded}>
+                                <Stack gap="xs">
+                                    <ErrorBoundary>
+                                        {displayMetricsAndDimensions && (
+                                            <AgentVisualizationMetricsAndDimensions
+                                                metricQuery={metricQuery}
+                                                fieldsMap={fields}
+                                            />
+                                        )}
 
-                            {chartConfig.filters ? (
-                                <AgentVisualizationFilters
-                                    filters={metricQuery.filters}
-                                    fieldsMap={fields}
-                                />
-                            ) : null}
-                        </ErrorBoundary>
-                    </Stack>
+                                        {displayFilters ? (
+                                            <AgentVisualizationFilters
+                                                filters={metricQuery.filters}
+                                                fieldsMap={fields}
+                                            />
+                                        ) : null}
+                                    </ErrorBoundary>
+                                </Stack>
+                            </Collapse>
+                        </Stack>
+                    ) : null}
                 </Stack>
             </VisualizationProvider>
         </MetricQueryDataProvider>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.utils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.utils.test.ts
@@ -1,0 +1,82 @@
+import { AiResultType, FilterOperator, type Filters } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    getVisualizationFieldsCount,
+    getVisualizationFiltersCount,
+    shouldDisplayMetricsAndDimensions,
+    shouldDisplayVisualizationFilters,
+} from './AiVisualizationRenderer.utils';
+
+describe('AiVisualizationRenderer utils', () => {
+    it('shows metric and dimension chips for switchable query result charts', () => {
+        expect(
+            shouldDisplayMetricsAndDimensions(AiResultType.QUERY_RESULT),
+        ).toBe(true);
+    });
+
+    it('keeps legacy table result field chips hidden', () => {
+        expect(
+            shouldDisplayMetricsAndDimensions(AiResultType.TABLE_RESULT),
+        ).toBe(false);
+    });
+
+    it('shows filters from the executed metric query', () => {
+        const filters = {
+            dimensions: {
+                id: 'dimension-group',
+                and: [
+                    {
+                        id: 'status-filter',
+                        target: { fieldId: 'orders_status' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['complete'],
+                    },
+                ],
+            },
+        } satisfies Filters;
+
+        expect(shouldDisplayVisualizationFilters(filters)).toBe(true);
+    });
+
+    it('counts selected dimensions and metrics as fields', () => {
+        expect(
+            getVisualizationFieldsCount({
+                dimensions: ['orders_order_date_month'],
+                metrics: ['payments_total_revenue', 'orders_count'],
+            }),
+        ).toBe(3);
+    });
+
+    it('counts filter rules across filter groups', () => {
+        const filters = {
+            dimensions: {
+                id: 'dimension-group',
+                and: [
+                    {
+                        id: 'status-filter',
+                        target: { fieldId: 'orders_status' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['complete'],
+                    },
+                ],
+            },
+            metrics: {
+                id: 'metric-group',
+                and: [
+                    {
+                        id: 'revenue-filter',
+                        target: { fieldId: 'payments_total_revenue' },
+                        operator: FilterOperator.GREATER_THAN,
+                        values: [100],
+                    },
+                ],
+            },
+        } satisfies Filters;
+
+        expect(getVisualizationFiltersCount(filters)).toBe(2);
+    });
+
+    it('hides empty filters', () => {
+        expect(shouldDisplayVisualizationFilters({})).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.utils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.utils.ts
@@ -1,0 +1,19 @@
+import {
+    AiResultType,
+    countTotalFilterRules,
+    type Filters,
+    type MetricQuery,
+} from '@lightdash/common';
+
+export const shouldDisplayMetricsAndDimensions = (resultType: AiResultType) =>
+    resultType !== AiResultType.TABLE_RESULT;
+
+export const getVisualizationFieldsCount = (
+    metricQuery: Pick<MetricQuery, 'dimensions' | 'metrics'>,
+) => metricQuery.dimensions.length + metricQuery.metrics.length;
+
+export const getVisualizationFiltersCount = (filters: Filters) =>
+    countTotalFilterRules(filters);
+
+export const shouldDisplayVisualizationFilters = (filters: Filters) =>
+    getVisualizationFiltersCount(filters) > 0;


### PR DESCRIPTION
## Summary

- Restore field and filter visibility for AI artifact visualizations, including `query_result` artifacts.
- Collapse the artifact query details by default behind a compact borderless `Fields N · Filters N` toggle.
- Keep the existing field/filter chip layout available when expanded, and adjust the chart area flex sizing so details do not get clipped.

## Root Cause

The artifact redesign moved more chart chrome into the floating panel. The renderer still hid fields for `query_result` artifacts and only rendered filters based on the original chart config instead of the executed metric query filters.

## Validation

- `pnpm -F frontend test -- AiVisualizationRenderer.utils.test.ts`
- pre-commit frontend linter/formatter hooks
- frontend unused exports check