### PR TITLE
fix(ai-agents): disable follow-ups on read-only threads

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -225,6 +225,7 @@ import {
 } from '../ai/utils/populateCustomMetricsSQL';
 import { validateSelectedFieldsExistence } from '../ai/utils/validators';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
+import { canGeneratePostResponseSuggestions } from './suggestionAccess';
 
 type ThreadMessageContext = Array<
     Required<Pick<MessageElement, 'text' | 'user' | 'ts'>>
@@ -798,6 +799,22 @@ export class AiAgentService extends BaseService {
         }
 
         const agent = await this.getAgent(user, agentUuid, projectUuid);
+
+        if (threadUuid) {
+            const thread = await this.aiAgentModel.getThread({
+                organizationUuid,
+                agentUuid,
+                threadUuid,
+            });
+
+            if (!thread) {
+                throw new NotFoundError(`Thread not found: ${threadUuid}`);
+            }
+
+            if (!canGeneratePostResponseSuggestions(user.userUuid, thread)) {
+                return { chips: [] };
+            }
+        }
 
         const auditedAbility = this.createAuditedAbility(user);
         const canRunSql =

--- a/packages/backend/src/ee/services/AiAgentService/suggestionAccess.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/suggestionAccess.test.ts
@@ -1,0 +1,30 @@
+import { canGeneratePostResponseSuggestions } from './suggestionAccess';
+
+describe('canGeneratePostResponseSuggestions', () => {
+    it('allows owned web app threads', () => {
+        expect(
+            canGeneratePostResponseSuggestions('user-1', {
+                createdFrom: 'web_app',
+                user: { uuid: 'user-1' },
+            }),
+        ).toBe(true);
+    });
+
+    it('blocks shared threads owned by another user', () => {
+        expect(
+            canGeneratePostResponseSuggestions('user-1', {
+                createdFrom: 'web_app',
+                user: { uuid: 'user-2' },
+            }),
+        ).toBe(false);
+    });
+
+    it('blocks Slack threads', () => {
+        expect(
+            canGeneratePostResponseSuggestions('user-1', {
+                createdFrom: 'slack',
+                user: { uuid: 'user-1' },
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/suggestionAccess.ts
+++ b/packages/backend/src/ee/services/AiAgentService/suggestionAccess.ts
@@ -1,0 +1,11 @@
+type SuggestionThread = {
+    createdFrom: string;
+    user: {
+        uuid: string;
+    };
+};
+
+export const canGeneratePostResponseSuggestions = (
+    userUuid: string,
+    thread: SuggestionThread,
+) => thread.createdFrom === 'web_app' && thread.user.uuid === userUuid;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -32,6 +32,7 @@ import { EventName } from '../../../../../types/Events';
 import { useAgentSuggestions } from '../../hooks/useAgentSuggestions';
 import styles from './AgentChatInput.module.css';
 import { AgentSuggestionChips } from './AgentSuggestionChips';
+import { getAgentSuggestionModes } from './suggestionModes';
 
 const MAX_RECOMMENDED_THREAD_MESSAGE_COUNT = 15;
 
@@ -191,16 +192,15 @@ export const AgentChatInput = ({
         FeatureFlags.AiAgentSuggestions,
     );
 
-    const emptyStateMode =
-        !isMinimalMode &&
-        messageCount === 0 &&
-        suggestionsFlag.data?.enabled === true;
-    const postResponseMode =
-        messageCount > 0 &&
-        !loading &&
-        !!threadUuid &&
-        !!latestAssistantMessageUuid &&
-        suggestionsFlag.data?.enabled === true;
+    const { emptyStateMode, postResponseMode } = getAgentSuggestionModes({
+        disabled,
+        isMinimalMode,
+        loading,
+        messageCount,
+        latestAssistantMessageUuid,
+        suggestionsEnabled: suggestionsFlag.data?.enabled === true,
+        threadUuid,
+    });
 
     const suggestionsQuery = useAgentSuggestions({
         projectUuid,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/suggestionModes.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/suggestionModes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { getAgentSuggestionModes } from './suggestionModes';
+
+describe('getAgentSuggestionModes', () => {
+    it('disables post-response suggestions when the input is disabled', () => {
+        expect(
+            getAgentSuggestionModes({
+                disabled: true,
+                isMinimalMode: true,
+                loading: false,
+                messageCount: 2,
+                latestAssistantMessageUuid: 'message-1',
+                suggestionsEnabled: true,
+                threadUuid: 'thread-1',
+            }).postResponseMode,
+        ).toBe(false);
+    });
+
+    it('enables post-response suggestions for writable idle threads', () => {
+        expect(
+            getAgentSuggestionModes({
+                disabled: false,
+                isMinimalMode: true,
+                loading: false,
+                messageCount: 2,
+                latestAssistantMessageUuid: 'message-1',
+                suggestionsEnabled: true,
+                threadUuid: 'thread-1',
+            }).postResponseMode,
+        ).toBe(true);
+    });
+
+    it('disables empty-state suggestions when the input is disabled', () => {
+        expect(
+            getAgentSuggestionModes({
+                disabled: true,
+                isMinimalMode: false,
+                loading: false,
+                messageCount: 0,
+                suggestionsEnabled: true,
+            }).emptyStateMode,
+        ).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/suggestionModes.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/suggestionModes.ts
@@ -1,0 +1,32 @@
+type AgentSuggestionModeArgs = {
+    disabled: boolean;
+    isMinimalMode: boolean;
+    loading: boolean;
+    messageCount: number;
+    latestAssistantMessageUuid?: string;
+    suggestionsEnabled: boolean;
+    threadUuid?: string;
+};
+
+export const getAgentSuggestionModes = ({
+    disabled,
+    isMinimalMode,
+    loading,
+    messageCount,
+    latestAssistantMessageUuid,
+    suggestionsEnabled,
+    threadUuid,
+}: AgentSuggestionModeArgs) => {
+    const canFetchSuggestions = !disabled && suggestionsEnabled;
+
+    return {
+        emptyStateMode:
+            !isMinimalMode && messageCount === 0 && canFetchSuggestions,
+        postResponseMode:
+            messageCount > 0 &&
+            !loading &&
+            !!threadUuid &&
+            !!latestAssistantMessageUuid &&
+            canFetchSuggestions,
+    };
+};


### PR DESCRIPTION
## Summary
- Stop generating post-response suggestion chips for AI threads the current user cannot write to.
- Gate both empty-state and follow-up chip fetching in the chat input when the input is disabled.
- Add small pure tests around the new access/mode helpers.

## Testing
- Not run (not requested)
- Added unit coverage for the new suggestion access and mode checks