### PR TITLE
fix(skills): add `hidden` field to dashboard tab examples and docs

### DIFF
--- a/skills/developing-in-lightdash/resources/dashboard-best-practices.md
+++ b/skills/developing-in-lightdash/resources/dashboard-best-practices.md
@@ -105,17 +105,21 @@ Tabs help organize complex dashboards without overwhelming users:
 ```yaml
 tabs:
   - name: "Overview"      # Start with high-level view
+    hidden: false
     order: 0
-    uuid: "overview"
+    uuid: "1b1f4a7b-7e2d-4e91-8fd7-0d2bb54cb0c1"
   - name: "Trends"        # Time-based analysis
+    hidden: false
     order: 1
-    uuid: "trends"
+    uuid: "2c2f5b8c-8f3e-4fa2-90e8-1e3cc65dc1d2"
   - name: "Breakdown"     # Dimensional analysis
+    hidden: false
     order: 2
-    uuid: "breakdown"
+    uuid: "3d3f6c9d-904f-40b3-a1f9-2f4dd76ed2e3"
   - name: "Details"       # Detailed data tables
+    hidden: true          # Optional: editors can keep draft tabs out of view mode
     order: 3
-    uuid: "details"
+    uuid: "4e4f7dae-a150-41c4-b20a-3f5ee87fe3f4"
 ```
 
 **When to use tabs:**
@@ -123,6 +127,7 @@ tabs:
 - Content naturally groups into themes
 - Different audiences need different views
 - Analysis flows from summary to detail
+- Some tabs are draft/internal only: set `hidden: true` so editors keep them without exposing them in view mode
 
 **Tab naming tips:**
 - Keep names short (1-2 words)

--- a/skills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/skills/developing-in-lightdash/resources/dashboard-reference.md
@@ -15,7 +15,7 @@ filters:         # Dashboard-level filters
 name: "Sales Dashboard"
 slug: sales-dashboard
 spaceSlug: sales
-tabs: []         # Optional tabs for organization
+tabs: []         # Optional tabs for organization; tabs support hidden: true/false
 tiles: []        # Chart and content tiles
 verified: true   # Optional: true/false to verify/unverify on upload, omit to leave unchanged. Admins only.
 version: 1
@@ -178,12 +178,15 @@ Organize tiles into multiple views:
 ```yaml
 tabs:
   - name: "Overview"
+    hidden: false
     order: 0
     uuid: "b3f1a2c4-d5e6-4f78-9abc-def012345678"
   - name: "Details"
+    hidden: false
     order: 1
     uuid: "c4d2b3e5-f6a7-4089-bcde-f12345678901"
   - name: "Trends"
+    hidden: false
     order: 2
     uuid: "d5e3c4f6-a7b8-4190-cdef-234567890123"
 
@@ -445,12 +448,15 @@ slug: executive-sales-dashboard
 spaceSlug: leadership
 tabs:
   - name: "Overview"
+    hidden: false
     order: 0
     uuid: "e6f4d5a7-b8c9-4201-def0-345678901234"
   - name: "By Region"
+    hidden: false
     order: 1
     uuid: "f7a5e6b8-c9d0-4312-ef01-456789012345"
   - name: "By Product"
+    hidden: false
     order: 2
     uuid: "a8b6f7c9-d0e1-4423-f012-567890123456"
 


### PR DESCRIPTION
Closes:

### Description:
Adds `hidden` and proper UUID fields to tab examples throughout the dashboard reference and best practices documentation.

Tab definitions now include `hidden: true/false` to reflect that tabs can be hidden from view mode while remaining accessible to editors. This is useful for keeping draft or internal tabs out of the published dashboard view. The best practices guide also includes a new bullet point explaining when to use `hidden: true` for draft/internal tabs.

Tab UUIDs in examples have been updated from placeholder strings (e.g. `"overview"`, `"trends"`) to properly formatted UUID values to better reflect real usage.