### PR TITLE
fix: refresh data app dashboard tiles with the dashboard refresh button

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -187,6 +187,22 @@ a `previewRefreshKey` counter that gets baked into the iframe URL as `&r={key}`.
 which forces the browser to reload the iframe; the served bundle and the JWT are unaffected. The query inspector panel
 is cleared on refresh so the new query run isn't mixed with stale entries from the previous load.
 
+### Refreshing a data app inside a dashboard
+
+A data app embedded as a `DashboardDataAppTile` refreshes the same way a chart tile does when the dashboard's
+**refresh button** is pressed. The challenge is that the tile's queries run *inside* the sandboxed iframe (via the
+postMessage bridge), so they can't piggyback on the React Query invalidation that re-fetches chart tiles. Two pieces
+bridge that gap, both driven by `clearCacheAndFetch` in `DashboardTileStatusProvider`:
+
+- **Reload the iframe.** `clearCacheAndFetch` bumps a monotonic `refreshCounter` on the tile-status context.
+  `DashboardDataAppTile` bakes it into the iframe URL as `&r={refreshCounter}` (same convention as `AppGenerate`'s
+  `previewRefreshKey`), which forces the browser to reload the iframe so its mount-time metric queries re-fire. A
+  counter — not the sticky `invalidateCache` boolean — is required so repeat refreshes keep changing the URL.
+- **Bypass the warehouse cache.** `clearCacheAndFetch` also flips `invalidateCache` to `true`. The tile forwards it to
+  `AppIframePreview` → `useAppSdkBridge`, which stamps `invalidateCache` onto every intercepted metric-query POST —
+  exactly the same flag chart tiles send on refresh, and the same slot the bridge already uses to stamp
+  `dashboardFilters`. So the app's re-fired queries hit the warehouse fresh instead of serving cached results.
+
 ### Previewing older versions
 
 By default the preview iframe loads the **latest ready** version of the app — it auto-bumps every time a new iteration

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -14,6 +14,7 @@ import { useProject } from '../../hooks/useProject';
 import { useSpaceSummaries } from '../../hooks/useSpaces';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
+import useDashboardTileStatusContext from '../../providers/Dashboard/useDashboardTileStatusContext';
 import { convertDateDashboardFilters } from '../../utils/dateFilter';
 import LinkMenuItem from '../common/LinkMenuItem';
 import MantineIcon from '../common/MantineIcon';
@@ -60,6 +61,19 @@ const DataAppTile: FC<Props> = (props) => {
     const dashboardFiltersForApp = useMemo(
         () => convertDateDashboardFilters(tileDashboardFilters),
         [tileDashboardFilters],
+    );
+
+    // The dashboard refresh button bumps `refreshCounter` and flips
+    // `invalidateCache` (both via `clearCacheAndFetch`). Chart tiles re-fetch
+    // through React Query; this iframe re-fires its mount-time queries only on
+    // reload, so we bake the counter into the URL to force one, and forward
+    // invalidateCache so those re-fired queries bypass the warehouse cache —
+    // matching how a chart refreshes.
+    const invalidateCache = useDashboardTileStatusContext(
+        (c) => c.invalidateCache,
+    );
+    const refreshCounter = useDashboardTileStatusContext(
+        (c) => c.refreshCounter,
     );
 
     const previewOrigin = usePreviewOrigin();
@@ -128,7 +142,7 @@ const DataAppTile: FC<Props> = (props) => {
         token && latestReadyVersion
             ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/?f=${encodeURIComponent(
                   filtersKey,
-              )}#transport=postMessage&projectUuid=${projectUuid}`
+              )}&r=${refreshCounter}#transport=postMessage&projectUuid=${projectUuid}`
             : undefined;
 
     const isForbidden =
@@ -196,6 +210,7 @@ const DataAppTile: FC<Props> = (props) => {
                         expectedPreviewOrigin={previewOrigin}
                         identityKey={`${appUuid}:${latestReadyVersion}`}
                         dashboardFilters={dashboardFiltersForApp}
+                        invalidateCache={invalidateCache}
                     />
                 )}
             </Box>

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -57,6 +57,11 @@ type Props = {
      *  Set by `DashboardDataAppTile`; left undefined by `AppGenerate` where
      *  there's no dashboard context. */
     dashboardFilters?: DashboardFilters;
+    /** When true, every metric-query the iframe runs is sent with
+     *  `invalidateCache` so the backend bypasses the warehouse results cache.
+     *  Set by `DashboardDataAppTile` after a dashboard refresh, mirroring what
+     *  chart tiles send; left undefined elsewhere. */
+    invalidateCache?: boolean;
     /** Fired on every iframe `onload` (including the initial about:blank).
      *  Used by `MinimalApp` to gate the screenshot readiness signal. */
     onIframeLoad?: () => void;
@@ -91,6 +96,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onScreenshotAvailabilityChange,
             onInspectorCancelled,
             dashboardFilters,
+            invalidateCache,
             onIframeLoad,
         },
         ref,
@@ -114,6 +120,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
                 handleInspectorAnnounce,
                 handleScreenshotAnnounce,
                 dashboardFilters,
