### PR TITLE
feat(agents): add custom LLM provider headers

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -10,6 +10,8 @@ export const DEFAULT_OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
 export const DEFAULT_AZURE_EMBEDDING_MODEL = 'text-embedding-3-small';
 export const DEFAULT_BEDROCK_EMBEDDING_MODEL = 'cohere.embed-english-v3';
 
+const customHeadersSchema = z.record(z.string()).default({});
+
 export const aiCopilotConfigSchema = z
     .object({
         defaultProvider: z
@@ -29,6 +31,7 @@ export const aiCopilotConfigSchema = z
                     baseUrl: z.string().optional(),
                     availableModels: z.array(z.string()).optional(),
                     zeroDataRetention: z.boolean().default(false),
+                    customHeaders: customHeadersSchema,
                 })
                 .optional(),
             azure: z
@@ -42,6 +45,7 @@ export const aiCopilotConfigSchema = z
                         .string()
                         .default(DEFAULT_AZURE_EMBEDDING_MODEL),
                     useDeploymentBasedUrls: z.boolean().default(true),
+                    customHeaders: customHeadersSchema,
                 })
                 .optional(),
             anthropic: z
@@ -49,6 +53,7 @@ export const aiCopilotConfigSchema = z
                     apiKey: z.string(),
                     modelName: z.string().default(DEFAULT_ANTHROPIC_MODEL_NAME),
                     availableModels: z.array(z.string()).optional(),
+                    customHeaders: customHeadersSchema,
                 })
                 .optional(),
             openrouter: z
@@ -65,6 +70,7 @@ export const aiCopilotConfigSchema = z
                     modelName: z
                         .string()
                         .default(DEFAULT_OPENROUTER_MODEL_NAME),
+                    customHeaders: customHeadersSchema,
                 })
                 .optional(),
             bedrock: z
@@ -80,6 +86,7 @@ export const aiCopilotConfigSchema = z
                             .string()
                             .default(DEFAULT_BEDROCK_EMBEDDING_MODEL),
                         availableModels: z.array(z.string()).optional(),
+                        customHeaders: customHeadersSchema,
                     }),
                     z.object({
                         region: z.string(),
@@ -94,6 +101,7 @@ export const aiCopilotConfigSchema = z
                             .string()
                             .default(DEFAULT_BEDROCK_EMBEDDING_MODEL),
                         availableModels: z.array(z.string()).optional(),
+                        customHeaders: customHeadersSchema,
                     }),
                 ])
                 .optional(),

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -240,6 +240,7 @@ export const lightdashConfigMock: LightdashConfig = {
                     modelName: 'gpt-5.4',
                     embeddingModelName: 'text-embedding-3-small',
                     zeroDataRetention: false,
+                    customHeaders: {},
                 },
             },
             verifiedAnswerSimilarityThreshold: 0.6,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -16,6 +16,7 @@ import {
     getMaybeBase64EncodedFromEnvironmentVariable,
     getMultiProjectSetupConfig,
     getObjectFromEnvironmentVariable,
+    getStringRecordFromEnvironmentVariable,
     parseConfig,
     parseOrganizationMemberRoleArray,
 } from './parseConfig';
