### PR TITLE
fix: include charts in loose dashbaords on upload

### DIFF
--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -1,0 +1,113 @@
+import { DashboardAsCode } from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { testHelpers } from './download';
+
+const { getDashboardChartSlugs } = testHelpers;
+
+type LooseDashboard = DashboardAsCode & { needsUpdating: boolean };
+
+const makeLooseDashboard = (
+    slug: string,
+    chartSlugs: (string | undefined)[],
+): LooseDashboard =>
+    ({
+        slug,
+        name: slug,
+        spaceSlug: 'test-space',
+        version: 1,
+        tiles: chartSlugs.map((chartSlug) => ({
+            properties: chartSlug ? { chartSlug } : {},
+        })),
+        needsUpdating: false,
+    }) as unknown as LooseDashboard;
+
+const writeFolderDashboard = async (
+    baseDir: string,
+    slug: string,
+    chartSlugs: string[],
+) => {
+    const tilesYaml = chartSlugs
+        .map(
+            (s) =>
+                `  - properties:\n      chartSlug: ${s}\n    type: saved_chart`,
+        )
+        .join('\n');
+    const yaml = `contentType: dashboard\nname: ${slug}\nslug: ${slug}\nspaceSlug: test-space\ntiles:\n${tilesYaml}\nversion: 1\n`;
+    await fs.writeFile(path.join(baseDir, 'dashboards', `${slug}.yml`), yaml);
+};
+
+describe('getDashboardChartSlugs', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'download-test-'));
+        await fs.mkdir(path.join(tmpDir, 'dashboards'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('extracts chart slugs from folder dashboards', async () => {
+        await writeFolderDashboard(tmpDir, 'folder-dash', [
+            'chart-a',
+            'chart-b',
+        ]);
+        const slugs = await getDashboardChartSlugs([], tmpDir);
+        expect(slugs.sort()).toEqual(['chart-a', 'chart-b']);
+    });
+
+    it('extracts chart slugs from loose dashboards (PROD-7869 regression)', async () => {
+        const loose = makeLooseDashboard('loose-dash', [
+            'loose-chart-1',
+            'loose-chart-2',
+        ]);
+        const slugs = await getDashboardChartSlugs([], tmpDir, [loose]);
+        expect(slugs.sort()).toEqual(['loose-chart-1', 'loose-chart-2']);
+    });
+
+    it('extracts chart slugs from both folder and loose dashboards when unioned', async () => {
+        await writeFolderDashboard(tmpDir, 'folder-dash', ['folder-chart']);
+        const loose = makeLooseDashboard('loose-dash', ['loose-chart']);
+        const slugs = await getDashboardChartSlugs([], tmpDir, [loose]);
+        expect(slugs.sort()).toEqual(['folder-chart', 'loose-chart']);
+    });
+
+    it('filters by slug across both folder and loose sources', async () => {
+        await writeFolderDashboard(tmpDir, 'folder-dash', ['folder-chart']);
+        const loose = makeLooseDashboard('loose-dash', ['loose-chart']);
+
+        const onlyFolder = await getDashboardChartSlugs(
+            ['folder-dash'],
+            tmpDir,
+            [loose],
+        );
+        expect(onlyFolder).toEqual(['folder-chart']);
+
+        const onlyLoose = await getDashboardChartSlugs(['loose-dash'], tmpDir, [
+            loose,
+        ]);
+        expect(onlyLoose).toEqual(['loose-chart']);
+    });
+
+    it('returns empty array when slug filter matches no dashboards', async () => {
+        await writeFolderDashboard(tmpDir, 'folder-dash', ['folder-chart']);
+        const loose = makeLooseDashboard('loose-dash', ['loose-chart']);
+        const slugs = await getDashboardChartSlugs(['nonexistent'], tmpDir, [
+            loose,
+        ]);
+        expect(slugs).toEqual([]);
+    });
+
+    it('skips tiles without a chartSlug (e.g. markdown, loom)', async () => {
+        const loose = makeLooseDashboard('loose-dash', [
+            'real-chart',
+            undefined,
+            undefined,
+        ]);
+        const slugs = await getDashboardChartSlugs([], tmpDir, [loose]);
+        expect(slugs).toEqual(['real-chart']);
+    });
+});

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -1417,11 +1417,13 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
 const getDashboardChartSlugs = async (
     dashboardSlugs: string[],
     customPath?: string,
+    looseDashboards: (DashboardAsCode & { needsUpdating: boolean })[] = [],
 ) => {
-    const dashboardItems = await readCodeFiles<DashboardAsCode>(
+    const folderDashboards = await readCodeFiles<DashboardAsCode>(
         'dashboards',
         customPath,
     );
+    const dashboardItems = [...folderDashboards, ...looseDashboards];
 
     const filteredDashboardItems =
         dashboardSlugs.length > 0
@@ -1496,6 +1498,19 @@ export const uploadHandler = async (
         const hasFilters =
             options.charts.length > 0 || options.dashboards.length > 0;
 
+        // Discover loose YAML files (outside charts/ and dashboards/) classified by contentType
+        const looseFiles = await readLooseCodeFiles(options.path);
+        if (looseFiles.charts.length > 0) {
+            GlobalState.log(
+                `Found ${looseFiles.charts.length} chart(s) outside charts/ directory (classified by contentType)`,
+            );
+        }
+        if (looseFiles.dashboards.length > 0) {
+            GlobalState.log(
+                `Found ${looseFiles.dashboards.length} dashboard(s) outside dashboards/ directory (classified by contentType)`,
+            );
+        }
+
         // Always include the charts from dashboards if includeCharts is true regardless of the charts filters
         const chartSlugs = options.includeCharts
             ? Array.from(
@@ -1504,6 +1519,7 @@ export const uploadHandler = async (
                       ...(await getDashboardChartSlugs(
                           options.dashboards,
                           options.path,
+                          looseFiles.dashboards,
                       )),
                   ]),
               )
@@ -1527,19 +1543,6 @@ export const uploadHandler = async (
         if (Object.keys(spaceNames).length > 0) {
             GlobalState.log(
                 `Found ${Object.keys(spaceNames).length} space definition(s)`,
-            );
-        }
-
-        // Discover loose YAML files (outside charts/ and dashboards/) classified by contentType
-        const looseFiles = await readLooseCodeFiles(options.path);
-        if (looseFiles.charts.length > 0) {
-            GlobalState.log(
-                `Found ${looseFiles.charts.length} chart(s) outside charts/ directory (classified by contentType)`,
-            );
-        }
-        if (looseFiles.dashboards.length > 0) {
-            GlobalState.log(
-                `Found ${looseFiles.dashboards.length} dashboard(s) outside dashboards/ directory (classified by contentType)`,
             );
         }
 
@@ -1619,4 +1622,8 @@ export const uploadHandler = async (
             },
         });
     }
+};
+
+export const testHelpers = {
+    getDashboardChartSlugs,
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #23438, PROD-7869 <!-- reference the related issue e.g. #150 -->

### Description:  

lightdash upload --dashboards <slug> --include-charts skips chart upload when dashboards are stored as "loose" YAML files (outside the dashboards/ subdirectory, classified by contentType). Output shows No charts filters provided, skipping, and local chart edits silently never reach the server. The misleading Total charts updated: N comes from the server re-saving existing chart state during dashboard promotion, not from the local YAML.

Root cause
getDashboardChartSlugs reads only via readCodeFiles('dashboards', ...) (folder-only), even though the rest of uploadHandler already discovers loose dashboards via readLooseCodeFiles. Loose dashboards never contribute slugs, so the chart upload step gets an empty filter and is skipped.

Fix
getDashboardChartSlugs now unions folder dashboards with loose dashboards passed in by the caller.
uploadHandler now calls readLooseCodeFiles before computing chartSlugs and passes looseFiles.dashboards in. Avoids a second directory walk.