### PR TITLE
fix(turbo): set frontend build outputs to build

### DIFF
--- a/packages/frontend/turbo.json
+++ b/packages/frontend/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["build/**"]
+    }
+  }
+}


### PR DESCRIPTION
Summary- Set frontend outputs to `build/`

Changes- Adjusted Turbo/frontend build configuration to output artifacts into `build/`

Related- Fixes issue where outputs were not directed to the `build/` directory.