### PR TITLE
fix(pivot): add `passthroughDimensions` to carry hidden non-sort dims through SQL for cross-field `richText`/`image` templates

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -11722,11 +11722,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -11784,11 +11784,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -18943,6 +18943,10 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                passthroughDimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'GroupByColumn' },
+                },
                 sortOnlyDimensions: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'GroupByColumn' },
@@ -23670,7 +23674,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -23680,7 +23684,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -23690,7 +23694,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -23703,7 +23707,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -30293,6 +30297,13 @@ const models: TsoaRoute.Models = {
                                 {
                                     dataType: 'nestedObjectLiteral',
                                     nestedProperties: {
+                                        passthroughDimensions: {
+                                            dataType: 'array',
+                                            array: {
+                                                dataType: 'refAlias',
+                                                ref: 'GroupByColumn',
+                                            },
+                                        },
                                         originalColumns: {
                                             ref: 'ResultColumns',
                                             required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13309,8 +13309,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13368,8 +13368,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -19926,6 +19926,13 @@
             },
             "PivotConfiguration": {
                 "properties": {
+                    "passthroughDimensions": {
+                        "items": {
+                            "$ref": "#/components/schemas/GroupByColumn"
+                        },
+                        "type": "array",
+                        "description": "Hidden pivot-column dimensions that are NOT sort targets but still need\ntheir values carried through the SQL pipeline so that other fields'\n`richText` / `image:` templates can reference them via\n`row.<table>.<field>.raw`. They participate in `group_by_query` SELECT\nand GROUP BY (same as sortOnlyDimensions) but do NOT affect\n`column_ranking` ORDER BY (they don't drive sort). Without this bucket\nthe dim would be dropped entirely from the query and `row.*.raw`\nreferences would silently resolve to undefined."
+                    },
                     "sortOnlyDimensions": {
                         "items": {
                             "$ref": "#/components/schemas/GroupByColumn"
@@ -24935,22 +24942,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -31413,6 +31420,12 @@
                         "properties": {
                             "pivotDetails": {
                                 "properties": {
+                                    "passthroughDimensions": {
+                                        "items": {
+                                            "$ref": "#/components/schemas/GroupByColumn"
+                                        },
+                                        "type": "array"
+                                    },
                                     "originalColumns": {
                                         "$ref": "#/components/schemas/ResultColumns"
                                     },
@@ -34008,7 +34021,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3009.3",
+        "version": "0.3011.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -124,6 +124,7 @@ import type { INatsClient } from '../../clients/NatsClient';
 import { createLocalParquetUploadStream } from '../../clients/ResultsFileStorageClients/LocalParquetUploadStream';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { getDuckdbRuntimeConfig } from '../../ee/services/AsyncQueryService/getDuckdbRuntimeConfig';
+import Logger from '../../logging/logger';
 import { measureTime } from '../../logging/measureTime';
 import { getSchedulerContext } from '../../logging/winston';
 import { DownloadAuditModel } from '../../models/DownloadAuditModel';
@@ -720,6 +721,11 @@ export class AsyncQueryService extends ProjectService {
             groupByColumns: pivotConfiguration.groupByColumns,
             sortBy: pivotConfiguration.sortBy,
             originalColumns: originalColumns || {},
+            ...(pivotConfiguration.passthroughDimensions &&
+                pivotConfiguration.passthroughDimensions.length > 0 && {
+                    passthroughDimensions:
+                        pivotConfiguration.passthroughDimensions,
+                }),
         };
     }
 
@@ -1582,6 +1588,15 @@ export class AsyncQueryService extends ProjectService {
         let pivotTotalRows = 0;
         let unpivotedColumns: ResultColumns = {};
 
+        // Passthrough dims should be 1-to-1 with the visible row/pivot dims —
+        // they ride along through `group_by_query` GROUP BY but are not in
+        // row_ranking, so multiple warehouse rows with the same row_index
+        // can carry conflicting passthrough values. We keep the first one
+        // (deterministic by warehouse row order) and remember which dims
+        // had conflicts for a debug log — useful when devs investigate
+        // "wrong image showing in pivot" reports.
+        const passthroughCardinalityViolations = new Set<string>();
+
         const writeAndTransformRowsIfPivot = pivotConfiguration
             ? async (
                   rows: WarehouseResults['rows'],
@@ -1603,8 +1618,12 @@ export class AsyncQueryService extends ProjectService {
                       fields,
                   );
 
-                  const { indexColumn, valuesColumns, groupByColumns } =
-                      pivotConfiguration;
+                  const {
+                      indexColumn,
+                      valuesColumns,
+                      groupByColumns,
+                      passthroughDimensions,
+                  } = pivotConfiguration;
 
                   if (!groupByColumns || groupByColumns.length === 0) {
                       // When there are no group by columns, we can just derive the value columns from the values columns config
@@ -1655,6 +1674,73 @@ export class AsyncQueryService extends ProjectService {
                               currentTransformedRow = {};
                           }
                           currentRowIndex = row.row_index;
+                      }
+
+                      // Carry passthrough dim values onto the row so that
+                      // cross-field richText / image templates can resolve
+                      // `row.<table>.<field>.raw` even when the field's own
+                      // column is hidden from the rendered pivot. The first
+                      // warehouse row for a row_index wins. Run on EVERY
+                      // warehouse row (not just on row_index change) so we
+                      // can detect cardinality violations: if a later row
+                      // with the same row_index carries a different value
+                      // for the same passthrough dim, the dim isn't
+                      // 1-to-1 with the visible row/pivot dims.
+                      if (passthroughDimensions && currentTransformedRow) {
+                          for (const dim of passthroughDimensions) {
+                              const incoming = row[dim.reference];
+                              const existing =
+                                  currentTransformedRow[dim.reference];
+                              if (incoming === undefined) {
+                                  // Warehouse row missing the field — nothing
+                                  // to merge. Existing value (if any) wins.
+                              } else if (existing === undefined) {
+                                  currentTransformedRow[dim.reference] =
+                                      incoming;
+                              } else if (
+                                  !passthroughCardinalityViolations.has(
+                                      dim.reference,
+                                  )
+                              ) {
+                                  // Compare raw values to handle the
+                                  // `{value: {raw, formatted}}` envelope and
+                                  // bare-value warehouse shapes. Normalise via
+                                  // JSON.stringify so object-typed warehouse
+                                  // values (Dates, JSON columns) are compared
+                                  // by content, not reference — reference
+                                  // equality would treat every row as a
+                                  // violation for those types.
+                                  const pickRaw = (v: unknown) => {
+                                      if (
+                                          v !== null &&
+                                          typeof v === 'object' &&
+                                          'value' in v &&
+                                          v.value !== null &&
+                                          typeof v.value === 'object' &&
+                                          'raw' in v.value
+                                      ) {
+                                          return (v.value as { raw: unknown })
+                                              .raw;
+                                      }
+                                      return v;
+                                  };
+                                  const existingRaw = pickRaw(existing);
+                                  const incomingRaw = pickRaw(incoming);
+                                  const same =
+                                      existingRaw === incomingRaw ||
+                                      (existingRaw !== null &&
+                                          incomingRaw !== null &&
+                                          typeof existingRaw === 'object' &&
+                                          typeof incomingRaw === 'object' &&
+                                          JSON.stringify(existingRaw) ===
+                                              JSON.stringify(incomingRaw));
+                                  if (!same) {
+                                      passthroughCardinalityViolations.add(
+                                          dim.reference,
+                                      );
+                                  }
+                              }
+                          }
                       }
 
                       const pivotValues =
@@ -1768,6 +1854,23 @@ export class AsyncQueryService extends ProjectService {
         if (currentTransformedRow) {
             pivotTotalRows += 1;
             await write?.([currentTransformedRow]);
+        }
+
+        const passthroughCardinalityWarnings = Array.from(
+            passthroughCardinalityViolations,
+        );
+        if (passthroughCardinalityWarnings.length > 0) {
+            // Debug-level so we don't spam prod logs for misconfigured charts.
+            // Surface via Logger.debug for devs investigating user reports of
+            // "wrong image showing"; the dim isn't 1-to-1 with the visible
+            // pivot/row dims so the first warehouse row's value wins
+            // arbitrarily. No user-facing UI consumer yet — see PROD-7873 PR
+            // description for the deferred surface.
+            Logger.debug(
+                `Pivot passthrough dimensions had multiple values per row_index — values rendered in cross-field templates are arbitrary. Fields: ${passthroughCardinalityWarnings.join(
+                    ', ',
+                )}`,
+            );
         }
 
         return {

--- a/packages/backend/src/services/AsyncQueryService/getPivotedColumns.ts
+++ b/packages/backend/src/services/AsyncQueryService/getPivotedColumns.ts
@@ -10,7 +10,7 @@ export function getPivotedColumns(
     pivotConfiguration: NonNullable<QueryHistory['pivotConfiguration']>,
     pivotValuesColumns: string[],
 ): ResultColumns {
-    const { indexColumn } = pivotConfiguration;
+    const { indexColumn, passthroughDimensions } = pivotConfiguration;
     const indexColumns = normalizeIndexColumns(indexColumn);
 
     // Create an object with all index columns
@@ -22,8 +22,29 @@ export function getPivotedColumns(
         {} as ResultColumns,
     );
 
+    // Include passthrough dimensions so their per-row values survive the
+    // streaming pipeline and reach the frontend, where cross-field richText /
+    // image templates resolve `row.<table>.<field>.raw` via TanStack's
+    // (visibility-hidden) column cells.
+    //
+    // Skip passthrough refs that aren't present in unpivotedColumns —
+    // writing `undefined` into ResultColumns would lie about the column
+    // shape and could crash downstream consumers that assume entries are
+    // truthy. The dim is still carried on each row by AsyncQueryService's
+    // row transformer, so the lookup is templates-only; losing the column
+    // metadata entry just means the field isn't listed in the columns map.
+    const passthroughColumnsResult = (passthroughDimensions ?? []).reduce(
+        (acc, { reference }) => {
+            const col = unpivotedColumns[reference];
+            if (col === undefined) return acc;
+            return { ...acc, [reference]: col };
+        },
+        {} as ResultColumns,
+    );
+
     return {
         ...indexColumnsResult,
+        ...passthroughColumnsResult,
         ...pivotValuesColumns.reduce(
             (acc, valueColumn) => ({
                 ...acc,

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -5480,4 +5480,109 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).toContain('column_ranking AS (');
         });
     });
+
+    describe('passthroughDimensions — hidden non-sort pivot dims carried for cross-field templating (PROD-7873)', () => {
+        // Fixture: orders_status is the visible pivot column; orders_image_url
+        // is a hidden helper dim that is NOT a sort target. Other fields
+        // (e.g. a richText on orders_status) reference it via
+        // `row.orders.orders_image_url.raw`. We need its values to survive
+        // the SQL pipeline so that template variable resolves at render time.
+
+        test('passthroughDimensions appears in group_by_query SELECT and GROUP BY but NOT in column_ranking ORDER BY', () => {
+            const pivotConfiguration = {
+                indexColumn: [
+                    {
+                        reference: 'customer_id',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'orders_status' }],
+                sortBy: undefined,
+                passthroughDimensions: [{ reference: 'orders_image_url' }],
+                // No sortBy — this is the "hidden, not sorted" case.
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+            const collapsed = replaceWhitespace(result);
+
+            // group_by_query SELECT includes the passthrough dim alongside
+            // the visible groupBy column and the index column.
+            expect(collapsed).toContain(
+                'group_by_query AS (SELECT "orders_status", "orders_image_url", "customer_id"',
+            );
+            expect(collapsed).toContain(
+                'group by "orders_status", "orders_image_url", "customer_id"',
+            );
+
+            // No column_ranking is emitted at all when there's no sortBy
+            // (defensive: passthrough does not synthesize a sort).
+            expect(collapsed).not.toContain('column_ranking');
+
+            // pivot_query SELECT carries the passthrough dim through so its
+            // value lands on each output row.
+            expect(collapsed).toContain('g."orders_image_url"');
+        });
+
+        test('passthroughDimensions does NOT spread as a pivot column header (no extra DISTINCT SELECT slot)', () => {
+            const pivotConfiguration = {
+                indexColumn: [
+                    {
+                        reference: 'customer_id',
+                        type: VizIndexType.CATEGORY,
+                    },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'orders_status' }],
+                sortBy: [
+                    {
+                        reference: 'revenue',
+                        direction: SortByDirection.DESC,
+                    },
+                ],
+                passthroughDimensions: [{ reference: 'orders_image_url' }],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+            const collapsed = replaceWhitespace(result);
+
+            // Metric sort path: column_ranking is emitted, but its DISTINCT
+            // SELECT must contain ONLY the visible groupBy (orders_status) —
+            // passthrough must NOT inflate the pivot header cardinality.
+            const colRankingStart = collapsed.indexOf(
+                'column_ranking AS (SELECT DISTINCT',
+            );
+            expect(colRankingStart).toBeGreaterThanOrEqual(0);
+            const colRankingEnd = collapsed.indexOf(
+                ', DENSE_RANK()',
+                colRankingStart,
+            );
+            const colRankingSelect = collapsed.slice(
+                colRankingStart,
+                colRankingEnd,
+            );
+            expect(colRankingSelect).toContain('"orders_status"');
+            expect(colRankingSelect).not.toContain('"orders_image_url"');
+        });
+    });
 });

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -137,6 +137,9 @@ export class PivotQueryBuilder {
         for (const col of this.pivotConfiguration.sortOnlyDimensions ?? []) {
             existingRefs.add(col.reference);
         }
+        for (const col of this.pivotConfiguration.passthroughDimensions ?? []) {
+            existingRefs.add(col.reference);
+        }
 
         const allTableCalculationIds = new Set(
             Object.values(this.itemsMap)
@@ -395,6 +398,11 @@ export class PivotQueryBuilder {
      * @param sortOnlyDimensions - Pivot-column dims that are hidden from display
      *   but still need to pass through the GROUP BY so they're available for
      *   column ORDER BY (sortOnlyDimensions in PivotConfiguration).
+     * @param passthroughDimensions - Pivot-column dims that are hidden and
+     *   NOT sort targets, but still need to pass through the GROUP BY so
+     *   other fields' richText / image templates can reference them via
+     *   `row.<table>.<field>.raw`. Unlike sortOnlyDimensions, they do NOT
+     *   participate in any ORDER BY downstream.
      * @returns SQL for the group_by_query CTE
      */
     private getGroupByQuerySQL(
@@ -402,6 +410,7 @@ export class PivotQueryBuilder {
         valuesColumns: PivotConfiguration['valuesColumns'],
         groupByColumns: PivotConfiguration['groupByColumns'],
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
+        passthroughDimensions?: PivotConfiguration['passthroughDimensions'],
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
@@ -412,6 +421,13 @@ export class PivotQueryBuilder {
             // pivot-spread columns (not in groupByColumns), but they still
             // need to survive the aggregation pipeline.
             ...(sortOnlyDimensions || []).map(
+                (col) => `${q}${col.reference}${q}`,
+            ),
+            // Passthrough dimensions: hidden non-sort pivot dims that need
+            // to flow through to row data so cross-field templates can read
+            // their values via row.<table>.<field>.raw. Like sortOnlyDimensions
+            // they survive GROUP BY but do not affect any ORDER BY.
+            ...(passthroughDimensions || []).map(
                 (col) => `${q}${col.reference}${q}`,
             ),
             ...indexColumns.map((col) => `${q}${col.reference}${q}`),
@@ -1236,12 +1252,21 @@ export class PivotQueryBuilder {
         >,
         usePrecomputedRankings: boolean = false,
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
+        passthroughDimensions?: PivotConfiguration['passthroughDimensions'],
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
         const selectReferences = [
             ...indexColumns.map((col) => `g.${q}${col.reference}${q}`),
             ...groupByColumns.map((col) => `g.${q}${col.reference}${q}`),
+            // Passthrough dimensions: hidden non-sort pivot dims that need
+            // to flow through to row data for cross-field richText/image
+            // templates. They are in group_by_query (added by
+            // getGroupByQuerySQL) but not pivot-spread, so include them
+            // explicitly here so they reach the final SELECT.
+            ...(passthroughDimensions || []).map(
+                (col) => `g.${q}${col.reference}${q}`,
+            ),
             ...(valuesColumns || []).map((col) => {
                 const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                     col.reference,
@@ -1489,6 +1514,7 @@ export class PivotQueryBuilder {
         sortBy: PivotConfiguration['sortBy'],
         columnLimit: number | undefined,
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
+        passthroughDimensions?: PivotConfiguration['passthroughDimensions'],
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const rowLimit = this.limit ?? DEFAULT_PIVOT_ROW_LIMIT;
@@ -1547,6 +1573,7 @@ export class PivotQueryBuilder {
             metricFirstValueQueries,
             needsPrecomputedRankings,
             sortOnlyDimensions,
+            passthroughDimensions,
         );
 
         let maxColumnsPerValueColumnSql = '';
@@ -1663,6 +1690,7 @@ export class PivotQueryBuilder {
             sortBy,
             sortOnlyColumns,
             sortOnlyDimensions,
+            passthroughDimensions,
         } = this.pivotConfiguration;
 
         // Merge sort-only columns into valuesColumns for SQL generation.
@@ -1695,6 +1723,7 @@ export class PivotQueryBuilder {
             valuesColumns,
             groupByColumns,
             sortOnlyDimensions,
+            passthroughDimensions,
         );
 
         let finalSql: string;
@@ -1710,6 +1739,7 @@ export class PivotQueryBuilder {
                 sortBy,
                 columnLimit,
                 sortOnlyDimensions,
+                passthroughDimensions,
             );
         } else {
             finalSql = this.getSimpleQuerySQL(baseSql, groupByQuery, sortBy);

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -1398,7 +1398,14 @@ describe('derivePivotConfigurationFromChart', () => {
             ).toBe(true);
         });
 
-        it('drops a hidden pivot-column dim entirely when it is not in sorts', () => {
+        it('routes a hidden pivot-column dim with no sort entry to passthroughDimensions (PROD-7873)', () => {
+            // Hidden + not sorted used to drop the dim from the query entirely,
+            // which broke richText / image templates on visible fields that
+            // reference the hidden field via `row.<table>.<field>.raw`.
+            // Now the dim carries through via passthroughDimensions: it stays
+            // in `group_by_query` SELECT/GROUP BY so its values reach the
+            // result rows, but it does NOT appear as a pivot column header
+            // and does NOT drive any ORDER BY.
             const chartConfig = {
                 type: ChartType.TABLE,
                 config: {
@@ -1440,15 +1447,22 @@ describe('derivePivotConfigurationFromChart', () => {
 
             expect(result).toBeDefined();
 
-            // orders_status_priority should NOT be in groupByColumns
+            // orders_status_priority must NOT be in groupByColumns
+            // (still hidden from rendered pivot column headers).
             expect(
                 result?.groupByColumns?.some(
                     (c) => c.reference === 'orders_status_priority',
                 ),
             ).toBe(false);
 
-            // sortOnlyDimensions should be empty (no sort on hidden pivot dim)
+            // sortOnlyDimensions should be empty (the dim isn't a sort target).
             expect(result?.sortOnlyDimensions ?? []).toEqual([]);
+
+            // passthroughDimensions should carry the hidden dim through SQL
+            // so cross-field templates can reference it.
+            expect(result?.passthroughDimensions).toEqual([
+                { reference: 'orders_status_priority' },
+            ]);
         });
 
         it('does not affect non-hidden pivot-column dims', () => {
@@ -1617,11 +1631,13 @@ describe('derivePivotConfigurationFromChart', () => {
             expect(result?.sortOnlyColumns ?? []).toEqual([]);
         });
 
-        it('drops a hidden dimension from indexColumn even when it is NOT in sorts', () => {
-            // Hidden + not sorted → just dropped (not added to sortOnlyColumns either).
-            // orders_status is hidden (visible: false) and NOT in sorts.
-            // payments_payment_method is the pivot dimension (groupByColumn).
-            // Result: orders_status must NOT appear in indexColumn or sortOnlyColumns.
+        it('routes a hidden row dim with no sort entry to passthroughDimensions (PROD-7873)', () => {
+            // Hidden + not sorted row dim used to be dropped from the query
+            // entirely, breaking richText / image templates on visible fields
+            // that referenced the hidden field via `row.<table>.<field>.raw`.
+            // Now it routes through passthroughDimensions: removed from
+            // indexColumn rendering, but its values survive `group_by_query`
+            // SELECT/GROUP BY so they reach the result rows.
             const chartConfig = {
                 type: ChartType.TABLE,
                 config: {
@@ -1645,7 +1661,7 @@ describe('derivePivotConfigurationFromChart', () => {
                 ...mockMetricQuery,
                 dimensions: ['payments_payment_method', 'orders_status'],
                 metrics: ['payments_total_revenue'],
-                // No sort on orders_status — it is purely hidden with no sort role.
+                // No sort on orders_status — purely hidden with no sort role.
                 sorts: [],
             };
 
@@ -1657,7 +1673,8 @@ describe('derivePivotConfigurationFromChart', () => {
 
             expect(result).toBeDefined();
 
-            // orders_status must NOT appear in indexColumn
+            // orders_status must NOT appear in indexColumn (still hidden from
+            // rendered row labels).
             let indexRefs: string[];
             if (Array.isArray(result?.indexColumn)) {
                 indexRefs = result!.indexColumn.map((c) => c.reference);
@@ -1668,14 +1685,18 @@ describe('derivePivotConfigurationFromChart', () => {
             }
             expect(indexRefs).not.toContain('orders_status');
 
-            // orders_status must NOT appear in sortOnlyColumns (it's not sorted)
+            // Not a sort target → not in sortOnlyColumns.
             const sortOnlyRefs = (result?.sortOnlyColumns ?? []).map(
                 (c) => c.reference,
             );
             expect(sortOnlyRefs).not.toContain('orders_status');
-
-            // sortOnlyColumns should be empty (no hidden sort dim)
             expect(result?.sortOnlyColumns ?? []).toEqual([]);
+
+            // passthroughDimensions carries the hidden row dim through SQL
+            // so cross-field templates can reference it.
+            expect(result?.passthroughDimensions).toEqual([
+                { reference: 'orders_status' },
+            ]);
         });
     });
 });

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -215,15 +215,19 @@ function getTablePivotConfiguration(
 
     // Identify hidden dimensions (visible: false in columnProperties).
     // ANY hidden dim is excluded from indexColumn / groupByColumns.
-    // Among hidden dims, those that also appear in sorts participate in SQL
-    // for sort ordering but do not render as visible columns.
-    // Hidden dims that are NOT sorted are simply dropped entirely.
+    // Hidden pivot-column dims are routed three ways:
+    //   - sorted → sortOnlyDimensions (drive column ORDER BY)
+    //   - not sorted → passthroughDimensions (carry values through GROUP BY so
+    //     other fields' richText/image templates can read them via `row.*.raw`)
+    // Hidden row-index dims still drop to sortOnlyColumns or are excluded
+    // entirely from indexColumn.
     const hiddenFieldIds = getHiddenTableFields(chartConfig);
     const sortFieldIds = new Set(metricQuery.sorts.map((s) => s.fieldId));
 
     // Group by columns are the pivot dimensions — exclude hidden ones.
-    // Hidden pivot-column dims are either routed to sortOnlyDimensions (if sorted)
-    // or dropped entirely (if not sorted).
+    // Hidden pivot-column dims are routed to either sortOnlyDimensions (if
+    // sorted) or passthroughDimensions (if not sorted) — never dropped, so
+    // cross-field templates that reference them keep working.
     const allPivotGroupByColumns = pivotColumns
         .map((col: string) => ({
             reference: col,
@@ -245,9 +249,23 @@ function getTablePivotConfiguration(
         )
         .map((col) => ({ reference: col.reference }));
 
+    // Hidden pivot-column dims that are NOT sorted → carried through SQL as
+    // passthrough data so other visible fields' richText / image templates
+    // can reference them via `row.<table>.<field>.raw`. Without this routing
+    // these dims would be dropped entirely and the template reference would
+    // silently resolve to undefined.
+    const passthroughPivotDimensions = allPivotGroupByColumns
+        .filter(
+            (col) =>
+                hiddenFieldIds.includes(col.reference) &&
+                !sortFieldIds.has(col.reference),
+        )
+        .map((col) => ({ reference: col.reference }));
+
     const groupByRefs = new Set([
         ...groupByColumns.map((c) => c.reference),
         ...sortOnlyPivotDimensions.map((c) => c.reference),
+        ...passthroughPivotDimensions.map((c) => c.reference),
     ]);
 
     // All hidden dims that are NOT pivot-column dims (i.e., row-index dims).
@@ -267,6 +285,22 @@ function getTablePivotConfiguration(
             aggregation: VizAggregationOptions.ANY,
         }));
 
+    // Hidden row-index dims that are NOT sorted → carried through SQL via
+    // passthroughDimensions (same mechanism as hidden pivot-column dims).
+    // They survive group_by_query GROUP BY so their per-row value reaches
+    // result rows for cross-field richText / image templates. Don't render
+    // as an index column. Assumes 1-to-1 cardinality with the visible row
+    // dims (the typical case: an `image_url` derived from `status`).
+    const passthroughRowDimensions = metricQuery.dimensions
+        .filter(
+            (d) =>
+                allHiddenDimRefs.has(d) &&
+                !sortFieldIds.has(d) &&
+                // Don't double-route if already a sortOnly row dim
+                !sortOnlyRowDimensions.some((s) => s.reference === d),
+        )
+        .map((d) => ({ reference: d }));
+
     // When computing index columns, treat ALL hidden dims the same as value columns
     // so they are excluded from indexColumn (preventing them from rendering as
     // row-index columns). This covers both sort-only hidden dims and hidden dims
@@ -285,6 +319,7 @@ function getTablePivotConfiguration(
     const allGroupByColumnsForIndex = [
         ...groupByColumns,
         ...sortOnlyPivotDimensions,
+        ...passthroughPivotDimensions,
     ];
 
     // Find columns that are not groupBy or value columns (these become index columns)
@@ -304,6 +339,13 @@ function getTablePivotConfiguration(
         }),
         ...(sortOnlyPivotDimensions.length > 0 && {
             sortOnlyDimensions: sortOnlyPivotDimensions,
+        }),
+        ...((passthroughPivotDimensions.length > 0 ||
+            passthroughRowDimensions.length > 0) && {
+            passthroughDimensions: [
+                ...passthroughPivotDimensions,
+                ...passthroughRowDimensions,
+            ],
         }),
     };
 

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1898,3 +1898,129 @@ describe('convertSqlPivotedRowsToPivotData metric ordering (#19838 / #19919)', (
         ]);
     });
 });
+
+describe('passthrough dimensions (PROD-7873)', () => {
+    // Two paths produce the same passthrough behavior:
+    //   1. DECLARED — backend ran the query with `passthroughDimensions` in
+    //      pivotConfiguration and surfaces it via `pivotDetails.passthroughDimensions`.
+    //   2. INFERRED — user just hid a dim without re-running the query;
+    //      pivotDetails is stale but the row data still carries the value,
+    //      and we synthesize the passthrough from `hiddenDimensionFieldIds`.
+    //
+    // The two must produce identical shape (pivotColumnInfo + allCombinedData),
+    // otherwise users see a flicker on the first render after hide vs. after refetch.
+
+    const baseInputRow = {
+        orders_order_date_year: {
+            value: {
+                raw: '2025-01-01T00:00:00Z',
+                formatted: '2025',
+            },
+        },
+        // Passthrough dim's value sits on each row under its natural field id.
+        orders_status_image_url: {
+            value: {
+                raw: 'https://placehold.co/60?text=A',
+                formatted: 'https://placehold.co/60?text=A',
+            },
+        },
+        payments_total_revenue_any_bank_transfer: {
+            value: { raw: 100, formatted: '100' },
+        },
+    };
+
+    it('declared and inferred paths produce identical pivotColumnInfo + allCombinedData', () => {
+        const sharedArgs = {
+            rows: [baseInputRow],
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: false,
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId: string) => fieldId,
+            groupedSubtotals: undefined,
+        };
+
+        // Path 1: backend declared the passthrough explicitly in pivotDetails.
+        const declared = convertSqlPivotedRowsToPivotData({
+            ...sharedArgs,
+            pivotDetails: {
+                ...SQL_PIVOT_DETAILS,
+                passthroughDimensions: [
+                    { reference: 'orders_status_image_url' },
+                ],
+            },
+        });
+
+        // Path 2: pivotDetails is stale (no passthroughDimensions yet) but
+        // `hiddenDimensionFieldIds` carries the same intent and the row data
+        // is still present — the inferred path picks it up.
+        const inferred = convertSqlPivotedRowsToPivotData({
+            ...sharedArgs,
+            pivotDetails: {
+                ...SQL_PIVOT_DETAILS,
+                // no passthroughDimensions here
+            },
+            pivotConfig: {
+                ...sharedArgs.pivotConfig,
+                hiddenDimensionFieldIds: ['orders_status_image_url'],
+            },
+        });
+
+        expect(declared.retrofitData.pivotColumnInfo).toEqual(
+            inferred.retrofitData.pivotColumnInfo,
+        );
+        expect(declared.retrofitData.allCombinedData).toEqual(
+            inferred.retrofitData.allCombinedData,
+        );
+
+        // Both paths must register the passthrough column with the right marker.
+        const passthroughEntries = declared.retrofitData.pivotColumnInfo.filter(
+            (c) => c.columnType === 'passthrough',
+        );
+        expect(passthroughEntries).toEqual([
+            {
+                fieldId: 'orders_status_image_url',
+                baseId: 'orders_status_image_url',
+                underlyingId: undefined,
+                columnType: 'passthrough',
+            },
+        ]);
+    });
+
+    it('inferred path skips a hidden field that is already an indexColumn', () => {
+        // If `orders_order_date_year` is hidden but still listed in
+        // pivotDetails.indexColumn (cached-results-after-hide path), it must
+        // NOT be inferred as a passthrough — it's already in TanStack's
+        // column model via the index columns. Double-registering would
+        // create duplicate cells in `getAllCells()`.
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: [baseInputRow],
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: false,
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+                // Hidden, but it's an index column — guard must skip it.
+                hiddenDimensionFieldIds: ['orders_order_date_year'],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId: string) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        const passthroughEntries = result.retrofitData.pivotColumnInfo.filter(
+            (c) => c.columnType === 'passthrough',
+        );
+        expect(passthroughEntries).toEqual([]);
+    });
+});

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -254,6 +254,19 @@ const getColSpanByKey = (
         }, 0);
 };
 
+/**
+ * Rebuilds `data.retrofitData.{allCombinedData,pivotColumnInfo}` from
+ * indexValues + dataValues + rowTotals so the TanStack table renderer has
+ * a flat row shape per output row.
+ *
+ * INVARIANT: `allCombinedData.length === indexValues.length`. The
+ * `convertSqlPivotedRowsToPivotData` caller emits one row per input warehouse
+ * row (1-to-1), and a separate post-processing step in that caller attaches
+ * passthrough dimension values onto each output row positionally by index.
+ * If this function ever starts coalescing/dropping rows, the positional
+ * merge will silently associate passthrough values with the wrong rows.
+ * The caller has a dev-mode warn that catches this during testing.
+ */
 const combinedRetrofit = (
     data: PivotData,
     getField: FieldFunction,
@@ -1462,6 +1475,64 @@ export const convertSqlPivotedRowsToPivotData = ({
         hasIndex,
     });
 
+    // Passthrough dims — hidden non-sort pivot dims whose raw values are
+    // carried on each row so cross-field richText / image templates can
+    // resolve `row.<table>.<field>.raw` even though the dim has no rendered
+    // column. Backend AsyncQueryService writes these values onto each row
+    // under the field's natural reference.
+    //
+    // Two sources:
+    //   1. `pivotDetails.passthroughDimensions` — set by the backend when the
+    //      query was built with the field already in `passthroughDimensions`.
+    //   2. `hiddenDimensionFieldIds` ∩ row keys — handles the "user just hid
+    //      a previously-visible dim and the cached results haven't refetched
+    //      yet" case: the row data still carries the value from when the dim
+    //      was visible, so we can opt it into passthrough on the fly. This
+    //      makes the image stay rendered immediately on hide without
+    //      requiring a re-run of the query.
+    //
+    // Note: we don't add them to allCombinedData / pivotColumnInfo here —
+    // combinedRetrofit (below) rebuilds both, so additions here would be
+    // discarded. The merge happens post-combinedRetrofit.
+    const declaredPassthroughs = pivotDetails.passthroughDimensions ?? [];
+    const declaredPassthroughRefs = new Set(
+        declaredPassthroughs.map((d) => d.reference),
+    );
+    const groupByRefs = new Set(
+        (pivotDetails.groupByColumns ?? []).map((c) => c.reference),
+    );
+    // Use the RAW `pivotDetails.indexColumn` (pre-filter), not the local
+    // `indexColumns` array which already has hidden refs removed via
+    // `isDimVisibleInPivot`. We're trying to detect "this field is
+    // structurally an indexColumn in the cached pivot shape", and the
+    // filtered list would always say "not present" for hidden fields.
+    const indexColumnRefs = new Set<string>();
+    if (pivotDetails.indexColumn) {
+        if (Array.isArray(pivotDetails.indexColumn)) {
+            for (const col of pivotDetails.indexColumn) {
+                indexColumnRefs.add(col.reference);
+            }
+        } else {
+            indexColumnRefs.add(pivotDetails.indexColumn.reference);
+        }
+    }
+    const firstRow = rows[0];
+    const inferredPassthroughs: typeof declaredPassthroughs = firstRow
+        ? hiddenDimensionFieldIds
+              .filter(
+                  (fieldId) =>
+                      !declaredPassthroughRefs.has(fieldId) &&
+                      !groupByRefs.has(fieldId) &&
+                      !indexColumnRefs.has(fieldId) &&
+                      firstRow[fieldId] !== undefined,
+              )
+              .map((fieldId) => ({ reference: fieldId }))
+        : [];
+    const passthroughDimensions = [
+        ...declaredPassthroughs,
+        ...inferredPassthroughs,
+    ];
+
     // Build retrofit data for backwards compatibility
     const allCombinedData = rows
         .map((row) => {
@@ -1631,7 +1702,69 @@ export const convertSqlPivotedRowsToPivotData = ({
         groupedSubtotals,
     };
 
-    return combinedRetrofit(pivotData, getField, getFieldLabel, parameters);
+    const retrofitted = combinedRetrofit(
+        pivotData,
+        getField,
+        getFieldLabel,
+        parameters,
+    );
+
+    // combinedRetrofit rebuilds retrofitData.{allCombinedData,pivotColumnInfo}
+    // from indexValues + dataValues + rowTotals, so any passthrough additions
+    // we made earlier are gone. Re-attach them here:
+    //   - Append passthrough entries to pivotColumnInfo so PivotTable
+    //     registers a TanStack column (hidden via columnVisibility).
+    //   - Merge passthrough values from the corresponding input row onto
+    //     each output row (1-to-1 by index — convertSqlPivotedRowsToPivotData
+    //     emits one output row per input row).
+    //
+    // INVARIANT: combinedRetrofit.retrofitData.allCombinedData.length must
+    // equal rows.length — the positional merge below depends on this. If
+    // anyone adds row coalescing inside combinedRetrofit (or upstream changes
+    // how SQL-pivoted rows fan out), passthrough values would silently shift
+    // to the wrong row. The dev-mode warn below catches that during testing
+    // without crashing prod for users.
+    if (passthroughDimensions.length > 0) {
+        if (
+            process.env.NODE_ENV !== 'production' &&
+            retrofitted.retrofitData.allCombinedData.length !== rows.length
+        ) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[pivot] passthrough positional merge invariant violated: ` +
+                    `allCombinedData.length=${retrofitted.retrofitData.allCombinedData.length} ` +
+                    `!= rows.length=${rows.length}. Passthrough values may be ` +
+                    `attached to the wrong rows. Investigate combinedRetrofit ` +
+                    `for row coalescing.`,
+            );
+        }
+        retrofitted.retrofitData.pivotColumnInfo = [
+            ...retrofitted.retrofitData.pivotColumnInfo,
+            ...passthroughDimensions.map((dim) => ({
+                fieldId: dim.reference,
+                baseId: dim.reference,
+                underlyingId: undefined,
+                columnType: 'passthrough' as const,
+            })),
+        ];
+        retrofitted.retrofitData.allCombinedData =
+            retrofitted.retrofitData.allCombinedData.map(
+                (combinedRow, rowIndex) => {
+                    const inputRow = rows[rowIndex];
+                    if (!inputRow) return combinedRow;
+                    const enriched: ResultRow = { ...combinedRow };
+                    for (const dim of passthroughDimensions) {
+                        const value = inputRow[dim.reference];
+                        if (value !== undefined) {
+                            enriched[dim.reference] = value;
+                        }
+                    }
+                    return enriched;
+                },
+            );
+    }
+
+    return retrofitted;
 };
 
 export type PivotResultsDataCell = {
@@ -1794,9 +1927,16 @@ export const pivotResultsAsData = ({
         [[]],
     );
 
-    const fieldIds = Object.values(
-        pivotedResults.retrofitData.pivotColumnInfo,
-    ).map((field) => field.fieldId);
+    // Passthrough columns are registered in pivotColumnInfo so the pivot
+    // table can render cross-field richText / image templates that read
+    // `row.<table>.<field>.raw`. They must NOT appear in CSV / XLSX
+    // exports — the user explicitly hid the column from the visualization,
+    // and the "hide" semantic includes exports. Filtered here so every
+    // downstream consumer of pivotResultsAsData (CSV, XLSX, etc.) inherits
+    // the exclusion.
+    const fieldIds = Object.values(pivotedResults.retrofitData.pivotColumnInfo)
+        .filter((field) => field.columnType !== 'passthrough')
+        .map((field) => field.fieldId);
 
     const hasIndex = pivotedResults.indexValues.length > 0;
     const dataRows = pivotedResults.retrofitData.allCombinedData.map((row) => {

--- a/packages/common/src/pivot/pivotResultsAsCsv.test.ts
+++ b/packages/common/src/pivot/pivotResultsAsCsv.test.ts
@@ -292,4 +292,88 @@ describe('pivotResultsAsCsv', () => {
             expect(allValues).toContain('Docs');
         });
     });
+
+    describe('passthrough dimension filtering (PROD-7873)', () => {
+        // SQL-pivot path: when a hidden dim is carried through SQL as
+        // `passthroughDimensions` so its values can be referenced by
+        // cross-field richText / image templates, those values must NOT
+        // leak into CSV / XLSX exports — the "hide" semantic includes
+        // exports.
+        it('omits passthrough dim values from CSV output even when present on rows', () => {
+            const rows: ResultRow[] = [
+                {
+                    page: { value: { raw: '/home', formatted: '/home' } },
+                    site_image_url: {
+                        value: {
+                            raw: 'https://placehold.co/60?text=Blog',
+                            formatted: 'https://placehold.co/60?text=Blog',
+                        },
+                    },
+                    views_sum: { value: { raw: 6, formatted: '6.0' } },
+                },
+                {
+                    page: { value: { raw: '/about', formatted: '/about' } },
+                    site_image_url: {
+                        value: {
+                            raw: 'https://placehold.co/60?text=Docs',
+                            formatted: 'https://placehold.co/60?text=Docs',
+                        },
+                    },
+                    views_sum: { value: { raw: 12, formatted: '12.0' } },
+                },
+            ];
+
+            const result = pivotResultsAsCsv({
+                pivotConfig: {
+                    pivotDimensions: [],
+                    metricsAsRows: false,
+                    hiddenDimensionFieldIds: ['site_image_url'],
+                },
+                rows,
+                itemMap: buildItemsMap(),
+                metricQuery: {
+                    exploreName: 'test',
+                    ...METRIC_QUERY_2DIM_2METRIC,
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    customDimensions: [],
+                    metricOverrides: {},
+                    dimensionOverrides: {},
+                },
+                customLabels: undefined,
+                onlyRaw: false,
+                maxColumnLimit: 60,
+                pivotDetails: {
+                    totalColumnCount: 1,
+                    valuesColumns: [
+                        {
+                            aggregation: 'any' as never,
+                            pivotValues: [],
+                            referenceField: 'views',
+                            pivotColumnName: 'views_sum',
+                        },
+                    ],
+                    indexColumn: [
+                        { type: 'category' as never, reference: 'page' },
+                    ],
+                    groupByColumns: [],
+                    sortBy: undefined,
+                    originalColumns: {},
+                    passthroughDimensions: [{ reference: 'site_image_url' }],
+                },
+            });
+
+            const allValues = result.flat();
+            // Passthrough field id must not appear in the CSV
+            expect(allValues).not.toContain('site_image_url');
+            // Passthrough values (the placeholder URLs) must not leak
+            expect(allValues.some((v) => v.includes('placehold.co'))).toBe(
+                false,
+            );
+            // The visible index dim and metric must still appear
+            expect(allValues).toContain('/home');
+            expect(allValues).toContain('6.0');
+        });
+    });
 });

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -741,6 +741,11 @@ export type ReadyQueryResultsPage = ResultsPaginationMetadata<ResultRow> & {
         groupByColumns: GroupByColumn[] | undefined;
         sortBy: SortBy | undefined;
         originalColumns: ResultColumns;
+        // Hidden pivot-column dims that are carried through the SQL pipeline
+        // for cross-field richText/image templates (`row.<table>.<field>.raw`)
+        // but are not rendered as pivot column headers. Their raw values are
+        // attached to each result row under their fieldId.
+        passthroughDimensions?: GroupByColumn[];
     } | null;
 };
 

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -48,6 +48,17 @@ export type PivotConfiguration = {
      * Mirrors `sortOnlyColumns` (which serves the same purpose for metrics).
      */
     sortOnlyDimensions?: GroupByColumn[];
+    /**
+     * Hidden pivot-column dimensions that are NOT sort targets but still need
+     * their values carried through the SQL pipeline so that other fields'
+     * `richText` / `image:` templates can reference them via
+     * `row.<table>.<field>.raw`. They participate in `group_by_query` SELECT
+     * and GROUP BY (same as sortOnlyDimensions) but do NOT affect
+     * `column_ranking` ORDER BY (they don't drive sort). Without this bucket
+     * the dim would be dropped entirely from the query and `row.*.raw`
+     * references would silently resolve to undefined.
+     */
+    passthroughDimensions?: GroupByColumn[];
 };
 
 type Field =

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -595,6 +595,19 @@ const PivotTable: FC<PivotTableProps> = ({
         );
     }, [hasCustomWidths, colWidths]);
 
+    // Passthrough columns are registered with TanStack so their values
+    // surface in `getAllCells()` for richText / image row context, but they
+    // must not render as headers or body cells.
+    const columnVisibility = useMemo(() => {
+        const visibility: Record<string, boolean> = {};
+        for (const col of data.retrofitData.pivotColumnInfo) {
+            if (col.columnType === 'passthrough') {
+                visibility[col.fieldId] = false;
+            }
+        }
+        return visibility;
+    }, [data.retrofitData.pivotColumnInfo]);
+
     const table = useReactTable({
         data: data.retrofitData.allCombinedData,
         columns: columns,
@@ -602,6 +615,7 @@ const PivotTable: FC<PivotTableProps> = ({
             grouping,
             expanded,
             columnOrder: columnOrder,
+            columnVisibility,
             columnPinning: {
                 left: [ROW_NUMBER_COLUMN_ID],
             },


### PR DESCRIPTION
Closes: PROD-7873

### Description:

Fixes a bug where hidden pivot-column dimensions were being dropped entirely from the SQL pipeline, causing `richText` and `image:` templates on visible fields that referenced those hidden fields via `row.<table>.<field>.raw` to silently resolve to `undefined` and break image rendering in pivot tables.

**Root cause:** When a pivot-column dimension was hidden (`visible: false`) and not used as a sort target, it was excluded from `group_by_query` SELECT and GROUP BY entirely. This meant its value never reached the result rows, so any cross-field template referencing it had nothing to resolve.

**Fix:** Introduces a `passthroughDimensions` bucket in `PivotConfiguration`. Hidden pivot-column and row-index dimensions that are not sort targets are now routed into `passthroughDimensions` instead of being dropped. These dimensions:
- Are included in `group_by_query` SELECT and GROUP BY so their values flow through the SQL pipeline to each result row.
- Do **not** appear as rendered pivot column headers.
- Do **not** participate in `column_ranking` ORDER BY (they don't drive sort).
- Are registered as hidden TanStack columns (via `columnVisibility`) so their values surface in `getAllCells()` row context for richText/image template resolution.
- Are explicitly excluded from CSV/XLSX exports — the "hide" semantic applies to exports as well.

A `status_image_url` additional dimension has been added to the jaffle shop demo `orders.yml` to reproduce and validate the richText + hide-pivot-column interaction, using a `CONCAT`-derived placeholder image URL and a `richText` template on the `status` field that references it via `row.orders.status_image_url.raw`.