### PR TITLE
refactor(dashboard): decouple dashboard routing from router with `DashboardPageProvider`

### DIFF
--- a/packages/frontend/src/components/MinimalDashboardTabs/index.tsx
+++ b/packages/frontend/src/components/MinimalDashboardTabs/index.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTabWithUrls } from '@lightdash/common';
+import { type DashboardTab } from '@lightdash/common';
 import {
     ActionIcon,
     Button,
@@ -13,7 +13,6 @@ import {
     IconChevronLeft,
     IconChevronRight,
 } from '@tabler/icons-react';
-import { useNavigate } from 'react-router';
 import { useIsTruncated } from '../../hooks/useIsTruncated';
 import MantineIcon from '../common/MantineIcon';
 import styles from './MinimalDashboardTabs.module.css';
@@ -21,14 +20,18 @@ import styles from './MinimalDashboardTabs.module.css';
 const MinimalDashboardTabs = ({
     tabs,
     activeTabId,
+    onTabChange,
 }: {
-    tabs: DashboardTabWithUrls[];
+    tabs: DashboardTab[];
     activeTabId: string | null;
+    onTabChange: (tabUuid: string) => void;
 }) => {
-    const navigate = useNavigate();
     const { ref, isTruncated } = useIsTruncated();
 
     const activeTab = tabs.find((tab) => tab.uuid === activeTabId) ?? tabs[0];
+    const activeTabIndex = tabs.findIndex((tab) => tab.uuid === activeTab.uuid);
+    const previousTab = tabs[activeTabIndex - 1];
+    const nextTab = tabs[activeTabIndex + 1];
 
     return (
         <Group p="xs" bg="background" gap={10} justify="space-between">
@@ -36,11 +39,11 @@ const MinimalDashboardTabs = ({
                 size="md"
                 color="gray"
                 onClick={() => {
-                    if (activeTab.prevUrl) {
-                        void navigate(activeTab.prevUrl);
+                    if (previousTab) {
+                        onTabChange(previousTab.uuid);
                     }
                 }}
-                disabled={!activeTab.prevUrl}
+                disabled={!previousTab}
             >
                 <MantineIcon icon={IconChevronLeft} size="lg" />
             </ActionIcon>
@@ -71,7 +74,7 @@ const MinimalDashboardTabs = ({
                                 <Menu.Item
                                     key={tab.uuid}
                                     onClick={() => {
-                                        void navigate(tab.selfUrl);
+                                        onTabChange(tab.uuid);
                                     }}
                                 >
                                     <Text
@@ -95,11 +98,11 @@ const MinimalDashboardTabs = ({
                 size="md"
                 color="gray"
                 onClick={() => {
-                    if (activeTab.nextUrl) {
-                        void navigate(activeTab.nextUrl);
+                    if (nextTab) {
+                        onTabChange(nextTab.uuid);
                     }
                 }}
-                disabled={!activeTab.nextUrl}
+                disabled={!nextTab}
             >
                 <MantineIcon icon={IconChevronRight} size="lg" />
             </ActionIcon>

--- a/packages/frontend/src/ee/pages/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/pages/EmbedDashboard.tsx
@@ -2,7 +2,9 @@ import { IconUnlink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useParams } from 'react-router';
 import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
+import { getEmbedDashboardTabPath } from '../../providers/Dashboard/dashboardPageUtils';
 import DashboardProvider from '../../providers/Dashboard/DashboardProvider';
+import { DashboardRouterProvider } from '../../providers/Dashboard/DashboardRouterProvider';
 import EmbedDashboard from '../features/embed/EmbedDashboard/components/EmbedDashboard';
 import useEmbed from '../providers/Embed/useEmbed';
 
@@ -29,9 +31,17 @@ const EmbedDashboardPage: FC<{
     }
 
     return (
-        <DashboardProvider embedToken={embedToken} projectUuid={projectUuid}>
-            <EmbedDashboard containerStyles={containerStyles} />
-        </DashboardProvider>
+        <DashboardRouterProvider
+            buildTabPath={getEmbedDashboardTabPath}
+            projectUuid={projectUuid}
+        >
+            <DashboardProvider
+                embedToken={embedToken}
+                projectUuid={projectUuid}
+            >
+                <EmbedDashboard containerStyles={containerStyles} />
+            </DashboardProvider>
+        </DashboardRouterProvider>
     );
 };
 export default EmbedDashboardPage;

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -2,7 +2,6 @@ import {
     BinType,
     ChartType,
     CustomDimensionType,
-    DateGranularity,
     getItemId,
     isCartesianChartConfig,
     type BinRange,
@@ -28,6 +27,7 @@ import {
     useExplorerSelector,
 } from '../features/explorer/store';
 import useApp from '../providers/App/useApp';
+import { getDateZoomGranularityFromSearch } from '../providers/Dashboard/dashboardPageUtils';
 import {
     defaultQueryExecution,
     defaultState,
@@ -112,23 +112,9 @@ export const getExplorerUrlFromCreateSavedChartVersion = (
     };
 };
 
-export const useDateZoomGranularitySearch = ():
-    | DateGranularity
-    | string
-    | undefined => {
+export const useDateZoomGranularitySearch = () => {
     const { search } = useLocation();
-
-    const searchParams = new URLSearchParams(search);
-    const dateZoomParam = searchParams.get('dateZoom');
-    if (!dateZoomParam) return undefined;
-
-    const standardMatch = Object.values(DateGranularity).find(
-        (granularity) =>
-            granularity.toLowerCase() === dateZoomParam.toLowerCase(),
-    );
-    // Return standard match if found, otherwise use the param directly
-    // (supports custom granularity keys like "slt_week")
-    return standardMatch ?? dateZoomParam;
+    return getDateZoomGranularityFromSearch(search);
 };
 
 // To handle older url params where exploreName wasn't required

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -33,7 +33,9 @@ import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
 import useApp from '../providers/App/useApp';
 import DashboardAiAgentContextBridge from '../providers/Dashboard/DashboardAiAgentContextBridge';
+import { getDashboardTabPath } from '../providers/Dashboard/dashboardPageUtils';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
+import { DashboardRouterProvider } from '../providers/Dashboard/DashboardRouterProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../providers/Dashboard/useDashboardTileStatusContext';
 import useFullscreen from '../providers/Fullscreen/useFullscreen';
@@ -891,14 +893,16 @@ const DashboardPage: FC = () => {
     const dashboardCommentsCheck = useDashboardCommentsCheck(user?.data);
 
     return (
-        <DashboardProvider
-            key={dashboardUuid}
-            projectUuid={projectUuid}
-            dashboardCommentsCheck={dashboardCommentsCheck}
-        >
-            <DashboardAiAgentContextBridge />
-            <Dashboard />
-        </DashboardProvider>
+        <DashboardRouterProvider buildTabPath={getDashboardTabPath}>
+            <DashboardProvider
+                key={dashboardUuid}
+                projectUuid={projectUuid}
+                dashboardCommentsCheck={dashboardCommentsCheck}
+            >
+                <DashboardAiAgentContextBridge />
+                <Dashboard />
+            </DashboardProvider>
+        </DashboardRouterProvider>
     );
 };
 

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -14,9 +14,8 @@ import {
 } from '@lightdash/common';
 import { useSessionStorage } from '@mantine/hooks';
 import { IconLayoutDashboard } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useEffect, useMemo, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
-import { useParams } from 'react-router';
 import ScreenshotProgressIndicator from '../components/common/ScreenshotProgressIndicator';
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
@@ -33,20 +32,20 @@ import {
 } from '../features/dashboardTabs/gridUtils';
 import { useScheduler } from '../features/scheduler/hooks/useScheduler';
 import { useDashboardQuery } from '../hooks/dashboard/useDashboard';
-import { useDateZoomGranularitySearch } from '../hooks/useExplorerRoute';
-import useSearchParams from '../hooks/useSearchParams';
+import {
+    getActiveDashboardTab,
+    getDateZoomGranularityFromSearch,
+    getMinimalDashboardTabPath,
+    sortDashboardTabs,
+} from '../providers/Dashboard/dashboardPageUtils';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
+import { DashboardRouterProvider } from '../providers/Dashboard/DashboardRouterProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
+import { useDashboardPageContext } from '../providers/Dashboard/useDashboardPageContext';
 import useDashboardTileStatusContext from '../providers/Dashboard/useDashboardTileStatusContext';
 import '../styles/react-grid.css';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
-
-type TabWithUrls = DashboardTab & {
-    prevUrl: string | null;
-    nextUrl: string | null;
-    selfUrl: string;
-};
 
 type TabGroup = {
     key: string;
@@ -61,8 +60,9 @@ type MinimalDashboardContentProps = {
     gridProps: ReturnType<typeof getResponsiveGridLayoutProps>;
     isTabEmpty: boolean;
     canNavigateBetweenTabs: boolean;
-    tabsWithUrls: TabWithUrls[];
+    tabs: DashboardTab[];
     activeTab: DashboardTab | null;
+    onTabChange: (tabUuid: string) => void;
 };
 
 const renderDashboardTile = (tile: Dashboard['tiles'][number]) => {
@@ -143,8 +143,9 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
     gridProps,
     isTabEmpty,
     canNavigateBetweenTabs,
-    tabsWithUrls,
+    tabs,
     activeTab,
+    onTabChange,
 }) => {
     const dashboard = useDashboardContext((c) => c.dashboard);
     const isDashboardLoading = useDashboardContext((c) => c.isDashboardLoading);
@@ -200,8 +201,9 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
             {/* This is when viewing a dashboard with tabs in mobile mode - you can navigate between tabs. */}
             {canNavigateBetweenTabs && (
                 <MinimalDashboardTabs
-                    tabs={tabsWithUrls}
+                    tabs={tabs}
                     activeTabId={activeTab?.uuid || null}
+                    onTabChange={onTabChange}
                 />
             )}
 
@@ -262,14 +264,20 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
     );
 };
 
-const MinimalDashboard: FC = () => {
-    const { projectUuid, dashboardUuid, tabUuid } = useParams<{
-        projectUuid: string;
-        dashboardUuid: string;
-        tabUuid?: string;
-    }>();
+export const MinimalDashboardView: FC = () => {
+    const projectUuid = useDashboardPageContext((c) => c.projectUuid);
+    const dashboardUuid = useDashboardPageContext((c) => c.dashboardUuid);
+    const tabUuid = useDashboardPageContext((c) => c.tabUuid);
+    const search = useDashboardPageContext((c) => c.search);
+    const switchToTab = useDashboardPageContext((c) => c.switchToTab);
 
-    const schedulerUuid = useSearchParams('schedulerUuid');
+    const searchParams = useMemo(() => new URLSearchParams(search), [search]);
+    const schedulerUuid = searchParams.get('schedulerUuid');
+    const schedulerTabs = searchParams.get('selectedTabs');
+    const dateZoom = useMemo(
+        () => getDateZoomGranularityFromSearch(search),
+        [search],
+    );
 
     const [sendNowSchedulerFilters] = useSessionStorage<
         DashboardFilterRule[] | undefined
@@ -283,9 +291,6 @@ const MinimalDashboard: FC = () => {
         key: SessionStorageKeys.SEND_NOW_SCHEDULER_PARAMETERS,
     });
 
-    const schedulerTabs = useSearchParams('selectedTabs');
-    const dateZoom = useDateZoomGranularitySearch();
-
     const {
         data: dashboard,
         isError: isDashboardError,
@@ -295,16 +300,15 @@ const MinimalDashboard: FC = () => {
         projectUuid,
     });
 
-    const [activeTab, setActiveTab] = useState<DashboardTab | null>(null);
-
-    useEffect(() => {
-        // Minimal/embed renders are always treated as view mode — hidden tabs
-        // should not be selectable. Fall back to the first visible tab.
-        const visibleTabs = dashboard?.tabs.filter((tab) => !tab.hidden) ?? [];
-        const matchedTab =
-            visibleTabs.find((tab) => tab.uuid === tabUuid) ?? visibleTabs[0];
-        setActiveTab(matchedTab || null);
-    }, [tabUuid, dashboard?.tabs]);
+    const activeTab = useMemo(
+        () =>
+            getActiveDashboardTab({
+                tabs: dashboard?.tabs ?? [],
+                tabUuid,
+                isEditMode: false,
+            }) ?? null,
+        [dashboard?.tabs, tabUuid],
+    );
 
     const {
         data: scheduler,
@@ -337,30 +341,14 @@ const MinimalDashboard: FC = () => {
         return undefined;
     }, [schedulerTabs]);
 
-    const generateTabUrl = useCallback(
-        (tabId: string) =>
-            `/minimal/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tabId}`,
-        [projectUuid, dashboardUuid],
-    );
-
     const sortedTabs = useMemo(
-        () => dashboard?.tabs.sort((a, b) => a.order - b.order) ?? [],
+        () => sortDashboardTabs(dashboard?.tabs ?? []),
         [dashboard?.tabs],
     );
-
-    const tabsWithUrls = useMemo(() => {
-        return sortedTabs.map((tab, index) => {
-            const prevTab = sortedTabs[index - 1];
-            const nextTab = sortedTabs[index + 1];
-
-            return {
-                ...tab,
-                prevUrl: prevTab ? generateTabUrl(prevTab.uuid) : null,
-                nextUrl: nextTab ? generateTabUrl(nextTab.uuid) : null,
-                selfUrl: generateTabUrl(tab.uuid),
-            };
-        });
-    }, [sortedTabs, generateTabUrl]);
+    const navigableTabs = useMemo(
+        () => sortedTabs.filter((tab) => !tab.hidden),
+        [sortedTabs],
+    );
 
     const gridProps = getResponsiveGridLayoutProps({
         stackVerticallyOnSmallestBreakpoint: true,
@@ -387,7 +375,9 @@ const MinimalDashboard: FC = () => {
 
                 // Show legacy tiles (without tabUuid) on the first tab for backwards compatibility
                 const tileHasNoTab = !tile.tabUuid;
-                const isFirstTab = activeTab.uuid === sortedTabs[0]?.uuid;
+                const isFirstTab =
+                    activeTab.uuid ===
+                    (navigableTabs[0]?.uuid ?? sortedTabs[0]?.uuid);
 
                 return tileHasNoTab && isFirstTab;
             }) ?? [];
@@ -402,7 +392,13 @@ const MinimalDashboard: FC = () => {
             );
             return tabAIndex - tabBIndex;
         });
-    }, [dashboard?.tiles, schedulerTabsSelected, activeTab, sortedTabs]);
+    }, [
+        dashboard?.tiles,
+        schedulerTabsSelected,
+        activeTab,
+        navigableTabs,
+        sortedTabs,
+    ]);
 
     const layouts = useMemo(() => {
         return {
@@ -508,7 +504,7 @@ const MinimalDashboard: FC = () => {
         activeTab && filteredAndSortedDashboardTiles.length === 0;
 
     const canNavigateBetweenTabs =
-        !schedulerTabsSelected && tabsWithUrls.length > 0;
+        !schedulerTabsSelected && navigableTabs.length > 0;
 
     return (
         <DashboardProvider
@@ -528,11 +524,18 @@ const MinimalDashboard: FC = () => {
                 gridProps={gridProps}
                 isTabEmpty={!!isTabEmpty}
                 canNavigateBetweenTabs={canNavigateBetweenTabs}
-                tabsWithUrls={tabsWithUrls}
+                tabs={navigableTabs}
                 activeTab={activeTab}
+                onTabChange={switchToTab}
             />
         </DashboardProvider>
     );
 };
+
+const MinimalDashboard: FC = () => (
+    <DashboardRouterProvider buildTabPath={getMinimalDashboardTabPath}>
+        <MinimalDashboardView />
+    </DashboardRouterProvider>
+);
 
 export default MinimalDashboard;

--- a/packages/frontend/src/providers/Dashboard/DashboardInMemoryProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardInMemoryProvider.tsx
@@ -1,0 +1,80 @@
+import { useUncontrolled } from '@mantine/hooks';
+import { type PropsWithChildren, useCallback, useMemo } from 'react';
+import {
+    DashboardPageProvider,
+    type DashboardPageStateAdapter,
+} from './DashboardPageProvider';
+
+type DashboardInMemoryProviderProps = PropsWithChildren<{
+    projectUuid?: string;
+    dashboardUuid?: string;
+    tabUuid?: string | null;
+    defaultTabUuid?: string | null;
+    mode?: string;
+    search?: string;
+    defaultSearch?: string;
+    onSearchChange?: (search: string) => void;
+    onTabChange?: (tabUuid?: string) => void;
+}>;
+
+export const DashboardInMemoryProvider = (
+    props: DashboardInMemoryProviderProps,
+) => {
+    const [tabUuidValue, setTabUuid] = useUncontrolled<string | null>({
+        value: props.tabUuid,
+        defaultValue: props.defaultTabUuid,
+        finalValue: null,
+        onChange: (nextTabUuid) => {
+            props.onTabChange?.(nextTabUuid ?? undefined);
+        },
+    });
+    const [search, setSearch] = useUncontrolled({
+        value: props.search,
+        defaultValue: props.defaultSearch,
+        finalValue: '',
+        onChange: props.onSearchChange,
+    });
+
+    const replaceSearch = useCallback(
+        (nextSearch: string) => {
+            setSearch(nextSearch);
+        },
+        [setSearch],
+    );
+
+    const switchToTab = useCallback(
+        (nextTabUuid?: string) => {
+            setTabUuid(nextTabUuid ?? null);
+        },
+        [setTabUuid],
+    );
+
+    const tabUuid = tabUuidValue ?? undefined;
+
+    const adapter = useMemo<DashboardPageStateAdapter>(
+        () => ({
+            projectUuid: props.projectUuid,
+            dashboardUuid: props.dashboardUuid,
+            tabUuid,
+            mode: props.mode,
+            search,
+            replaceSearch,
+            switchToTab,
+        }),
+        [
+            props.dashboardUuid,
+            props.mode,
+            props.projectUuid,
+            replaceSearch,
+            search,
+            switchToTab,
+            tabUuid,
+        ],
+    );
+
+    return (
+        <DashboardPageProvider adapter={adapter}>
+            {props.children}
+        </DashboardPageProvider>
+    );
+};

--- a/packages/frontend/src/providers/Dashboard/DashboardPageProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardPageProvider.tsx
@@ -1,0 +1,46 @@
+import { type PropsWithChildren, useMemo } from 'react';
+import { DashboardPageContext } from './useDashboardPageContext';
+
+export type DashboardPagePathArgs = {
+    projectUuid?: string;
+    dashboardUuid?: string;
+    mode?: string;
+    tabUuid?: string;
+};
+
+export type DashboardPageStateAdapter = {
+    projectUuid?: string;
+    dashboardUuid?: string;
+    tabUuid?: string;
+    mode?: string;
+    search: string;
+    replaceSearch: (search: string) => void;
+    switchToTab: (tabUuid?: string) => void;
+};
+
+export type DashboardPageContextType = DashboardPageStateAdapter & {
+    isEditMode: boolean;
+};
+
+type DashboardPageProviderProps = PropsWithChildren<{
+    adapter: DashboardPageStateAdapter;
+}>;
+
+export const DashboardPageProvider = ({
+    adapter,
+    children,
+}: DashboardPageProviderProps) => {
+    const value = useMemo(
+        () => ({
+            ...adapter,
+            isEditMode: adapter.mode === 'edit',
+        }),
+        [adapter],
+    );
+
+    return (
+        <DashboardPageContext.Provider value={value}>
+            {children}
+        </DashboardPageContext.Provider>
+    );
+};

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -36,7 +36,6 @@ import React, {
     useRef,
     useState,
 } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
 import { useDeepCompareEffect, useMount } from 'react-use';
 import { getConditionalRuleLabelFromItem } from '../../components/common/Filters/FilterInputs/utils';
 import { type SdkFilter } from '../../ee/features/embed/EmbedDashboard/types';
@@ -64,8 +63,10 @@ import {
     useSavedDashboardFiltersOverrides,
 } from '../../hooks/useSavedDashboardFiltersOverrides';
 import DashboardContext from './context';
+import { getActiveDashboardTab } from './dashboardPageUtils';
 import DashboardTileStatusProvider from './DashboardTileStatusProvider';
 import useDashboardContext from './useDashboardContext';
+import { useDashboardPageContext } from './useDashboardPageContext';
 import useDashboardTileStatusContext from './useDashboardTileStatusContext';
 
 const emptyFilters: DashboardFilters = {
@@ -97,32 +98,26 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     defaultInvalidateCache,
     children,
 }) => {
-    const { search, pathname } = useLocation();
-    const navigate = useNavigate();
+    const dashboardUuid = useDashboardPageContext((c) => c.dashboardUuid);
+    const tabUuid = useDashboardPageContext((c) => c.tabUuid);
+    const isEditMode = useDashboardPageContext((c) => c.isEditMode);
+    const search = useDashboardPageContext((c) => c.search);
+    const replaceSearch = useDashboardPageContext((c) => c.replaceSearch);
+    const routeProjectUuid = useDashboardPageContext((c) => c.projectUuid);
+    const resolvedProjectUuid = projectUuid ?? routeProjectUuid;
     const { showToastWarning, showToastInfo } = useToaster();
     const hasNotifiedLockedOverrideRef = useRef(false);
-
-    const { dashboardUuid, tabUuid, mode } = useParams<{
-        dashboardUuid: string;
-        tabUuid?: string;
-        mode?: string;
-    }>() as {
-        dashboardUuid: string;
-        tabUuid?: string;
-        mode?: string;
-    };
 
     // Reset the "locked filter override" toast guard on dashboard navigation
     // so each dashboard gets a fresh chance to notify the viewer.
     useEffect(() => {
         hasNotifiedLockedOverrideRef.current = false;
     }, [dashboardUuid]);
-    const isEditMode = mode === 'edit';
 
     const {
         mutateAsync: versionRefresh,
         isLoading: isRefreshingDashboardVersion,
-    } = useDashboardVersionRefresh(dashboardUuid, projectUuid);
+    } = useDashboardVersionRefresh(dashboardUuid ?? '', resolvedProjectUuid);
 
     // Embedded dashboards will not be using this query hook to load the dashboard,
     // so we need to set the dashboard manually
@@ -135,7 +130,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         error: dashboardError,
     } = useDashboardQuery({
         uuidOrSlug: dashboardUuid,
-        projectUuid,
+        projectUuid: resolvedProjectUuid,
         useQueryOptions: {
             select: (d) => {
                 if (schedulerFilters) {
@@ -158,8 +153,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     });
 
     const { data: dashboardComments } = useGetComments(
-        dashboardUuid,
-        projectUuid,
+        dashboardUuid ?? '',
+        resolvedProjectUuid,
         !!dashboardCommentsCheck &&
             !!dashboardCommentsCheck.canViewDashboardComments,
     );
@@ -331,15 +326,13 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     // In view mode, hidden tabs are not selectable — fall back to the first
     // visible tab if the URL points at a hidden tab. In edit mode all tabs are selectable.
     useEffect(() => {
-        if (dashboardTabs && dashboardTabs.length > 0) {
-            const selectableTabs = isEditMode
-                ? dashboardTabs
-                : dashboardTabs.filter((tab) => !tab.hidden);
-            const tabsForFallback =
-                selectableTabs.length > 0 ? selectableTabs : dashboardTabs;
-            const urlMatch = selectableTabs.find((tab) => tab.uuid === tabUuid);
-            setActiveTab(urlMatch ?? tabsForFallback[0]);
-        }
+        setActiveTab(
+            getActiveDashboardTab({
+                tabs: dashboardTabs,
+                tabUuid,
+                isEditMode,
+            }),
+        );
     }, [dashboardTabs, tabUuid, isEditMode]);
 
     // Apply scheduler parameters when provided (for scheduled deliveries)
@@ -504,10 +497,10 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     }, [tileParameterReferences]);
 
     const { data: projectParameters } = useParameters(
-        projectUuid,
+        resolvedProjectUuid,
         Array.from(dashboardParameterReferences ?? []),
         {
-            enabled: !!projectUuid && !!dashboardParameterReferences,
+            enabled: !!resolvedProjectUuid && !!dashboardParameterReferences,
         },
     );
 
@@ -551,15 +544,9 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         const newSearch = newParams.toString();
 
         if (currentSearch !== newSearch) {
-            void navigate(
-                {
-                    pathname,
-                    search: newParams.toString(),
-                },
-                { replace: true },
-            );
+            replaceSearch(newSearch);
         }
-    }, [dateZoomGranularity, search, navigate, pathname, embed.mode]);
+    }, [dateZoomGranularity, search, replaceSearch, embed.mode]);
 
     const {
         overridesForSavedDashboardFilters,
@@ -611,7 +598,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         data: dashboardAvailableFiltersData,
     } = useDashboardsAvailableFilters(
         savedChartUuidsAndTileUuids ?? [],
-        projectUuid,
+        resolvedProjectUuid,
         embedToken,
     );
 
@@ -930,20 +917,13 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         const newSearch = newParams.toString();
         const currentSearch = currentParams.toString();
         if (newSearch !== currentSearch) {
-            void navigate(
-                {
-                    pathname,
-                    search: newSearch,
-                },
-                { replace: true },
-            );
+            replaceSearch(newSearch);
         }
     }, [
         dashboardFilters,
         safeTemporaryFilters,
-        navigate,
-        pathname,
         overridesForSavedDashboardFilters,
+        replaceSearch,
         search,
         embed.mode,
     ]);
@@ -1493,7 +1473,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     );
 
     const value = {
-        projectUuid,
+        projectUuid: resolvedProjectUuid,
         isDashboardLoading,
         dashboard: dashboard || embedDashboard,
         setEmbedDashboard,

--- a/packages/frontend/src/providers/Dashboard/DashboardRouterProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardRouterProvider.tsx
@@ -1,0 +1,100 @@
+import { type PropsWithChildren, useCallback, useMemo } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import {
+    DashboardPageProvider,
+    type DashboardPagePathArgs,
+    type DashboardPageStateAdapter,
+} from './DashboardPageProvider';
+
+type DashboardRouterProviderProps = PropsWithChildren<{
+    buildTabPath: (args: DashboardPagePathArgs) => string | undefined;
+    projectUuid?: string;
+    dashboardUuid?: string;
+    tabUuid?: string;
+    mode?: string;
+}>;
+
+export const DashboardRouterProvider = ({
+    buildTabPath,
+    projectUuid: projectUuidOverride,
+    dashboardUuid: dashboardUuidOverride,
+    tabUuid: tabUuidOverride,
+    mode: modeOverride,
+    children,
+}: DashboardRouterProviderProps) => {
+    const { pathname, search } = useLocation();
+    const navigate = useNavigate();
+    const params = useParams<{
+        projectUuid?: string;
+        dashboardUuid?: string;
+        tabUuid?: string;
+        mode?: string;
+    }>();
+
+    const projectUuid = projectUuidOverride ?? params.projectUuid;
+    const dashboardUuid = dashboardUuidOverride ?? params.dashboardUuid;
+    const tabUuid = tabUuidOverride ?? params.tabUuid;
+    const mode = modeOverride ?? params.mode;
+
+    const replaceSearch = useCallback(
+        (nextSearch: string) => {
+            void navigate(
+                {
+                    pathname,
+                    search: nextSearch,
+                },
+                { replace: true },
+            );
+        },
+        [navigate, pathname],
+    );
+
+    const switchToTab = useCallback(
+        (nextTabUuid?: string) => {
+            const nextPath = buildTabPath({
+                projectUuid,
+                dashboardUuid,
+                mode,
+                tabUuid: nextTabUuid,
+            });
+
+            if (!nextPath) return;
+
+            void navigate(
+                {
+                    pathname: nextPath,
+                    search,
+                },
+                { replace: true },
+            );
+        },
+        [buildTabPath, dashboardUuid, mode, navigate, projectUuid, search],
+    );
+
+    const adapter = useMemo<DashboardPageStateAdapter>(
+        () => ({
+            projectUuid,
+            dashboardUuid,
+            tabUuid,
+            mode,
+            search,
+            replaceSearch,
+            switchToTab,
+        }),
+        [
+            dashboardUuid,
+            mode,
+            projectUuid,
+            replaceSearch,
+            search,
+            switchToTab,
+            tabUuid,
+        ],
+    );
+
+    return (
+        <DashboardPageProvider adapter={adapter}>
+            {children}
+        </DashboardPageProvider>
+    );
+};

--- a/packages/frontend/src/providers/Dashboard/dashboardPageUtils.test.ts
+++ b/packages/frontend/src/providers/Dashboard/dashboardPageUtils.test.ts
@@ -1,0 +1,93 @@
+import { DateGranularity, type DashboardTab } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    getActiveDashboardTab,
+    getDashboardTabPath,
+    getDateZoomGranularityFromSearch,
+    getEmbedDashboardTabPath,
+    getMinimalDashboardTabPath,
+    sortDashboardTabs,
+} from './dashboardPageUtils';
+
+const tabs: DashboardTab[] = [
+    {
+        uuid: 'hidden-first',
+        name: 'Hidden first',
+        order: 0,
+        hidden: true,
+    },
+    {
+        uuid: 'visible-second',
+        name: 'Visible second',
+        order: 1,
+        hidden: false,
+    },
+];
+
+describe('dashboardPageUtils', () => {
+    it('sorts tabs without mutating input', () => {
+        const unsorted = [tabs[1], tabs[0]];
+
+        expect(sortDashboardTabs(unsorted).map((tab) => tab.uuid)).toEqual([
+            'hidden-first',
+            'visible-second',
+        ]);
+        expect(unsorted.map((tab) => tab.uuid)).toEqual([
+            'visible-second',
+            'hidden-first',
+        ]);
+    });
+
+    it('skips hidden tabs in view mode', () => {
+        expect(
+            getActiveDashboardTab({
+                tabs,
+                tabUuid: 'hidden-first',
+                isEditMode: false,
+            })?.uuid,
+        ).toBe('visible-second');
+    });
+
+    it('allows hidden tabs in edit mode', () => {
+        expect(
+            getActiveDashboardTab({
+                tabs,
+                tabUuid: 'hidden-first',
+                isEditMode: true,
+            })?.uuid,
+        ).toBe('hidden-first');
+    });
+
+    it('parses date zoom from search', () => {
+        expect(getDateZoomGranularityFromSearch('?dateZoom=month')).toBe(
+            DateGranularity.MONTH,
+        );
+        expect(getDateZoomGranularityFromSearch('?dateZoom=custom_week')).toBe(
+            'custom_week',
+        );
+    });
+
+    it('builds dashboard paths for each backend', () => {
+        expect(
+            getDashboardTabPath({
+                projectUuid: 'project',
+                dashboardUuid: 'dashboard',
+                mode: 'view',
+                tabUuid: 'tab',
+            }),
+        ).toBe('/projects/project/dashboards/dashboard/view/tabs/tab');
+        expect(
+            getMinimalDashboardTabPath({
+                projectUuid: 'project',
+                dashboardUuid: 'dashboard',
+                tabUuid: 'tab',
+            }),
+        ).toBe('/minimal/projects/project/dashboards/dashboard/view/tabs/tab');
+        expect(
+            getEmbedDashboardTabPath({
+                projectUuid: 'project',
+                tabUuid: 'tab',
+            }),
+        ).toBe('/embed/project/tabs/tab');
+    });
+});

--- a/packages/frontend/src/providers/Dashboard/dashboardPageUtils.ts
+++ b/packages/frontend/src/providers/Dashboard/dashboardPageUtils.ts
@@ -1,0 +1,84 @@
+import { DateGranularity, type DashboardTab } from '@lightdash/common';
+
+type DashboardPagePathArgs = {
+    projectUuid?: string;
+    dashboardUuid?: string;
+    mode?: string;
+    tabUuid?: string;
+};
+
+export const sortDashboardTabs = (tabs: DashboardTab[]) =>
+    [...tabs].sort((a, b) => a.order - b.order);
+
+export const getActiveDashboardTab = ({
+    tabs,
+    tabUuid,
+    isEditMode,
+}: {
+    tabs: DashboardTab[];
+    tabUuid?: string;
+    isEditMode: boolean;
+}) => {
+    const sortedTabs = sortDashboardTabs(tabs);
+    if (sortedTabs.length === 0) return undefined;
+
+    const selectableTabs = isEditMode
+        ? sortedTabs
+        : sortedTabs.filter((tab) => !tab.hidden);
+    const fallbackTabs =
+        selectableTabs.length > 0 ? selectableTabs : sortedTabs;
+
+    return fallbackTabs.find((tab) => tab.uuid === tabUuid) ?? fallbackTabs[0];
+};
+
+export const getDateZoomGranularityFromSearch = (
+    search: string,
+): DateGranularity | string | undefined => {
+    const searchParams = new URLSearchParams(search);
+    const dateZoomParam = searchParams.get('dateZoom');
+    if (!dateZoomParam) return undefined;
+
+    const standardMatch = Object.values(DateGranularity).find(
+        (granularity) =>
+            granularity.toLowerCase() === dateZoomParam.toLowerCase(),
+    );
+
+    return standardMatch ?? dateZoomParam;
+};
+
+export const getDashboardTabPath = ({
+    projectUuid,
+    dashboardUuid,
+    mode,
+    tabUuid,
+}: DashboardPagePathArgs) => {
+    if (!projectUuid || !dashboardUuid) return undefined;
+
+    const resolvedMode = mode ?? 'view';
+    const basePath = `/projects/${projectUuid}/dashboards/${dashboardUuid}/${resolvedMode}`;
+
+    return tabUuid ? `${basePath}/tabs/${tabUuid}` : basePath;
+};
+
+export const getMinimalDashboardTabPath = ({
+    projectUuid,
+    dashboardUuid,
+    tabUuid,
+}: DashboardPagePathArgs) => {
+    if (!projectUuid || !dashboardUuid) return undefined;
+
+    const basePath = `/minimal/projects/${projectUuid}/dashboards/${dashboardUuid}`;
+
+    return tabUuid ? `${basePath}/view/tabs/${tabUuid}` : basePath;
+};
+
+export const getEmbedDashboardTabPath = ({
+    projectUuid,
+    tabUuid,
+}: DashboardPagePathArgs) => {
+    if (!projectUuid) return undefined;
+
+    const basePath = `/embed/${projectUuid}`;
+
+    return tabUuid ? `${basePath}/tabs/${tabUuid}` : basePath;
+};

--- a/packages/frontend/src/providers/Dashboard/useDashboardPageContext.ts
+++ b/packages/frontend/src/providers/Dashboard/useDashboardPageContext.ts
@@ -1,0 +1,19 @@
+import { createContext, useContextSelector } from 'use-context-selector';
+import { type DashboardPageContextType } from './DashboardPageProvider';
+
+export const DashboardPageContext = createContext<
+    DashboardPageContextType | undefined
+>(undefined);
+
+export const useDashboardPageContext = <Selected>(
+    selector: (value: DashboardPageContextType) => Selected,
+) =>
+    useContextSelector(DashboardPageContext, (context) => {
+        if (context === undefined) {
+            throw new Error(
+                'useDashboardPageContext must be used within a DashboardPageProvider',
+            );
+        }
+
+        return selector(context);
+    });


### PR DESCRIPTION
Closes:

### Description:

Decouples dashboard routing logic from `DashboardProvider` and `MinimalDashboard` by introducing a dedicated `DashboardPageProvider` abstraction layer. This allows dashboard state (active tab, search params, project/dashboard UUIDs) to be sourced from either the React Router context or an in-memory state, making the dashboard components more portable and testable.

Key changes:

- Introduces `DashboardPageProvider` and `DashboardPageContext` to hold routing-related state (`tabUuid`, `search`, `projectUuid`, `dashboardUuid`, `mode`, `replaceSearch`, `switchToTab`) independently of React Router.
- Adds `DashboardRouterProvider`, which reads from React Router params/location and wires them into `DashboardPageProvider`. Used by the standard dashboard, minimal dashboard, and embed dashboard pages.
- Adds `DashboardInMemoryProvider` for cases where routing state needs to be managed in-memory (e.g. SDK/embed scenarios without a router).
- Extracts shared logic into `dashboardPageUtils.ts`: `sortDashboardTabs`, `getActiveDashboardTab`, `getDateZoomGranularityFromSearch`, and path builders (`getDashboardTabPath`, `getMinimalDashboardTabPath`, `getEmbedDashboardTabPath`).
- `MinimalDashboardTabs` no longer navigates internally — it now accepts an `onTabChange` callback and plain `DashboardTab[]` instead of `DashboardTabWithUrls[]`, removing the URL-building responsibility from the component.
- `DashboardProvider` no longer directly calls `useNavigate`, `useLocation`, or `useParams` — it reads all routing state from `useDashboardPageContext`.
- Adds unit tests for `dashboardPageUtils` covering tab sorting, active tab resolution (including hidden tab handling in view vs. edit mode), date zoom parsing, and path building.