### PR TITLE
fix(ai-agents): bring back loadSkill tool

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -21,6 +21,7 @@ import { getGetKnowledgeDocumentContent } from '../tools/getKnowledgeDocumentCon
 import { getImproveContext } from '../tools/improveContext';
 import { getListKnowledgeDocuments } from '../tools/listKnowledgeDocuments';
 import { getListWarehouseTables } from '../tools/listWarehouseTables';
+import { getLoadSkill } from '../tools/loadSkill';
 import { getProposeChange } from '../tools/proposeChange';
 import { getReadContent } from '../tools/readContent';
 import { getRunQuery } from '../tools/runQuery';
@@ -259,6 +260,13 @@ const getAgentTools = (
         getKnowledgeDocumentContent: dependencies.getKnowledgeDocumentContent,
     });
 
+    const loadSkill =
+        args.availableSkills.length > 0
+            ? getLoadSkill({
+                  loadSkill: dependencies.loadSkill,
+              })
+            : null;
+
     const tools: ToolSet = {
         findContent,
         discoverFields,
@@ -283,6 +291,7 @@ const getAgentTools = (
         ...(runSql ? { runSql } : {}),
         ...(listWarehouseTables ? { listWarehouseTables } : {}),
         ...(describeWarehouseTable ? { describeWarehouseTable } : {}),
+        ...(loadSkill ? { loadSkill } : {}),
     };
 
     const mergedTools = { ...tools, ...mcpToolSetup.tools };


### PR DESCRIPTION
Closes:

### Description:
Adds a `loadSkill` tool to the V2 agent, which is conditionally included in the agent's tool set when there are available skills. The tool is initialized with a `loadSkill` dependency and only registered if `args.availableSkills` is non-empty.