### PR TITLE
feat: add per-org generic OIDC SSO with dynamic strategy cache and admin settings panel

### DIFF
--- a/docs/oidc-sso.md
+++ b/docs/oidc-sso.md
@@ -1,0 +1,89 @@
+# Generic OIDC SSO
+
+Per-organization generic OpenID Connect SSO. Follows the same model as
+[Azure AD](./azure-ad-sso.md) and [Okta](./okta-sso.md) — read those first for
+the shared discovery / cross-org / rollout model. This doc covers only the
+OIDC-specific differences.
+
+## Strategy mechanism: same as Azure (async strategy cache)
+
+OIDC uses `openid-client` with async issuer discovery
+(`Issuer.discover(metadataDocumentEndpoint)`), so it follows the **Azure
+pattern**, not Okta's per-request one:
+
+- `createGenericOidcStrategyForConfig(config)` in
+  [`oidcStrategy.ts`](../packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts)
+  builds the strategy from a config object using the **client-secret flow**.
+- `apiV1Router.ts` registers per-org strategies as `oidc:<orgUuid>` in a cache
+  with a 10-minute TTL (`registerGenericOidcStrategyForOrg`, async because of
+  discovery), resolves them by email login-hint
+  (`resolveGenericOidcStrategyName`), and re-registers from the DB on callback
+  if evicted. The strategy name is stored on `req.session.oauth.oidcStrategyName`.
+- The env-based `'oidc'` strategy (registered at startup in `App.ts`) is the
+  fallback, exactly like Azure.
+
+**Per-org supports the client-secret flow only.** The env-based path
+(`createGenericOidcPassportStrategy`) additionally supports the
+`private_key_jwt` / x509 cert flow; per-org config does not expose it (the
+current customers — deepl, verto — use client secret).
+
+### Operational notes (discovery in the request path)
+
+Unlike Azure — whose endpoints are templated from the tenant ID, so building a
+strategy is synchronous — generic OIDC must call `Issuer.discover()` (a network
+fetch of the discovery document) to learn the authorize/token/userinfo
+endpoints. This is why `registerGenericOidcStrategyForOrg` is `async` and runs
+inside the login/callback request path. The cost is bounded:
+
+- **Cached:** discovery only runs on a strategy-cache *miss* — roughly once per
+  10 minutes per org, not on every login.
+- **Timeout:** `openid-client` applies a default **3500ms** HTTP timeout, so a
+  slow/unreachable metadata endpoint fails fast (`RPError`) rather than hanging
+  the worker.
+- **Contained:** a misconfigured `metadataDocumentEndpoint` only delays/fails
+  *that* org's login (currently surfaced as a 500 via `next(error)`); other
+  orgs and the env-based path are unaffected.
+
+### Backwards compatibility with env config
+
+The env path is untouched: `App.ts` still registers the `'oidc'` strategy at
+startup (gated on `isGenericOidcPassportStrategyAvailableToUse`), and
+`createGenericOidcPassportStrategy` is unchanged. The async per-org registration
+is reached only when a DB-stored OIDC config matches; env-only instances fall
+back to the startup-registered `'oidc'` strategy with identical behavior.
+
+## Config fields
+
+Stored encrypted in `organization_sso_configurations` (`provider = 'oidc'`):
+
+| Field | Purpose |
+|---|---|
+| `clientId` / `clientSecret` | OIDC client credentials (secret encrypted; never returned — `hasClientSecret` instead). |
+| `metadataDocumentEndpoint` | OIDC discovery document URL (`.well-known/openid-configuration`). |
+| `scopes` | Optional space-separated scopes; defaults to `openid profile email`. `null` when unset. |
+
+Shared flag columns (`enabled`, `override_email_domains`, `email_domains`,
+`allow_password`) behave as documented for Azure.
+
+## Discovery, login options, endpoints
+
+- `getLoginOptions` is provider-generic: `'oidc'` maps 1:1 to
+  `OpenIdIdentityIssuerType.GENERIC_OIDC`, so discovery, force-redirect and
+  password suppression work unchanged.
+- Endpoints: `GET/PUT/DELETE /api/v1/org/sso/oidc` on `OrganizationSsoController`.
+- Frontend: `GenericOidcSsoPanel` (uses `IconLock` as its icon — OIDC has no
+  brand logo), `useGenericOidcSsoConfig` hooks, and `forceShow` support on the
+  `GENERIC_OIDC` case of `ThirdPartySignInButton`.
+
+## File map (OIDC-specific additions)
+
+| Path | Purpose |
+|---|---|
+| `packages/common/src/types/organizationSso.ts` | `GENERIC_OIDC` provider, `GenericOidcSsoConfig`, summary/upsert/response shapes |
+| `packages/backend/src/models/OrganizationSsoModel.ts` | `GENERIC_OIDC → GenericOidcSsoConfig` in the provider map |
+| `packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts` | `getGenericOidcConfig` / `upsertGenericOidcConfig` / `deleteGenericOidcConfig` |
+| `packages/backend/src/ee/controllers/OrganizationSsoController.ts` | `/api/v1/org/sso/oidc` endpoints |
+| `packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts` | `createGenericOidcStrategyForConfig` |
+| `packages/backend/src/routers/apiV1Router.ts` | `oidc:<orgUuid>` strategy cache + resolution, login/callback rewiring |
+| `packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.tsx` | Admin UI |
+| `packages/frontend/src/hooks/organization/useOrganizationSso.ts` | `useGenericOidcSsoConfig` hooks |

--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -13,6 +13,7 @@ declare module 'express-session' {
             };
             azureAdStrategyName?: string | undefined;
             oktaOrganizationUuid?: string | undefined;
