### PR TITLE
fix: load images from theme correctly in apps

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -313,7 +313,7 @@ export default class App {
         // route. The matching GET handler remains auth-gated by `requireToken`.
         if (this.lightdashConfig.appRuntime.s3) {
             expressApp.options(
-                '/api/apps/:appUuid/versions/:version/assets/:filename',
+                '/api/apps/:appUuid/versions/:version/t/:token/assets/:filename',
                 (_req, res) => {
                     res.setHeader('Access-Control-Allow-Origin', '*');
                     res.setHeader(

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -62,18 +62,12 @@ const isSafeFilename = (filename: string): boolean =>
     /^[a-zA-Z0-9._-]+$/.test(filename) && !filename.includes('..');
 
 /**
- * Rewrites Vite-generated asset references in HTML to include a token
- * query parameter so asset requests authenticate themselves.
- *
- * Matches patterns like:
- *   src="./assets/index-BxK29f.js"
- *   href="./assets/style-DhJ93k.css"
+ * Validates that a token is in a plausible JWT shape (3 base64url
+ * segments). Tighter validation runs in `verifyPreviewToken`; this guard
+ * just keeps stray bytes from being included in S3 keys / logs.
  */
-const injectTokenIntoAssetUrls = (html: string, token: string): string =>
-    html.replace(
-        /((?:src|href)="\.\/assets\/[^"]+)"/g,
-        `$1?token=${encodeURIComponent(token)}"`,
-    );
+const isPlausibleToken = (token: string): boolean =>
+    /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(token);
 
 export const createAppPreviewRouter = (
     config: AppRuntimeConfig,
@@ -128,10 +122,10 @@ export const createAppPreviewRouter = (
               })
             : null;
 
-    const cspHeaderValue = buildCspHeader(config, frameAncestors);
+    const cspHeader = buildCspHeader(config, frameAncestors);
 
     const setSecurityHeaders = (res: express.Response): void => {
-        res.setHeader('Content-Security-Policy', cspHeaderValue);
+        res.setHeader('Content-Security-Policy', cspHeader);
         res.removeHeader('X-Frame-Options');
         res.setHeader('X-Content-Type-Options', 'nosniff');
         res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
@@ -188,24 +182,19 @@ export const createAppPreviewRouter = (
         }
     };
 
-    /**
-     * Buffers an S3 readable stream into a UTF-8 string.
-     */
-    const bufferS3Body = (body: NodeJS.ReadableStream): Promise<string> =>
-        new Promise((resolve, reject) => {
-            const chunks: Buffer[] = [];
-            body.on('data', (chunk: Buffer) => chunks.push(chunk));
-            body.on('end', () =>
-                resolve(Buffer.concat(chunks).toString('utf-8')),
-            );
-            body.on('error', reject);
-        });
-
     // -- Auth middleware ------------------------------------------------
 
-    /** Verifies a JWT from the `?token` query param. */
+    /**
+     * Verifies a JWT from the `:token` path segment.
+     *
+     * The token lives in the URL path (not a query param) so that Vite's
+     * relative asset URLs (`./assets/foo.js`) naturally inherit the
+     * token when the browser resolves them against the iframe's URL.
+     * That way runtime-rendered <img> / dynamic chunks / lazy modules all
+     * authenticate without any client-side URL rewriting.
+     */
     const requireToken: express.RequestHandler = (req, res, next) => {
-        const { appUuid, version } = req.params;
+        const { appUuid, version, token } = req.params;
 
         if (!isValidUuid(appUuid)) {
             res.status(400).json({
@@ -224,8 +213,13 @@ export const createAppPreviewRouter = (
             return;
         }
 
-        const token =
-            typeof req.query.token === 'string' ? req.query.token : undefined;
+        if (typeof token !== 'string' || !isPlausibleToken(token)) {
+            res.status(401).json({
+                status: 'error',
+                error: { message: 'Invalid token' },
+            });
+            return;
+        }
 
         const result = verifyPreviewToken(
             token,
@@ -249,10 +243,10 @@ export const createAppPreviewRouter = (
     // -- Routes ---------------------------------------------------------
 
     // Redirect to trailing slash so relative asset paths resolve correctly.
-    // e.g. "assets/foo.css" from "/api/apps/X/versions/Y" would resolve to
-    //       "/api/apps/X/versions/assets/foo.css" (wrong)
-    // but from "/api/apps/X/versions/Y/" resolves correctly.
-    router.get('/:appUuid/versions/:version', (req, res) => {
+    // Without it, "./assets/foo.css" from "/api/apps/X/versions/Y/t/Z" would
+    // resolve to "/api/apps/X/versions/Y/t/assets/foo.css" (wrong); the
+    // trailing slash makes it resolve to ".../t/Z/assets/foo.css".
+    router.get('/:appUuid/versions/:version/t/:token', (req, res) => {
         const queryString = req.originalUrl.includes('?')
             ? req.originalUrl.slice(req.originalUrl.indexOf('?'))
             : '';
@@ -260,9 +254,14 @@ export const createAppPreviewRouter = (
     });
 
     // Serve index.html for an app version.
-    // Rewrites asset URLs to include the token so asset requests authenticate.
+    //
+    // The token-in-path scheme means every relative asset URL emitted by
+    // Vite (`./assets/foo.js`) inherits the token segment when the browser
+    // resolves it against this URL — no bundle rewriting or client-side
+    // patching is needed for runtime-rendered assets (theme images,
+    // dynamic imports, lazy chunks) to authenticate.
     router.get(
-        '/:appUuid/versions/:version/',
+        '/:appUuid/versions/:version/t/:token/',
         requireToken,
         async (req, res) => {
             const { appUuid, version } = req.params;
@@ -277,8 +276,6 @@ export const createAppPreviewRouter = (
                 return;
             }
 
-            const token = req.query.token as string;
-
             setSecurityHeaders(res);
             res.setHeader('Content-Type', 'text/html; charset=utf-8');
             res.setHeader('Cache-Control', 'no-store');
@@ -287,8 +284,7 @@ export const createAppPreviewRouter = (
                 res.locals.previewTokenPayload as PreviewTokenPayload,
             );
 
-            const html = await bufferS3Body(result.body);
-            res.send(injectTokenIntoAssetUrls(html, token));
+            result.body.pipe(res);
         },
     );
 
@@ -306,7 +302,7 @@ export const createAppPreviewRouter = (
     // Mounted as `router.use` so it runs before the GET handler and
     // short-circuits OPTIONS preflights.
     router.use(
-        '/:appUuid/versions/:version/assets/:filename',
+        '/:appUuid/versions/:version/t/:token/assets/:filename',
         (req, res, next) => {
             res.setHeader('Access-Control-Allow-Origin', '*');
             res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
@@ -327,9 +323,10 @@ export const createAppPreviewRouter = (
         },
     );
 
-    // Serve static assets (JS, CSS, fonts). Authenticated via ?token query param.
+    // Serve static assets (JS, CSS, fonts, images). The token segment in
+    // the path authenticates the request.
     router.get(
-        '/:appUuid/versions/:version/assets/:filename',
+        '/:appUuid/versions/:version/t/:token/assets/:filename',
         requireToken,
         async (req, res) => {
             const { filename } = req.params;

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -126,7 +126,7 @@ const DataAppTile: FC<Props> = (props) => {
 
     const previewUrl =
         token && latestReadyVersion
-            ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/?token=${token}&f=${encodeURIComponent(
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/?f=${encodeURIComponent(
                   filtersKey,
               )}#transport=postMessage&projectUuid=${projectUuid}`
             : undefined;

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
@@ -54,7 +54,7 @@ const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
     );
 
     const previewUrl = tokenQuery.data
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/?token=${tokenQuery.data.token}&f=${encodeURIComponent(
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/?f=${encodeURIComponent(
               filtersKey,
           )}#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -202,7 +202,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
 
         const previewOrigin = usePreviewOrigin();
         const previewUrl = token
-            ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/?token=${token}&r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
             : undefined;
 
         if (isLoading) {

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -155,7 +155,7 @@ export default function AppPreviewTest() {
     }
 
     const previewUrl = token
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
 
     if (isLoading) {

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -100,7 +100,7 @@ export default function MinimalApp() {
     }
 
     const previewUrl = token
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
     if (!previewUrl) return null;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: PROD-7840

### Description:

Fix image URLs for images loaded from theme.

The data-app preview iframe now carries its JWT auth token as a URL path segment (/api/apps/{appUuid}/versions/{version}/t/{token}/...) instead of a query parameter (?token=...). This was driven by a runtime auth failure — Vite content-hashes asset URLs into the JS bundle at build time, so React-rendered calls were hitting our auth-gated asset endpoint without the token and getting 401s. The previous attempt to fix this required injecting an inline bootstrap script that monkey-patched DOM prototype setters (HTMLImageElement.prototype.src, setAttribute, etc.) plus a MutationObserver to rewrite every src/href assignment, all gated by a per-request CSP nonce. With the token now in the path, Vite's relative URLs (./assets/foo.js) naturally resolve against the iframe URL and inherit the token segment automatically — no rewriting needed. Security-wise this is a clear win: CSP tightens from script-src 'self' 'nonce-XXX' (inline scripts permitted) to script-src 'self' (no inline scripts at all), ~110 lines of HTML-mutation and DOM-patching code go away, a new isPlausibleToken regex gates input before HMAC verify as defense in depth, and CDN cache keys now naturally include the token (closing a default-config footgun where authed responses could be served to anonymous requests). The one operational follow-up is that path-segment secrets are less commonly auto-redacted by log scrubbers than ?token= query params, so a small URL-sanitizing logger middleware is worth adding — but the pre-existing scheme had the same exposure, so this is a refinement rather than a regression.
