### PR TITLE
feat(ai-agents): add `generateUuids` tool for stable UUID generation

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -16,6 +16,7 @@ import { getDescribeWarehouseTable } from '../tools/describeWarehouseTable';
 import { getEditContent } from '../tools/editContent';
 import { getFindContent } from '../tools/findContent';
 import { getGenerateDashboardV2 } from '../tools/generateDashboardV2';
+import { getGenerateUuids } from '../tools/generateUuids';
 import { getGetDashboardCharts } from '../tools/getDashboardCharts';
 import { getGetKnowledgeDocumentContent } from '../tools/getKnowledgeDocumentContent';
 import { getImproveContext } from '../tools/improveContext';
@@ -266,6 +267,7 @@ const getAgentTools = (
                   loadSkill: dependencies.loadSkill,
               })
             : null;
+    const generateUuids = getGenerateUuids();
 
     const tools: ToolSet = {
         findContent,
@@ -283,6 +285,7 @@ const getAgentTools = (
         runQuery,
         runSavedChart,
         generateDashboard,
+        generateUuids,
         ...(args.canManageAgent ? { improveContext } : {}),
         ...(args.enableSelfImprovement && args.canManageAgent
             ? { proposeChange }

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/dashboard-reference.md
@@ -204,6 +204,8 @@ Add section headers:
 
 ## Dashboard Tabs
 
+**IMPORTANT:** Tab `uuid` values must be valid UUIDs (e.g., `"a1b2c3d4-e5f6-7890-abcd-ef1234567890"`), not friendly names. The linter will reject non-UUID values. Generate UUIDs with `generateUuids` tool.
+
 Organize tiles into multiple views:
 
 ```json

--- a/packages/backend/src/ee/services/ai/tools/generateUuids.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateUuids.ts
@@ -1,0 +1,52 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { toModelOutput } from '../utils/toModelOutput';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+
+export const toolGenerateUuidsArgsSchema = z
+    .object({
+        count: z
+            .number()
+            .min(1)
+            .max(20)
+            .describe('Number of UUIDs to generate.'),
+    })
+    .describe(
+        'Generate one or more UUIDs to use as stable identifiers when creating new objects.',
+    );
+
+const toolGenerateUuidsOutputSchema = z.object({
+    result: z.string(),
+    metadata: z.object({
+        status: z.enum(['success', 'error']),
+    }),
+});
+
+export const getGenerateUuids = () =>
+    tool({
+        description: toolGenerateUuidsArgsSchema.description,
+        inputSchema: toolGenerateUuidsArgsSchema,
+        outputSchema: toolGenerateUuidsOutputSchema,
+        execute: async ({ count }) => {
+            try {
+                return {
+                    result: JSON.stringify({
+                        uuids: Array.from({ length: count }, () =>
+                            crypto.randomUUID(),
+                        ),
+                    }),
+                    metadata: {
+                        status: 'success' as const,
+                    },
+                };
+            } catch (error) {
+                return {
+                    result: toolErrorHandler(error, 'Error generating UUIDs.'),
+                    metadata: {
+                        status: 'error' as const,
+                    },
+                };
+            }
+        },
+        toModelOutput: ({ output }) => toModelOutput(output),
+    });

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -30,6 +30,7 @@ import { DbAiAgentToolCall } from '../../../database/entities/ai';
 import { defaultAgentOptions } from '../agents/agentV2';
 import { discoverFieldsInputSchema } from '../agents/discoverFields/schema';
 import { getOpenaiGptmodel } from '../models/openai-gpt';
+import { toolGenerateUuidsArgsSchema } from '../tools/generateUuids';
 
 const toolLoadSkillArgsSchema = z
     .object({
@@ -68,6 +69,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     generateTimeSeriesVizConfig: 'time_series_chart',
     generateBarVizConfig: 'vertical_bar_chart',
     loadSkill: 'load_skill',
+    generateUuids: 'generate_uuids',
     runQuery: 'query_result',
     runSavedChart: 'run_saved_chart',
     runSql: 'run_sql',
@@ -99,6 +101,7 @@ const TOOL_SCHEMAS = {
     editContent: toolEditContentArgsSchema,
     improveContext: toolImproveContextArgsSchema,
     loadSkill: toolLoadSkillArgsSchema,
+    generateUuids: toolGenerateUuidsArgsSchema,
     proposeChange: toolProposeChangeArgsSchema,
     runQuery: toolRunQueryArgsSchema,
     runSavedChart: toolRunSavedChartArgsSchema,

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -14,6 +14,7 @@ const VisualizationTools = [
 export const ToolNameSchema = z.enum([
     ...VisualizationTools,
     'generateDashboard',
+    'generateUuids',
     'findContent',
     'findExplores',
     'findFields',
@@ -55,6 +56,7 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     generateTableVizConfig: 'Generating a table',
     generateTimeSeriesVizConfig: 'Generating a line chart',
     generateDashboard: 'Generating a dashboard',
+    generateUuids: 'Generating UUIDs',
     findCharts: 'Finding relevant charts',
     getDashboardCharts: 'Looking up dashboard charts',
     readContent: 'Reading content',
@@ -83,6 +85,7 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         generateTableVizConfig: 'Generated a table',
         generateTimeSeriesVizConfig: 'Generated a line chart',
         generateDashboard: 'Generated a dashboard',
+        generateUuids: 'Generated UUIDs',
         findCharts: 'Found relevant charts',
         getDashboardCharts: 'Found dashboard charts',
         readContent: 'Read content',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -95,6 +95,12 @@ type SqlApprovalSegment = {
 };
 type StreamSegment = TextSegment | ToolGroup | SqlApprovalSegment;
 
+const HIDDEN_TOOL_NAMES = new Set<AiAgentToolName>([
+    'improveContext',
+    'proposeChange',
+    'generateUuids',
+]);
+
 const segmentStreamParts = (
     parts: StreamPart[],
     decidedToolCallIds: string[],
@@ -105,10 +111,7 @@ const segmentStreamParts = (
             segments.push({ kind: 'text', text: part.text, idx });
             return;
         }
-        if (
-            part.toolName === 'improveContext' ||
-            part.toolName === 'proposeChange'
-        ) {
+        if (HIDDEN_TOOL_NAMES.has(part.toolName)) {
             return;
         }
         if (
@@ -662,8 +665,7 @@ const AssistantBubbleContent: FC<{
                 // the final markdown answer below as the hero.
                 const renderableToolCalls = message.toolCalls.filter(
                     (tc) =>
-                        tc.toolName !== 'improveContext' &&
-                        tc.toolName !== 'proposeChange' &&
+                        !HIDDEN_TOOL_NAMES.has(tc.toolName) &&
                         // Subagent children render nested under their parent's row, not as top-level siblings.
                         tc.parentToolCallId === null,
                 );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -216,6 +216,7 @@ export const ToolCallDescription: FC<{
             );
         case 'listKnowledgeDocuments':
         case 'discoverFields':
+        case 'generateUuids':
         case 'improveContext':
         case 'loadSkill':
         case 'proposeChange':

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -34,6 +34,7 @@ export const getToolIcon = (toolName: AiAgentToolName) => {
             generateTimeSeriesVizConfig: IconChartLine,
             generateTableVizConfig: IconTable,
             generateDashboard: IconLayoutDashboard,
+            generateUuids: IconSelector,
             findContent: IconSearch,
             findDashboards: IconLayoutDashboard,
             findCharts: IconChartDots3,


### PR DESCRIPTION
Closes:

### Description:

Adds a `generateUuids` tool to the AI agent that allows the model to generate valid UUIDs on demand. This is particularly important when creating dashboard tabs, where `uuid` fields must be valid UUIDs rather than friendly names — the linter will reject non-UUID values.

The tool accepts a `count` parameter and returns the requested number of UUIDs. The dashboard reference documentation has been updated to explicitly instruct the model to use `generateUuids` when populating tab UUID fields.

The tool is hidden from the chat UI (alongside `improveContext` and `proposeChange`) since it is an internal implementation detail not meaningful to the user, though it does surface a "Generating UUIDs" / "Generated UUIDs" status message in the tool call display when visible.