+            oidcStrategyName?: string | undefined;
         };
         slack: {
             teamId?: string | undefined;

--- a/packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts
@@ -2,6 +2,7 @@
 /// <reference path="../../../@types/express-session.d.ts" />
 import {
     ArgumentsOf,
+    GenericOidcSsoConfig,
     LightdashError,
     OpenIdIdentityIssuerType,
     OpenIdUser,
@@ -186,6 +187,42 @@ export const createGenericOidcPassportStrategy = async () => {
         /**
          * This is compatible, but types differ from what's otherwise expected.
          */
+        genericOidcHandler(
+            OpenIdIdentityIssuerType.GENERIC_OIDC,
+            issuer.metadata.issuer,
+        ) as unknown as StrategyVerifyCallback<unknown>,
+    );
+};
+
+/**
+ * Builds a generic OIDC passport strategy from a plain config object using the
+ * client-secret flow. Used by the per-org DB-stored config path. (The env-based
+ * `createGenericOidcPassportStrategy` additionally supports the private_key_jwt
+ * / x509 cert flow, which per-org config does not expose.)
+ */
+export const createGenericOidcStrategyForConfig = async (
+    config: GenericOidcSsoConfig,
+) => {
+    const issuer = await Issuer.discover(config.metadataDocumentEndpoint);
+
+    const client = new issuer.Client({
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+        token_endpoint_auth_method: 'client_secret_basic',
+    });
+
+    return new OpenIdClientStrategy(
+        {
+            client,
+            passReqToCallback: true,
+            params: {
+                redirect_uri: new URL(
+                    `/api/v1${lightdashConfig.auth.oidc.callbackPath}`,
+                    lightdashConfig.siteUrl,
+                ).href,
+                scope: config.scopes || 'openid profile email',
+            },
+        },
         genericOidcHandler(
             OpenIdIdentityIssuerType.GENERIC_OIDC,
             issuer.metadata.issuer,

--- a/packages/backend/src/ee/controllers/OrganizationSsoController.ts
+++ b/packages/backend/src/ee/controllers/OrganizationSsoController.ts
@@ -1,12 +1,15 @@
 import {
     ApiAzureAdSsoConfigResponse,
     ApiErrorPayload,
+    ApiGenericOidcSsoConfigResponse,
     ApiOktaSsoConfigResponse,
     ApiSuccessEmpty,
     ApiUpsertAzureAdSsoConfigResponse,
+    ApiUpsertGenericOidcSsoConfigResponse,
     ApiUpsertOktaSsoConfigResponse,
     assertRegisteredAccount,
     UpsertAzureAdSsoConfig,
+    UpsertGenericOidcSsoConfig,
     UpsertOktaSsoConfig,
 } from '@lightdash/common';
 import {
@@ -161,6 +164,72 @@ export class OrganizationSsoController extends BaseController {
         await this.services
             .getOrganizationSsoService()
             .deleteOktaConfig(req.account);
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Returns the current organization's generic OIDC SSO configuration
+     * (sensitive fields are not included).
+     * @summary Get generic OIDC SSO configuration
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/oidc')
+    @OperationId('GetGenericOidcSsoConfig')
+    async getGenericOidcConfig(
+        @Request() req: express.Request,
+    ): Promise<ApiGenericOidcSsoConfigResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationSsoService()
+            .getGenericOidcConfig(req.account);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Creates or updates the current organization's generic OIDC SSO
+     * configuration. Omit `clientSecret` to preserve the previously stored
+     * secret on updates.
+     * @summary Upsert generic OIDC SSO configuration
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Put('/oidc')
+    @OperationId('UpsertGenericOidcSsoConfig')
+    async upsertGenericOidcConfig(
+        @Request() req: express.Request,
+        @Body() body: UpsertGenericOidcSsoConfig,
+    ): Promise<ApiUpsertGenericOidcSsoConfigResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationSsoService()
+            .upsertGenericOidcConfig(req.account, body);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Removes the current organization's generic OIDC SSO configuration.
+     * @summary Delete generic OIDC SSO configuration
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Delete('/oidc')
+    @OperationId('DeleteGenericOidcSsoConfig')
+    async deleteGenericOidcConfig(
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getOrganizationSsoService()
+            .deleteGenericOidcConfig(req.account);
         this.setStatus(200);
         return { status: 'ok', results: undefined };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -11743,11 +11743,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -11805,11 +11805,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12354,13 +12354,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -12421,11 +12421,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -16490,6 +16490,113 @@ const models: TsoaRoute.Models = {
                         oauth2ClientId: { dataType: 'string', required: true },
                         oktaDomain: { dataType: 'string', required: true },
                         oauth2Issuer: { dataType: 'string', required: true },
+                    },
+                },
+                { ref: 'Partial_OrganizationSsoMethodFlags_' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_GenericOidcSsoConfig.clientId-or-metadataDocumentEndpoint-or-scopes_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    clientId: { dataType: 'string', required: true },
+                    metadataDocumentEndpoint: {
+                        dataType: 'string',
+                        required: true,
+                    },
+                    scopes: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GenericOidcSsoConfigSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_GenericOidcSsoConfig.clientId-or-metadataDocumentEndpoint-or-scopes_',
+                },
+                { ref: 'OrganizationSsoMethodFlags' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        hasClientSecret: {
+                            dataType: 'boolean',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGenericOidcSsoConfigResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'GenericOidcSsoConfigSummary' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpsertGenericOidcSsoConfigResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'GenericOidcSsoConfigSummary', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpsertGenericOidcSsoConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        scopes: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                        },
+                        metadataDocumentEndpoint: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                        clientSecret: { dataType: 'string' },
+                        clientId: { dataType: 'string', required: true },
                     },
                 },
                 { ref: 'Partial_OrganizationSsoMethodFlags_' },
@@ -23813,7 +23920,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -23823,7 +23930,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -23833,7 +23940,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -23846,7 +23953,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -24501,7 +24608,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24511,7 +24618,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24521,7 +24628,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -24534,7 +24641,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -43258,6 +43365,177 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'deleteOktaConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSsoController_getGenericOidcConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/org/sso/oidc',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSsoController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSsoController.prototype.getGenericOidcConfig,
+        ),
+
+        async function OrganizationSsoController_getGenericOidcConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSsoController_getGenericOidcConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSsoController>(
+                        OrganizationSsoController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getGenericOidcConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSsoController_upsertGenericOidcConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpsertGenericOidcSsoConfig',
+        },
+    };
+    app.put(
+        '/api/v1/org/sso/oidc',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSsoController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSsoController.prototype.upsertGenericOidcConfig,
+        ),
+
+        async function OrganizationSsoController_upsertGenericOidcConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSsoController_upsertGenericOidcConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSsoController>(
+                        OrganizationSsoController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertGenericOidcConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSsoController_deleteGenericOidcConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.delete(
+        '/api/v1/org/sso/oidc',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSsoController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSsoController.prototype.deleteGenericOidcConfig,
+        ),
+
+        async function OrganizationSsoController_deleteGenericOidcConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSsoController_deleteGenericOidcConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSsoController>(
+                        OrganizationSsoController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteGenericOidcConfig',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13314,8 +13314,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13373,8 +13373,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13634,19 +13634,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -13655,8 +13655,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "rejected",
                                                             "timeout"
                                                         ]
@@ -17509,6 +17509,104 @@
                             "oktaDomain",
                             "oauth2Issuer"
                         ],
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Partial_OrganizationSsoMethodFlags_"
+                    }
+                ]
+            },
+            "Pick_GenericOidcSsoConfig.clientId-or-metadataDocumentEndpoint-or-scopes_": {
+                "properties": {
+                    "clientId": {
+                        "type": "string"
+                    },
+                    "metadataDocumentEndpoint": {
+                        "type": "string",
+                        "description": "OIDC discovery document URL (`.well-known/openid-configuration`)."
+                    },
+                    "scopes": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Optional extra scopes (space-separated) appended to the auth request."
+                    }
+                },
+                "required": ["clientId", "metadataDocumentEndpoint", "scopes"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "GenericOidcSsoConfigSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_GenericOidcSsoConfig.clientId-or-metadataDocumentEndpoint-or-scopes_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OrganizationSsoMethodFlags"
+                    },
+                    {
+                        "properties": {
+                            "hasClientSecret": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["hasClientSecret"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiGenericOidcSsoConfigResponse": {
+                "properties": {
+                    "results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/GenericOidcSsoConfigSummary"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiUpsertGenericOidcSsoConfigResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/GenericOidcSsoConfigSummary"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "UpsertGenericOidcSsoConfig": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "scopes": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "metadataDocumentEndpoint": {
+                                "type": "string"
+                            },
+                            "clientSecret": {
+                                "type": "string",
+                                "description": "When omitted on update, the stored secret is preserved. Required on create."
+                            },
+                            "clientId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["metadataDocumentEndpoint", "clientId"],
                         "type": "object"
                     },
                     {
@@ -25082,22 +25180,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -25657,22 +25755,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -39436,6 +39534,108 @@
                 },
                 "description": "Removes the current organization's Okta SSO configuration.",
                 "summary": "Delete Okta SSO configuration",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/org/sso/oidc": {
+            "get": {
+                "operationId": "GetGenericOidcSsoConfig",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGenericOidcSsoConfigResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Returns the current organization's generic OIDC SSO configuration\n(sensitive fields are not included).",
+                "summary": "Get generic OIDC SSO configuration",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            },
+            "put": {
+                "operationId": "UpsertGenericOidcSsoConfig",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUpsertGenericOidcSsoConfigResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Creates or updates the current organization's generic OIDC SSO\nconfiguration. Omit `clientSecret` to preserve the previously stored\nsecret on updates.",
+                "summary": "Upsert generic OIDC SSO configuration",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpsertGenericOidcSsoConfig"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "DeleteGenericOidcSsoConfig",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Removes the current organization's generic OIDC SSO configuration.",
+                "summary": "Delete generic OIDC SSO configuration",
                 "tags": ["Organizations"],
                 "security": [],
                 "parameters": []

--- a/packages/backend/src/models/OrganizationSsoModel.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.ts
@@ -1,5 +1,6 @@
 import {
     AzureAdSsoConfig,
+    GenericOidcSsoConfig,
     OktaSsoConfig,
     OrganizationSsoMethodFlags,
     OrganizationSsoProvider,
@@ -17,6 +18,7 @@ type OrganizationSsoModelArguments = {
 type ProviderConfigTypeMap = {
     [OrganizationSsoProvider.AZUREAD]: AzureAdSsoConfig;
     [OrganizationSsoProvider.OKTA]: OktaSsoConfig;
+    [OrganizationSsoProvider.GENERIC_OIDC]: GenericOidcSsoConfig;
 };
 
 export type OrganizationSsoMethod<P extends OrganizationSsoProvider> = {

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -24,6 +24,10 @@ import {
     getDatabricksOidcEndpointsFromHost,
     getDatabricksStrategyName,
 } from '../controllers/authentication/strategies/databricksStrategy';
+import {
+    createGenericOidcStrategyForConfig,
+    isGenericOidcPassportStrategyAvailableToUse,
+} from '../controllers/authentication/strategies/oidcStrategy';
 import { AiAgentService } from '../ee/services/AiAgentService/AiAgentService';
 import { createAuditLogEvent } from '../logging/auditLog';
 import { createActorFromUser } from '../logging/caslAuditWrapper';
@@ -213,6 +217,67 @@ const resolveAzureAdStrategyName = async (
     return undefined;
 };
 
+// Cache dynamic generic-OIDC strategies (keyed `oidc:<orgUuid>`), mirroring the
+// Azure AD cache. Building the strategy is async (OIDC issuer discovery), so
+// registration is async too. Evicted after the same TTL so rotated secrets are
+// eventually picked up.
+const genericOidcStrategyCache = new Map<
+    string,
+    { timer: ReturnType<typeof setTimeout> }
+>();
+
+const registerGenericOidcStrategyForOrg = async (
+    organizationUuid: string,
+    config: import('@lightdash/common').GenericOidcSsoConfig,
+): Promise<string> => {
+    const strategyName = `oidc:${organizationUuid}`;
+    const existing = genericOidcStrategyCache.get(strategyName);
+    // Always re-register so config changes (e.g. rotated secret) take effect.
+    passport.use(
+        strategyName,
+        await createGenericOidcStrategyForConfig(config),
+    );
+    if (existing) {
+        clearTimeout(existing.timer);
+    }
+    const timer = setTimeout(() => {
+        genericOidcStrategyCache.delete(strategyName);
+        passport.unuse(strategyName);
+    }, AZURE_AD_STRATEGY_TTL_MS);
+    genericOidcStrategyCache.set(strategyName, { timer });
+    return strategyName;
+};
+
+/**
+ * Resolves the generic-OIDC strategy name for this request, registering the
+ * per-org strategy dynamically. Returns undefined when neither a per-org DB
+ * config matching the email domain nor an env-based fallback is available.
+ */
+const resolveGenericOidcStrategyName = async (
+    req: express.Request,
+): Promise<string | undefined> => {
+    const ssoService = req.services.getOrganizationSsoService();
+    const email = getLoginHint(req);
+
+    if (email) {
+        const method = await ssoService.findEnabledMethodForEmail(
+            email,
+            OrganizationSsoProvider.GENERIC_OIDC,
+        );
+        if (method) {
+            return registerGenericOidcStrategyForOrg(
+                method.organizationUuid,
+                method.config,
+            );
+        }
+    }
+    // Fall back to the env-based strategy registered at startup, if available.
+    if (isGenericOidcPassportStrategyAvailableToUse) {
+        return 'oidc';
+    }
+    return undefined;
+};
+
 const authenticateDatabricks = (
     getAuthenticateOptions?: (
         req: express.Request,
@@ -396,22 +461,76 @@ apiV1Router.get(
 apiV1Router.get(
     lightdashConfig.auth.oidc.loginPath,
     storeOIDCRedirect,
-    passport.authenticate(
-        'oidc',
-        lightdashConfig.auth.oidc.scopes
-            ? {
-                  scope: lightdashConfig.auth.oidc.scopes,
-              }
-            : {},
-    ),
+    async (req, res, next) => {
+        try {
+            const strategyName = await resolveGenericOidcStrategyName(req);
+            if (!strategyName) {
+                res.status(404).json({
+                    status: 'error',
+                    message: 'OIDC SSO is not configured',
+                });
+                return;
+            }
+            req.session.oauth = req.session.oauth || {};
+            req.session.oauth.oidcStrategyName = strategyName;
+            // Per-org strategies bake the scope into the client params; the
+            // env-based 'oidc' strategy still takes its scope here.
+            const authenticateOptions: passport.AuthenticateOptions =
+                strategyName === 'oidc' && lightdashConfig.auth.oidc.scopes
+                    ? { scope: lightdashConfig.auth.oidc.scopes }
+                    : {};
+            passport.authenticate(strategyName, authenticateOptions)(
+                req,
+                res,
+                next,
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
 );
 
-apiV1Router.get(lightdashConfig.auth.oidc.callbackPath, (req, res, next) =>
-    passport.authenticate('oidc', {
-        failureRedirect: getOidcRedirectURL(false)(req),
-        successRedirect: getOidcRedirectURL(true)(req),
-        failureFlash: true,
-    })(req, res, next),
+apiV1Router.get(
+    lightdashConfig.auth.oidc.callbackPath,
+    async (req, res, next) => {
+        try {
+            const sessionStrategyName = req.session.oauth?.oidcStrategyName;
+            const strategyName =
+                sessionStrategyName ??
+                (await resolveGenericOidcStrategyName(req));
+            if (!strategyName) {
+                res.status(404).json({
+                    status: 'error',
+                    message: 'OIDC SSO is not configured',
+                });
+                return;
+            }
+            // Re-register the per-org strategy if it was evicted (e.g. a server
+            // restart between login and callback).
+            if (
+                strategyName.startsWith('oidc:') &&
+                !genericOidcStrategyCache.has(strategyName)
+            ) {
+                const orgUuid = strategyName.slice('oidc:'.length);
+                const config = await req.services
+                    .getOrganizationSsoService()
+                    .getConfigForOrganization(
+                        orgUuid,
+                        OrganizationSsoProvider.GENERIC_OIDC,
+                    );
+                if (config) {
+                    await registerGenericOidcStrategyForOrg(orgUuid, config);
+                }
+            }
+            passport.authenticate(strategyName, {
+                failureRedirect: getOidcRedirectURL(false)(req),
+                successRedirect: getOidcRedirectURL(true)(req),
+                failureFlash: true,
+            })(req, res, next);
+        } catch (error) {
+            next(error);
+        }
+    },
 );
 
 apiV1Router.get(

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
@@ -4,6 +4,8 @@ import {
     AzureAdSsoConfigSummary,
     FeatureFlags,
     ForbiddenError,
+    GenericOidcSsoConfig,
+    GenericOidcSsoConfigSummary,
     NotFoundError,
     OktaSsoConfig,
     OktaSsoConfigSummary,
@@ -12,6 +14,7 @@ import {
     ParameterError,
     UnexpectedServerError,
     UpsertAzureAdSsoConfig,
+    UpsertGenericOidcSsoConfig,
     UpsertOktaSsoConfig,
     type RegisteredAccount,
 } from '@lightdash/common';
@@ -54,6 +57,19 @@ const toOktaSummary = (
     authorizationServerId: method.config.authorizationServerId,
     extraScopes: method.config.extraScopes,
     hasClientSecret: !!method.config.oauth2ClientSecret,
+    enabled: method.enabled,
+    overrideEmailDomains: method.overrideEmailDomains,
+    emailDomains: method.emailDomains,
+    allowPassword: method.allowPassword,
+});
+
+const toGenericOidcSummary = (
+    method: OrganizationSsoMethod<OrganizationSsoProvider.GENERIC_OIDC>,
+): GenericOidcSsoConfigSummary => ({
+    clientId: method.config.clientId,
+    metadataDocumentEndpoint: method.config.metadataDocumentEndpoint,
+    scopes: method.config.scopes,
+    hasClientSecret: !!method.config.clientSecret,
     enabled: method.enabled,
     overrideEmailDomains: method.overrideEmailDomains,
     emailDomains: method.emailDomains,
@@ -353,6 +369,96 @@ export class OrganizationSsoService extends BaseService {
         await this.organizationSsoModel.delete(
             organizationUuid,
             OrganizationSsoProvider.OKTA,
+        );
+    }
+
+    async getGenericOidcConfig(
+        account: RegisteredAccount,
+    ): Promise<GenericOidcSsoConfigSummary | null> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageSso(account);
+        const method = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.GENERIC_OIDC,
+        );
+        return method ? toGenericOidcSummary(method) : null;
+    }
+
+    async upsertGenericOidcConfig(
+        account: RegisteredAccount,
+        data: UpsertGenericOidcSsoConfig,
+    ): Promise<GenericOidcSsoConfigSummary> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageSso(account);
+
+        if (!data.clientId?.trim() || !data.metadataDocumentEndpoint?.trim()) {
+            throw new ParameterError(
+                'clientId and metadataDocumentEndpoint are required',
+            );
+        }
+
+        if (data.emailDomains && data.emailDomains.length > 0) {
+            OrganizationSsoService.validateEmailDomains(data.emailDomains);
+        }
+
+        const existing = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.GENERIC_OIDC,
+        );
+
+        const clientSecret =
+            data.clientSecret?.trim() || existing?.config.clientSecret;
+        if (!clientSecret) {
+            throw new ParameterError('clientSecret is required');
+        }
+
+        const config: GenericOidcSsoConfig = {
+            clientId: data.clientId.trim(),
+            clientSecret,
+            metadataDocumentEndpoint: data.metadataDocumentEndpoint.trim(),
+            scopes: data.scopes?.trim() || null,
+        };
+
+        const flags: Partial<OrganizationSsoMethodFlags> = {
+            enabled: data.enabled,
+            overrideEmailDomains: data.overrideEmailDomains,
+            emailDomains: data.emailDomains,
+            allowPassword: data.allowPassword,
+        };
+
+        await this.organizationSsoModel.upsert(
+            organizationUuid,
+            OrganizationSsoProvider.GENERIC_OIDC,
+            config,
+            flags,
+            account.user.userUuid,
+        );
+
+        const refreshed = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.GENERIC_OIDC,
+        );
+        if (!refreshed) {
+            throw new UnexpectedServerError(
+                'Failed to read back upserted SSO configuration',
+            );
+        }
+        return toGenericOidcSummary(refreshed);
+    }
+
+    async deleteGenericOidcConfig(account: RegisteredAccount): Promise<void> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageSso(account);
+        const existing = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.GENERIC_OIDC,
+        );
+        if (!existing) {
+            throw new NotFoundError('No OIDC SSO configuration found');
+        }
+        await this.organizationSsoModel.delete(
+            organizationUuid,
+            OrganizationSsoProvider.GENERIC_OIDC,
         );
     }
 

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -722,6 +722,79 @@ describe('UserService', () => {
         });
     });
 
+    describe('getLoginOptions per-org generic OIDC discovery', () => {
+        // Per-org OIDC config lives in the DB; the instance has no OIDC env
+        // config. Proves the generic discovery path maps provider 'oidc' to the
+        // GENERIC_OIDC login option independently of env config.
+        const oidcMethod = {
+            organizationUuid: 'org-1',
+            provider: OpenIdIdentityIssuerType.GENERIC_OIDC as unknown as never,
+            config: {
+                clientId: 'cid',
+                clientSecret: 'sec',
+                metadataDocumentEndpoint:
+                    'https://idp.acme.com/.well-known/openid-configuration',
+                scopes: null,
+            },
+            enabled: true,
+            overrideEmailDomains: false,
+            emailDomains: [],
+            allowPassword: true,
+        };
+
+        const configWithGoogleEnv: LightdashConfig = {
+            ...lightdashConfigMock,
+            auth: {
+                ...lightdashConfigMock.auth,
+                google: {
+                    ...lightdashConfigMock.auth.google,
+                    enabled: true,
+                    loginPath: '/login/google',
+                },
+                oidc: {
+                    ...lightdashConfigMock.auth.oidc,
+                    loginPath: '/login/oidc',
+                },
+            },
+        };
+
+        test('per-org OIDC match suppresses instance Google (returning user with password)', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([oidcMethod]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                true,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('user@acme.com')).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                showOptions: ['email', 'oidc'],
+            });
+        });
+
+        test('brand-new user matching per-org OIDC → forceRedirect to /login/oidc', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([oidcMethod]);
+            (userModel.findUserByEmail as jest.Mock).mockResolvedValueOnce(
+                undefined,
+            );
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                false,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('newbie@acme.com')).toEqual({
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/oidc?login_hint=newbie%40acme.com',
+                showOptions: ['oidc'],
+            });
+        });
+    });
+
     describe('loginWithOpenId', () => {
         test('should throw error if provider not allowed', async () => {
             await expect(

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -151,6 +151,7 @@ import {
 } from './organizationMemberProfile';
 import {
     type AzureAdSsoConfigSummary,
+    type GenericOidcSsoConfigSummary,
     type OktaSsoConfigSummary,
 } from './organizationSso';
 import type { ResultsPaginationMetadata } from './paginateResults';
@@ -936,6 +937,7 @@ type ApiResults =
     | AllowedEmailDomains
     | AzureAdSsoConfigSummary
     | OktaSsoConfigSummary
+    | GenericOidcSsoConfigSummary
     | UpdateAllowedEmailDomains
     | UserAllowedOrganization[]
     | EmailStatusExpiring

--- a/packages/common/src/types/organizationSso.ts
+++ b/packages/common/src/types/organizationSso.ts
@@ -1,6 +1,7 @@
 export enum OrganizationSsoProvider {
     AZUREAD = 'azuread',
     OKTA = 'okta',
+    GENERIC_OIDC = 'oidc',
 }
 
 export const isOrganizationSsoProvider = (
@@ -108,4 +109,41 @@ export type ApiOktaSsoConfigResponse = {
 export type ApiUpsertOktaSsoConfigResponse = {
     status: 'ok';
     results: OktaSsoConfigSummary;
+};
+
+export type GenericOidcSsoConfig = {
+    clientId: string;
+    clientSecret: string;
+    /** OIDC discovery document URL (`.well-known/openid-configuration`). */
+    metadataDocumentEndpoint: string;
+    /** Optional extra scopes (space-separated) appended to the auth request. */
+    scopes: string | null;
+};
+
+export type GenericOidcSsoConfigSummary = Pick<
+    GenericOidcSsoConfig,
+    'clientId' | 'metadataDocumentEndpoint' | 'scopes'
+> &
+    OrganizationSsoMethodFlags & {
+        hasClientSecret: boolean;
+    };
+
+export type UpsertGenericOidcSsoConfig = {
+    clientId: string;
+    /**
+     * When omitted on update, the stored secret is preserved. Required on create.
+     */
+    clientSecret?: string;
+    metadataDocumentEndpoint: string;
+    scopes?: string | null;
+} & Partial<OrganizationSsoMethodFlags>;
+
+export type ApiGenericOidcSsoConfigResponse = {
+    status: 'ok';
+    results: GenericOidcSsoConfigSummary | null;
+};
+
+export type ApiUpsertGenericOidcSsoConfigResponse = {
+    status: 'ok';
+    results: GenericOidcSsoConfigSummary;
 };

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/GenericOidcSsoPanel.tsx
@@ -1,0 +1,396 @@
+import {
+    Badge,
+    Button,
+    Checkbox,
+    Divider,
+    Group,
+    PasswordInput,
+    Stack,
+    Switch,
+    TagsInput,
+    Text,
+    TextInput,
+    ThemeIcon,
+    Title,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import {
+    IconChevronDown,
+    IconChevronUp,
+    IconLock,
+    IconShieldCheck,
+    IconTrash,
+} from '@tabler/icons-react';
+import { useEffect, useState, type FC } from 'react';
+import { useToggle } from 'react-use';
+import { useAllowedEmailDomains } from '../../../hooks/organization/useAllowedDomains';
+import {
+    useDeleteGenericOidcSsoConfig,
+    useGenericOidcSsoConfig,
+    useUpsertGenericOidcSsoConfig,
+} from '../../../hooks/organization/useOrganizationSso';
+import EmptyStateLoader from '../../common/EmptyStateLoader';
+import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
+import { SettingsCard } from '../../common/Settings/SettingsCard';
+import FormSection from '../../ProjectConnection/Inputs/FormSection';
+
+type FormValues = {
+    clientId: string;
+    clientSecret: string;
+    metadataDocumentEndpoint: string;
+    scopes: string;
+    enabled: boolean;
+    overrideEmailDomains: boolean;
+    emailDomains: string[];
+    allowPassword: boolean;
+};
+
+const GenericOidcSsoPanel: FC = () => {
+    const { data: existing, isLoading } = useGenericOidcSsoConfig();
+    const { data: allowedEmailDomains } = useAllowedEmailDomains();
+    const upsert = useUpsertGenericOidcSsoConfig();
+    const deleteConfig = useDeleteGenericOidcSsoConfig();
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [isOpen, toggleOpen] = useToggle(false);
+
+    const isConfigured = !!existing;
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            clientId: '',
+            clientSecret: '',
+            metadataDocumentEndpoint: '',
+            scopes: '',
+            enabled: true,
+            overrideEmailDomains: false,
+            emailDomains: [],
+            allowPassword: true,
+        },
+        validate: {
+            clientId: (value) =>
+                value.trim().length === 0 ? 'Client ID is required' : null,
+            metadataDocumentEndpoint: (value) =>
+                value.trim().length === 0
+                    ? 'Discovery document URL is required'
+                    : null,
+            clientSecret: (value) =>
+                !existing && value.trim().length === 0
+                    ? 'Client secret is required'
+                    : null,
+            emailDomains: (value, values) =>
+                values.overrideEmailDomains && value.length === 0
+                    ? 'Add at least one domain when override is enabled'
+                    : null,
+        },
+    });
+
+    useEffect(() => {
+        form.setValues({
+            clientId: existing?.clientId ?? '',
+            clientSecret: '',
+            metadataDocumentEndpoint: existing?.metadataDocumentEndpoint ?? '',
+            scopes: existing?.scopes ?? '',
+            enabled: existing?.enabled ?? true,
+            overrideEmailDomains: existing?.overrideEmailDomains ?? false,
+            emailDomains: existing?.emailDomains ?? [],
+            allowPassword: existing?.allowPassword ?? true,
+        });
+        form.resetDirty();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        existing?.clientId,
+        existing?.metadataDocumentEndpoint,
+        existing?.scopes,
+        existing?.enabled,
+        existing?.overrideEmailDomains,
+        existing?.emailDomains,
+        existing?.allowPassword,
+    ]);
+
+    const orgDomains = allowedEmailDomains?.emailDomains ?? [];
+
+    const handleSubmit = form.onSubmit((values) => {
+        upsert.mutate({
+            clientId: values.clientId.trim(),
+            metadataDocumentEndpoint: values.metadataDocumentEndpoint.trim(),
+            scopes: values.scopes.trim() || null,
+            enabled: values.enabled,
+            overrideEmailDomains: values.overrideEmailDomains,
+            emailDomains: values.emailDomains.map((d) =>
+                d.trim().toLowerCase(),
+            ),
+            allowPassword: values.allowPassword,
+            ...(values.clientSecret.trim().length > 0
+                ? { clientSecret: values.clientSecret.trim() }
+                : {}),
+        });
+    });
+
+    // The Enabled toggle persists immediately (secret omitted = preserved), so
+    // turning it off disables sign-in without opening the configuration.
+    const handleToggleEnabled = (enabled: boolean) => {
+        form.setFieldValue('enabled', enabled);
+        if (!existing) return;
+        upsert.mutate({
+            clientId: existing.clientId,
+            metadataDocumentEndpoint: existing.metadataDocumentEndpoint,
+            scopes: existing.scopes,
+            enabled,
+            overrideEmailDomains: existing.overrideEmailDomains,
+            emailDomains: existing.emailDomains,
+            allowPassword: existing.allowPassword,
+        });
+    };
+
+    return (
+        <SettingsCard p="lg" pos="relative">
+            {isLoading ? (
+                <EmptyStateLoader mih={80} />
+            ) : (
+                <Stack gap="md">
+                    <Group
+                        justify="space-between"
+                        align="flex-start"
+                        wrap="nowrap"
+                    >
+                        <Group gap="sm" wrap="nowrap" align="flex-start">
+                            <ThemeIcon
+                                variant="light"
+                                color="gray"
+                                size="lg"
+                                radius="sm"
+                            >
+                                <MantineIcon icon={IconLock} />
+                            </ThemeIcon>
+                            <Stack gap={2}>
+                                <Title order={5}>OpenID Connect</Title>
+                                <Text c="dimmed" size="sm" maw={460}>
+                                    Single sign-on via a generic OpenID Connect
+                                    provider. Users whose email matches the
+                                    discovery whitelist see a "Sign in with
+                                    OpenID Connect" button; instance-level SSO
+                                    is suppressed for matched users.
+                                </Text>
+                            </Stack>
+                        </Group>
+                        {isConfigured ? (
+                            <Switch
+                                label="Enabled"
+                                labelPosition="left"
+                                checked={form.values.enabled}
+                                disabled={upsert.isLoading}
+                                onChange={(event) =>
+                                    handleToggleEnabled(
+                                        event.currentTarget.checked,
+                                    )
+                                }
+                            />
+                        ) : (
+                            <Badge color="gray" variant="outline" size="lg">
+                                Not configured
+                            </Badge>
+                        )}
+                    </Group>
+
+                    {isConfigured ? (
+                        <Button
+                            variant="default"
+                            w="fit-content"
+                            leftSection={
+                                <MantineIcon
+                                    icon={
+                                        isOpen ? IconChevronUp : IconChevronDown
+                                    }
+                                />
+                            }
+                            onClick={() => toggleOpen()}
+                        >
+                            {isOpen
+                                ? 'Hide configuration'
+                                : 'Edit configuration'}
+                        </Button>
+                    ) : (
+                        !isOpen && (
+                            <Button
+                                variant="default"
+                                w="fit-content"
+                                onClick={() => toggleOpen()}
+                            >
+                                Set up OpenID Connect
+                            </Button>
+                        )
+                    )}
+
+                    <FormSection isOpen={isOpen} name="oidc-configuration">
+                        <Stack gap="md">
+                            <Divider />
+                            <form onSubmit={handleSubmit}>
+                                <Stack>
+                                    <Title order={6}>
+                                        Application credentials
+                                    </Title>
+                                    <TextInput
+                                        label="Discovery document URL"
+                                        placeholder="https://idp.example.com/.well-known/openid-configuration"
+                                        description="The OIDC discovery document URL for your identity provider."
+                                        required
+                                        {...form.getInputProps(
+                                            'metadataDocumentEndpoint',
+                                        )}
+                                    />
+                                    <TextInput
+                                        label="Client ID"
+                                        placeholder="your-oidc-client-id"
+                                        description="From your identity provider's application settings."
+                                        required
+                                        {...form.getInputProps('clientId')}
+                                    />
+                                    <PasswordInput
+                                        label="Client secret"
+                                        placeholder={
+                                            existing
+                                                ? 'Leave blank to keep the existing secret'
+                                                : 'OIDC client secret value'
+                                        }
+                                        description="The client secret from your identity provider."
+                                        required={!existing}
+                                        {...form.getInputProps('clientSecret')}
+                                    />
+
+                                    <Title order={6} mt="md">
+                                        Advanced
+                                    </Title>
+                                    <TextInput
+                                        label="Scopes"
+                                        placeholder="Optional — defaults to openid profile email"
+                                        description="Space-separated OAuth scopes to request."
+                                        {...form.getInputProps('scopes')}
+                                    />
+
+                                    <Title order={6} mt="md">
+                                        Discovery
+                                    </Title>
+                                    <Checkbox
+                                        label="Override organization's allowed email domains"
+                                        description="When unchecked, users matching any of the organization's allowed email domains see this method."
+                                        checked={
+                                            form.values.overrideEmailDomains
+                                        }
+                                        onChange={(event) =>
+                                            form.setFieldValue(
+                                                'overrideEmailDomains',
+                                                event.currentTarget.checked,
+                                            )
+                                        }
+                                    />
+                                    {form.values.overrideEmailDomains ? (
+                                        <TagsInput
+                                            label="Email domains for this method"
+                                            description="Only users whose email domain matches one of these will see OpenID Connect. Domains are case-insensitive."
+                                            placeholder="acme.com, acme.io"
+                                            value={form.values.emailDomains}
+                                            onChange={(domains) =>
+                                                form.setFieldValue(
+                                                    'emailDomains',
+                                                    domains,
+                                                )
+                                            }
+                                            error={form.errors.emailDomains}
+                                            clearable
+                                        />
+                                    ) : (
+                                        <Text size="sm" c="dimmed">
+                                            Using organization's allowed email
+                                            domains:{' '}
+                                            {orgDomains.length > 0 ? (
+                                                <b>{orgDomains.join(', ')}</b>
+                                            ) : (
+                                                <i>none configured</i>
+                                            )}
+                                        </Text>
+                                    )}
+
+                                    <Title order={6} mt="md">
+                                        Password sign-in
+                                    </Title>
+                                    <Checkbox
+                                        label="Allow password sign-in for users matching this method"
+                                        description="When unchecked, users whose email domain matches OIDC discovery will not see the password input. Lenient rule: if any matching method allows password, it is shown."
+                                        checked={form.values.allowPassword}
+                                        onChange={(event) =>
+                                            form.setFieldValue(
+                                                'allowPassword',
+                                                event.currentTarget.checked,
+                                            )
+                                        }
+                                    />
+
+                                    <Group justify="space-between" mt="md">
+                                        {existing ? (
+                                            <Button
+                                                variant="outline"
+                                                color="red"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                    />
+                                                }
+                                                onClick={() =>
+                                                    setDeleteOpen(true)
+                                                }
+                                            >
+                                                Remove configuration
+                                            </Button>
+                                        ) : (
+                                            <div />
+                                        )}
+                                        <Button
+                                            type="submit"
+                                            loading={upsert.isLoading}
+                                            disabled={upsert.isLoading}
+                                        >
+                                            {existing
+                                                ? 'Save changes'
+                                                : 'Enable OpenID Connect'}
+                                        </Button>
+                                    </Group>
+                                </Stack>
+                            </form>
+                        </Stack>
+                    </FormSection>
+                </Stack>
+            )}
+
+            {deleteOpen && (
+                <MantineModal
+                    opened
+                    onClose={() => setDeleteOpen(false)}
+                    title="Remove OpenID Connect configuration"
+                    icon={IconShieldCheck}
+                    cancelLabel="Cancel"
+                    actions={
+                        <Button
+                            color="red"
+                            loading={deleteConfig.isLoading}
+                            onClick={async () => {
+                                await deleteConfig.mutateAsync();
+                                setDeleteOpen(false);
+                            }}
+                        >
+                            Remove
+                        </Button>
+                    }
+                >
+                    <Text>
+                        After removing this configuration, users in this
+                        organization will no longer be able to sign in with
+                        OpenID Connect via the per-organization configuration.
+                    </Text>
+                </MantineModal>
+            )}
+        </SettingsCard>
+    );
+};
+
+export default GenericOidcSsoPanel;

--- a/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
+++ b/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
@@ -156,9 +156,11 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
                 />
             ) : null;
         case OpenIdIdentityIssuerType.GENERIC_OIDC:
-            return health.data?.auth.oidc.enabled ? (
+            return health.data?.auth.oidc.enabled || forceShow ? (
                 <ThirdPartySignInButtonBase
-                    loginPath={health.data.auth.oidc.loginPath}
+                    loginPath={
+                        health.data?.auth.oidc.loginPath ?? '/login/oidc'
+                    }
                     redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}

--- a/packages/frontend/src/hooks/organization/useOrganizationSso.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationSso.ts
@@ -1,8 +1,10 @@
 import {
     type ApiError,
     type AzureAdSsoConfigSummary,
+    type GenericOidcSsoConfigSummary,
     type OktaSsoConfigSummary,
     type UpsertAzureAdSsoConfig,
+    type UpsertGenericOidcSsoConfig,
     type UpsertOktaSsoConfig,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -148,6 +150,79 @@ export const useDeleteOktaSsoConfig = () => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to remove Okta SSO settings',
+                apiError: error,
+            });
+        },
+    });
+};
+
+const OIDC_QUERY_KEY = ['organization_sso', 'oidc'];
+
+const getGenericOidcSsoConfig = async () =>
+    lightdashApi<GenericOidcSsoConfigSummary | null>({
+        url: '/org/sso/oidc',
+        method: 'GET',
+        body: undefined,
+    });
+
+const upsertGenericOidcSsoConfig = async (data: UpsertGenericOidcSsoConfig) =>
+    lightdashApi<GenericOidcSsoConfigSummary>({
+        url: '/org/sso/oidc',
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+
+const deleteGenericOidcSsoConfig = async () =>
+    lightdashApi<undefined>({
+        url: '/org/sso/oidc',
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useGenericOidcSsoConfig = () =>
+    useQuery<GenericOidcSsoConfigSummary | null, ApiError>({
+        queryKey: OIDC_QUERY_KEY,
+        queryFn: getGenericOidcSsoConfig,
+    });
+
+export const useUpsertGenericOidcSsoConfig = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<
+        GenericOidcSsoConfigSummary,
+        ApiError,
+        UpsertGenericOidcSsoConfig
+    >(upsertGenericOidcSsoConfig, {
+        mutationKey: ['organization_sso', 'oidc', 'upsert'],
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(OIDC_QUERY_KEY);
+            showToastSuccess({
+                title: 'OIDC SSO settings saved',
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to save OIDC SSO settings',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useDeleteGenericOidcSsoConfig = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<undefined, ApiError>(deleteGenericOidcSsoConfig, {
+        mutationKey: ['organization_sso', 'oidc', 'delete'],
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(OIDC_QUERY_KEY);
+            showToastSuccess({
+                title: 'OIDC SSO settings removed',
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to remove OIDC SSO settings',
                 apiError: error,
             });
         },

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -63,6 +63,7 @@ import { MyWarehouseConnectionsPanel } from '../components/UserSettings/MyWareho
 import OAuthClientsPanel from '../components/UserSettings/OAuthClientsPanel';
 import OrganizationPanel from '../components/UserSettings/OrganizationPanel';
 import AzureAdSsoPanel from '../components/UserSettings/OrganizationSso/AzureAdSsoPanel';
+import GenericOidcSsoPanel from '../components/UserSettings/OrganizationSso/GenericOidcSsoPanel';
 import OktaSsoPanel from '../components/UserSettings/OrganizationSso/OktaSsoPanel';
 import { OrganizationWarehouseCredentialsPanel } from '../components/UserSettings/OrganizationWarehouseCredentialsPanel';
 import PasswordPanel from '../components/UserSettings/PasswordPanel';
@@ -495,6 +496,7 @@ const Settings: FC = () => {
                         </Stack>
                         <AzureAdSsoPanel />
                         <OktaSsoPanel />
+                        <GenericOidcSsoPanel />
                     </Stack>
                 ),
             });


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7551/admin-panel-generic-oidc-sso-configuration

<img width="495" height="656" alt="CleanShot 2026-05-25 at 16 53 08" src="https://github.com/user-attachments/assets/b22f70a0-f796-4f9f-80bc-e548526cc338" />

### Description:

Adds per-organization generic OpenID Connect (OIDC) SSO support, following the same model as the existing Azure AD and Okta integrations.

**Backend**
- Introduces `GENERIC_OIDC` as a new `OrganizationSsoProvider` (`provider = 'oidc'`) with `GenericOidcSsoConfig`, `GenericOidcSsoConfigSummary`, and `UpsertGenericOidcSsoConfig` types in `organizationSso.ts`.
- Adds `createGenericOidcStrategyForConfig(config)` in `oidcStrategy.ts`, which performs async OIDC issuer discovery via `openid-client` and builds a client-secret-flow passport strategy from a DB-stored config object.
- Registers per-org strategies as `oidc:<orgUuid>` in a TTL-based cache in `apiV1Router.ts` (mirroring the Azure AD pattern). The login and callback routes now resolve the correct strategy dynamically by email login-hint, storing the resolved name on `req.session.oauth.oidcStrategyName`. The callback handler re-registers the strategy from the DB if it was evicted between login and callback.
- Adds `getGenericOidcConfig`, `upsertGenericOidcConfig`, and `deleteGenericOidcConfig` methods to `OrganizationSsoService`, with the same feature-flag and permission guards used by Azure AD and Okta.
- Exposes `GET /api/v1/org/sso/oidc`, `PUT /api/v1/org/sso/oidc`, and `DELETE /api/v1/org/sso/oidc` endpoints on `OrganizationSsoController`. The client secret is never returned in responses; `hasClientSecret` is used instead, and omitting `clientSecret` on update preserves the stored value.

**Frontend**
- Adds `GenericOidcSsoPanel` to the organization SSO settings page, with fields for discovery document URL, client ID, client secret, optional scopes, email domain override, and password sign-in toggle.
- Adds `useGenericOidcSsoConfig`, `useUpsertGenericOidcSsoConfig`, and `useDeleteGenericOidcSsoConfig` hooks.
- `ThirdPartySignInButton` now renders the OIDC button when `forceShow` is set, even when the instance-level OIDC env config is not enabled, enabling per-org OIDC discovery to surface the button correctly.

**Tests**
- Adds `UserService` unit tests covering per-org OIDC discovery: verifies that a matching per-org OIDC method suppresses instance-level Google SSO, and that a brand-new user matching a per-org OIDC config receives a `forceRedirect` to the OIDC login path.