### PR TITLE
feat(data-apps): invalidate cache on standalone data app refresh

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -180,12 +180,21 @@ Users can cancel a building version. This atomically marks it as `status='error'
 
 ### Refreshing the preview
 
-A refresh button in the preview header reloads the iframe to re-execute the app's metric queries against the warehouse,
-without kicking off a new code-gen iteration. The motivating use case is "I just pushed a semantic-layer change while
-Claude is still iterating in the sidebar — show me what the queries look like now." Implementation: `AppGenerate` owns
-a `previewRefreshKey` counter that gets baked into the iframe URL as `&r={key}`. Bumping the counter changes the URL,
-which forces the browser to reload the iframe; the served bundle and the JWT are unaffected. The query inspector panel
-is cleared on refresh so the new query run isn't mixed with stale entries from the previous load.
+A refresh button reloads the iframe to re-execute the app's metric queries against the warehouse, without kicking off a
+new code-gen iteration. The motivating use case is "I just pushed a semantic-layer change while Claude is still
+iterating in the sidebar — show me what the queries look like now." Both the builder (`AppGenerate`) and the standalone
+preview page (`AppPreviewTest`) carry one.
+
+Implementation: each page owns a `refreshKey`/`previewRefreshKey` counter baked into the iframe URL as `?r={key}`.
+Bumping the counter changes the URL, which forces the browser to reload the iframe; the served bundle and the JWT are
+unaffected. The query inspector panel is cleared on refresh so the new query run isn't mixed with stale entries from
+the previous load.
+
+Refreshing also **invalidates the warehouse cache**. Alongside the counter, each page latches an `invalidateCache`
+boolean to `true` on the first refresh and forwards it through `AppIframePreview` → `useAppSdkBridge`, which stamps
+`invalidateCache` onto every intercepted metric-query POST — the same flag chart tiles send. The flag starts `false`
+so the initial page load can still serve cached results fast; once you've asked for a refresh, every subsequent query
+runs against the warehouse fresh. (This mirrors the sticky behaviour of the dashboard tile below.)
 
 ### Refreshing a data app inside a dashboard
 

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -170,6 +170,10 @@ type AppPreviewProps = {
      *  bundle, but the new query string defeats any caching and flushes
      *  whatever in-iframe state was running. */
     refreshKey: number;
+    /** When true, the iframe's metric queries are sent with `invalidateCache`
+     *  so the warehouse results cache is bypassed. Latched on by the preview
+     *  refresh button so a manual refresh always re-runs against the warehouse. */
+    invalidateCache?: boolean;
     onQueryEvent?: (event: QueryEvent) => void;
     inspectorEnabled?: boolean;
     onElementSelected?: (event: { label: string }) => void;
@@ -185,6 +189,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
             appUuid,
             version,
             refreshKey,
+            invalidateCache,
             onQueryEvent,
             inspectorEnabled,
             onElementSelected,
@@ -233,6 +238,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
                 src={previewUrl}
                 expectedPreviewOrigin={previewOrigin}
                 identityKey={appUuid}
+                invalidateCache={invalidateCache}
                 onQueryEvent={onQueryEvent}
                 inspectorEnabled={inspectorEnabled}
                 onElementSelected={onElementSelected}
@@ -916,8 +922,13 @@ const AppGenerate: FC = () => {
     // semantic-layer change and wants to see it reflected without waiting
     // on the in-progress code-gen iteration.
     const [previewRefreshKey, setPreviewRefreshKey] = useState(0);
+    // Latched on by the first manual refresh: a refresh means "show me fresh
+    // data", so from then on the preview's queries bypass the warehouse cache.
+    // Starts false so the initial load can still serve cached results fast.
+    const [invalidatePreviewCache, setInvalidatePreviewCache] = useState(false);
     const handleRefreshPreview = useCallback(() => {
         setPreviewRefreshKey((k) => k + 1);
+        setInvalidatePreviewCache(true);
         if (persistLogs) {
             interruptInFlightQueries();
         } else {
@@ -2530,6 +2541,7 @@ const AppGenerate: FC = () => {
                                     appUuid={previewApp.appUuid}
                                     version={previewApp.version}
                                     refreshKey={previewRefreshKey}
+                                    invalidateCache={invalidatePreviewCache}
                                     onQueryEvent={handleQueryEvent}
                                     inspectorEnabled={inspectorEnabled}
                                     onElementSelected={handleElementSelected}

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -6,10 +6,12 @@ import {
     IconDatabase,
     IconDots,
     IconPencil,
+    IconRefresh,
     IconSend,
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
+import MantineIcon from '../components/common/MantineIcon';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
@@ -89,6 +91,18 @@ export default function AppPreviewTest() {
     // the user opens the panel are still captured.
     const { queries, handleQueryEvent, clearQueries } = useTrackedAppQueries();
 
+    // Manual refresh: bumping the counter changes the iframe URL, forcing a
+    // reload so the app's metric queries re-fire. `invalidateCache` latches on
+    // with the first refresh so those re-fired queries bypass the warehouse
+    // results cache — the initial load still serves cached results fast.
+    const [refreshKey, setRefreshKey] = useState(0);
+    const [invalidateCache, setInvalidateCache] = useState(false);
+    const handleRefresh = useCallback(() => {
+        setRefreshKey((k) => k + 1);
+        setInvalidateCache(true);
+        clearQueries();
+    }, [clearQueries]);
+
     // Close menu when the iframe receives focus (i.e. user clicked on it)
     const handleBlur = useCallback(() => {
         if (menuOpened) {
@@ -155,7 +169,7 @@ export default function AppPreviewTest() {
     }
 
     const previewUrl = token
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
 
     if (isLoading) {
@@ -198,7 +212,7 @@ export default function AppPreviewTest() {
                             size="lg"
                             radius="xl"
                         >
-                            <IconDots size={18} />
+                            <MantineIcon icon={IconDots} size={18} />
                         </ActionIcon>
                     </Menu.Target>
                     <Menu.Dropdown>
@@ -214,6 +228,12 @@ export default function AppPreviewTest() {
                                 Continue building
                             </Menu.Item>
                         )}
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconRefresh} />}
+                            onClick={handleRefresh}
+                        >
+                            Refresh
+                        </Menu.Item>
                         {canEditApp &&
                             scheduledDeliveriesFlag.data?.enabled && (
                                 <Menu.Item
@@ -236,6 +256,7 @@ export default function AppPreviewTest() {
                 src={previewUrl}
                 expectedPreviewOrigin={previewOrigin}
                 identityKey={`${appUuid}:${version}`}
+                invalidateCache={invalidateCache}
                 onQueryEvent={handleQueryEvent}
             />
             {!queriesPanelHidden && (


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7814/i-want-to-invalidate-or-refresh-cached-query-results-from-an-app

### Description:
Extend the refresh-invalidates-cache behaviour from dashboard tiles to standalone data apps:

- App builder (AppGenerate): the existing preview refresh button now latches invalidateCache on, so refreshed queries bypass the warehouse results cache.
- Standalone preview (AppPreviewTest): add a Refresh menu item (below Continue building) that reloads the iframe via an ?r= counter, clears the query inspector, and latches invalidateCache on.