+                invalidateCache,
             );
         const { captureScreenshot } = useIframeScreenshot(iframeRef);
 

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -138,6 +138,13 @@ export function useAppSdkBridge(
      * is not involved — generated apps stay filter-agnostic.
      */
     dashboardFilters?: DashboardFilters,
+    /**
+     * When true, `invalidateCache` is stamped onto every intercepted
+     * metric-query POST so the backend bypasses the warehouse results cache —
+     * mirrors what chart tiles send after the dashboard refresh button is
+     * pressed. Set by `DashboardDataAppTile`; left undefined elsewhere.
+     */
+    invalidateCache?: boolean,
 ) {
     // Embed mode adapts the bridge's outgoing fetches in two ways:
     //   - Attaches the embed JWT header in lieu of session cookies
@@ -205,14 +212,19 @@ export function useAppSdkBridge(
                 return;
             }
 
-            // Stamp dashboard filters onto outgoing metric-query bodies. The
-            // backend drops filters whose fields aren't in the query's
-            // explore, so it's safe to send the full set on every call.
+            // Stamp dashboard filters and the cache-invalidation flag onto
+            // outgoing metric-query bodies. The backend drops filters whose
+            // fields aren't in the query's explore, so it's safe to send the
+            // full set on every call. `invalidateCache` mirrors what charts
+            // send on a dashboard refresh so the app's queries bypass the
+            // warehouse results cache too.
             const effectiveBody =
-                isMetricQueryPost(method, path) && dashboardFilters
+                isMetricQueryPost(method, path) &&
+                (dashboardFilters || invalidateCache)
                     ? {
                           ...(body as Record<string, unknown> | undefined),
-                          dashboardFilters,
+                          ...(dashboardFilters ? { dashboardFilters } : {}),
+                          ...(invalidateCache ? { invalidateCache } : {}),
                       }
                     : body;
 
@@ -394,6 +406,7 @@ export function useAppSdkBridge(
             onInspectorAvailable,
             onScreenshotAvailable,
             dashboardFilters,
+            invalidateCache,
             embedToken,
             embedProjectUuid,
         ],

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -46,6 +46,10 @@ const DashboardTileStatusProvider: React.FC<
         defaultInvalidateCache === true,
     );
 
+    // Bumped on every refresh so iframe-based tiles (data apps) can force a
+    // reload — they can't piggyback on React Query invalidation like charts do.
+    const [refreshCounter, setRefreshCounter] = useState<number>(0);
+
     const [sqlChartTilesMetadata, setSqlChartTilesMetadata] = useState<
         Record<string, SqlChartTileMetadata>
     >({});
@@ -227,6 +231,12 @@ const DashboardTileStatusProvider: React.FC<
 
         // Causes results refetch
         setInvalidateCache(true);
+
+        // Drives the iframe reload for data-app tiles (charts re-fetch via
+        // React Query invalidation, which happens separately in the refresh
+        // button). Bumping every call covers repeat refreshes — unlike
+        // invalidateCache, which is sticky once true.
+        setRefreshCounter((prev) => prev + 1);
     }, []);
 
     const updateSqlChartTilesMetadata = useCallback(
@@ -270,6 +280,7 @@ const DashboardTileStatusProvider: React.FC<
             addResultsCacheTime,
             preAggregateStatuses,
             invalidateCache,
+            refreshCounter,
             isAutoRefresh,
             setIsAutoRefresh,
             clearCacheAndFetch,
@@ -297,6 +308,7 @@ const DashboardTileStatusProvider: React.FC<
             addResultsCacheTime,
             preAggregateStatuses,
             invalidateCache,
+            refreshCounter,
             isAutoRefresh,
             clearCacheAndFetch,
             sqlChartTilesMetadata,

--- a/packages/frontend/src/providers/Dashboard/tileStatusTypes.ts
+++ b/packages/frontend/src/providers/Dashboard/tileStatusTypes.ts
@@ -9,6 +9,14 @@ export type DashboardTileStatusContextType = {
     addResultsCacheTime: (cacheMetadata?: CacheMetadata) => void;
     preAggregateStatuses: Record<string, TilePreAggregateStatus>;
     invalidateCache: boolean | undefined;
+    /**
+     * Monotonic counter bumped on every manual/auto refresh (via
+     * `clearCacheAndFetch`). Chart tiles re-fetch through React Query
+     * invalidation, but data-app tiles run their queries inside an iframe that
+     * only re-fires them on reload — they bake this counter into the iframe URL
+     * to force that reload. See `DashboardDataAppTile`.
+     */
+    refreshCounter: number;
     isAutoRefresh: boolean;
     setIsAutoRefresh: (autoRefresh: boolean) => void;
     clearCacheAndFetch: () => void;


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/PROD-7814/i-want-to-invalidate-or-refresh-cached-query-results-from-an-app

### Description:
The dashboard refresh button re-ran chart queries but left embedded data app tiles untouched. Data apps run their queries inside the sandboxed iframe via the postMessage bridge, so they can't piggyback on the React Query invalidation that refreshes charts.
