### PR TITLE
fix(ai-agents): improve edit content error message and add exhaustive type check

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/editContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/editContent.ts
@@ -53,7 +53,7 @@ export const getEditContent = ({ editContent }: Dependencies) =>
                 return {
                     result: toolErrorHandler(
                         error,
-                        `Error editing ${type} "${slug}"`,
+                        `Error editing ${type} "${slug}". Patch was not applied.`,
                     ),
                     metadata: {
                         status: 'error' as const,

--- a/packages/backend/src/ee/services/ai/utils/AiAgentContentValidation.ts
+++ b/packages/backend/src/ee/services/ai/utils/AiAgentContentValidation.ts
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     chartAsCodeSchema,
     dashboardAsCodeSchema,
     ParameterError,
@@ -141,7 +142,14 @@ export class AiAgentContentValidation {
 
     private getValidator(type: ContentType): ValidateFunction {
         const validators = this.getValidators();
-        return type === 'chart' ? validators.chart : validators.dashboard;
+        switch (type) {
+            case 'chart':
+                return validators.chart;
+            case 'dashboard':
+                return validators.dashboard;
+            default:
+                return assertUnreachable(type, 'Unsupported content type');
+        }
     }
 
     private getValidators(): {


### PR DESCRIPTION
Closes:

### Description:

Improves error messaging when a patch fails to apply during content editing by appending `"Patch was not applied."` to the error message, making it clearer to the AI agent that the edit did not take effect.

Also replaces the implicit fallback in `getValidator` with an exhaustive `switch` statement using `assertUnreachable`, ensuring that any unsupported `ContentType` values are caught at compile time rather than silently falling through.