### PR TITLE
fix(sql-runner): preserve user ORDER BY → LIMIT adjacency

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.mocks.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.mocks.ts
@@ -61,11 +61,13 @@ export const QUERY_WITH_FILTER_SQL =
 export const QUERY_WITH_TWO_FILTERS_SQL =
     'SELECT\n"test_table"."test_field" AS "test_field"\nFROM "test_table"\nWHERE ((\n("test_table"."test_field") IN (\'test_value\')\n) AND (\n("test_table"."test_field") IS NOT NULL\n))';
 
-export const QUERY_WITH_SUBQUERY_SQL =
-    'SELECT\n"test_field" AS "test_field"\nFROM (\nSELECT test_field FROM source_table WHERE test_field IS NOT NULL\n) AS "subquery"';
+// User-provided FROM SQL with no filters is no longer wrapped in an outer
+// SELECT — wrapping severs the user's ORDER BY from any LIMIT (PROD-7880).
+export const UNWRAPPED_FROM_SUBQUERY_SQL =
+    'SELECT test_field FROM source_table WHERE test_field IS NOT NULL';
 
-export const QUERY_WITH_SUBQUERY_SEMICOLON_COMMENTS_SQL =
-    'SELECT\n"test_field" AS "test_field"\nFROM (\nSELECT test_field FROM source_table WHERE test_field IS NOT NULL\n) AS "subquery"';
+export const UNWRAPPED_FROM_SUBQUERY_WITH_COMMENTS_SQL =
+    'SELECT test_field FROM source_table WHERE test_field IS NOT NULL';
 
 export const QUERY_WITH_NESTED_FILTERS_SQL =
     'SELECT\n"table"."field1" AS "field1",\n"table"."field2" AS "field2",\n"table"."field3" AS "field3"\nFROM "table"\nWHERE ((\n("table"."field1") IN (\'value1\')\n) AND ((\n("table"."field2") > (10)\n) OR (\n("table"."field3") = true\n)))';
@@ -77,10 +79,10 @@ export const QUERY_WITH_LIMIT_SQL =
     'SELECT\n"test_table"."test_field" AS "test_field"\nFROM "test_table"\nLIMIT 100';
 
 export const QUERY_WITH_LIMIT_OFFSET_SQL =
-    'SELECT\n"test_table"."test_field" AS "test_field"\nFROM (\nSELECT * FROM source_table WHERE field IS NOT NULL\n) AS "subquery"\nLIMIT 50 OFFSET 10';
+    'SELECT * FROM source_table WHERE field IS NOT NULL LIMIT 50 OFFSET 10';
 
 export const QUERY_WITH_LIMIT_OFFSET_MIN_SQL =
-    'SELECT\n"test_table"."test_field" AS "test_field"\nFROM (\nSELECT * FROM source_table WHERE field IS NOT NULL\n) AS "subquery"\nLIMIT 30 OFFSET 5';
+    'SELECT * FROM source_table WHERE field IS NOT NULL LIMIT 30 OFFSET 5';
 
 export const QUERY_WITH_LIMIT_ONLY_LIMIT_SQL =
-    'SELECT\n"test_table"."test_field" AS "test_field"\nFROM (\nSELECT * FROM source_table WHERE field IS NOT NULL\n) AS "subquery"\nLIMIT 75';
+    'SELECT * FROM source_table WHERE field IS NOT NULL LIMIT 75';

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.test.ts
@@ -14,13 +14,13 @@ import {
     QUERY_WITH_LIMIT_ONLY_LIMIT_SQL,
     QUERY_WITH_LIMIT_SQL,
     QUERY_WITH_NESTED_FILTERS_SQL,
-    QUERY_WITH_SUBQUERY_SEMICOLON_COMMENTS_SQL,
-    QUERY_WITH_SUBQUERY_SQL,
     QUERY_WITH_TWO_FILTERS_SQL,
     SECOND_FILTER_RULE,
     SIMPLE_FILTER_RULE,
     SIMPLE_QUERY_SQL,
     SIMPLE_REFERENCE_MAP,
+    UNWRAPPED_FROM_SUBQUERY_SQL,
+    UNWRAPPED_FROM_SUBQUERY_WITH_COMMENTS_SQL,
 } from './SqlQueryBuilder.mocks';
 
 describe('SqlQueryBuilder class', () => {
@@ -124,7 +124,7 @@ describe('SqlQueryBuilder class', () => {
                 },
                 DEFAULT_CONFIG,
             );
-            expect(queryBuilder.toSql()).toBe(QUERY_WITH_SUBQUERY_SQL);
+            expect(queryBuilder.toSql()).toBe(UNWRAPPED_FROM_SUBQUERY_SQL);
         });
 
         it('should handle SQL with semicolons and comments in FROM', () => {
@@ -146,7 +146,7 @@ describe('SqlQueryBuilder class', () => {
                 DEFAULT_CONFIG,
             );
             expect(queryBuilder.toSql()).toBe(
-                QUERY_WITH_SUBQUERY_SEMICOLON_COMMENTS_SQL,
+                UNWRAPPED_FROM_SUBQUERY_WITH_COMMENTS_SQL,
             );
         });
     });
