### PR TITLE
feat(data-apps): add parameter support to QueryBuilder and apiTransport

### DIFF
--- a/packages/query-sdk/README.md
+++ b/packages/query-sdk/README.md
@@ -98,6 +98,41 @@ lightdash
 
 Supported filter operators: `equals`, `notEquals`, `greaterThan`, `lessThan`, `greaterThanOrEqual`, `lessThanOrEqual`, `inThePast`, `notInThePast`, `inTheNext`, `inTheCurrent`, `notInTheCurrent`, `inBetween`, `notInBetween`, `isNull`, `notNull`, `startsWith`, `endsWith`, `include`, `doesNotInclude`.
 
+## Parameters
+
+Lightdash parameters (`${lightdash.parameters.X}` substitutions) let a query swap out
+pieces of SQL at runtime — for example a comparison-mode dropdown that switches a
+year-over-year window between `YTD` and `Last 12 Months`.
+
+Parameters must be declared in `lightdash.yml` / model YAML and referenced via
+`${lightdash.parameters.X}` in SQL. Pass values at query time with `.parameters()`:
+
+```tsx
+function YoYChart() {
+    const [mode, setMode] = useState('YTD');
+
+    const { data } = useLightdash(
+        lightdash
+            .model('orders')
+            .metrics(['revenue_current', 'revenue_previous'])
+            .parameters({ comparison_mode: mode }),
+    );
+
+    // Changing `mode` produces a new query whose cache key includes the
+    // parameter value, so results re-fetch and the Current / Previous
+    // figures update for the selected window.
+    return (
+        <select value={mode} onChange={(e) => setMode(e.target.value)}>
+            <option value="YTD">Year to date</option>
+            <option value="L12M">Last 12 months</option>
+        </select>
+    );
+}
+```
+
+`.parameters()` is immutable and merges with prior calls (later keys win). Values can be
+strings, numbers, or arrays of either. They are sent at the top level of the API request.
+
 ## Results
 
 `useLightdash(query)` returns:

--- a/packages/query-sdk/src/apiTransport.ts
+++ b/packages/query-sdk/src/apiTransport.ts
@@ -231,6 +231,11 @@ export function createApiTransport(
                         ? { customDimensions: query.customDimensions }
                         : {}),
                 },
+                // Parameters go at the TOP LEVEL of the body — the backend reads
+                // `body.parameters`, not `body.query.parameters`.
+                ...(query.parameters && Object.keys(query.parameters).length > 0
+                    ? { parameters: query.parameters }
+                    : {}),
             };
 
             // Pass label as transport metadata (not in the API body)

--- a/packages/query-sdk/src/query.ts
+++ b/packages/query-sdk/src/query.ts
@@ -17,6 +17,7 @@ import type {
     CustomDimension,
     Filter,
     InternalFilterDefinition,
+    ParametersValuesMap,
     QueryDefinition,
     Sort,
     TableCalculation,
@@ -32,6 +33,7 @@ type BuilderState = {
     additionalMetrics: AdditionalMetric[];
     customDimensions: CustomDimension[];
     limit: number;
+    parameters: ParametersValuesMap;
     label: string | undefined;
 };
 
@@ -65,6 +67,7 @@ export class QueryBuilder {
                 additionalMetrics: [],
                 customDimensions: [],
                 limit: 500,
+                parameters: {},
                 label: undefined,
             };
         } else {
@@ -165,6 +168,19 @@ export class QueryBuilder {
         });
     }
 
+    /**
+     * Set Lightdash parameter values (`${lightdash.parameters.X}` substitutions).
+     * Merges with any values from prior `.parameters()` calls — later keys win.
+     *
+     * Parameters must be declared in `lightdash.yml` / model YAML and referenced
+     * via `${lightdash.parameters.X}` in SQL.
+     */
+    parameters(map: ParametersValuesMap): QueryBuilder {
+        return this._clone({
+            parameters: { ...this._state.parameters, ...map },
+        });
+    }
+
     /** Set the maximum number of rows to return (default: 500) */
     limit(n: number): QueryBuilder {
         return this._clone({ limit: n });
@@ -182,6 +198,9 @@ export class QueryBuilder {
             additionalMetrics: this._state.additionalMetrics,
             customDimensions: this._state.customDimensions,
             limit: this._state.limit,
+            ...(Object.keys(this._state.parameters).length > 0
+                ? { parameters: this._state.parameters }
+                : {}),
             ...(this._state.label ? { label: this._state.label } : {}),
         };
     }

--- a/packages/query-sdk/src/types.ts
+++ b/packages/query-sdk/src/types.ts
@@ -103,6 +103,14 @@ export type CustomDimension = {
     dimensionId: string;
 };
 
