### PR TITLE
fix(ai-agents): clean MCP tool call labels

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -33,6 +33,7 @@ import { getToolCallChipLabel } from './utils/getToolCallChipLabel';
 import {
     getMcpServerForToolName,
     getMcpToolDisplayMetadata,
+    getMcpToolDisplayName,
 } from './utils/mcpToolDisplay';
 import { stripMarkdown } from './utils/stripMarkdown';
 import { getToolIcon } from './utils/toolIcons';
@@ -243,6 +244,9 @@ const LatestRow: FC<{
     const mcpDisplayMetadata = builtInToolName
         ? undefined
         : getMcpToolDisplayMetadata(group.toolName, mcpServer);
+    const mcpToolDisplayName = builtInToolName
+        ? null
+        : getMcpToolDisplayName(group.toolName);
     const label = builtInToolName
         ? isLive
             ? TOOL_DISPLAY_MESSAGES[builtInToolName]
@@ -299,13 +303,13 @@ const LatestRow: FC<{
                     key={`label-${group.toolName}-${isLive ? 'live' : 'done'}`}
                 >
                     <Text size="xs" className={styles.latestLabel}>
-                        Using MCP {mcpDisplayMetadata?.label ?? 'MCP'}:
+                        Using {mcpDisplayMetadata?.label ?? 'MCP'}:
                     </Text>
                     <ToolCallChip
                         maxWidth={260}
                         className={styles.latestMcpToolChip}
                     >
-                        {group.toolName}
+                        {mcpToolDisplayName}
                     </ToolCallChip>
                 </Group>
             )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
@@ -26,6 +26,7 @@ import { getToolCallChipLabel } from './utils/getToolCallChipLabel';
 import {
     getMcpServerForToolName,
     getMcpToolDisplayMetadata,
+    getMcpToolDisplayName,
 } from './utils/mcpToolDisplay';
 import { type ToolCallSummary } from './utils/types';
 
@@ -77,6 +78,9 @@ export const ToolCallRow: FC<Props> = ({
     const mcpDisplayMetadata = builtInToolName
         ? undefined
         : getMcpToolDisplayMetadata(toolName, mcpServer);
+    const mcpToolDisplayName = builtInToolName
+        ? null
+        : getMcpToolDisplayName(toolName);
     const label = builtInToolName
         ? status === 'running'
             ? TOOL_DISPLAY_MESSAGES[builtInToolName]
@@ -167,9 +171,9 @@ export const ToolCallRow: FC<Props> = ({
                 </Text>
             ) : (
                 <Text size="xs" className={styles.label}>
-                    Used MCP {mcpDisplayMetadata?.label ?? 'MCP'}:{' '}
+                    Used {mcpDisplayMetadata?.label ?? 'MCP'}:{' '}
                     <ToolCallChip maxWidth={260} className={styles.mcpToolChip}>
-                        {toolName}
+                        {mcpToolDisplayName}
                     </ToolCallChip>
                 </Text>
             )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.test.ts
@@ -3,6 +3,7 @@ import {
     getMcpProviderMetadata,
     getMcpServerDisplayName,
     getMcpServerForToolName,
+    getMcpToolDisplayName,
     getMcpToolParts,
     getMcpToolDisplayMetadata,
     sanitizeMcpToolKeyPart,
@@ -30,6 +31,15 @@ describe('mcpToolDisplay', () => {
 
     it('uses the same server name sanitization as backend MCP tool names', () => {
         expect(sanitizeMcpToolKeyPart('Acme Docs MCP')).toBe('acme_docs_mcp');
+    });
+
+    it('renders readable MCP tool names without repeated server prefixes', () => {
+        expect(getMcpToolDisplayName('mcp_github__create_issue')).toBe(
+            'Create issue',
+        );
+        expect(getMcpToolDisplayName('mcp_notion_mcp__notion_search')).toBe(
+            'Search',
+        );
     });
 
     it('matches tool calls to attached MCP servers and uses the stored icon URL', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.ts
@@ -36,6 +36,8 @@ export const getMcpToolParts = (toolName: string) => {
     };
 };
 
+const splitMcpKey = (key: string) => key.split('_').filter(Boolean);
+
 export const sanitizeMcpToolKeyPart = (value: string) => {
     const sanitized = value
         .replace(/[^a-zA-Z0-9_]+/g, '_')
@@ -76,6 +78,29 @@ export const getMcpProviderMetadata = (
 
 export const getMcpServerDisplayName = (toolName: string) =>
     getMcpProviderMetadata(toolName).label;
+
+export const getMcpToolDisplayName = (toolName: string) => {
+    const parts = getMcpToolParts(toolName);
+    if (!parts?.toolKey) {
+        return toolName;
+    }
+
+    const serverTokens = splitMcpKey(parts.serverKey).filter(
+        (token) => token !== 'mcp',
+    );
+    const toolTokens = splitMcpKey(parts.toolKey);
+    const hasRepeatedServerPrefix =
+        serverTokens.length > 0 &&
+        serverTokens.every((token, index) => toolTokens[index] === token);
+    const displayTokens = hasRepeatedServerPrefix
+        ? toolTokens.slice(serverTokens.length)
+        : toolTokens;
+    const displayKey = displayTokens.length
+        ? displayTokens.join('_')
+        : parts.toolKey;
+
+    return friendlyName(displayKey) || parts.toolKey;
+};
 
 export const getMcpServerForToolName = (
     toolName: string,


### PR DESCRIPTION
## Summary
- remove redundant hardcoded MCP wording from AI agent MCP tool call labels
- render a readable MCP tool action name instead of the raw `mcp_*` tool id
- cover repeated server-prefix stripping, e.g. `mcp_notion_mcp__notion_search` -> `Search`

## Validation
- `pnpm -F frontend run linter src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.ts src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.test.ts`
- `pnpm exec oxfmt packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.ts packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.test.ts --check`
- `pnpm common-build`
- `pnpm formula:build`
- `pnpm -F frontend exec vitest run src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/mcpToolDisplay.test.ts`
- `pnpm -F frontend typecheck`