### PR TITLE
fix: replace boolean `enabled` with `permission_mode` enum for MCP server tool settings

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -264,11 +264,25 @@ export type AiMcpServerToolTable = Knex.CompositeTableType<
 
 export const AiAgentMcpServerToolTableName = 'ai_agent_mcp_server_tool';
 
+export const AiAgentMcpServerToolPermissionModes = [
+    'always_allow',
+    'ask',
+    'always_deny',
+] as const;
+
+export type DbAiAgentMcpServerToolPermissionMode =
+    (typeof AiAgentMcpServerToolPermissionModes)[number];
+
 export type DbAiAgentMcpServerTool = {
     ai_agent_uuid: string;
     ai_mcp_server_uuid: string;
     ai_mcp_server_tool_uuid: string;
-    enabled: boolean;
+    /**
+     * @deprecated Kept for rolling deploy safety. New code should use
+     * `permission_mode` instead.
+     */
+    enabled?: boolean;
+    permission_mode: DbAiAgentMcpServerToolPermissionMode;
     created_at: Date;
     updated_at: Date;
 };

--- a/packages/backend/src/ee/database/migrations/20260522110000_add_permission_mode_to_ai_agent_mcp_server_tool.ts
+++ b/packages/backend/src/ee/database/migrations/20260522110000_add_permission_mode_to_ai_agent_mcp_server_tool.ts
@@ -1,0 +1,49 @@
+import { Knex } from 'knex';
+
+const AiAgentMcpServerToolTableName = 'ai_agent_mcp_server_tool';
+const PermissionModeColumnName = 'permission_mode';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiAgentMcpServerToolTableName))) return;
+
+    if (
+        !(await knex.schema.hasColumn(
+            AiAgentMcpServerToolTableName,
+            PermissionModeColumnName,
+        ))
+    ) {
+        await knex.schema.alterTable(AiAgentMcpServerToolTableName, (table) => {
+            table
+                .string(PermissionModeColumnName)
+                .notNullable()
+                .defaultTo('always_deny');
+        });
+    }
+
+    if (await knex.schema.hasColumn(AiAgentMcpServerToolTableName, 'enabled')) {
+        await knex.schema.alterTable(AiAgentMcpServerToolTableName, (table) => {
+            table.boolean('enabled').notNullable().defaultTo(false).alter();
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiAgentMcpServerToolTableName))) return;
+
+    if (await knex.schema.hasColumn(AiAgentMcpServerToolTableName, 'enabled')) {
+        await knex.raw(
+            `alter table "${AiAgentMcpServerToolTableName}" alter column "enabled" drop default`,
+        );
+    }
+
+    if (
+        await knex.schema.hasColumn(
+            AiAgentMcpServerToolTableName,
+            PermissionModeColumnName,
+        )
+    ) {
+        await knex.schema.alterTable(AiAgentMcpServerToolTableName, (table) => {
+            table.dropColumn(PermissionModeColumnName);
+        });
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -9,8 +9,6 @@ import {
     AiAgentEvaluationRunResult,
     AiAgentEvaluationRunSummary,
     AiAgentEvaluationSummary,
-    AiAgentMcpServerTool,
-    AiAgentMcpServerToolUpdate,
     AiAgentMessage,
     AiAgentMessageAssistant,
     AiAgentMessageAssistantArtifact,
@@ -133,6 +131,7 @@ import {
     DbAiAgentIntegration,
     DbAiAgentMcpServer,
     DbAiAgentMcpServerTool,
+    DbAiAgentMcpServerToolPermissionMode,
     DbAiAgentSlackIntegration,
     DbAiMcpServer,
     DbAiMcpServerCredential,
@@ -168,6 +167,21 @@ type Dependencies = {
     lightdashConfig: LightdashConfig;
     encryptionUtil: EncryptionUtil;
 };
+
+export const AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW: DbAiAgentMcpServerToolPermissionMode =
+    'always_allow';
+export const AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY: DbAiAgentMcpServerToolPermissionMode =
+    'always_deny';
+
+export type AiAgentMcpServerToolPermissionSetting = AiMcpServerTool & {
+    agentUuid: string;
+    permissionMode: DbAiAgentMcpServerToolPermissionMode;
+};
+
+export type AiAgentMcpServerToolPermissionSettingUpdate = Pick<
+    AiAgentMcpServerToolPermissionSetting,
+    'toolName' | 'permissionMode'
+>;
 
 export type AiMcpBearerCredentialPayload = {
     type: 'bearer';
@@ -734,15 +748,17 @@ export class AiAgentModel {
         };
     }
 
-    private static toAiAgentMcpServerTool(args: {
+    private static toAiAgentMcpServerToolPermissionSetting(args: {
         agentUuid: string;
         tool: DbAiMcpServerTool;
         setting?: DbAiAgentMcpServerTool;
-    }): AiAgentMcpServerTool {
+    }): AiAgentMcpServerToolPermissionSetting {
         return {
             ...AiAgentModel.toAiMcpServerTool(args.tool),
             agentUuid: args.agentUuid,
-            enabled: args.setting?.enabled ?? false,
+            permissionMode:
+                args.setting?.permission_mode ??
+                AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY,
         };
     }
 
@@ -767,6 +783,7 @@ export class AiAgentModel {
             ai_mcp_server_uuid: `${AiAgentMcpServerToolTableName}.ai_mcp_server_uuid`,
             ai_mcp_server_tool_uuid: `${AiAgentMcpServerToolTableName}.ai_mcp_server_tool_uuid`,
             enabled: `${AiAgentMcpServerToolTableName}.enabled`,
+            permission_mode: `${AiAgentMcpServerToolTableName}.permission_mode`,
             created_at: `${AiAgentMcpServerToolTableName}.created_at`,
             updated_at: `${AiAgentMcpServerToolTableName}.updated_at`,
         } satisfies Record<keyof DbAiAgentMcpServerTool, Knex.Value>;
@@ -946,7 +963,7 @@ export class AiAgentModel {
     async upsertDiscoveredMcpServerTools(args: {
         serverUuid: string;
         tools: AiMcpServerToolInput[];
-        defaultEnabledForExistingAttachments?: boolean;
+        defaultPermissionModeForExistingAttachments?: DbAiAgentMcpServerToolPermissionMode;
         trx?: Knex;
     }): Promise<AiMcpServerTool[]> {
         const trx = args.trx ?? this.database;
@@ -1025,9 +1042,9 @@ export class AiAgentModel {
                                 ai_mcp_server_uuid: row.ai_mcp_server_uuid,
                                 ai_mcp_server_tool_uuid:
                                     tool.ai_mcp_server_tool_uuid,
-                                enabled:
-                                    args.defaultEnabledForExistingAttachments ??
-                                    false,
+                                permission_mode:
+                                    args.defaultPermissionModeForExistingAttachments ??
+                                    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY,
                                 created_at: trx.fn.now(),
                                 updated_at: trx.fn.now(),
                             })),
@@ -1053,7 +1070,7 @@ export class AiAgentModel {
         agentUuid: string;
         serverUuid: string;
         trx?: Knex;
-    }): Promise<AiAgentMcpServerTool[]> {
+    }): Promise<AiAgentMcpServerToolPermissionSetting[]> {
         const trx = args.trx ?? this.database;
 
         const attachment = await this.getAgentMcpServerAttachment({
@@ -1091,7 +1108,7 @@ export class AiAgentModel {
         );
 
         return toolRows.map((tool) =>
-            AiAgentModel.toAiAgentMcpServerTool({
+            AiAgentModel.toAiAgentMcpServerToolPermissionSetting({
                 agentUuid: args.agentUuid,
                 tool,
                 setting: settingMap.get(tool.ai_mcp_server_tool_uuid),
@@ -1102,9 +1119,9 @@ export class AiAgentModel {
     async upsertAgentMcpServerToolSettings(args: {
         agentUuid: string;
         serverUuid: string;
-        toolSettings: AiAgentMcpServerToolUpdate[];
+        toolSettings: AiAgentMcpServerToolPermissionSettingUpdate[];
         trx?: Knex;
-    }): Promise<AiAgentMcpServerTool[]> {
+    }): Promise<AiAgentMcpServerToolPermissionSetting[]> {
         const trx = args.trx ?? this.database;
         const settingMap = new Map(
             args.toolSettings.map((tool) => [tool.toolName, tool] as const),
@@ -1154,7 +1171,7 @@ export class AiAgentModel {
                     ai_agent_uuid: attachment.ai_agent_uuid,
                     ai_mcp_server_uuid: attachment.ai_mcp_server_uuid,
                     ai_mcp_server_tool_uuid: toolUuidByName.get(tool.toolName)!,
-                    enabled: tool.enabled,
+                    permission_mode: tool.permissionMode,
                     created_at: trx.fn.now(),
                     updated_at: trx.fn.now(),
                 })),
@@ -1165,7 +1182,7 @@ export class AiAgentModel {
                 'ai_mcp_server_tool_uuid',
             ])
             .merge({
-                enabled: trx.raw('excluded.enabled'),
+                permission_mode: trx.raw('excluded.permission_mode'),
                 updated_at: trx.fn.now(),
             });
 
@@ -1179,7 +1196,7 @@ export class AiAgentModel {
     async initializeAgentMcpServerToolSettings(args: {
         agentUuid: string;
         serverUuid: string;
-        enabled: boolean;
+        permissionMode: DbAiAgentMcpServerToolPermissionMode;
         trx?: Knex;
     }): Promise<void> {
         const trx = args.trx ?? this.database;
@@ -1209,7 +1226,7 @@ export class AiAgentModel {
                     ai_agent_uuid: attachment.ai_agent_uuid,
                     ai_mcp_server_uuid: attachment.ai_mcp_server_uuid,
                     ai_mcp_server_tool_uuid: tool.ai_mcp_server_tool_uuid,
-                    enabled: args.enabled,
+                    permission_mode: args.permissionMode,
                     created_at: trx.fn.now(),
                     updated_at: trx.fn.now(),
                 })),
@@ -1257,7 +1274,10 @@ export class AiAgentModel {
                 `${AiAgentMcpServerToolTableName}.ai_mcp_server_uuid`,
                 attachment.ai_mcp_server_uuid,
             )
-            .andWhere(`${AiAgentMcpServerToolTableName}.enabled`, true)
+            .andWhere(
+                `${AiAgentMcpServerToolTableName}.permission_mode`,
+                AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
+            )
             .orderBy(`${AiMcpServerToolTableName}.tool_name`, 'asc');
 
         return rows.map((row) => row.tool_name);
@@ -2126,7 +2146,8 @@ export class AiAgentModel {
                     this.initializeAgentMcpServerToolSettings({
                         agentUuid,
                         serverUuid,
-                        enabled: true,
+                        permissionMode:
+                            AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
                         trx,
                     }),
                 ),

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -238,6 +238,23 @@ describe('AiAgentService MCP support', () => {
                 agent.uuid,
                 mcpServer.uuid,
             );
+        const listPermissionModes = async () =>
+            context
+                .db('ai_agent_mcp_server_tool as settings')
+                .innerJoin('ai_mcp_server_tool as tools', function joinTools() {
+                    this.on(
+                        'settings.ai_mcp_server_tool_uuid',
+                        '=',
+                        'tools.ai_mcp_server_tool_uuid',
+                    );
+                })
+                .select({
+                    toolName: 'tools.tool_name',
+                    permissionMode: 'settings.permission_mode',
+                })
+                .where('settings.ai_agent_uuid', agent.uuid)
+                .andWhere('settings.ai_mcp_server_uuid', mcpServer.uuid)
+                .orderBy('tools.tool_name', 'asc');
 
         expect(
             initialAgentToolSettings.map((tool) => ({
@@ -248,6 +265,12 @@ describe('AiAgentService MCP support', () => {
             {
                 toolName: 'search',
                 enabled: true,
+            },
+        ]);
+        await expect(listPermissionModes()).resolves.toEqual([
+            {
+                toolName: 'search',
+                permissionMode: 'always_allow',
             },
         ]);
         await expect(
@@ -299,6 +322,16 @@ describe('AiAgentService MCP support', () => {
                 enabled: true,
             },
         ]);
+        await expect(listPermissionModes()).resolves.toEqual([
+            {
+                toolName: 'lookup',
+                permissionMode: 'always_deny',
+            },
+            {
+                toolName: 'search',
+                permissionMode: 'always_allow',
+            },
+        ]);
 
         await services.aiAgentService.updateAgentMcpServerTools(
             context.testUser,
@@ -316,6 +349,16 @@ describe('AiAgentService MCP support', () => {
                 serverUuid: mcpServer.uuid,
             }),
         ).resolves.toEqual(['lookup', 'search']);
+        await expect(listPermissionModes()).resolves.toEqual([
+            {
+                toolName: 'lookup',
+                permissionMode: 'always_allow',
+            },
+            {
+                toolName: 'search',
+                permissionMode: 'always_allow',
+            },
+        ]);
 
         availableTools = [
             {
@@ -359,6 +402,12 @@ describe('AiAgentService MCP support', () => {
                 serverUuid: mcpServer.uuid,
             }),
         ).resolves.toEqual(['lookup']);
+        await expect(listPermissionModes()).resolves.toEqual([
+            {
+                toolName: 'lookup',
+                permissionMode: 'always_allow',
+            },
+        ]);
 
         const sensitiveMcpServers =
             await models.aiAgentModel.getAgentMcpServersWithSensitiveData(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7,7 +7,6 @@ import {
     AiAgentEvalRunJobPayload,
     AiAgentEvaluationRun,
     AiAgentEvaluationSummary,
-    AiAgentMcpServerToolUpdate,
     AiAgentNotFoundError,
     AiAgentSummary,
     AiAgentThread,
@@ -149,7 +148,14 @@ import {
 import { wrapSentryTransaction } from '../../../utils';
 import { validatePublicHttpUrl } from '../../../utils/ssrfProtection';
 import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
-import { AiAgentModel, type AiMcpCredential } from '../../models/AiAgentModel';
+import {
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
+    AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY,
+    AiAgentModel,
+    type AiAgentMcpServerToolPermissionSetting,
+    type AiAgentMcpServerToolPermissionSettingUpdate,
+    type AiMcpCredential,
+} from '../../models/AiAgentModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { selectBestAgentWithContext } from '../ai/agents/agentSelector';
@@ -1950,8 +1956,10 @@ export class AiAgentService extends BaseService {
         return this.aiAgentModel.upsertDiscoveredMcpServerTools({
             serverUuid: args.mcpServerUuid,
             tools,
-            defaultEnabledForExistingAttachments:
-                args.defaultEnabledForExistingAttachments,
+            defaultPermissionModeForExistingAttachments:
+                args.defaultEnabledForExistingAttachments
+                    ? AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW
+                    : undefined,
         });
     }
 
@@ -2020,6 +2028,25 @@ export class AiAgentService extends BaseService {
             );
     }
 
+    private static toApiAgentMcpServerTool(
+        tool: AiAgentMcpServerToolPermissionSetting,
+    ) {
+        const { permissionMode, ...apiTool } = tool;
+
+        return {
+            ...apiTool,
+            enabled:
+                permissionMode ===
+                AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
+        };
+    }
+
+    private static toAgentMcpServerToolPermissionMode(enabled: boolean) {
+        return enabled
+            ? AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW
+            : AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY;
+    }
+
     public async listAgentMcpServerTools(
         user: SessionUser,
         projectUuid: string,
@@ -2029,10 +2056,12 @@ export class AiAgentService extends BaseService {
         await this.assertCanManageAgent(user, agentUuid, projectUuid);
         await this.getProjectMcpServerOrThrow(projectUuid, mcpServerUuid);
 
-        return this.aiAgentModel.listAgentMcpServerTools({
-            agentUuid,
-            serverUuid: mcpServerUuid,
-        });
+        return this.aiAgentModel
+            .listAgentMcpServerTools({
+                agentUuid,
+                serverUuid: mcpServerUuid,
+            })
+            .then((tools) => tools.map(AiAgentService.toApiAgentMcpServerTool));
     }
 
     public async updateAgentMcpServerTools(
@@ -2045,22 +2074,35 @@ export class AiAgentService extends BaseService {
         await this.assertCanManageAgent(user, agentUuid, projectUuid);
         await this.getProjectMcpServerOrThrow(projectUuid, mcpServerUuid);
 
-        const toolSettings: AiAgentMcpServerToolUpdate[] = [
-            ...new Map<string, AiAgentMcpServerToolUpdate>(
+        const toolSettings: AiAgentMcpServerToolPermissionSettingUpdate[] = [
+            ...new Map<string, AiAgentMcpServerToolPermissionSettingUpdate>(
                 body.toolSettings.map(
-                    (tool): [string, AiAgentMcpServerToolUpdate] => [
-                        tool.toolName,
+                    (
                         tool,
+                    ): [
+                        string,
+                        AiAgentMcpServerToolPermissionSettingUpdate,
+                    ] => [
+                        tool.toolName,
+                        {
+                            toolName: tool.toolName,
+                            permissionMode:
+                                AiAgentService.toAgentMcpServerToolPermissionMode(
+                                    tool.enabled,
+                                ),
+                        },
                     ],
                 ),
             ).values(),
         ];
 
-        return this.aiAgentModel.upsertAgentMcpServerToolSettings({
-            agentUuid,
-            serverUuid: mcpServerUuid,
-            toolSettings,
-        });
+        return this.aiAgentModel
+            .upsertAgentMcpServerToolSettings({
+                agentUuid,
+                serverUuid: mcpServerUuid,
+                toolSettings,
+            })
+            .then((tools) => tools.map(AiAgentService.toApiAgentMcpServerTool));
     }
 
     public async createMcpServer(


### PR DESCRIPTION
Closes:

### Description:

Replaces the boolean `enabled` field on `ai_agent_mcp_server_tool` with a `permission_mode` column that supports three explicit states: `always_allow`, `ask`, and `always_deny`.

A database migration adds the `permission_mode` column with a default of `always_deny` and ensures the existing `enabled` column has a safe default for rolling deploys. The `enabled` column is marked as deprecated in the type definition and retained only for backward compatibility during the transition.

Internally, all model methods now read and write `permission_mode` instead of `enabled`. The public API surface is kept stable — `listAgentMcpServerTools` and `updateAgentMcpServerTools` still accept and return the `enabled` boolean, with `AiAgentService` handling the translation between the boolean API shape and the new `permission_mode` values (`true` → `always_allow`, `false` → `always_deny`).

Integration tests are extended to assert that the correct `permission_mode` values are persisted to the database at each stage of the tool settings lifecycle.