### PR TITLE
feat(data-apps): show queries panel in app preview

### DIFF
--- a/packages/frontend/src/features/apps/QueryInspector.module.css
+++ b/packages/frontend/src/features/apps/QueryInspector.module.css
@@ -1,10 +1,3 @@
-.iconOnly {
-    position: absolute;
-    bottom: var(--mantine-spacing-sm);
-    left: var(--mantine-spacing-sm);
-    z-index: 10;
-}
-
 .container {
     position: absolute;
     bottom: var(--mantine-spacing-sm);

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -36,8 +36,26 @@ type Props = {
     queries: TrackedQuery[];
     projectUuid: string;
     onClear: () => void;
-    persistLogs: boolean;
-    onPersistLogsChange: (value: boolean) => void;
+    /** Persist preference + handler — when omitted, the "Persist" switch is
+     *  hidden. The builder wires this up; the preview omits it because the
+     *  preview iframe doesn't reload mid-session so the toggle would be a
+     *  no-op, and sharing the localStorage key would let viewers flip
+     *  builder behavior. */
+    persistLogs?: boolean;
+    onPersistLogsChange?: (value: boolean) => void;
+    /** Initial value of the internal `collapsed` state. Defaults to `true`
+     *  so the builder's panel boots as a collapsed title bar. The preview
+     *  passes `false` to open expanded when the user clicks "View queries". */
+    defaultCollapsed?: boolean;
+    /** Called when the user clicks the X. The parent owns visibility and
+     *  should unmount the panel in response — both builder and preview
+     *  re-open it via a "View queries" menu item. */
+    onDismiss: () => void;
+    /** When `false`, the panel stays visible (as a collapsed title bar) even
+     *  with no queries. The builder defaults to `true` so the panel hides
+     *  until queries arrive; the preview passes `false` so once opened from
+     *  the menu the panel remains visible. */
+    hideWhenEmpty?: boolean;
 };
 
 const statusColor = (status: TrackedQuery['status']): string => {
@@ -336,9 +354,11 @@ const QueryInspector: FC<Props> = ({
     onClear,
     persistLogs,
     onPersistLogsChange,
+    defaultCollapsed = true,
+    onDismiss,
+    hideWhenEmpty = true,
 }) => {
-    const [collapsed, setCollapsed] = useState(true);
-    const [dismissed, setDismissed] = useState(false);
+    const [collapsed, setCollapsed] = useState(defaultCollapsed);
     const [height, setHeight] = useState(DEFAULT_HEIGHT);
     const dragRef = useRef<{
         startY: number;
@@ -373,11 +393,13 @@ const QueryInspector: FC<Props> = ({
         dragRef.current = null;
     }, []);
 
-    const handleDismiss = useCallback((e: React.MouseEvent) => {
-        e.stopPropagation();
-        setDismissed(true);
-        setCollapsed(true);
-    }, []);
+    const handleDismiss = useCallback(
+        (e: React.MouseEvent) => {
+            e.stopPropagation();
+            onDismiss();
+        },
+        [onDismiss],
+    );
 
     const handleClear = useCallback(
         (e: React.MouseEvent) => {
@@ -390,25 +412,10 @@ const QueryInspector: FC<Props> = ({
     // Hide the panel entirely only when there's nothing to show *and* the
     // user hasn't engaged with it. If they've expanded it (e.g. cleared the
     // log to wait for fresh queries), keep it mounted with an empty state so
-    // the next query lands somewhere visible.
-    if (queries.length === 0 && collapsed) return null;
-
-    // Dismissed — show a small icon to reopen
-    if (dismissed) {
-        return (
-            <Box className={classes.iconOnly}>
-                <ActionIcon
-                    variant="filled"
-                    color="gray"
-                    size="md"
-                    radius="xl"
-                    onClick={() => setDismissed(false)}
-                >
-                    <MantineIcon icon={IconDatabase} size={14} />
-                </ActionIcon>
-            </Box>
-        );
-    }
+    // the next query lands somewhere visible. The preview opts out of this
+    // hide-when-empty behavior (`hideWhenEmpty={false}`) so once opened from
+    // the menu the panel stays visible even before queries arrive.
+    if (hideWhenEmpty && queries.length === 0 && collapsed) return null;
 
     return (
         <Box
@@ -442,24 +449,26 @@ const QueryInspector: FC<Props> = ({
                                 <MantineIcon icon={IconTrash} size={12} />
                             </ActionIcon>
                         </Tooltip>
-                        <Tooltip
-                            label="Preserve queries across iframe refreshes and new app versions"
-                            withArrow
-                            position="top"
-                        >
-                            <Box onClick={(e) => e.stopPropagation()}>
-                                <Switch
-                                    size="xs"
-                                    label="Persist"
-                                    checked={persistLogs}
-                                    onChange={(e) =>
-                                        onPersistLogsChange(
-                                            e.currentTarget.checked,
-                                        )
-                                    }
-                                />
-                            </Box>
-                        </Tooltip>
+                        {onPersistLogsChange && (
+                            <Tooltip
+                                label="Preserve queries across iframe refreshes and new app versions"
+                                withArrow
+                                position="top"
+                            >
+                                <Box onClick={(e) => e.stopPropagation()}>
+                                    <Switch
+                                        size="xs"
+                                        label="Persist"
+                                        checked={persistLogs ?? false}
+                                        onChange={(e) =>
+                                            onPersistLogsChange(
+                                                e.currentTarget.checked,
+                                            )
+                                        }
+                                    />
+                                </Box>
+                            </Tooltip>
+                        )}
                     </>
                 )}
                 <ActionIcon variant="subtle" size="xs" color="gray">

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
@@ -1,0 +1,143 @@
+import { useLocalStorage } from '@mantine-8/hooks';
+import { useCallback, useRef, useState } from 'react';
+import type { QueryEvent } from './useAppSdkBridge';
+
+const PERSIST_LOGS_STORAGE_KEY = 'data-apps:persist-logs';
+
+export type UseTrackedAppQueriesResult = {
+    queries: QueryEvent[];
+    persistLogs: boolean;
+    setPersistLogs: (value: boolean) => void;
+    handleQueryEvent: (event: QueryEvent) => void;
+    clearQueries: () => void;
+    interruptInFlightQueries: () => void;
+};
+
+/**
+ * Tracks metric queries emitted by the app preview iframe SDK bridge.
+ *
+ * Owns the merge logic that turns POST initiations + poll results into a
+ * single timeline entry per query, plus the "interrupted by reload" recovery
+ * used by the builder when the preview iframe restarts mid-query.
+ *
+ * Shared between the builder (`AppGenerate`) where the queries panel is
+ * always-on, and the preview (`AppPreviewTest`) where it's opt-in via a menu.
+ * Preview uses only `queries`, `handleQueryEvent`, and `clearQueries` — the
+ * persist/interrupt machinery is builder-specific (preview iframe never
+ * reloads mid-session) but is harmless to expose.
+ */
+export const useTrackedAppQueries = (): UseTrackedAppQueriesResult => {
+    const [queries, setQueries] = useState<QueryEvent[]>([]);
+    // Mirrors Chrome DevTools "Preserve log". When off (default), the queries
+    // panel is cleared on iframe refresh and on new-version load — fresh
+    // bundles re-run their queries, so stale entries would only confuse the
+    // user. Stored in localStorage so the preference survives a tab close
+    // and stays consistent across tabs.
+    const [persistLogs, setPersistLogs] = useLocalStorage<boolean>({
+        key: PERSIST_LOGS_STORAGE_KEY,
+        defaultValue: false,
+    });
+    // Request IDs of queries we marked as interrupted on iframe reload. The
+    // bridge's parent-side fetch keeps running after the iframe dies and will
+    // emit a late `running` event for them — without this guard that event
+    // would resurrect the entry as 'running', or (if not matched) get appended
+    // as a fresh ghost entry. The set grows for the page session; entries are
+    // short request IDs, so the footprint is negligible.
+    const interruptedRequestIdsRef = useRef<Set<string>>(new Set());
+
+    const clearQueries = useCallback(() => {
+        setQueries([]);
+    }, []);
+
+    // Move pending/running entries into a terminal `error` state. Used when
+    // the preview iframe reloads with persistLogs on — the iframe that would
+    // have polled their queryUuids is dead, so they would otherwise sit
+    // non-terminal forever.
+    const interruptInFlightQueries = useCallback(() => {
+        setQueries((prev) => {
+            let mutated = false;
+            const next = prev.map((q) => {
+                if (q.status !== 'pending' && q.status !== 'running') {
+                    return q;
+                }
+                mutated = true;
+                interruptedRequestIdsRef.current.add(q.id);
+                return {
+                    ...q,
+                    status: 'error' as const,
+                    error: 'Interrupted by reload',
+                };
+            });
+            return mutated ? next : prev;
+        });
+    }, []);
+
+    const handleQueryEvent = useCallback((event: QueryEvent) => {
+        // Drop late events (typically the POST-resolution `running` event)
+        // for requests we already marked interrupted — without this they
+        // either un-terminal the entry or get appended as a ghost.
+        if (interruptedRequestIdsRef.current.has(event.id)) {
+            return;
+        }
+        setQueries((prev) => {
+            // If this event has a queryUuid, merge it with an existing entry
+            if (event.queryUuid) {
+                const existing = prev.find(
+                    (q) => q.queryUuid === event.queryUuid,
+                );
+                if (existing) {
+                    // Don't resurrect a terminal entry. Covers the rare race
+                    // where iframe-1 managed to issue a poll GET before
+                    // dying, so a late `ready` event arrives keyed on the
+                    // (already-interrupted) queryUuid.
+                    if (
+                        existing.status === 'ready' ||
+                        existing.status === 'error'
+                    ) {
+                        return prev;
+                    }
+                    return prev.map((q) =>
+                        q.queryUuid === event.queryUuid
+                            ? {
+                                  ...q,
+                                  label: event.label ?? q.label,
+                                  status: event.status,
+                                  rowCount: event.rowCount ?? q.rowCount,
+                                  durationMs: event.durationMs ?? q.durationMs,
+                                  error: event.error ?? q.error,
+                                  rawMetricQuery:
+                                      event.rawMetricQuery ?? q.rawMetricQuery,
+                              }
+                            : q,
+                    );
+                }
+            }
+            // If this is a POST initiation with queryUuid, check if we
+            // have a pending entry from the same request id to merge
+            const pendingIdx = prev.findIndex(
+                (q) => q.id === event.id && q.status === 'pending',
+            );
+            if (pendingIdx >= 0) {
+                return prev.map((q, i) =>
+                    i === pendingIdx
+                        ? {
+                              ...event,
+                              rawMetricQuery:
+                                  event.rawMetricQuery ?? q.rawMetricQuery,
+                          }
+                        : q,
+                );
+            }
+            return [...prev, event];
+        });
+    }, []);
+
+    return {
+        queries,
+        persistLogs,
+        setPersistLogs,
+        handleQueryEvent,
+        clearQueries,
+        interruptInFlightQueries,
+    };
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -29,12 +29,12 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
-import { useLocalStorage } from '@mantine-8/hooks';
 import {
     IconAppsOff,
     IconAppWindow,
     IconArrowUp,
     IconCopy,
+    IconDatabase,
     IconDots,
     IconExternalLink,
     IconArrowBackUp,
@@ -110,6 +110,7 @@ import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
 import { useRestoreAppVersion } from '../features/apps/hooks/useRestoreAppVersion';
+import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQueries';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import QueryInspector from '../features/apps/QueryInspector';
 import { getTemplate } from '../features/apps/templates';
@@ -125,8 +126,6 @@ import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
 import useApp from '../providers/App/useApp';
 import classes from './AppGenerate.module.css';
-
-const PERSIST_LOGS_STORAGE_KEY = 'data-apps:persist-logs';
 
 /**
  * Parse `[tag "text" @loc]` (or `[tag @loc]`, `[tag "text"]`, `[tag]`) from
@@ -348,48 +347,19 @@ const AppGenerate: FC = () => {
     const [screenshotAvailable, setScreenshotAvailable] = useState(false);
     const [isCapturingScreenshot, setIsCapturingScreenshot] = useState(false);
     const previewRef = useRef<AppIframePreviewHandle>(null);
-    const [trackedQueries, setTrackedQueries] = useState<QueryEvent[]>([]);
-    // Mirrors Chrome DevTools "Preserve log". When off (default), the queries
-    // panel is cleared on iframe refresh and on new-version load — fresh
-    // bundles re-run their queries, so stale entries would only confuse the
-    // user. Stored in localStorage so the preference survives a tab close
-    // and stays consistent across tabs.
-    const [persistLogs, setPersistLogs] = useLocalStorage<boolean>({
-        key: PERSIST_LOGS_STORAGE_KEY,
-        defaultValue: false,
-    });
-    // Request IDs of queries we marked as interrupted on iframe reload. The
-    // bridge's parent-side fetch keeps running after the iframe dies and will
-    // emit a late `running` event for them — without this guard that event
-    // would resurrect the entry as 'running', or (if not matched) get appended
-    // as a fresh ghost entry. The set grows for the page session; entries are
-    // short request IDs, so the footprint is negligible.
-    const interruptedRequestIdsRef = useRef<Set<string>>(new Set());
-    const handleClearQueries = useCallback(() => {
-        setTrackedQueries([]);
-    }, []);
-    // Move pending/running entries into a terminal `error` state. Used when
-    // the preview iframe reloads with persistLogs on — the iframe that would
-    // have polled their queryUuids is dead, so they would otherwise sit
-    // non-terminal forever.
-    const interruptInFlightQueries = useCallback(() => {
-        setTrackedQueries((prev) => {
-            let mutated = false;
-            const next = prev.map((q) => {
-                if (q.status !== 'pending' && q.status !== 'running') {
-                    return q;
-                }
-                mutated = true;
-                interruptedRequestIdsRef.current.add(q.id);
-                return {
-                    ...q,
-                    status: 'error' as const,
-                    error: 'Interrupted by reload',
-                };
-            });
-            return mutated ? next : prev;
-        });
-    }, []);
+    const {
+        queries: trackedQueries,
+        persistLogs,
+        setPersistLogs,
+        handleQueryEvent,
+        clearQueries,
+        interruptInFlightQueries,
+    } = useTrackedAppQueries();
+    // Parent-owned visibility so the X dismisses the panel completely and the
+    // user re-opens it from the dots menu — same model as preview, for
+    // consistency. Defaults to visible because the builder is the technical
+    // workflow where seeing queries as they fire is the point.
+    const [queriesPanelHidden, setQueriesPanelHidden] = useState(false);
     const handleElementSelected = useCallback((event: { label: string }) => {
         const ref = parseElementRefLabel(event.label);
         if (!ref) {
@@ -405,65 +375,6 @@ const AppGenerate: FC = () => {
     // every render of this page.
     const handleInspectorCancelled = useCallback(() => {
         setInspectorEnabled(false);
-    }, []);
-    const handleQueryEvent = useCallback((event: QueryEvent) => {
-        // Drop late events (typically the POST-resolution `running` event)
-        // for requests we already marked interrupted — without this they
-        // either un-terminal the entry or get appended as a ghost.
-        if (interruptedRequestIdsRef.current.has(event.id)) {
-            return;
-        }
-        setTrackedQueries((prev) => {
-            // If this event has a queryUuid, merge it with an existing entry
-            if (event.queryUuid) {
-                const existing = prev.find(
-                    (q) => q.queryUuid === event.queryUuid,
-                );
-                if (existing) {
-                    // Don't resurrect a terminal entry. Covers the rare race
-                    // where iframe-1 managed to issue a poll GET before
-                    // dying, so a late `ready` event arrives keyed on the
-                    // (already-interrupted) queryUuid.
-                    if (
-                        existing.status === 'ready' ||
-                        existing.status === 'error'
-                    ) {
-                        return prev;
-                    }
-                    return prev.map((q) =>
-                        q.queryUuid === event.queryUuid
-                            ? {
-                                  ...q,
-                                  label: event.label ?? q.label,
-                                  status: event.status,
-                                  rowCount: event.rowCount ?? q.rowCount,
-                                  durationMs: event.durationMs ?? q.durationMs,
-                                  error: event.error ?? q.error,
-                                  rawMetricQuery:
-                                      event.rawMetricQuery ?? q.rawMetricQuery,
-                              }
-                            : q,
-                    );
-                }
-            }
-            // If this is a POST initiation with queryUuid, check if we
-            // have a pending entry from the same request id to merge
-            const pendingIdx = prev.findIndex(
-                (q) => q.id === event.id && q.status === 'pending',
-            );
-            if (pendingIdx >= 0) {
-                return prev.map((q, i) =>
-                    i === pendingIdx
-                        ? {
-                              ...event,
-                              rawMetricQuery:
-                                  event.rawMetricQuery ?? q.rawMetricQuery,
-                          }
-                        : q,
-                );
-            }
-            return [...prev, event];
-        });
     }, []);
     const [localMessages, setLocalMessages] = useState<ChatMessage[]>([]);
     // Pre-build clarification round: captured submission args that we need
@@ -511,7 +422,7 @@ const AppGenerate: FC = () => {
         setImageAttachments([]);
         setLocalMessages([]);
         setPin(null);
-        setTrackedQueries([]);
+        clearQueries();
         setInspectorEnabled(false);
         setInspectorAvailable(false);
         setScreenshotAvailable(false);
@@ -526,7 +437,7 @@ const AppGenerate: FC = () => {
             urls.forEach((url) => URL.revokeObjectURL(url)),
         );
         sentImagesByPrompt.current.clear();
-    }, []);
+    }, [clearQueries]);
     useEffect(() => {
         const prev = prevUrlAppUuid.current;
         prevUrlAppUuid.current = urlAppUuid;
@@ -945,9 +856,14 @@ const AppGenerate: FC = () => {
         if (persistLogs) {
             interruptInFlightQueries();
         } else {
-            setTrackedQueries([]);
+            clearQueries();
         }
-    }, [previewApp?.version, persistLogs, interruptInFlightQueries]);
+    }, [
+        previewApp?.version,
+        persistLogs,
+        interruptInFlightQueries,
+        clearQueries,
+    ]);
 
     // Manual refresh counter for the preview iframe. The iframe URL embeds
     // this value, so bumping it forces the browser to reload the iframe and
@@ -960,9 +876,9 @@ const AppGenerate: FC = () => {
         if (persistLogs) {
             interruptInFlightQueries();
         } else {
-            setTrackedQueries([]);
+            clearQueries();
         }
-    }, [persistLogs, interruptInFlightQueries]);
+    }, [persistLogs, interruptInFlightQueries, clearQueries]);
 
     const scrollToBottom = useCallback(() => {
         messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -2306,7 +2222,20 @@ const AppGenerate: FC = () => {
                                                 Preview latest
                                             </Menu.Item>
                                         )}
-                                        {previewApp && <Menu.Divider />}
+                                        <Menu.Item
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconDatabase}
+                                                    size={14}
+                                                />
+                                            }
+                                            onClick={() =>
+                                                setQueriesPanelHidden(false)
+                                            }
+                                        >
+                                            View queries
+                                        </Menu.Item>
+                                        <Menu.Divider />
                                         <Menu.Item
                                             leftSection={
                                                 <MantineIcon
@@ -2542,13 +2471,18 @@ const AppGenerate: FC = () => {
                                     </Text>
                                 </Box>
                             )}
-                            <QueryInspector
-                                queries={trackedQueries}
-                                projectUuid={projectUuid!}
-                                onClear={handleClearQueries}
-                                persistLogs={persistLogs}
-                                onPersistLogsChange={setPersistLogs}
-                            />
+                            {!queriesPanelHidden && (
+                                <QueryInspector
+                                    queries={trackedQueries}
+                                    projectUuid={projectUuid!}
+                                    onClear={clearQueries}
+                                    persistLogs={persistLogs}
+                                    onPersistLogsChange={setPersistLogs}
+                                    onDismiss={() =>
+                                        setQueriesPanelHidden(true)
+                                    }
+                                />
+                            )}
                         </Box>
                     </Box>
                 </Panel>

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -3,6 +3,7 @@ import { FeatureFlags } from '@lightdash/common';
 import { ActionIcon, Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
 import {
     IconAppsOff,
+    IconDatabase,
     IconDots,
     IconPencil,
     IconSend,
@@ -14,7 +15,9 @@ import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
+import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQueries';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
+import QueryInspector from '../features/apps/QueryInspector';
 import { AppSchedulersModal } from '../features/scheduler/components/SchedulerModals';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../hooks/useSpaces';
@@ -78,6 +81,13 @@ export default function AppPreviewTest() {
 
     const [menuOpened, setMenuOpened] = useState(false);
     const [schedulerModalOpen, setSchedulerModalOpen] = useState(false);
+    const [queriesPanelHidden, setQueriesPanelHidden] = useState(true);
+
+    // Query tracking from the preview iframe. The panel is opt-in (hidden by
+    // default in preview because most viewers aren't technical), but we wire
+    // up the SDK bridge callback unconditionally so queries that run before
+    // the user opens the panel are still captured.
+    const { queries, handleQueryEvent, clearQueries } = useTrackedAppQueries();
 
     // Close menu when the iframe receives focus (i.e. user clicked on it)
     const handleBlur = useCallback(() => {
@@ -174,25 +184,25 @@ export default function AppPreviewTest() {
 
     return (
         <Box className={classes.previewContainer}>
-            {canEditApp && (
-                <Box className={classes.menuOverlay}>
-                    <Menu
-                        position="bottom-end"
-                        withinPortal
-                        opened={menuOpened}
-                        onChange={setMenuOpened}
-                    >
-                        <Menu.Target>
-                            <ActionIcon
-                                variant="filled"
-                                color="gray"
-                                size="lg"
-                                radius="xl"
-                            >
-                                <IconDots size={18} />
-                            </ActionIcon>
-                        </Menu.Target>
-                        <Menu.Dropdown>
+            <Box className={classes.menuOverlay}>
+                <Menu
+                    position="bottom-end"
+                    withinPortal
+                    opened={menuOpened}
+                    onChange={setMenuOpened}
+                >
+                    <Menu.Target>
+                        <ActionIcon
+                            variant="filled"
+                            color="gray"
+                            size="lg"
+                            radius="xl"
+                        >
+                            <IconDots size={18} />
+                        </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        {canEditApp && (
                             <Menu.Item
                                 leftSection={<IconPencil size={14} />}
                                 onClick={() =>
@@ -203,7 +213,9 @@ export default function AppPreviewTest() {
                             >
                                 Continue building
                             </Menu.Item>
-                            {scheduledDeliveriesFlag.data?.enabled && (
+                        )}
+                        {canEditApp &&
+                            scheduledDeliveriesFlag.data?.enabled && (
                                 <Menu.Item
                                     leftSection={<IconSend size={14} />}
                                     onClick={() => setSchedulerModalOpen(true)}
@@ -211,15 +223,31 @@ export default function AppPreviewTest() {
                                     Schedule delivery
                                 </Menu.Item>
                             )}
-                        </Menu.Dropdown>
-                    </Menu>
-                </Box>
-            )}
+                        <Menu.Item
+                            leftSection={<IconDatabase size={14} />}
+                            onClick={() => setQueriesPanelHidden(false)}
+                        >
+                            View queries
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
+            </Box>
             <AppIframePreview
                 src={previewUrl}
                 expectedPreviewOrigin={previewOrigin}
                 identityKey={`${appUuid}:${version}`}
+                onQueryEvent={handleQueryEvent}
             />
+            {!queriesPanelHidden && (
+                <QueryInspector
+                    queries={queries}
+                    projectUuid={projectUuid}
+                    onClear={clearQueries}
+                    defaultCollapsed={false}
+                    hideWhenEmpty={false}
+                    onDismiss={() => setQueriesPanelHidden(true)}
+                />
+            )}
             {schedulerModalOpen && (
                 <AppSchedulersModal
                     projectUuid={projectUuid}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7836/show-queries-panel-also-in-data-apps-preview

### Description:
Viewers couldn't validate the data powering a data app — the queries panel only existed in the builder. Now both pages expose it via a "View queries" item in the dots menu, and the close action is aligned: the X fully unmounts the panel and re-opening goes through the menu (no more floating icon affordance).

- Extract query-tracking state and merge logic into `useTrackedAppQueries` so the builder and preview share one source of truth.
- Make `QueryInspector` parent-controlled for visibility: `onDismiss` is required, `defaultCollapsed` / `hideWhenEmpty` are new optional props, and `persistLogs` is optional (preview hides the switch since its iframe doesn't reload mid-session).
- Preview shows "View queries" to all viewers (ungated by `canEditApp`); edit/schedule items stay editor-only.