+// --- Parameter types ---
+
+/** A single Lightdash parameter value (`${lightdash.parameters.X}` substitution) */
+export type ParameterValue = string | number | string[] | number[];
+
+/** Map of parameter name to value, passed at query time */
+export type ParametersValuesMap = Record<string, ParameterValue>;
+
 // --- Internal types (used by transport) ---
 
 export type InternalFilterDefinition = {
@@ -122,6 +130,11 @@ export type QueryDefinition = {
     additionalMetrics: AdditionalMetric[];
     customDimensions: CustomDimension[];
     limit: number;
+    /**
+     * Lightdash parameter values (`${lightdash.parameters.X}` substitutions).
+     * Sent at the top level of the API request body, not nested under `query`.
+     */
+    parameters?: ParametersValuesMap;
     /** Human-readable label for dev tools / query inspector (not sent to the API) */
     label?: string;
 };

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -30,7 +30,7 @@ Available at `@/components/ui/<name>`:
 
 ## Semantic Layer (dbt models)
 
-The available data models are defined in dbt YAML files at **`/tmp/dbt-repo/models/`**. Read these to discover every model, dimension, metric, and join available to you. **Never guess field names** — use only what's in the YAML.
+The available data models are defined in dbt YAML files at **`/tmp/dbt-repo/models/`**. Read these to discover every model, dimension, metric, join, and parameter available to you. **Never guess field names** — use only what's in the YAML. (Parameters live in a `parameters:` block under `meta:` / `config.meta:`, or in `lightdash.config.yml` — see [Parameters](#parameters).)
 
 ### Reading dbt YAML
 
@@ -359,6 +359,60 @@ Each additional metric needs:
 - If the metric exists in the dbt YAML → use `.metrics(['metric_name'])`
 - If you need a custom aggregation not in the YAML → define it with `.additionalMetrics()` AND include its name in `.metrics()`
 
+### Parameters
+
+Parameters are project- or model-level variables declared in the dbt YAML and substituted into SQL via `${lightdash.parameters.…}`. They let one query swap pieces of its SQL at runtime — e.g. the docs' metric-based parameter, where a single dropdown controls which metric a KPI shows (`total_revenue`, `won_revenue`, `deal_count`, `win_rate`). Pass values at query time with `.parameters()`:
+
+```ts
+const kpiQuery = query('deals')
+    .label('Selected KPI')
+    .metrics(['selected_kpi'])
+    .limit(1)
+    .parameters({ kpi_selector: 'total_revenue' });
+```
+
+`.parameters(map)` is immutable and merges across calls (later keys win). Values can be a string, number, or array of either: `{ region: ['EMEA', 'AMER'] }`.
+
+**Key naming mirrors the SQL reference syntax** — get this wrong and the value is silently ignored:
+
+| Parameter scope | Declared in | SQL reference | `.parameters()` key |
+|---|---|---|---|
+| Project-level | `lightdash.config.yml` | `${lightdash.parameters.region}` | `{ region: 'EMEA' }` |
+| Model-level | a model's `meta.parameters` | `${lightdash.parameters.orders.region}` | `{ 'orders.region': 'EMEA' }` |
+
+**Discover available parameters before using them** — never guess parameter names or values. Look for a `parameters:` block in `lightdash.config.yml` (project-level) or under a model's `meta:` / `config.meta:` (model-level). Each entry's key is the parameter name; its `options` / `default` tell you the valid values:
+
+```yaml
+# lightdash.config.yml — project-level parameter
+parameters:
+    kpi_selector:
+        label: "KPI Metric"
+        options: ["total_revenue", "won_revenue", "deal_count", "win_rate"]
+        default: "total_revenue"
+```
+
+**Driving a parameter from UI** — `useLightdash` keys its cache off the built query (parameters included), so a parameter bound to component state re-fetches when it changes. Keep the base query at module scope and apply `.parameters()` in a `useMemo` (same pattern as global filters — never build the whole query in render):
+
+```tsx
+const baseQuery = query('deals')
+    .label('Selected KPI')
+    .metrics(['selected_kpi'])
+    .limit(1);
+
+export function SelectedKpi() {
+    const [kpi, setKpi] = useState('total_revenue');
+    const q = useMemo(
+        () => baseQuery.parameters({ kpi_selector: kpi }),
+        [kpi],
+    );
+    const { data, format, loading } = useLightdash(q);
+    // a <Select> bound to setKpi (total_revenue | won_revenue | deal_count | win_rate)
+    // re-runs the query when changed
+}
+```
+
+Parameters are independent of `.filters()` — a filter restricts which rows are scanned; a parameter changes the SQL itself. Use a parameter only when the YAML declares one; otherwise reach for `.filters()`.
+
 ### `useLightdash(query)` return value
 
 | Field | Type | Use for |
@@ -413,7 +467,7 @@ formatDateFns(parseISO(row.order_date as string), 'EEEE, MMM d');
 
 #### Chart axes
 
-**Every `<XAxis>` and `<YAxis>` in the app must have a `tickFormatter`.** No exceptions — including year axes that "look like they'd be fine" (`race_date_year` is still a full ISO timestamp at the data layer; Recharts will render `2025-01-01T00:00:00Z`, not `2025`).
+**Every `<XAxis>` and `<YAxis>` in the app must have a `tickFormatter`.** No exceptions — including year axes that "look like they'd be fine" (`order_date_year` is still a full ISO timestamp at the data layer; Recharts will render `2025-01-01T00:00:00Z`, not `2025`).
 
 ```tsx
 import { XAxis, YAxis } from 'recharts';
@@ -974,7 +1028,7 @@ function DrillResults({ query: q }) {
 | `.metrics()` on a pre-aggregated model | Re-aggregates already-aggregated values → wrong numbers | If `wins` is a dimension in the YAML, use `.dimensions(['wins'])` |
 | `.metrics(['max_cumulative_points'])` instead of `.dimensions(['cumulative_points'])` | Aggregates per-row data into a single value — collapses line charts | Check YAML: is it under `columns[].name` (dimension) or `meta.metrics` (metric)? |
 | Unused dimensions in `.dimensions()` | Changes GROUP BY → wrong numbers | Only include dimensions you render |
-| Querying hidden fields (`driver_id`) | Leaks internal IDs | Skip fields with `hidden: true` |
+| Querying hidden fields (`customer_id`) | Leaks internal IDs | Skip fields with `hidden: true` |
 | Calling `createClient()` in app code | Not needed — client is set up in `main.jsx` | `import { query, useLightdash } from '@lightdash/query-sdk'` |
 | Qualified names like `orders_total_revenue` | Double-qualified → unknown field | Short names only |
 | Joined table field without dot notation: `customer_name` | Resolves to `orders_customer_name` → unknown field | Use `customers.customer_name` for joined tables |
@@ -993,6 +1047,9 @@ function DrillResults({ query: q }) {
 | Skipping `tickFormatter` on a year axis because "year is just a number" | Year dimensions (`*_year`) are still full ISO timestamps at the data layer, so the axis renders `2025-01-01T00:00:00Z` | Apply the same `formatDate(...)` `tickFormatter` to year axes — `formatDate` will collapse to `2025` for year-grain columns |
 | Using `format(row, 'order_date')` for a date column in a table cell | Renders `2025-03-17` (zero-padded tabular) — readable but ugly in dashboards | `formatField(row, col, format, 'cell')` from `@/lib/format` — renders `Mar 17, 2025` while still routing currency/% metrics through the server format |
 | Treating `row.order_date_month` as a `Date` or short string | It's a full ISO timestamp string (`2025-03-01T00:00:00Z`) for every grain | Pass through `formatDate` / `formatField`, or `parseISO` it before doing date math |
+| Wrong `.parameters()` key scope | Value silently ignored — query returns the default | Project-level → bare name (`{ region }`); model-level → `model.param` (`{ 'orders.region' }`), matching the `${lightdash.parameters.…}` reference |
+| Inventing a parameter not declared in the YAML | Backend ignores unknown params; nothing changes | Only pass parameters that exist in a model's `meta.parameters` or `lightdash.config.yml`. Use `.filters()` for row restriction instead |
+| Applying `.parameters()` at module scope for a UI-driven value | Value never updates when the control changes | Apply `.parameters()` in a `useMemo` keyed on the state value; keep the base query at module scope |
 | Building drill query inside render | Infinite re-fetching | Build in onClick handler, store in state |
 | Drilling by a dimension already in the source query | Pointless — same grouping | Pick a different, more granular dimension |
 | Using `e.chartX`/`e.chartY` for menu position | Chart-relative coords — menu appears at wrong position | Recharts `onClick` has no native event; capture `clientX`/`clientY` from a wrapper `<div onPointerDown>` via `useRef` — pointerdown fires before onClick so the ref is ready (see action menu example) |


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7768/query-sdk-add-parameter-support-to-querybuilder-and-apitransport

### Description:
Add a `.parameters()` method to QueryBuilder so Data Apps can pass Lightdash parameters (`${lightdash.parameters.X}` substitutions) when running a query.

### Testing

Example for two different F1 point systems
<img width="1185" height="878" alt="image" src="https://github.com/user-attachments/assets/a1ab4178-bd1d-400f-9771-278c8e441d77" />


<img width="480" height="550" alt="prod-7768-parameters-classic" src="https://github.com/user-attachments/assets/0b9cd683-27dd-4026-bb47-8718bc0f1b93" />
<img width="480" height="550" alt="prod-7768-parameters-modern" src="https://github.com/user-attachments/assets/52a65281-3d2a-4313-b1e4-c09f82a32cbe" />