@@ -370,6 +371,97 @@ describe('getObjectFromEnvironmentVariable', () => {
         expect(() =>
             getObjectFromEnvironmentVariable('INVALID_OBJECT'),
         ).toThrowError(ParseError);
+    });
+});
+
+describe('getStringRecordFromEnvironmentVariable', () => {
+    test('returns undefined if env var is not defined', () => {
+        expect(
+            getStringRecordFromEnvironmentVariable('MISSING_ENV_VAR'),
+        ).toEqual(undefined);
+    });
+
+    test('returns string record if env var value is valid', () => {
+        process.env.VALID_STRING_RECORD =
+            '{"x-lightdash-use-case":"analytics-copilot","x-cost-center":"data-platform"}';
+        expect(
+            getStringRecordFromEnvironmentVariable('VALID_STRING_RECORD'),
+        ).toEqual({
+            'x-lightdash-use-case': 'analytics-copilot',
+            'x-cost-center': 'data-platform',
+        });
+    });
+
+    test('throws error if env var is not an object with string values', () => {
+        process.env.INVALID_STRING_RECORD = '{"team":["data"]}';
+        expect(() =>
+            getStringRecordFromEnvironmentVariable('INVALID_STRING_RECORD'),
+        ).toThrowError(ParseError);
+        expect(() =>
+            getStringRecordFromEnvironmentVariable('INVALID_STRING_RECORD'),
+        ).not.toThrow(/"team":\["data"\]/);
+    });
+
+    test('throws error if env var is explicit falsy JSON', () => {
+        process.env.INVALID_STRING_RECORD = 'null';
+        expect(() =>
+            getStringRecordFromEnvironmentVariable('INVALID_STRING_RECORD'),
+        ).toThrowError(ParseError);
+    });
+});
+
+test('Should parse AI provider custom headers from env', () => {
+    process.env.OPENAI_API_KEY = 'test-openai-key';
+    process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
+    process.env.OPENROUTER_API_KEY = 'test-openrouter-key';
+    process.env.AZURE_AI_API_KEY = 'test-azure-key';
+    process.env.AZURE_AI_ENDPOINT = 'https://example.openai.azure.com';
+    process.env.AZURE_AI_API_VERSION = '2026-01-01';
+    process.env.AZURE_AI_DEPLOYMENT_NAME = 'gpt-5';
+    process.env.BEDROCK_API_KEY = 'test-bedrock-key';
+    process.env.BEDROCK_REGION = 'eu-west-1';
+    process.env.OPENAI_CUSTOM_HEADERS =
+        '{"x-lightdash-llm-provider":"openai","x-gateway-route":"responses-api"}';
+    process.env.ANTHROPIC_CUSTOM_HEADERS =
+        '{"x-lightdash-llm-provider":"anthropic","x-gateway-route":"messages-api"}';
+    process.env.OPENROUTER_CUSTOM_HEADERS =
+        '{"x-lightdash-llm-provider":"openrouter","x-gateway-route":"router-api"}';
+    process.env.AZURE_AI_CUSTOM_HEADERS =
+        '{"x-lightdash-llm-provider":"azure-openai","x-gateway-route":"azure-deployment"}';
+    process.env.BEDROCK_CUSTOM_HEADERS =
+        '{"x-lightdash-llm-provider":"bedrock","x-gateway-route":"aws-runtime"}';
+
+    expect(parseConfig().ai.copilot.providers).toMatchObject({
+        openai: {
+            customHeaders: {
+                'x-lightdash-llm-provider': 'openai',
+                'x-gateway-route': 'responses-api',
+            },
+        },
+        anthropic: {
+            customHeaders: {
+                'x-lightdash-llm-provider': 'anthropic',
+                'x-gateway-route': 'messages-api',
+            },
+        },
+        openrouter: {
+            customHeaders: {
+                'x-lightdash-llm-provider': 'openrouter',
+                'x-gateway-route': 'router-api',
+            },
+        },
+        azure: {
+            customHeaders: {
+                'x-lightdash-llm-provider': 'azure-openai',
+                'x-gateway-route': 'azure-deployment',
+            },
+        },
+        bedrock: {
+            customHeaders: {
+                'x-lightdash-llm-provider': 'bedrock',
+                'x-gateway-route': 'aws-runtime',
+            },
+        },
     });
 });
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -139,6 +139,24 @@ export const getObjectFromEnvironmentVariable = (
     }
 };
 
