### PR TITLE
fix(ai-agent): wrap ToolCallChip as <span> to fix invalid HTML in chat

### DIFF
--- a/packages/frontend/src/components/common/TruncatedText/index.tsx
+++ b/packages/frontend/src/components/common/TruncatedText/index.tsx
@@ -10,6 +10,10 @@ import { useIsTruncated } from '../../../hooks/useIsTruncated';
 interface TruncatedTextProps extends Omit<TextProps, 'truncate'> {
     children: string;
     maxWidth: number | string;
+    /** Render the inner element as <span> instead of <p>. Use when the
+     *  TruncatedText is nested inside another block-level text element to
+     *  avoid invalid HTML (<p> inside <p>). */
+    inline?: boolean;
 }
 
 /**
@@ -19,6 +23,7 @@ interface TruncatedTextProps extends Omit<TextProps, 'truncate'> {
 const TruncatedText: FC<TruncatedTextProps> = ({
     children,
     maxWidth,
+    inline,
     ...textProps
 }) => {
     const { ref, isTruncated } = useIsTruncated<HTMLParagraphElement>();
@@ -35,6 +40,7 @@ const TruncatedText: FC<TruncatedTextProps> = ({
                 fz="sm"
                 truncate="end"
                 maw={maxWidth}
+                span={inline}
                 {...textProps}
             >
                 {children}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallChip.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallChip.tsx
@@ -29,6 +29,7 @@ export const ToolCallChip: FC<ToolCallChipProps> = ({
     ...rest
 }) => (
     <Badge
+        component="span"
         color="gray"
         variant="light"
         size="xs"
@@ -43,6 +44,7 @@ export const ToolCallChip: FC<ToolCallChipProps> = ({
     >
         {typeof children === 'string' ? (
             <TruncatedText
+                inline
                 maxWidth={maxWidth}
                 fz="inherit"
                 c="inherit"


### PR DESCRIPTION
## Summary

- Wraps `ToolCallChip`'s `<Badge>` as `component="span"` so it stops emitting `<div>` inside the outer `<Text>` (=`<p>`) that every tool-call description uses
- Adds an optional `inline` prop to `TruncatedText` that switches the inner `<Text>` to `<span>`; used from `ToolCallChip` to stop emitting `<p>` inside `<p>` via the truncation tooltip

## Background

`Sentry: LIGHTDASH-FRONTEND-41T` (React error `#185`, Maximum update depth) and `LIGHTDASH-FRONTEND-52C` (`Cannot close an errored readable stream`) first appeared **2026-05-14** — the day PR #23008 (chat overhaul) introduced `ToolCallChip` and refactored every tool-call description to wrap it inside `<Text c="dimmed">`. Since then, 1077+ occurrences across 341 users / 898 orgs. Tracked internally as `PROD-7019`.

Mantine `<Text>` defaults to `<p>`, Mantine `<Badge>` defaults to `<div>`, and Mantine `<Text>` (used inside `TruncatedText`) also defaults to `<p>`. Every tool-call description in `packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/` follows the same shape:

```tsx
<Text c=\"dimmed\" size=\"xs\">      {/* <p> */}
  …
  <ToolCallChip>…</ToolCallChip>   {/* <div>, with <p> inside via TruncatedText */}
</Text>
```

Browsers auto-close the outer `<p>` when they see `<div>` or `<p>` inside it. Under React 19's production reconciler this DOM-vs-VDOM mismatch turns into reconciliation churn that scales with the number of violations on the page; for a thread with many tool calls the churn climbs into the maximum-update-depth limit.

## Validation

| Thread shared in Pylon | Pre-fix (prod build) | Post-fix (prod build) |
|---|---|---|
| `<div>` inside `<p>` violations | 133 | 0 |
| `<p>` with invalid descendants | 40 | 0 |
| Console HTML errors (dev) | 4 | 0 |
| Other `TruncatedText` callers (6 places) | unchanged | unchanged (`inline` defaults to undefined) |

The end-to-end React `#185` crash itself could not be reproduced locally because the catch site in `useAiAgentThreadStreamMutation.ts` only fires while a stream is being consumed, and the cloned thread is static. The fix definitely removes the HTML violations; the link from HTML violations to React `#185` is a strong inference (timing match with PR #23008, Sentry stack frames in `react-dom-client` reconciliation, severity scales with tool-call count) but is not a live before/after repro.

## Test plan

- [x] `pnpm -F frontend typecheck` passes
- [x] `pnpm -F frontend lint` passes on changed files
- [x] Visual: chips render identically (Mantine styles via classes, tag change is invisible)
- [x] DOM scan: zero invalid `<p>` parents on a 59-tool-call thread post-fix
- [ ] Manual: confirm Pylon issue no longer hits the crash on a deploy with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)