@@ -327,6 +327,31 @@ describe('SqlQueryBuilder class', () => {
             );
 
             expect(queryBuilder.toSql()).toContain('LIMIT 10 OFFSET 5');
+        });
+
+        // PROD-7880: an outer LIMIT applied after a subquery wrap lets the
+        // optimizer drop the user's ORDER BY, returning arbitrary rows. The
+        // builder must keep ORDER BY adjacent to LIMIT in the emitted SQL.
+        it('should keep user ORDER BY adjacent to LIMIT (no subquery wrap)', () => {
+            const queryBuilder = new SqlQueryBuilder(
+                {
+                    referenceMap: SIMPLE_REFERENCE_MAP,
+                    select: ['test_field'],
+                    from: {
+                        name: 'subquery',
+                        sql: 'SELECT badge, COUNT(DISTINCT user_id) AS active_profiles FROM exploded GROUP BY 1 ORDER BY active_profiles DESC, badge ASC LIMIT 5',
+                    },
+                    limit: 500,
+                },
+                DEFAULT_CONFIG,
+            );
+
+            const sql = queryBuilder.toSql();
+            expect(sql).not.toMatch(/\)\s*AS\s*"sql_query"/i);
+            expect(sql).not.toMatch(/\)\s*AS\s*"subquery"/i);
+            expect(sql).toMatch(
+                /ORDER BY active_profiles DESC, badge ASC\s+LIMIT 5\s*$/i,
+            );
         });
     });
 

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.ts
@@ -11,6 +11,7 @@ import {
 } from '@lightdash/common';
 import { safeReplaceParameters } from './parameters';
 import {
+    applyLimitToSqlQuery,
     extractOuterLimitOffsetFromSQL,
     removeCommentsAndOuterLimitOffset,
     removeTrailingSemicolon,
@@ -201,21 +202,40 @@ export class SqlQueryBuilder {
         return `LIMIT ${limitToAppend}${offsetString}`;
     }
 
+    private hasFilters(): boolean {
+        if (!this.filters) return false;
+        const items = isAndFilterGroup(this.filters)
+            ? this.filters.and
+            : this.filters.or;
+        return items.length > 0;
+    }
+
     getSqlAndReferences(): {
         sql: string;
         parameterReferences: string[];
         missingParameterReferences: string[];
         usedParameters: ParametersValuesMap;
     } {
-        // Combine all parts of the query
-        const sql = [
-            this.selectsToSql(),
-            this.fromToSql(),
-            this.filtersToSql(),
-            this.limitToSql(),
-        ]
-            .filter((l) => l !== undefined)
-            .join('\n');
+        // When the FROM is a user-provided SQL subquery and no filters need
+        // to be applied, return the user's SQL with LIMIT appended directly
+        // instead of wrapping in an outer SELECT. Wrapping puts the user's
+        // ORDER BY inside the subquery where Snowflake/BigQuery/Redshift
+        // optimizers can drop it, making the outer LIMIT return arbitrary
+        // rows (PROD-7880).
+        const sql =
+            this.from.sql && !this.hasFilters()
+                ? applyLimitToSqlQuery({
+                      sqlQuery: this.from.sql,
+                      limit: this.limit,
+                  })
+                : [
+                      this.selectsToSql(),
+                      this.fromToSql(),
+                      this.filtersToSql(),
+                      this.limitToSql(),
+                  ]
+                      .filter((l) => l !== undefined)
+                      .join('\n');
 
         const { replacedSql, references, missingReferences } =
             safeReplaceParameters({


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7880/sql-runner-returns-wrong-aggregate-values-when-user-provided-limit-is

### Description:
Customer reported SQL Runner returning different aggregate values on Snowflake depending on the user-supplied LIMIT. Reproduced locally by running a CTE + COUNT(DISTINCT) + ORDER BY against JAFFLE.TRACKS_RAW via `lightdash sql`: rows came back unsorted — `report_exported,3352` appeared at row 16 below `ticket_reopened,345`, even though the user SQL ended with `ORDER BY unique_users DESC, EVENT_NAME ASC`. Snowflake QUERY_HISTORY confirmed the warehouse received:

    SELECT "EVENT_NAME" AS "EVENT_NAME", ...
    FROM (
      <user SQL ending with ORDER BY ...>
    ) AS "sql_query"
    LIMIT 50000

The user's ORDER BY is inside the subquery, LIMIT is on the outer SELECT. Per ANSI SQL — and explicitly per Snowflake/BigQuery/Redshift docs — ORDER BY inside an unconstrained subquery is a hint the optimizer is free to drop. So the outer LIMIT N returns N arbitrary rows. With small user-LIMITs (e.g. LIMIT 5) every run looks "wrong" in a different way; with the default 50k limit the bug was masked when all rows fit but ordering was still non-deterministic.

The wrap is built by SqlQueryBuilder, originally introduced to allow applying dashboard filters on top of user SQL. But SQL charts don't support filters yet (see AsyncQueryService.ts comment), so in 100% of today's production traffic the wrap is purely cosmetic — and it silently breaks ORDER BY.

Fix: when `from.sql` is set and no filters apply, bypass the wrap and return the user's SQL with LIMIT appended via the existing `applyLimitToSqlQuery` helper. The wrap branch is preserved for the unused filter path so a future SQL-chart-with-filters feature isn't broken by this change.

Why safe:
- The new shape is identical to the legacy `streamSqlQueryIntoFile` path that has shipped `applyLimitToSqlQuery` in production for years. We're aligning the v2 async path with the legacy path.
- Single production callsite (AsyncQueryService.prepareSqlChartAsync QueryArgs); the conditional gate is precise.
- Verified live on Snowflake (bug fixed — rows now sorted), Postgres (no observable change — Postgres preserved subquery ORDER BY de facto), and BigQuery (no observable change on the F1 dataset; fix eliminates latent optimizer risk on larger plans).
- 411 QueryBuilder tests pass, including a new regression test asserting ORDER BY stays adjacent to LIMIT for a customer-shaped query. Three existing subquery+limit snapshots updated to expect the new flat output.