+export const getStringRecordFromEnvironmentVariable = (
+    name: string,
+): Record<string, string> | undefined => {
+    const value = getObjectFromEnvironmentVariable(name);
+    if (value === undefined) {
+        return undefined;
+    }
+
+    const result = z.record(z.string()).safeParse(value);
+    if (!result.success) {
+        throw new ParseError(
+            `Cannot parse environment variable "${name}". Value must be a JSON object with string values. Error: ${result.error.message}`,
+        );
+    }
+
+    return result.data;
+};
+
 const getArrayFromCommaSeparatedList = (envVar: string) => {
     const raw = process.env[envVar];
     if (!raw) {
@@ -150,6 +168,9 @@ const getArrayFromCommaSeparatedList = (envVar: string) => {
         .map((domain) => domain.trim())
         .filter((domain) => domain.length > 0);
 };
+
+const getProviderCustomHeaders = (envVar: string): Record<string, string> =>
+    getStringRecordFromEnvironmentVariable(envVar) ?? {};
 
 export const getHexColorsFromEnvironmentVariable = (
     colorPalette: string | undefined,
@@ -827,7 +848,7 @@ const parseAndSanitizeSchedulerTasks = (): Array<SchedulerTaskName> => {
     return ALL_TASK_NAMES;
 };
 
-const getBedrockConfig = () => {
+const getBedrockConfig = (customHeaders: Record<string, string>) => {
     if (process.env.BEDROCK_API_KEY) {
         return {
             apiKey: process.env.BEDROCK_API_KEY,
@@ -840,6 +861,7 @@ const getBedrockConfig = () => {
             availableModels: getArrayFromCommaSeparatedList(
                 'BEDROCK_AVAILABLE_MODELS',
             ),
+            customHeaders,
         } as const;
     }
     if (process.env.BEDROCK_ACCESS_KEY_ID) {
@@ -856,6 +878,7 @@ const getBedrockConfig = () => {
             availableModels: getArrayFromCommaSeparatedList(
                 'BEDROCK_AVAILABLE_MODELS',
             ),
+            customHeaders,
         } as const;
     }
 
@@ -890,6 +913,9 @@ export const getAiConfig = () => ({
                       process.env.AZURE_EMBEDDING_DEPLOYMENT_NAME,
                   useDeploymentBasedUrls:
                       process.env.AZURE_USE_DEPLOYMENT_BASED_URLS !== 'false',
+                  customHeaders: getProviderCustomHeaders(
+                      'AZURE_AI_CUSTOM_HEADERS',
+                  ),
               }
             : undefined,
         openai: process.env.OPENAI_API_KEY
@@ -907,6 +933,9 @@ export const getAiConfig = () => ({
                   ),
                   zeroDataRetention:
                       process.env.OPENAI_ZERO_DATA_RETENTION === 'true',
+                  customHeaders: getProviderCustomHeaders(
+                      'OPENAI_CUSTOM_HEADERS',
+                  ),
               }
             : undefined,
         anthropic:
@@ -920,6 +949,9 @@ export const getAiConfig = () => ({
                       availableModels: getArrayFromCommaSeparatedList(
                           'ANTHROPIC_AVAILABLE_MODELS',
                       ),
+                      customHeaders: getProviderCustomHeaders(
+                          'ANTHROPIC_CUSTOM_HEADERS',
+                      ),
                   }
                 : undefined,
         openrouter: process.env.OPENROUTER_API_KEY
@@ -932,9 +964,14 @@ export const getAiConfig = () => ({
                   allowedProviders: getArrayFromCommaSeparatedList(
                       'OPENROUTER_ALLOWED_PROVIDERS',
                   ),
+                  customHeaders: getProviderCustomHeaders(
+                      'OPENROUTER_CUSTOM_HEADERS',
+                  ),
               }
             : undefined,
-        bedrock: getBedrockConfig(),
+        bedrock: getBedrockConfig(
+            getProviderCustomHeaders('BEDROCK_CUSTOM_HEADERS'),
+        ),
     },
     maxQueryLimit:
         getIntegerFromEnvironmentVariable('AI_COPILOT_MAX_QUERY_LIMIT') ||

--- a/packages/backend/src/ee/clients/OpenAi.ts
+++ b/packages/backend/src/ee/clients/OpenAi.ts
@@ -9,8 +9,12 @@ import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { Runnable } from '@langchain/core/runnables';
 import { ChatOpenAI, ChatOpenAICallOptions } from '@langchain/openai';
 import { sleep, UnexpectedServerError } from '@lightdash/common';
+import { type LightdashConfig } from '../../config/parseConfig';
 
 const DEFAULT_RETRY_TIMEOUT_MS = 5000;
+
+type OpenAiProviderConfig =
+    LightdashConfig['ai']['copilot']['providers']['openai'];
 
 class TokenUsageHandler extends BaseCallbackHandler {
     tokenUsage: TokenUsage | undefined;
@@ -32,14 +36,17 @@ export default class OpenAi {
 
     model: ChatOpenAI<ChatOpenAICallOptions> | undefined;
 
-    constructor() {
-        this.openAiApiKey = process.env.OPENAI_API_KEY;
+    constructor(openAiProviderConfig: OpenAiProviderConfig) {
+        this.openAiApiKey = openAiProviderConfig?.apiKey;
 
-        this.model = this.openAiApiKey
+        this.model = openAiProviderConfig
             ? new ChatOpenAI({
-                  openAIApiKey: this.openAiApiKey,
+                  openAIApiKey: openAiProviderConfig.apiKey,
                   modelName: 'gpt-5.4-2026-03-05',
                   temperature: 0.2,
+                  configuration: {
+                      defaultHeaders: openAiProviderConfig.customHeaders,
+                  },
               })
             : undefined;
     }

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -127,7 +127,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     dashboardSummaryModel: models.getDashboardSummaryModel(),
                     projectService: repository.getProjectService(),
                     featureFlagService: repository.getFeatureFlagService(),
-                    openAi: new OpenAi(), // TODO This should go in client repository as soon as it is available
+                    openAi: new OpenAi(
+                        context.lightdashConfig.ai.copilot.providers.openai,
+                    ), // TODO This should go in client repository as soon as it is available
                 }),
             aiAgentService: ({
                 models,

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -47,6 +47,7 @@ describeOrSkip.concurrent('agent integration tests', () => {
             modelName: 'gpt-5.4',
             embeddingModelName: 'text-embedding-3-small',
             zeroDataRetention: false,
+            customHeaders: {},
         },
         getModelPreset('openai', 'gpt-5.4')!,
     );

--- a/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
+++ b/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
@@ -14,6 +14,7 @@ export const getAnthropicModel = (
 ): AiModel<typeof PROVIDER> => {
     const anthropic = createAnthropic({
         apiKey: config.apiKey,
+        headers: config.customHeaders,
     });
 
     const model = anthropic(preset.modelId);

--- a/packages/backend/src/ee/services/ai/models/azure-openai-gpt-4.1.ts
+++ b/packages/backend/src/ee/services/ai/models/azure-openai-gpt-4.1.ts
@@ -12,6 +12,7 @@ export const getAzureProvider = (
         baseURL: config.endpoint,
         apiVersion: config.apiVersion,
         useDeploymentBasedUrls: config.useDeploymentBasedUrls,
+        headers: config.customHeaders,
     });
 
 export const getAzureGpt41Model = (

--- a/packages/backend/src/ee/services/ai/models/bedrock.ts
+++ b/packages/backend/src/ee/services/ai/models/bedrock.ts
@@ -34,11 +34,13 @@ export const getBedrockProvider = (
         ? createAmazonBedrock({
               apiKey: config.apiKey,
               region: config.region,
+              headers: config.customHeaders,
           })
         : createAmazonBedrock({
               region: config.region,
               accessKeyId: config.accessKeyId,
               secretAccessKey: config.secretAccessKey,
+              headers: config.customHeaders,
               ...(config.sessionToken
                   ? { sessionToken: config.sessionToken }
                   : {}),

--- a/packages/backend/src/ee/services/ai/models/openai-embedding.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-embedding.ts
@@ -10,6 +10,7 @@ export const getOpenAIEmbeddingModel = (
     const openai = createOpenAI({
         apiKey: config.apiKey,
         ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+        headers: config.customHeaders,
     });
 
     return openai.embedding(config.embeddingModelName);

--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -15,6 +15,7 @@ export const getOpenaiGptmodel = (
     const openai = createOpenAI({
         apiKey: config.apiKey,
         ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+        headers: config.customHeaders,
     });
     const { supportsReasoning, modelId } = preset;
 

--- a/packages/backend/src/ee/services/ai/models/openrouter.ts
+++ b/packages/backend/src/ee/services/ai/models/openrouter.ts
@@ -13,6 +13,7 @@ export const getOpenRouterModel = (
     const openrouter = createOpenRouter({
         apiKey: `${config.apiKey}`,
         compatibility: 'strict',
+        headers: config.customHeaders,
         extraBody: {
             /** @ref https://openrouter.ai/docs/features/provider-routing */
             provider: {


### PR DESCRIPTION
Closes #23377
Closes ZAP-443

## Summary

Adds per-provider `customHeaders` support for outbound LLM API requests. Each AI provider (OpenAI, Azure, Anthropic, OpenRouter, Bedrock) gains an optional headers map applied to every outgoing request, configurable via env var.

## Configuration

| Env var | Provider |
|---|---|
| `OPENAI_CUSTOM_HEADERS` | OpenAI |
| `AZURE_AI_CUSTOM_HEADERS` | Azure |
| `ANTHROPIC_CUSTOM_HEADERS` | Anthropic |
| `OPENROUTER_CUSTOM_HEADERS` | OpenRouter |
| `BEDROCK_CUSTOM_HEADERS` | Bedrock |

Each accepts a JSON object of string→string, e.g.:

```
OPENAI_CUSTOM_HEADERS='{"x-gateway-use-case":"lightdash-ai","x-gateway-team":"analytics-engineering"}'
```

Headers are propagated through the respective provider SDK clients. Empty / unset → no extra headers.

## Why

Self-hosted deployments routing LLM traffic through an internal OpenAI-compatible gateway need to attach attribution headers (use-case, team, etc.) on every request. The fix is provider-scoped because different deployments may route different providers through different gateways.

## Test plan

- [x] Unit tests for `getStringRecordFromEnvironmentVariable` (valid JSON, missing var, non-record value, invalid value type)
- [ ] Deploy to a self-hosted instance with `OPENAI_CUSTOM_HEADERS` set and confirm headers reach the provider