### PR TITLE
feat: validate organization SSO provider URLs are public https (PROD-7895)

### DIFF
--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
@@ -26,6 +26,7 @@ import {
     OrganizationSsoModel,
 } from '../../models/OrganizationSsoModel';
 import { UserModel } from '../../models/UserModel';
+import { validatePublicHttpUrl } from '../../utils/ssrfProtection';
 import { BaseService } from '../BaseService';
 
 type OrganizationSsoServiceArguments = {
@@ -168,6 +169,25 @@ export class OrganizationSsoService extends BaseService {
         }
     }
 
+    /**
+     * SSO provider URLs (the OIDC discovery document, the Okta domain) are
+     * fetched server-side during issuer discovery, so they must resolve to a
+     * public https address. Rejects localhost, private and internal-network
+     * addresses (DNS-resolved). Validated when the config is saved.
+     */
+    private static async assertPublicSsoUrl(
+        rawUrl: string,
+        label: string,
+    ): Promise<void> {
+        try {
+            await validatePublicHttpUrl(rawUrl);
+        } catch {
+            throw new ParameterError(
+                `${label} must be a valid public https URL — localhost, private and internal network addresses are not allowed.`,
+            );
+        }
+    }
+
     private assertCanManageSso(account: RegisteredAccount): string {
         const organizationUuid = account.organization?.organizationUuid;
         if (!organizationUuid) {
@@ -304,6 +324,13 @@ export class OrganizationSsoService extends BaseService {
             );
         }
 
+        // The Okta domain builds the issuer URL fetched server-side during
+        // discovery — require a public https URL.
+        await OrganizationSsoService.assertPublicSsoUrl(
+            `https://${data.oktaDomain.trim().replace(/^https?:\/\//, '')}`,
+            'Okta domain',
+        );
+
         if (data.emailDomains && data.emailDomains.length > 0) {
             OrganizationSsoService.validateEmailDomains(data.emailDomains);
         }
@@ -396,6 +423,13 @@ export class OrganizationSsoService extends BaseService {
                 'clientId and metadataDocumentEndpoint are required',
             );
         }
+
+        // The discovery document URL is fetched server-side during discovery —
+        // require a public https URL.
+        await OrganizationSsoService.assertPublicSsoUrl(
+            data.metadataDocumentEndpoint.trim(),
+            'OIDC discovery document URL',
+        );
 
         if (data.emailDomains && data.emailDomains.length > 0) {
             OrganizationSsoService.validateEmailDomains(data.emailDomains);


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-7895/project-endpoints-behind-https-validated-urls](https://linear.app/lightdash/issue/PROD-7895/project-endpoints-behind-https-validated-urls)



![CleanShot 2026-05-26 at 09.48.01.png](https://app.graphite.com/user-attachments/assets/761e952f-21d9-4d15-93d4-065be24f28bf.png)



Validates that org-admin-supplied SSO provider URLs are valid public https URLs when saving per-organization SSO config:

- **Generic OIDC** — the discovery document URL
- **Okta** — the org domain (used to build the issuer URL)

Both are fetched server-side during issuer discovery, so they must resolve to a public address. Reuses the existing `validatePublicHttpUrl` util. Azure is unaffected (its endpoints are templated). Validation runs at **save time only** — existing stored configs and env-based config are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)