### PR TITLE
feat: add per-org OneLogin SSO with dynamic strategy cache and admin settings panel

### DIFF
--- a/docs/onelogin-sso.md
+++ b/docs/onelogin-sso.md
@@ -1,0 +1,57 @@
+# OneLogin SSO
+
+Per-organization OneLogin SSO. Follows the [Azure AD](./azure-ad-sso.md)
+pattern — read that first for the shared discovery / cross-org / rollout model.
+This doc covers only the OneLogin-specific bits.
+
+## Strategy mechanism: same as Azure (sync strategy cache)
+
+OneLogin uses `passport-openidconnect` with endpoints **templated from the
+issuer** (`{issuer}/oidc/2/auth`, `/token`, `/me`), so building a strategy is
+**synchronous** — no issuer discovery, exactly like Azure (and unlike OIDC).
+
+- `createOneLoginStrategyForConfig(config)` in
+  [`oneLoginStrategy.ts`](../packages/backend/src/controllers/authentication/strategies/oneLoginStrategy.ts)
+  builds the strategy from a config object; the env-based `oneLoginPassportStrategy`
+  now uses the same builder.
+- `apiV1Router.ts` registers per-org strategies as `oneLogin:<orgUuid>` in a
+  cache with the shared 10-minute TTL (`registerOneLoginStrategyForOrg`),
+  resolves them by email login-hint (`resolveOneLoginStrategyName`), and
+  re-registers from the DB on callback if evicted. Strategy name is stored on
+  `req.session.oauth.oneLoginStrategyName`.
+- The env-based `'oneLogin'` strategy (registered at startup in `App.ts`) is
+  the fallback.
+
+## Config fields
+
+Stored encrypted in `organization_sso_configurations` (`provider = 'oneLogin'`):
+
+| Field | Purpose |
+|---|---|
+| `oauth2Issuer` | OneLogin OIDC issuer URL; the auth/token/userinfo endpoints are derived from it. |
+| `oauth2ClientId` / `oauth2ClientSecret` | OneLogin application credentials (secret encrypted; never returned — `hasClientSecret` instead). |
+
+Shared flag columns (`enabled`, `override_email_domains`, `email_domains`,
+`allow_password`) behave as documented for Azure.
+
+## Discovery, login options, endpoints
+
+- `getLoginOptions` is provider-generic: `'oneLogin'` maps 1:1 to
+  `OpenIdIdentityIssuerType.ONELOGIN`, so discovery, force-redirect and
+  password suppression work unchanged.
+- Endpoints: `GET/PUT/DELETE /api/v1/org/sso/oneLogin`.
+- Frontend: `OneLoginSsoPanel` (reuses `ONELOGIN_LOGO`), `useOneLoginSsoConfig`
+  hooks, and `forceShow` on the `ONELOGIN` case of `ThirdPartySignInButton`.
+
+## File map (OneLogin-specific additions)
+
+| Path | Purpose |
+|---|---|
+| `packages/common/src/types/organizationSso.ts` | `ONELOGIN` provider, `OneLoginSsoConfig`, summary/upsert/response shapes |
+| `packages/backend/src/models/OrganizationSsoModel.ts` | `ONELOGIN → OneLoginSsoConfig` in the provider map |
+| `packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts` | `get/upsert/deleteOneLoginConfig` |
+| `packages/backend/src/ee/controllers/OrganizationSsoController.ts` | `/api/v1/org/sso/oneLogin` endpoints |
+| `packages/backend/src/controllers/authentication/strategies/oneLoginStrategy.ts` | `createOneLoginStrategyForConfig` + availability flag |
+| `packages/backend/src/routers/apiV1Router.ts` | `oneLogin:<orgUuid>` strategy cache + resolution, login/callback rewiring |
+| `packages/frontend/src/components/UserSettings/OrganizationSso/OneLoginSsoPanel.tsx` | Admin UI |
+| `packages/frontend/src/hooks/organization/useOrganizationSso.ts` | `useOneLoginSsoConfig` hooks |

