### PR TITLE
feat: add `showRowGrouping` option to visually deduplicate repeated row dimension values

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -190,6 +190,14 @@ export enum FeatureFlags {
     HidePivotDimensions = 'hide-pivot-dimensions',
 
     /**
+     * Enable the "Group repeated row values" toggle on pivot tables — visual
+     * dedup of row-header dim values without rendering aggregate subtotal
+     * rows. Off by default while we validate the rendering across customer
+     * data shapes before GA.
+     */
+    PivotRowGrouping = 'pivot-row-grouping',
+
+    /**
      * Enable AI thread context compaction for streamed web-app conversations.
      */
     AiContextCompaction = 'ai-context-compaction',

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -426,6 +426,12 @@ export type TableChart = {
     showSubtotals?: boolean;
     /** Default subtotal rows to expanded (vs. collapsed). Only meaningful when showSubtotals is true. */
     showSubtotalsExpanded?: boolean;
+    /**
+     * Visually deduplicate repeated row-index dimension values across consecutive
+     * rows without showing aggregate subtotal rows. When `showSubtotals` is true,
+     * grouping is implicitly active and this flag is ignored. Defaults to false.
+     */
+    showRowGrouping?: boolean;
     /** Column-specific configuration */
     columns?: Record<string, ColumnProperties>;
     /** Conditional formatting rules */

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -232,6 +232,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
         showResultsTotal,
         showSubtotals,
         showSubtotalsExpanded,
+        showRowGrouping,
         updateColumnProperty,
     } = visualizationConfig.chartConfig;
 
@@ -308,6 +309,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 hideRowNumbers={hideRowNumbers}
                                 showSubtotals={showSubtotals}
                                 showSubtotalsExpanded={showSubtotalsExpanded}
+                                showRowGrouping={showRowGrouping}
                                 columnProperties={
                                     visualizationConfig.chartConfig
                                         .columnProperties
@@ -329,6 +331,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 hideRowNumbers={hideRowNumbers}
                                 showSubtotals={showSubtotals}
                                 showSubtotalsExpanded={showSubtotalsExpanded}
+                                showRowGrouping={showRowGrouping}
                                 columnProperties={
                                     visualizationConfig.chartConfig
                                         .columnProperties

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -3,6 +3,7 @@ import { Box, Checkbox, Stack, Switch, Tooltip } from '@mantine-8/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useIsHidePivotDimsEnabled } from '../../../hooks/useIsHidePivotDimsEnabled';
+import { useIsPivotRowGroupingEnabled } from '../../../hooks/useIsPivotRowGroupingEnabled';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
@@ -28,6 +29,7 @@ const GeneralSettings: FC = () => {
     const { showToastError } = useToaster();
 
     const isHidePivotDimsEnabled = useIsHidePivotDimsEnabled();
+    const isPivotRowGroupingEnabled = useIsPivotRowGroupingEnabled();
     const { dimensions } = resultsData?.metricQuery || {
         dimensions: [] as string[],
     };
@@ -158,12 +160,14 @@ const GeneralSettings: FC = () => {
         setShowRowCalculation,
         setShowSubtotals,
         setShowSubtotalsExpanded,
+        setShowRowGrouping,
         setShowTableNames,
         showColumnCalculation,
         showResultsTotal,
         showRowCalculation,
         showSubtotals,
         showSubtotalsExpanded,
+        showRowGrouping,
         showTableNames,
         rowLimit,
         setRowLimit,
@@ -338,6 +342,44 @@ const GeneralSettings: FC = () => {
                         !canUseSubtotals || metricsAsRows || !showSubtotals
                     }
                 />
+                {isPivotRowGroupingEnabled && (
+                    <Tooltip
+                        disabled={canUseSubtotals && !showSubtotals}
+                        label={
+                            showSubtotals
+                                ? 'Row grouping is always on when subtotals are enabled.'
+                                : metricsAsRows
+                                  ? 'Row grouping cannot be used with metrics as rows'
+                                  : `Row grouping can only be used on tables with at least two ${
+                                        isPivotTableEnabled ? 'un-pivoted' : ''
+                                    } dimensions`
+                        }
+                        w={300}
+                        multiline
+                        withinPortal
+                        position="top-start"
+                    >
+                        <Box>
+                            <Checkbox
+                                label="Group repeated row values"
+                                checked={
+                                    showSubtotals ||
+                                    (canUseSubtotals &&
+                                        !metricsAsRows &&
+                                        (showRowGrouping ?? false))
+                                }
+                                onChange={() => {
+                                    setShowRowGrouping(!showRowGrouping);
+                                }}
+                                disabled={
+                                    !canUseSubtotals ||
+                                    metricsAsRows ||
+                                    showSubtotals
+                                }
+                            />
+                        </Box>
+                    </Tooltip>
+                )}
             </Config.Section>
         </Stack>
     );

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -164,6 +164,12 @@ type PivotTableProps = BoxProps & // TODO: remove this
         getField: (fieldId: string) => ItemsMap[string] | undefined;
         showSubtotals?: boolean;
         showSubtotalsExpanded?: boolean;
+        /**
+         * When true, visually deduplicate repeated row-index dim values
+         * without rendering aggregate subtotal rows. Implicitly true when
+         * `showSubtotals` is true (subtotals always group).
+         */
+        showRowGrouping?: boolean;
         columnProperties?: Record<string, ColumnProperties>;
         isMinimal: boolean;
         isDashboard?: boolean;
@@ -194,6 +200,7 @@ const PivotTable: FC<PivotTableProps> = ({
     className,
     showSubtotals = false,
     showSubtotalsExpanded = false,
+    showRowGrouping = false,
     columnProperties = {},
     isMinimal = false,
     isDashboard = false,
@@ -206,14 +213,27 @@ const PivotTable: FC<PivotTableProps> = ({
     const { colorScheme } = useMantineColorScheme();
     const containerRef = useRef<HTMLDivElement>(null);
     const [grouping, setGrouping] = React.useState<GroupingState>([]);
+    // Row grouping without subtotals must always render expanded — there's
+    // no UI affordance to expand groups in that mode (no carat) and
+    // collapsed groups would hide all leaf data. Force-expanded when
+    // showRowGrouping is on without subtotals; otherwise honor showSubtotalsExpanded.
+    const groupingOnlyMode = showRowGrouping && !showSubtotals;
+    const expandAllByDefault = showSubtotalsExpanded || groupingOnlyMode;
     const [expanded, setExpanded] = React.useState<ExpandedState>(
-        showSubtotalsExpanded ? true : {},
+        expandAllByDefault ? true : {},
     );
-    const [prevShowSubtotalsExpanded, setPrevShowSubtotalsExpanded] =
-        React.useState(showSubtotalsExpanded);
-    if (showSubtotalsExpanded !== prevShowSubtotalsExpanded) {
-        setPrevShowSubtotalsExpanded(showSubtotalsExpanded);
-        setExpanded(showSubtotalsExpanded ? true : {});
+    // Re-derive `expanded` when the "should expand all" predicate flips
+    // (e.g. user toggles row grouping or subtotals-expanded). React's
+    // recommended render-time setState pattern for derived state from
+    // props — not a useEffect, no extra render (React detects the
+    // setState before commit and just renders once with the new value).
+    // We rely on `autoResetExpanded: false` (table config below) so
+    // TanStack doesn't wipe this on setGrouping calls.
+    const [prevExpandAllByDefault, setPrevExpandAllByDefault] =
+        React.useState(expandAllByDefault);
+    if (expandAllByDefault !== prevExpandAllByDefault) {
+        setPrevExpandAllByDefault(expandAllByDefault);
+        setExpanded(expandAllByDefault ? true : {});
     }
 
     const { handleResizeStart, resizeHandleClassName } = useColumnResize({
@@ -622,6 +642,13 @@ const PivotTable: FC<PivotTableProps> = ({
         },
         onGroupingChange: setGrouping,
         onExpandedChange: setExpanded,
+        // Don't let TanStack auto-collapse all rows when grouping changes —
+        // the expanded state is driven by `expandAllByDefault` (above) and
+        // we want it to survive the setGrouping call. Without this,
+        // toggling row-grouping leaves us with only top-level aggregate
+        // rows visible because TanStack resets expanded={} on every
+        // grouping change.
+        autoResetExpanded: false,
         getExpandedRowModel: getExpandedRowModel(),
         getGroupedRowModel: getGroupedRowModelLightdash(),
         getCoreRowModel: getCoreRowModel(),
@@ -922,7 +949,13 @@ const PivotTable: FC<PivotTableProps> = ({
 
     useEffect(() => {
         // TODO: Remove code duplicated from non-pivot table version.
-        if (showSubtotals) {
+        // Grouping is driven by either subtotals (renders aggregate rows) or
+        // row-grouping (visually dedups row dims without aggregates).
+        // Both reuse the same TanStack setGrouping machinery; the cell
+        // renderer downstream conditionally suppresses subtotal content
+        // when only row-grouping is on.
+        const groupingActive = showSubtotals || showRowGrouping;
+        if (groupingActive) {
             const groupedColumns = data.indexValueTypes.map(
                 (valueType) => valueType.fieldId,
             );
@@ -946,7 +979,13 @@ const PivotTable: FC<PivotTableProps> = ({
                 table.resetGrouping();
             }
         }
-    }, [showSubtotals, data.indexValueTypes, table, columnOrder]);
+    }, [
+        showSubtotals,
+        showRowGrouping,
+        data.indexValueTypes,
+        table,
+        columnOrder,
+    ]);
 
     return (
         <Table
@@ -1477,10 +1516,23 @@ const PivotTable: FC<PivotTableProps> = ({
                                             miw={rowNumberWidth}
                                             maw={rowNumberWidth}
                                         >
-                                            {flexRender(
-                                                cell.column.columnDef.cell,
-                                                cell.getContext(),
-                                            )}
+                                            {/* Suppress the row number on
+                                             * group-header rows when we're
+                                             * in grouping-only mode — those
+                                             * rows act as visual headers
+                                             * for the merged dim value, not
+                                             * data rows, so a counter on
+                                             * them reads as a parallel
+                                             * sequence interleaved with the
+                                             * leaf-row counter. */}
+                                            {groupingOnlyMode &&
+                                            row.getIsGrouped()
+                                                ? null
+                                                : flexRender(
+                                                      cell.column.columnDef
+                                                          .cell,
+                                                      cell.getContext(),
+                                                  )}
                                         </Table.Cell>
                                     );
                                 }
@@ -1703,63 +1755,90 @@ const PivotTable: FC<PivotTableProps> = ({
                                         )}
                                     >
                                         {cell.getIsGrouped() ? (
-                                            <Group spacing="two" noWrap>
-                                                <Button
-                                                    compact
-                                                    size="xs"
-                                                    variant="subtle"
-                                                    styles={(theme) => ({
-                                                        root: {
-                                                            height: 'unset',
-                                                            paddingLeft:
-                                                                theme.spacing
-                                                                    .two,
-                                                            paddingRight:
-                                                                theme.spacing
-                                                                    .xxs,
-                                                            fontFeatureSettings:
-                                                                "'tnum'",
-                                                        },
-                                                        leftIcon: {
-                                                            marginRight: 0,
-                                                        },
-                                                    })}
-                                                    onClick={(
-                                                        e: React.MouseEvent<HTMLButtonElement>,
-                                                    ) => {
-                                                        e.stopPropagation();
-                                                        e.preventDefault();
-                                                        toggleExpander();
-                                                    }}
-                                                    leftIcon={
-                                                        <MantineIcon
-                                                            size={14}
-                                                            icon={
-                                                                row.getIsExpanded()
-                                                                    ? IconChevronDown
-                                                                    : IconChevronRight
-                                                            }
-                                                        />
-                                                    }
-                                                    style={{
-                                                        color:
-                                                            fontColor ??
-                                                            'inherit',
-                                                    }}
-                                                >
-                                                    ({countSubRows(row)})
-                                                </Button>
-                                                {flexRender(
+                                            // Grouping-only mode (row dedup
+                                            // without subtotals): suppress the
+                                            // carat + group count chrome and
+                                            // just render the dim value. The
+                                            // expand-toggle would be a no-op
+                                            // anyway since groups are forced
+                                            // expanded in this mode.
+                                            groupingOnlyMode ? (
+                                                flexRender(
                                                     cell.column.columnDef.cell,
                                                     cell.getContext(),
-                                                )}
-                                            </Group>
+                                                )
+                                            ) : (
+                                                <Group spacing="two" noWrap>
+                                                    <Button
+                                                        compact
+                                                        size="xs"
+                                                        variant="subtle"
+                                                        styles={(theme) => ({
+                                                            root: {
+                                                                height: 'unset',
+                                                                paddingLeft:
+                                                                    theme
+                                                                        .spacing
+                                                                        .two,
+                                                                paddingRight:
+                                                                    theme
+                                                                        .spacing
+                                                                        .xxs,
+                                                                fontFeatureSettings:
+                                                                    "'tnum'",
+                                                            },
+                                                            leftIcon: {
+                                                                marginRight: 0,
+                                                            },
+                                                        })}
+                                                        onClick={(
+                                                            e: React.MouseEvent<HTMLButtonElement>,
+                                                        ) => {
+                                                            e.stopPropagation();
+                                                            e.preventDefault();
+                                                            toggleExpander();
+                                                        }}
+                                                        leftIcon={
+                                                            <MantineIcon
+                                                                size={14}
+                                                                icon={
+                                                                    row.getIsExpanded()
+                                                                        ? IconChevronDown
+                                                                        : IconChevronRight
+                                                                }
+                                                            />
+                                                        }
+                                                        style={{
+                                                            color:
+                                                                fontColor ??
+                                                                'inherit',
+                                                        }}
+                                                    >
+                                                        ({countSubRows(row)})
+                                                    </Button>
+                                                    {flexRender(
+                                                        cell.column.columnDef
+                                                            .cell,
+                                                        cell.getContext(),
+                                                    )}
+                                                </Group>
+                                            )
                                         ) : cell.getIsAggregated() ? (
-                                            flexRender(
-                                                cell.column.columnDef
-                                                    .aggregatedCell ??
-                                                    cell.column.columnDef.cell,
-                                                cell.getContext(),
+                                            // In grouping-only mode the
+                                            // aggregate row stands in for a
+                                            // dedup "header" — render the dim
+                                            // cells via getIsGrouped() above,
+                                            // but suppress the subtotal metric
+                                            // values so the row looks like a
+                                            // leaf row with the dim filled in.
+                                            groupingOnlyMode ? null : (
+                                                flexRender(
+                                                    cell.column.columnDef
+                                                        .aggregatedCell ??
+                                                        cell.column.columnDef
+                                                            .cell,
+                                                    cell.getContext(),
+                                                )
                                             )
                                         ) : cell.getIsPlaceholder() ? null : (
                                             flexRender(

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -28,6 +28,7 @@ import useEmbed from '../../ee/providers/Embed/useEmbed';
 import { useCalculateSubtotals } from '../useCalculateSubtotals';
 import { useCalculateTotal } from '../useCalculateTotal';
 import { useIsHidePivotDimsEnabled } from '../useIsHidePivotDimsEnabled';
+import { useIsPivotRowGroupingEnabled } from '../useIsPivotRowGroupingEnabled';
 import { type InfiniteQueryResults } from '../useQueryResults';
 import getDataAndColumns from './getDataAndColumns';
 
@@ -79,6 +80,14 @@ const useTableConfig = (
     );
     const [showSubtotalsExpanded, setShowSubtotalsExpanded] = useState<boolean>(
         tableChartConfig?.showSubtotalsExpanded ?? false,
+    );
+    // Raw, persisted value of the user toggle. We never clobber this with
+    // the flag — if the user saved `showRowGrouping: true` while the
+    // PivotRowGrouping flag was on and the flag later flips off, we want to
+    // preserve their intent for when the flag flips back. Renders use
+    // `effectiveShowRowGrouping` below which gates on the live flag value.
+    const [showRowGrouping, setShowRowGrouping] = useState<boolean>(
+        tableChartConfig?.showRowGrouping ?? false,
     );
     const [hideRowNumbers, setHideRowNumbers] = useState<boolean>(
         tableChartConfig?.hideRowNumbers === undefined
@@ -169,6 +178,7 @@ const useTableConfig = (
     // the buggy guard) keep rendering the dim. Flag-on opts into the new
     // behavior.
     const isHidePivotDimsEnabled = useIsHidePivotDimsEnabled();
+    const isPivotRowGroupingEnabled = useIsPivotRowGroupingEnabled();
 
     const isColumnVisible = useCallback(
         (fieldId: string) => {
@@ -657,6 +667,7 @@ const useTableConfig = (
             showResultsTotal,
             showSubtotals,
             showSubtotalsExpanded,
+            showRowGrouping,
             columns: columnProperties,
             hideRowNumbers,
             conditionalFormattings,
@@ -671,6 +682,7 @@ const useTableConfig = (
             showResultsTotal,
             showSubtotals,
             showSubtotalsExpanded,
+            showRowGrouping,
             columnProperties,
             conditionalFormattings,
             metricsAsRows,
@@ -697,6 +709,11 @@ const useTableConfig = (
             setShowSubtotals,
             showSubtotalsExpanded,
             setShowSubtotalsExpanded,
+            // Effective render value: flag gate ensures flag-off viewers
+            // of a flag-on-saved chart see legacy rendering. Raw value
+            // lives in `validConfig.showRowGrouping` for persistence.
+            showRowGrouping: isPivotRowGroupingEnabled && showRowGrouping,
+            setShowRowGrouping,
 
             columnProperties: exposedColumnProperties,
             setColumnProperties,
@@ -738,6 +755,9 @@ const useTableConfig = (
             setShowSubtotals,
             showSubtotalsExpanded,
             setShowSubtotalsExpanded,
+            showRowGrouping,
+            setShowRowGrouping,
+            isPivotRowGroupingEnabled,
 
             exposedColumnProperties,
             setColumnProperties,

--- a/packages/frontend/src/hooks/useIsPivotRowGroupingEnabled.ts
+++ b/packages/frontend/src/hooks/useIsPivotRowGroupingEnabled.ts
@@ -1,0 +1,11 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
+
+/**
+ * Returns whether the `pivot-row-grouping` feature flag is on. Wraps the
+ * standard server-flag lookup so callers don't repeat the boilerplate.
+ */
+export const useIsPivotRowGroupingEnabled = (): boolean => {
+    const { data } = useServerFeatureFlag(FeatureFlags.PivotRowGrouping);
+    return data?.enabled ?? false;
+};


### PR DESCRIPTION
Closes: #21069 <!-- reference the related issue e.g. #150 -->

### Description:

Adds a new **"Group repeated row values"** option to the table visualization configuration. When enabled, repeated dimension values in row index columns are visually deduplicated across consecutive rows — similar to how subtotals group rows, but without rendering aggregate subtotal rows.

Key behaviors:
- When `showSubtotals` is enabled, row grouping is implicitly active and the new toggle is disabled (subtotals always group).
- In grouping-only mode, groups are always force-expanded since there is no expand/collapse affordance (no chevron or row count badge is rendered).
- The expand/collapse chevron and group count chrome are suppressed in grouping-only mode — only the dimension value is rendered, making grouped rows appear as normal leaf rows.
- Aggregate metric cells are hidden in grouping-only mode to avoid showing subtotal values.
- The toggle is disabled when metrics-as-rows is active or when there are fewer than two dimensions available for grouping.