### PR TITLE
fix(ai-agents): migrate inline styles to CSS modules and fix overflow/truncation issues

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.module.css
@@ -1,0 +1,26 @@
+.bubble {
+    align-self: flex-end;
+    min-width: 0;
+    max-width: 100%;
+}
+
+.contextGroup {
+    min-width: 0;
+    max-width: 100%;
+}
+
+.messageCard {
+    overflow: visible;
+    background-color: color-mix(
+        in srgb,
+        var(--mantine-color-ldGray-1) 45%,
+        transparent
+    );
+}
+
+.markdown {
+    background-color: transparent;
+    color: var(--mantine-color-ldGray-8);
+    font-size: 0.8125rem;
+    font-weight: 500;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -7,6 +7,7 @@ import { Link, useParams } from 'react-router';
 import { useTimeAgo } from '../../../../../hooks/useTimeAgo';
 import useApp from '../../../../../providers/App/useApp';
 import { PinnedContextCard } from '../PinnedContextCard/PinnedContextCard';
+import styles from './AgentChatUserBubble.module.css';
 
 type Props = {
     message: AiAgentMessageUser<AiAgentUser>;
@@ -23,7 +24,7 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
     return (
         <Stack
             gap={2}
-            style={{ alignSelf: 'flex-end' }}
+            className={styles.bubble}
             bg={isActive ? 'ldGray.0' : 'transparent'}
         >
             <Stack gap={0} align="flex-end">
@@ -48,7 +49,12 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
             </Stack>
 
             {message.context.length > 0 && projectUuid && (
-                <Group gap="xs" wrap="wrap" justify="flex-end">
+                <Group
+                    gap="xs"
+                    wrap="wrap"
+                    justify="flex-end"
+                    className={styles.contextGroup}
+                >
                     {message.context.map((item, idx) => (
                         <PinnedContextCard
                             key={`${item.type}-${
@@ -70,20 +76,11 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                 px="sm"
                 withBorder
                 color="white"
-                style={{
-                    overflow: 'unset',
-                    backgroundColor:
-                        'color-mix(in srgb, var(--mantine-color-ldGray-1) 45%, transparent)',
-                }}
+                className={styles.messageCard}
             >
                 <MDEditor.Markdown
                     source={message.message}
-                    style={{
-                        backgroundColor: 'transparent',
-                        fontWeight: 500,
-                        fontSize: '0.8125rem',
-                        color: 'var(--mantine-color-ldGray-8)',
-                    }}
+                    className={styles.markdown}
                 />
             </Card>
         </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
@@ -17,6 +17,7 @@
     margin-right: var(--mantine-spacing-two);
     line-height: 1;
     min-width: 0;
+    max-width: 100%;
 }
 
 .contentLink:hover {

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.module.css
@@ -1,0 +1,4 @@
+.label {
+    flex: 1;
+    min-width: 0;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -10,6 +10,7 @@ import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
 import contentLinkStyles from '../ChatElements/ContentLink.module.css';
+import styles from './PinnedContextCard.module.css';
 
 type Props = {
     item: AiPromptContextItem;
@@ -72,7 +73,7 @@ export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
                 fillOpacity={0.2}
                 strokeWidth={1.9}
             />
-            <Text fz="sm" fw={500} m={0} truncate>
+            <Text fz="sm" fw={500} m={0} truncate className={styles.label}>
                 {meta.label}
             </Text>
             <MantineIcon


### PR DESCRIPTION
Closes:

### Description:

Moves inline styles in `AgentChatUserBubble` and `PinnedContextCard` into CSS modules to improve maintainability. Fixes text overflow and truncation issues in pinned context cards by adding `flex: 1` and `min-width: 0` to the label, and adds `max-width: 100%` constraints to the bubble, context group, and content link to prevent layout overflow.