### PR TITLE
fix: remove `isPaletteStagedDirty` guard from color palette resolution logic

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -104,29 +104,24 @@ const VisualizationCard: FC<Props> = memo((props) => {
     const stagedColorPaletteUuid = useExplorerSelector(
         selectUnsavedColorPaletteUuid,
     );
-    const isPaletteStagedDirty =
-        savedChart !== undefined &&
-        stagedColorPaletteUuid !== savedChart.colorPaletteUuid;
     const resolverChartUuid =
-        isPaletteStagedDirty && stagedColorPaletteUuid === null
-            ? undefined
-            : savedChart?.uuid;
+        stagedColorPaletteUuid === null ? undefined : savedChart?.uuid;
     const { data: resolvedPalette } = useProjectColorPalette(projectUuid, {
         chartUuid: resolverChartUuid,
         dashboardUuid: savedChart?.dashboardUuid ?? undefined,
     });
 
     const { data: palettes } = useColorPalettes({
-        enabled: isPaletteStagedDirty && stagedColorPaletteUuid !== null,
+        enabled: stagedColorPaletteUuid !== null,
     });
     const stagedPalette = useMemo(() => {
-        if (!isPaletteStagedDirty || stagedColorPaletteUuid === null) {
+        if (stagedColorPaletteUuid === null) {
             return undefined;
         }
         return palettes?.find(
             (p) => p.colorPaletteUuid === stagedColorPaletteUuid,
         );
-    }, [isPaletteStagedDirty, stagedColorPaletteUuid, palettes]);
+    }, [stagedColorPaletteUuid, palettes]);
 
     const colorPalette = useMemo(() => {
         if (stagedPalette) {


### PR DESCRIPTION
Closes:

### Description:
Removes the `isPaletteStagedDirty` intermediate variable and simplifies the color palette staging logic in `VisualizationCard`. The palette resolution and fetching now depend solely on whether `stagedColorPaletteUuid` is `null`, rather than also requiring a comparison against the saved chart's palette UUID. This makes the logic more straightforward and removes an unnecessary condition.