--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -14,6 +14,7 @@ declare module 'express-session' {
             azureAdStrategyName?: string | undefined;
             oktaOrganizationUuid?: string | undefined;
             oidcStrategyName?: string | undefined;
+            oneLoginStrategyName?: string | undefined;
         };
         slack: {
             teamId?: string | undefined;

--- a/packages/backend/src/controllers/authentication/strategies/oneLoginStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oneLoginStrategy.ts
@@ -1,42 +1,46 @@
 /// <reference path="../../../@types/passport-openidconnect.d.ts" />
 /// <reference path="../../../@types/express-session.d.ts" />
-import { OpenIdIdentityIssuerType } from '@lightdash/common';
+import { OneLoginSsoConfig, OpenIdIdentityIssuerType } from '@lightdash/common';
 import { Strategy as OpenIDConnectStrategy } from 'passport-openidconnect';
 import { URL } from 'url';
 import { lightdashConfig } from '../../../config/lightdashConfig';
 import { genericOidcHandler } from './oidcStrategy';
 
-export const oneLoginPassportStrategy = !(
+/**
+ * Builds a OneLogin passport strategy from a config object. OneLogin's OIDC
+ * endpoints are templated from the issuer (`{issuer}/oidc/2/...`), so this is
+ * synchronous (no discovery) — used by both the env-based and per-org paths.
+ */
+export const createOneLoginStrategyForConfig = (
+    config: OneLoginSsoConfig,
+): OpenIDConnectStrategy =>
+    new OpenIDConnectStrategy(
+        {
+            clientID: config.oauth2ClientId,
+            clientSecret: config.oauth2ClientSecret,
+            issuer: new URL(`/oidc/2`, config.oauth2Issuer).href,
+            callbackURL: new URL(
+                `/api/v1${lightdashConfig.auth.oneLogin.callbackPath}`,
+                lightdashConfig.siteUrl,
+            ).href,
+            authorizationURL: new URL(`/oidc/2/auth`, config.oauth2Issuer).href,
+            tokenURL: new URL(`/oidc/2/token`, config.oauth2Issuer).href,
+            userInfoURL: new URL(`/oidc/2/me`, config.oauth2Issuer).href,
+            passReqToCallback: true,
+        },
+        genericOidcHandler(OpenIdIdentityIssuerType.ONELOGIN),
+    );
+
+export const isOneLoginPassportStrategyAvailableToUse = !!(
     lightdashConfig.auth.oneLogin.oauth2ClientId &&
     lightdashConfig.auth.oneLogin.oauth2ClientSecret &&
     lightdashConfig.auth.oneLogin.oauth2Issuer
-)
-    ? undefined
-    : new OpenIDConnectStrategy(
-          {
-              clientID: lightdashConfig.auth.oneLogin.oauth2ClientId,
-              clientSecret: lightdashConfig.auth.oneLogin.oauth2ClientSecret,
-              issuer: new URL(
-                  `/oidc/2`,
-                  lightdashConfig.auth.oneLogin.oauth2Issuer,
-              ).href,
-              callbackURL: new URL(
-                  `/api/v1${lightdashConfig.auth.oneLogin.callbackPath}`,
-                  lightdashConfig.siteUrl,
-              ).href,
-              authorizationURL: new URL(
-                  `/oidc/2/auth`,
-                  lightdashConfig.auth.oneLogin.oauth2Issuer,
-              ).href,
-              tokenURL: new URL(
-                  `/oidc/2/token`,
-                  lightdashConfig.auth.oneLogin.oauth2Issuer,
-              ).href,
-              userInfoURL: new URL(
-                  `/oidc/2/me`,
-                  lightdashConfig.auth.oneLogin.oauth2Issuer,
-              ).href,
-              passReqToCallback: true,
-          },
-          genericOidcHandler(OpenIdIdentityIssuerType.ONELOGIN),
-      );
+);
+
+export const oneLoginPassportStrategy = isOneLoginPassportStrategyAvailableToUse
+    ? createOneLoginStrategyForConfig({
+          oauth2ClientId: lightdashConfig.auth.oneLogin.oauth2ClientId!,
+          oauth2ClientSecret: lightdashConfig.auth.oneLogin.oauth2ClientSecret!,
+          oauth2Issuer: lightdashConfig.auth.oneLogin.oauth2Issuer!,
+      })
+    : undefined;

--- a/packages/backend/src/ee/controllers/OrganizationSsoController.ts
+++ b/packages/backend/src/ee/controllers/OrganizationSsoController.ts
@@ -3,14 +3,17 @@ import {
     ApiErrorPayload,
     ApiGenericOidcSsoConfigResponse,
     ApiOktaSsoConfigResponse,
+    ApiOneLoginSsoConfigResponse,
     ApiSuccessEmpty,
     ApiUpsertAzureAdSsoConfigResponse,
     ApiUpsertGenericOidcSsoConfigResponse,
     ApiUpsertOktaSsoConfigResponse,
+    ApiUpsertOneLoginSsoConfigResponse,
     assertRegisteredAccount,
     UpsertAzureAdSsoConfig,
     UpsertGenericOidcSsoConfig,
     UpsertOktaSsoConfig,
+    UpsertOneLoginSsoConfig,
 } from '@lightdash/common';
 import {
     Body,
@@ -230,6 +233,72 @@ export class OrganizationSsoController extends BaseController {
         await this.services
             .getOrganizationSsoService()
             .deleteGenericOidcConfig(req.account);
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Returns the current organization's OneLogin SSO configuration (sensitive
+     * fields are not included).
+     * @summary Get OneLogin SSO configuration
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/oneLogin')
+    @OperationId('GetOneLoginSsoConfig')
+    async getOneLoginConfig(
+        @Request() req: express.Request,
+    ): Promise<ApiOneLoginSsoConfigResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationSsoService()
+            .getOneLoginConfig(req.account);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Creates or updates the current organization's OneLogin SSO
+     * configuration. Omit `oauth2ClientSecret` to preserve the previously
+     * stored secret on updates.
+     * @summary Upsert OneLogin SSO configuration
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Put('/oneLogin')
+    @OperationId('UpsertOneLoginSsoConfig')
+    async upsertOneLoginConfig(
+        @Request() req: express.Request,
+        @Body() body: UpsertOneLoginSsoConfig,
+    ): Promise<ApiUpsertOneLoginSsoConfigResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationSsoService()
+            .upsertOneLoginConfig(req.account, body);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Removes the current organization's OneLogin SSO configuration.
+     * @summary Delete OneLogin SSO configuration
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Delete('/oneLogin')
+    @OperationId('DeleteOneLoginSsoConfig')
+    async deleteOneLoginConfig(
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getOrganizationSsoService()
+            .deleteOneLoginConfig(req.account);
         this.setStatus(200);
         return { status: 'ok', results: undefined };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -11847,11 +11847,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12403,11 +12403,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12449,11 +12449,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12468,11 +12468,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12487,11 +12487,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12506,11 +12506,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16598,6 +16598,91 @@ const models: TsoaRoute.Models = {
                         },
                         clientSecret: { dataType: 'string' },
                         clientId: { dataType: 'string', required: true },
+                    },
+                },
+                { ref: 'Partial_OrganizationSsoMethodFlags_' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_OneLoginSsoConfig.oauth2Issuer-or-oauth2ClientId_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                oauth2ClientId: { dataType: 'string', required: true },
+                oauth2Issuer: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    OneLoginSsoConfigSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    ref: 'Pick_OneLoginSsoConfig.oauth2Issuer-or-oauth2ClientId_',
+                },
+                { ref: 'OrganizationSsoMethodFlags' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        hasClientSecret: {
+                            dataType: 'boolean',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiOneLoginSsoConfigResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'OneLoginSsoConfigSummary' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpsertOneLoginSsoConfigResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'OneLoginSsoConfigSummary', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpsertOneLoginSsoConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        oauth2ClientSecret: { dataType: 'string' },
+                        oauth2ClientId: { dataType: 'string', required: true },
+                        oauth2Issuer: { dataType: 'string', required: true },
                     },
                 },
                 { ref: 'Partial_OrganizationSsoMethodFlags_' },
@@ -23981,7 +24066,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -23991,7 +24076,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24001,7 +24086,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -24014,7 +24099,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -24669,7 +24754,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24679,7 +24764,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24689,7 +24774,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -24702,7 +24787,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -43597,6 +43682,177 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'deleteGenericOidcConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSsoController_getOneLoginConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/org/sso/oneLogin',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSsoController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSsoController.prototype.getOneLoginConfig,
+        ),
+
+        async function OrganizationSsoController_getOneLoginConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSsoController_getOneLoginConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSsoController>(
+                        OrganizationSsoController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getOneLoginConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSsoController_upsertOneLoginConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpsertOneLoginSsoConfig',
+        },
+    };
+    app.put(
+        '/api/v1/org/sso/oneLogin',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSsoController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSsoController.prototype.upsertOneLoginConfig,
+        ),
+
+        async function OrganizationSsoController_upsertOneLoginConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSsoController_upsertOneLoginConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSsoController>(
+                        OrganizationSsoController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertOneLoginConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSsoController_deleteOneLoginConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.delete(
+        '/api/v1/org/sso/oneLogin',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSsoController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSsoController.prototype.deleteOneLoginConfig,
+        ),
+
+        async function OrganizationSsoController_deleteOneLoginConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSsoController_deleteOneLoginConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSsoController>(
+                        OrganizationSsoController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteOneLoginConfig',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13412,6 +13412,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -17598,6 +17611,94 @@
                             }
                         },
                         "required": ["metadataDocumentEndpoint", "clientId"],
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Partial_OrganizationSsoMethodFlags_"
+                    }
+                ]
+            },
+            "Pick_OneLoginSsoConfig.oauth2Issuer-or-oauth2ClientId_": {
+                "properties": {
+                    "oauth2ClientId": {
+                        "type": "string"
+                    },
+                    "oauth2Issuer": {
+                        "type": "string"
+                    }
+                },
+                "required": ["oauth2ClientId", "oauth2Issuer"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "OneLoginSsoConfigSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_OneLoginSsoConfig.oauth2Issuer-or-oauth2ClientId_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/OrganizationSsoMethodFlags"
+                    },
+                    {
+                        "properties": {
+                            "hasClientSecret": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["hasClientSecret"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiOneLoginSsoConfigResponse": {
+                "properties": {
+                    "results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/OneLoginSsoConfigSummary"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiUpsertOneLoginSsoConfigResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/OneLoginSsoConfigSummary"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "UpsertOneLoginSsoConfig": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "oauth2ClientSecret": {
+                                "type": "string",
+                                "description": "When omitted on update, the stored secret is preserved. Required on create."
+                            },
+                            "oauth2ClientId": {
+                                "type": "string"
+                            },
+                            "oauth2Issuer": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["oauth2ClientId", "oauth2Issuer"],
                         "type": "object"
                     },
                     {
@@ -25226,22 +25327,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -25801,22 +25902,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -34515,7 +34616,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3018.0",
+        "version": "0.3019.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -39682,6 +39783,108 @@
                 },
                 "description": "Removes the current organization's generic OIDC SSO configuration.",
                 "summary": "Delete generic OIDC SSO configuration",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            }
+        },
+        "/api/v1/org/sso/oneLogin": {
+            "get": {
+                "operationId": "GetOneLoginSsoConfig",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOneLoginSsoConfigResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Returns the current organization's OneLogin SSO configuration (sensitive\nfields are not included).",
+                "summary": "Get OneLogin SSO configuration",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            },
+            "put": {
+                "operationId": "UpsertOneLoginSsoConfig",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUpsertOneLoginSsoConfigResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Creates or updates the current organization's OneLogin SSO\nconfiguration. Omit `oauth2ClientSecret` to preserve the previously\nstored secret on updates.",
+                "summary": "Upsert OneLogin SSO configuration",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpsertOneLoginSsoConfig"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "DeleteOneLoginSsoConfig",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Removes the current organization's OneLogin SSO configuration.",
+                "summary": "Delete OneLogin SSO configuration",
                 "tags": ["Organizations"],
                 "security": [],
                 "parameters": []

--- a/packages/backend/src/models/OrganizationSsoModel.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.ts
@@ -2,6 +2,7 @@ import {
     AzureAdSsoConfig,
     GenericOidcSsoConfig,
     OktaSsoConfig,
+    OneLoginSsoConfig,
     OrganizationSsoMethodFlags,
     OrganizationSsoProvider,
     UnexpectedServerError,
@@ -19,6 +20,7 @@ type ProviderConfigTypeMap = {
     [OrganizationSsoProvider.AZUREAD]: AzureAdSsoConfig;
     [OrganizationSsoProvider.OKTA]: OktaSsoConfig;
     [OrganizationSsoProvider.GENERIC_OIDC]: GenericOidcSsoConfig;
+    [OrganizationSsoProvider.ONELOGIN]: OneLoginSsoConfig;
 };
 
 export type OrganizationSsoMethod<P extends OrganizationSsoProvider> = {

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -28,6 +28,10 @@ import {
     createGenericOidcStrategyForConfig,
     isGenericOidcPassportStrategyAvailableToUse,
 } from '../controllers/authentication/strategies/oidcStrategy';
+import {
+    createOneLoginStrategyForConfig,
+    isOneLoginPassportStrategyAvailableToUse,
+} from '../controllers/authentication/strategies/oneLoginStrategy';
 import { AiAgentService } from '../ee/services/AiAgentService/AiAgentService';
 import { createAuditLogEvent } from '../logging/auditLog';
 import { createActorFromUser } from '../logging/caslAuditWrapper';
@@ -274,6 +278,62 @@ const resolveGenericOidcStrategyName = async (
     // Fall back to the env-based strategy registered at startup, if available.
     if (isGenericOidcPassportStrategyAvailableToUse) {
         return 'oidc';
+    }
+    return undefined;
+};
+
+// Cache dynamic OneLogin strategies (keyed `oneLogin:<orgUuid>`), mirroring the
+// Azure AD cache. OneLogin endpoints are templated from the issuer, so building
+// the strategy is synchronous. Evicted after the same TTL.
+const oneLoginStrategyCache = new Map<
+    string,
+    { timer: ReturnType<typeof setTimeout> }
+>();
+
+const registerOneLoginStrategyForOrg = (
+    organizationUuid: string,
+    config: import('@lightdash/common').OneLoginSsoConfig,
+): string => {
+    const strategyName = `oneLogin:${organizationUuid}`;
+    const existing = oneLoginStrategyCache.get(strategyName);
+    passport.use(strategyName, createOneLoginStrategyForConfig(config));
+    if (existing) {
+        clearTimeout(existing.timer);
+    }
+    const timer = setTimeout(() => {
+        oneLoginStrategyCache.delete(strategyName);
+        passport.unuse(strategyName);
+    }, AZURE_AD_STRATEGY_TTL_MS);
+    oneLoginStrategyCache.set(strategyName, { timer });
+    return strategyName;
+};
+
+/**
+ * Resolves the OneLogin strategy name for this request, registering the per-org
+ * strategy dynamically. Returns undefined when neither a per-org DB config
+ * matching the email domain nor an env-based fallback is available.
+ */
+const resolveOneLoginStrategyName = async (
+    req: express.Request,
+): Promise<string | undefined> => {
+    const ssoService = req.services.getOrganizationSsoService();
+    const email = getLoginHint(req);
+
+    if (email) {
+        const method = await ssoService.findEnabledMethodForEmail(
+            email,
+            OrganizationSsoProvider.ONELOGIN,
+        );
+        if (method) {
+            return registerOneLoginStrategyForOrg(
+                method.organizationUuid,
+                method.config,
+            );
+        }
+    }
+    // Fall back to the env-based strategy registered at startup, if available.
+    if (isOneLoginPassportStrategyAvailableToUse) {
+        return 'oneLogin';
     }
     return undefined;
 };
@@ -536,17 +596,67 @@ apiV1Router.get(
 apiV1Router.get(
     lightdashConfig.auth.oneLogin.loginPath,
     storeOIDCRedirect,
-    passport.authenticate('oneLogin', {
-        scope: ['openid', 'profile', 'email'],
-    }),
+    async (req, res, next) => {
+        try {
+            const strategyName = await resolveOneLoginStrategyName(req);
+            if (!strategyName) {
+                res.status(404).json({
+                    status: 'error',
+                    message: 'OneLogin SSO is not configured',
+                });
+                return;
+            }
+            req.session.oauth = req.session.oauth || {};
+            req.session.oauth.oneLoginStrategyName = strategyName;
+            passport.authenticate(strategyName, {
+                scope: ['openid', 'profile', 'email'],
+            })(req, res, next);
+        } catch (error) {
+            next(error);
+        }
+    },
 );
 
-apiV1Router.get(lightdashConfig.auth.oneLogin.callbackPath, (req, res, next) =>
-    passport.authenticate('oneLogin', {
-        failureRedirect: getOidcRedirectURL(false)(req),
-        successRedirect: getOidcRedirectURL(true)(req),
-        failureFlash: true,
-    })(req, res, next),
+apiV1Router.get(
+    lightdashConfig.auth.oneLogin.callbackPath,
+    async (req, res, next) => {
+        try {
+            const sessionStrategyName = req.session.oauth?.oneLoginStrategyName;
+            const strategyName =
+                sessionStrategyName ?? (await resolveOneLoginStrategyName(req));
+            if (!strategyName) {
+                res.status(404).json({
+                    status: 'error',
+                    message: 'OneLogin SSO is not configured',
+                });
+                return;
+            }
+            // Re-register the per-org strategy if it was evicted (e.g. a server
+            // restart between login and callback).
+            if (
+                strategyName.startsWith('oneLogin:') &&
+                !oneLoginStrategyCache.has(strategyName)
+            ) {
+                const orgUuid = strategyName.slice('oneLogin:'.length);
+                const config = await req.services
+                    .getOrganizationSsoService()
+                    .getConfigForOrganization(
+                        orgUuid,
+                        OrganizationSsoProvider.ONELOGIN,
+                    );
+                if (config) {
+                    registerOneLoginStrategyForOrg(orgUuid, config);
+                }
+            }
+            passport.authenticate(strategyName, {
+                failureRedirect: getOidcRedirectURL(false)(req),
+                successRedirect: getOidcRedirectURL(true)(req),
+                failureFlash: true,
+            })(req, res, next);
+        } catch (error) {
+            next(error);
+        }
+    },
 );
 
 apiV1Router.get(

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
@@ -9,6 +9,8 @@ import {
     NotFoundError,
     OktaSsoConfig,
     OktaSsoConfigSummary,
+    OneLoginSsoConfig,
+    OneLoginSsoConfigSummary,
     OrganizationSsoMethodFlags,
     OrganizationSsoProvider,
     ParameterError,
@@ -16,6 +18,7 @@ import {
     UpsertAzureAdSsoConfig,
     UpsertGenericOidcSsoConfig,
     UpsertOktaSsoConfig,
+    UpsertOneLoginSsoConfig,
     type RegisteredAccount,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -71,6 +74,18 @@ const toGenericOidcSummary = (
     metadataDocumentEndpoint: method.config.metadataDocumentEndpoint,
     scopes: method.config.scopes,
     hasClientSecret: !!method.config.clientSecret,
+    enabled: method.enabled,
+    overrideEmailDomains: method.overrideEmailDomains,
+    emailDomains: method.emailDomains,
+    allowPassword: method.allowPassword,
+});
+
+const toOneLoginSummary = (
+    method: OrganizationSsoMethod<OrganizationSsoProvider.ONELOGIN>,
+): OneLoginSsoConfigSummary => ({
+    oauth2Issuer: method.config.oauth2Issuer,
+    oauth2ClientId: method.config.oauth2ClientId,
+    hasClientSecret: !!method.config.oauth2ClientSecret,
     enabled: method.enabled,
     overrideEmailDomains: method.overrideEmailDomains,
     emailDomains: method.emailDomains,
@@ -493,6 +508,103 @@ export class OrganizationSsoService extends BaseService {
         await this.organizationSsoModel.delete(
             organizationUuid,
             OrganizationSsoProvider.GENERIC_OIDC,
+        );
+    }
+
+    async getOneLoginConfig(
+        account: RegisteredAccount,
+    ): Promise<OneLoginSsoConfigSummary | null> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageSso(account);
+        const method = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.ONELOGIN,
+        );
+        return method ? toOneLoginSummary(method) : null;
+    }
+
+    async upsertOneLoginConfig(
+        account: RegisteredAccount,
+        data: UpsertOneLoginSsoConfig,
+    ): Promise<OneLoginSsoConfigSummary> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageSso(account);
+
+        if (!data.oauth2ClientId?.trim() || !data.oauth2Issuer?.trim()) {
+            throw new ParameterError(
+                'oauth2ClientId and oauth2Issuer are required',
+            );
+        }
+
+        // The issuer builds the token/userinfo URLs fetched server-side during
+        // the callback — require a public https URL.
+        await OrganizationSsoService.assertPublicSsoUrl(
+            data.oauth2Issuer.trim(),
+            'OneLogin issuer URL',
+        );
+
+        if (data.emailDomains && data.emailDomains.length > 0) {
+            OrganizationSsoService.validateEmailDomains(data.emailDomains);
+        }
+
+        const existing = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.ONELOGIN,
+        );
+
+        const clientSecret =
+            data.oauth2ClientSecret?.trim() ||
+            existing?.config.oauth2ClientSecret;
+        if (!clientSecret) {
+            throw new ParameterError('oauth2ClientSecret is required');
+        }
+
+        const config: OneLoginSsoConfig = {
+            oauth2Issuer: data.oauth2Issuer.trim(),
+            oauth2ClientId: data.oauth2ClientId.trim(),
+            oauth2ClientSecret: clientSecret,
+        };
+
+        const flags: Partial<OrganizationSsoMethodFlags> = {
+            enabled: data.enabled,
+            overrideEmailDomains: data.overrideEmailDomains,
+            emailDomains: data.emailDomains,
+            allowPassword: data.allowPassword,
+        };
+
+        await this.organizationSsoModel.upsert(
+            organizationUuid,
+            OrganizationSsoProvider.ONELOGIN,
+            config,
+            flags,
+            account.user.userUuid,
+        );
+
+        const refreshed = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.ONELOGIN,
+        );
+        if (!refreshed) {
+            throw new UnexpectedServerError(
+                'Failed to read back upserted SSO configuration',
+            );
+        }
+        return toOneLoginSummary(refreshed);
+    }
+
+    async deleteOneLoginConfig(account: RegisteredAccount): Promise<void> {
+        await this.assertFeatureEnabled(account);
+        const organizationUuid = this.assertCanManageSso(account);
+        const existing = await this.organizationSsoModel.findMethod(
+            organizationUuid,
+            OrganizationSsoProvider.ONELOGIN,
+        );
+        if (!existing) {
+            throw new NotFoundError('No OneLogin SSO configuration found');
+        }
+        await this.organizationSsoModel.delete(
+            organizationUuid,
+            OrganizationSsoProvider.ONELOGIN,
         );
     }
 

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -795,6 +795,74 @@ describe('UserService', () => {
         });
     });
 
+    describe('getLoginOptions per-org OneLogin discovery', () => {
+        const oneLoginMethod = {
+            organizationUuid: 'org-1',
+            provider: OpenIdIdentityIssuerType.ONELOGIN as unknown as never,
+            config: {
+                oauth2Issuer: 'https://acme.onelogin.com',
+                oauth2ClientId: 'cid',
+                oauth2ClientSecret: 'sec',
+            },
+            enabled: true,
+            overrideEmailDomains: false,
+            emailDomains: [],
+            allowPassword: true,
+        };
+
+        const configWithGoogleEnv: LightdashConfig = {
+            ...lightdashConfigMock,
+            auth: {
+                ...lightdashConfigMock.auth,
+                google: {
+                    ...lightdashConfigMock.auth.google,
+                    enabled: true,
+                    loginPath: '/login/google',
+                },
+                oneLogin: {
+                    ...lightdashConfigMock.auth.oneLogin,
+                    loginPath: '/login/oneLogin',
+                },
+            },
+        };
+
+        test('per-org OneLogin match suppresses instance Google (returning user with password)', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([oneLoginMethod]);
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                true,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('user@acme.com')).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                showOptions: ['email', 'oneLogin'],
+            });
+        });
+
+        test('brand-new user matching per-org OneLogin → forceRedirect to /login/oneLogin', async () => {
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as jest.Mock
+            ).mockResolvedValueOnce([oneLoginMethod]);
+            (userModel.findUserByEmail as jest.Mock).mockResolvedValueOnce(
+                undefined,
+            );
+            (userModel.hasPasswordByEmail as jest.Mock).mockResolvedValueOnce(
+                false,
+            );
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions('newbie@acme.com')).toEqual({
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/oneLogin?login_hint=newbie%40acme.com',
+                showOptions: ['oneLogin'],
+            });
+        });
+    });
+
     describe('loginWithOpenId', () => {
         test('should throw error if provider not allowed', async () => {
             await expect(

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -153,6 +153,7 @@ import {
     type AzureAdSsoConfigSummary,
     type GenericOidcSsoConfigSummary,
     type OktaSsoConfigSummary,
+    type OneLoginSsoConfigSummary,
 } from './organizationSso';
 import type { ResultsPaginationMetadata } from './paginateResults';
 import type { ParametersValuesMap } from './parameters';
@@ -939,6 +940,7 @@ type ApiResults =
     | AzureAdSsoConfigSummary
     | OktaSsoConfigSummary
     | GenericOidcSsoConfigSummary
+    | OneLoginSsoConfigSummary
     | UpdateAllowedEmailDomains
     | UserAllowedOrganization[]
     | EmailStatusExpiring

--- a/packages/common/src/types/organizationSso.ts
+++ b/packages/common/src/types/organizationSso.ts
@@ -2,6 +2,7 @@ export enum OrganizationSsoProvider {
     AZUREAD = 'azuread',
     OKTA = 'okta',
     GENERIC_OIDC = 'oidc',
+    ONELOGIN = 'oneLogin',
 }
 
 export const isOrganizationSsoProvider = (
@@ -146,4 +147,37 @@ export type ApiGenericOidcSsoConfigResponse = {
 export type ApiUpsertGenericOidcSsoConfigResponse = {
     status: 'ok';
     results: GenericOidcSsoConfigSummary;
+};
+
+export type OneLoginSsoConfig = {
+    oauth2Issuer: string;
+    oauth2ClientId: string;
+    oauth2ClientSecret: string;
+};
+
+export type OneLoginSsoConfigSummary = Pick<
+    OneLoginSsoConfig,
+    'oauth2Issuer' | 'oauth2ClientId'
+> &
+    OrganizationSsoMethodFlags & {
+        hasClientSecret: boolean;
+    };
+
+export type UpsertOneLoginSsoConfig = {
+    oauth2Issuer: string;
+    oauth2ClientId: string;
+    /**
+     * When omitted on update, the stored secret is preserved. Required on create.
+     */
+    oauth2ClientSecret?: string;
+} & Partial<OrganizationSsoMethodFlags>;
+
+export type ApiOneLoginSsoConfigResponse = {
+    status: 'ok';
+    results: OneLoginSsoConfigSummary | null;
+};
+
+export type ApiUpsertOneLoginSsoConfigResponse = {
+    status: 'ok';
+    results: OneLoginSsoConfigSummary;
 };

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/OneLoginSsoPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/OneLoginSsoPanel.tsx
@@ -1,0 +1,379 @@
+import {
+    Badge,
+    Button,
+    Checkbox,
+    Divider,
+    Group,
+    Image,
+    PasswordInput,
+    Stack,
+    Switch,
+    TagsInput,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import {
+    IconChevronDown,
+    IconChevronUp,
+    IconShieldCheck,
+    IconTrash,
+} from '@tabler/icons-react';
+import { useEffect, useState, type FC } from 'react';
+import { useToggle } from 'react-use';
+import { useAllowedEmailDomains } from '../../../hooks/organization/useAllowedDomains';
+import {
+    useDeleteOneLoginSsoConfig,
+    useOneLoginSsoConfig,
+    useUpsertOneLoginSsoConfig,
+} from '../../../hooks/organization/useOrganizationSso';
+import EmptyStateLoader from '../../common/EmptyStateLoader';
+import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
+import { SettingsCard } from '../../common/Settings/SettingsCard';
+import { ONELOGIN_LOGO } from '../../common/ThirdPartySignInButton/ssoProviderLogos';
+import FormSection from '../../ProjectConnection/Inputs/FormSection';
+
+type FormValues = {
+    oauth2Issuer: string;
+    oauth2ClientId: string;
+    oauth2ClientSecret: string;
+    enabled: boolean;
+    overrideEmailDomains: boolean;
+    emailDomains: string[];
+    allowPassword: boolean;
+};
+
+const OneLoginSsoPanel: FC = () => {
+    const { data: existing, isLoading } = useOneLoginSsoConfig();
+    const { data: allowedEmailDomains } = useAllowedEmailDomains();
+    const upsert = useUpsertOneLoginSsoConfig();
+    const deleteConfig = useDeleteOneLoginSsoConfig();
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [isOpen, toggleOpen] = useToggle(false);
+
+    const isConfigured = !!existing;
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            oauth2Issuer: '',
+            oauth2ClientId: '',
+            oauth2ClientSecret: '',
+            enabled: true,
+            overrideEmailDomains: false,
+            emailDomains: [],
+            allowPassword: true,
+        },
+        validate: {
+            oauth2Issuer: (value) =>
+                value.trim().length === 0 ? 'Issuer is required' : null,
+            oauth2ClientId: (value) =>
+                value.trim().length === 0 ? 'Client ID is required' : null,
+            oauth2ClientSecret: (value) =>
+                !existing && value.trim().length === 0
+                    ? 'Client secret is required'
+                    : null,
+            emailDomains: (value, values) =>
+                values.overrideEmailDomains && value.length === 0
+                    ? 'Add at least one domain when override is enabled'
+                    : null,
+        },
+    });
+
+    useEffect(() => {
+        form.setValues({
+            oauth2Issuer: existing?.oauth2Issuer ?? '',
+            oauth2ClientId: existing?.oauth2ClientId ?? '',
+            oauth2ClientSecret: '',
+            enabled: existing?.enabled ?? true,
+            overrideEmailDomains: existing?.overrideEmailDomains ?? false,
+            emailDomains: existing?.emailDomains ?? [],
+            allowPassword: existing?.allowPassword ?? true,
+        });
+        form.resetDirty();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        existing?.oauth2Issuer,
+        existing?.oauth2ClientId,
+        existing?.enabled,
+        existing?.overrideEmailDomains,
+        existing?.emailDomains,
+        existing?.allowPassword,
+    ]);
+
+    const orgDomains = allowedEmailDomains?.emailDomains ?? [];
+
+    const handleSubmit = form.onSubmit((values) => {
+        upsert.mutate({
+            oauth2Issuer: values.oauth2Issuer.trim(),
+            oauth2ClientId: values.oauth2ClientId.trim(),
+            enabled: values.enabled,
+            overrideEmailDomains: values.overrideEmailDomains,
+            emailDomains: values.emailDomains.map((d) =>
+                d.trim().toLowerCase(),
+            ),
+            allowPassword: values.allowPassword,
+            ...(values.oauth2ClientSecret.trim().length > 0
+                ? { oauth2ClientSecret: values.oauth2ClientSecret.trim() }
+                : {}),
+        });
+    });
+
+    // The Enabled toggle persists immediately (secret omitted = preserved), so
+    // turning it off disables sign-in without opening the configuration.
+    const handleToggleEnabled = (enabled: boolean) => {
+        form.setFieldValue('enabled', enabled);
+        if (!existing) return;
+        upsert.mutate({
+            oauth2Issuer: existing.oauth2Issuer,
+            oauth2ClientId: existing.oauth2ClientId,
+            enabled,
+            overrideEmailDomains: existing.overrideEmailDomains,
+            emailDomains: existing.emailDomains,
+            allowPassword: existing.allowPassword,
+        });
+    };
+
+    return (
+        <SettingsCard p="lg" pos="relative">
+            {isLoading ? (
+                <EmptyStateLoader mih={80} />
+            ) : (
+                <Stack gap="md">
+                    <Group
+                        justify="space-between"
+                        align="flex-start"
+                        wrap="nowrap"
+                    >
+                        <Group gap="sm" wrap="nowrap" align="flex-start">
+                            <Image
+                                src={ONELOGIN_LOGO}
+                                w={28}
+                                h={28}
+                                mt={2}
+                                alt="OneLogin logo"
+                            />
+                            <Stack gap={2}>
+                                <Title order={5}>OneLogin</Title>
+                                <Text c="dimmed" size="sm" maw={460}>
+                                    Single sign-on via OneLogin. Users whose
+                                    email matches the discovery whitelist see a
+                                    "Sign in with OneLogin" button;
+                                    instance-level SSO is suppressed for matched
+                                    users.
+                                </Text>
+                            </Stack>
+                        </Group>
+                        {isConfigured ? (
+                            <Switch
+                                label="Enabled"
+                                labelPosition="left"
+                                checked={form.values.enabled}
+                                disabled={upsert.isLoading}
+                                onChange={(event) =>
+                                    handleToggleEnabled(
+                                        event.currentTarget.checked,
+                                    )
+                                }
+                            />
+                        ) : (
+                            <Badge color="gray" variant="outline" size="lg">
+                                Not configured
+                            </Badge>
+                        )}
+                    </Group>
+
+                    {isConfigured ? (
+                        <Button
+                            variant="default"
+                            w="fit-content"
+                            leftSection={
+                                <MantineIcon
+                                    icon={
+                                        isOpen ? IconChevronUp : IconChevronDown
+                                    }
+                                />
+                            }
+                            onClick={() => toggleOpen()}
+                        >
+                            {isOpen
+                                ? 'Hide configuration'
+                                : 'Edit configuration'}
+                        </Button>
+                    ) : (
+                        !isOpen && (
+                            <Button
+                                variant="default"
+                                w="fit-content"
+                                onClick={() => toggleOpen()}
+                            >
+                                Set up OneLogin
+                            </Button>
+                        )
+                    )}
+
+                    <FormSection isOpen={isOpen} name="onelogin-configuration">
+                        <Stack gap="md">
+                            <Divider />
+                            <form onSubmit={handleSubmit}>
+                                <Stack>
+                                    <Title order={6}>
+                                        Application credentials
+                                    </Title>
+                                    <TextInput
+                                        label="Issuer URL"
+                                        placeholder="https://your-org.onelogin.com"
+                                        description="Your OneLogin OIDC issuer URL."
+                                        required
+                                        {...form.getInputProps('oauth2Issuer')}
+                                    />
+                                    <TextInput
+                                        label="Client ID"
+                                        placeholder="your-onelogin-client-id"
+                                        description="From the OneLogin application's SSO settings."
+                                        required
+                                        {...form.getInputProps(
+                                            'oauth2ClientId',
+                                        )}
+                                    />
+                                    <PasswordInput
+                                        label="Client secret"
+                                        placeholder={
+                                            existing
+                                                ? 'Leave blank to keep the existing secret'
+                                                : 'OneLogin client secret value'
+                                        }
+                                        description="The client secret from the OneLogin application."
+                                        required={!existing}
+                                        {...form.getInputProps(
+                                            'oauth2ClientSecret',
+                                        )}
+                                    />
+
+                                    <Title order={6} mt="md">
+                                        Discovery
+                                    </Title>
+                                    <Checkbox
+                                        label="Override organization's allowed email domains"
+                                        description="When unchecked, users matching any of the organization's allowed email domains see this method."
+                                        checked={
+                                            form.values.overrideEmailDomains
+                                        }
+                                        onChange={(event) =>
+                                            form.setFieldValue(
+                                                'overrideEmailDomains',
+                                                event.currentTarget.checked,
+                                            )
+                                        }
+                                    />
+                                    {form.values.overrideEmailDomains ? (
+                                        <TagsInput
+                                            label="Email domains for this method"
+                                            description="Only users whose email domain matches one of these will see OneLogin. Domains are case-insensitive."
+                                            placeholder="acme.com, acme.io"
+                                            value={form.values.emailDomains}
+                                            onChange={(domains) =>
+                                                form.setFieldValue(
+                                                    'emailDomains',
+                                                    domains,
+                                                )
+                                            }
+                                            error={form.errors.emailDomains}
+                                            clearable
+                                        />
+                                    ) : (
+                                        <Text size="sm" c="dimmed">
+                                            Using organization's allowed email
+                                            domains:{' '}
+                                            {orgDomains.length > 0 ? (
+                                                <b>{orgDomains.join(', ')}</b>
+                                            ) : (
+                                                <i>none configured</i>
+                                            )}
+                                        </Text>
+                                    )}
+
+                                    <Title order={6} mt="md">
+                                        Password sign-in
+                                    </Title>
+                                    <Checkbox
+                                        label="Allow password sign-in for users matching this method"
+                                        description="When unchecked, users whose email domain matches OneLogin discovery will not see the password input. Lenient rule: if any matching method allows password, it is shown."
+                                        checked={form.values.allowPassword}
+                                        onChange={(event) =>
+                                            form.setFieldValue(
+                                                'allowPassword',
+                                                event.currentTarget.checked,
+                                            )
+                                        }
+                                    />
+
+                                    <Group justify="space-between" mt="md">
+                                        {existing ? (
+                                            <Button
+                                                variant="outline"
+                                                color="red"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                    />
+                                                }
+                                                onClick={() =>
+                                                    setDeleteOpen(true)
+                                                }
+                                            >
+                                                Remove configuration
+                                            </Button>
+                                        ) : (
+                                            <div />
+                                        )}
+                                        <Button
+                                            type="submit"
+                                            loading={upsert.isLoading}
+                                            disabled={upsert.isLoading}
+                                        >
+                                            {existing
+                                                ? 'Save changes'
+                                                : 'Enable OneLogin'}
+                                        </Button>
+                                    </Group>
+                                </Stack>
+                            </form>
+                        </Stack>
+                    </FormSection>
+                </Stack>
+            )}
+
+            {deleteOpen && (
+                <MantineModal
+                    opened
+                    onClose={() => setDeleteOpen(false)}
+                    title="Remove OneLogin configuration"
+                    icon={IconShieldCheck}
+                    cancelLabel="Cancel"
+                    actions={
+                        <Button
+                            color="red"
+                            loading={deleteConfig.isLoading}
+                            onClick={async () => {
+                                await deleteConfig.mutateAsync();
+                                setDeleteOpen(false);
+                            }}
+                        >
+                            Remove
+                        </Button>
+                    }
+                >
+                    <Text>
+                        After removing this configuration, users in this
+                        organization will no longer be able to sign in with
+                        OneLogin via the per-organization configuration.
+                    </Text>
+                </MantineModal>
+            )}
+        </SettingsCard>
+    );
+};
+
+export default OneLoginSsoPanel;

--- a/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
+++ b/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
@@ -127,9 +127,12 @@ export const ThirdPartySignInButton: FC<ThirdPartySignInButtonProps> = ({
                 />
             ) : null;
         case OpenIdIdentityIssuerType.ONELOGIN:
-            return health.data?.auth.oneLogin.enabled ? (
+            return health.data?.auth.oneLogin.enabled || forceShow ? (
                 <ThirdPartySignInButtonBase
-                    loginPath={health.data.auth.oneLogin.loginPath}
+                    loginPath={
+                        health.data?.auth.oneLogin.loginPath ??
+                        '/login/oneLogin'
+                    }
                     redirect={redirect}
                     intent={intent}
                     inviteCode={inviteCode}

--- a/packages/frontend/src/hooks/organization/useOrganizationSso.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationSso.ts
@@ -3,9 +3,11 @@ import {
     type AzureAdSsoConfigSummary,
     type GenericOidcSsoConfigSummary,
     type OktaSsoConfigSummary,
+    type OneLoginSsoConfigSummary,
     type UpsertAzureAdSsoConfig,
     type UpsertGenericOidcSsoConfig,
     type UpsertOktaSsoConfig,
+    type UpsertOneLoginSsoConfig,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
@@ -223,6 +225,75 @@ export const useDeleteGenericOidcSsoConfig = () => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to remove OIDC SSO settings',
+                apiError: error,
+            });
+        },
+    });
+};
+
+const ONELOGIN_QUERY_KEY = ['organization_sso', 'oneLogin'];
+
+const getOneLoginSsoConfig = async () =>
+    lightdashApi<OneLoginSsoConfigSummary | null>({
+        url: '/org/sso/oneLogin',
+        method: 'GET',
+        body: undefined,
+    });
+
+const upsertOneLoginSsoConfig = async (data: UpsertOneLoginSsoConfig) =>
+    lightdashApi<OneLoginSsoConfigSummary>({
+        url: '/org/sso/oneLogin',
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+
+const deleteOneLoginSsoConfig = async () =>
+    lightdashApi<undefined>({
+        url: '/org/sso/oneLogin',
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useOneLoginSsoConfig = () =>
+    useQuery<OneLoginSsoConfigSummary | null, ApiError>({
+        queryKey: ONELOGIN_QUERY_KEY,
+        queryFn: getOneLoginSsoConfig,
+    });
+
+export const useUpsertOneLoginSsoConfig = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<
+        OneLoginSsoConfigSummary,
+        ApiError,
+        UpsertOneLoginSsoConfig
+    >(upsertOneLoginSsoConfig, {
+        mutationKey: ['organization_sso', 'oneLogin', 'upsert'],
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(ONELOGIN_QUERY_KEY);
+            showToastSuccess({ title: 'OneLogin SSO settings saved' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to save OneLogin SSO settings',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useDeleteOneLoginSsoConfig = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<undefined, ApiError>(deleteOneLoginSsoConfig, {
+        mutationKey: ['organization_sso', 'oneLogin', 'delete'],
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(ONELOGIN_QUERY_KEY);
+            showToastSuccess({ title: 'OneLogin SSO settings removed' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to remove OneLogin SSO settings',
                 apiError: error,
             });
         },

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -65,6 +65,7 @@ import OrganizationPanel from '../components/UserSettings/OrganizationPanel';
 import AzureAdSsoPanel from '../components/UserSettings/OrganizationSso/AzureAdSsoPanel';
 import GenericOidcSsoPanel from '../components/UserSettings/OrganizationSso/GenericOidcSsoPanel';
 import OktaSsoPanel from '../components/UserSettings/OrganizationSso/OktaSsoPanel';
+import OneLoginSsoPanel from '../components/UserSettings/OrganizationSso/OneLoginSsoPanel';
 import { OrganizationWarehouseCredentialsPanel } from '../components/UserSettings/OrganizationWarehouseCredentialsPanel';
 import PasswordPanel from '../components/UserSettings/PasswordPanel';
 import ProfilePanel from '../components/UserSettings/ProfilePanel';
@@ -497,6 +498,7 @@ const Settings: FC = () => {
                         <AzureAdSsoPanel />
                         <OktaSsoPanel />
                         <GenericOidcSsoPanel />
+                        <OneLoginSsoPanel />
                     </Stack>
                 ),
             });


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-7552/admin-panel-onelogin-sso-configuration](https://linear.app/lightdash/issue/PROD-7552/admin-panel-onelogin-sso-configuration)

![CleanShot 2026-05-26 at 10.42.16.png](https://app.graphite.com/user-attachments/assets/f2548946-e6bc-45ac-9003-419534cafce3.png)

### Description:

Adds per-organization OneLogin SSO support, following the same pattern as Azure AD. Organizations can now configure OneLogin OIDC credentials stored encrypted in `organization_sso_configurations`, with discovery routing users to the correct per-org strategy based on their email domain.

**Backend:**

- Refactored `oneLoginStrategy.ts` to expose `createOneLoginStrategyForConfig(config)` so the same builder is used for both the env-based startup strategy and dynamically registered per-org strategies.
- Per-org strategies are registered as `oneLogin:<orgUuid>` in a cache with a 10-minute TTL, mirroring the Azure AD cache. The strategy name is stored on `req.session.oauth.oneLoginStrategyName` and re-registered from the DB on callback if evicted.
- Added `getOneLoginConfig`, `upsertOneLoginConfig`, and `deleteOneLoginConfig` to `OrganizationSsoService`, with issuer URL validation and client secret preservation on updates.
- Exposed `GET/PUT/DELETE /api/v1/org/sso/oneLogin` endpoints via `OrganizationSsoController`.
- Added `OrganizationSsoProvider.ONELOGIN` to the provider map in `OrganizationSsoModel`.

**Frontend:**

- Added `OneLoginSsoPanel` admin UI with fields for issuer URL, client ID, client secret, email domain discovery overrides, and password sign-in control.
- Added `useOneLoginSsoConfig`, `useUpsertOneLoginSsoConfig`, and `useDeleteOneLoginSsoConfig` hooks.
- The `ThirdPartySignInButton` for OneLogin now respects `forceShow` so per-org discovery can surface the button even when the instance-level env config is absent.
- `OneLoginSsoPanel` is rendered in the organization SSO settings page alongside the Azure AD, Okta, and Generic OIDC panels.

**Tests:**

- Added `getLoginOptions` unit tests covering per-org OneLogin discovery: domain-matched users see only `['email', 'oneLogin']`, and brand-new users matching a per-org OneLogin config are force-redirected to the OneLogin login path.