### PR TITLE
fix: resolve color palette using chart's existing palette when staged palette is null

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -105,7 +105,9 @@ const VisualizationCard: FC<Props> = memo((props) => {
         selectUnsavedColorPaletteUuid,
     );
     const resolverChartUuid =
-        stagedColorPaletteUuid === null ? undefined : savedChart?.uuid;
+        stagedColorPaletteUuid === null && savedChart?.colorPaletteUuid != null
+            ? undefined
+            : savedChart?.uuid;
     const { data: resolvedPalette } = useProjectColorPalette(projectUuid, {
         chartUuid: resolverChartUuid,
         dashboardUuid: savedChart?.dashboardUuid ?? undefined,


### PR DESCRIPTION
Closes:

### Description:

Fixes an issue with color palette resolution logic in the `VisualizationCard` component. Previously, the `resolverChartUuid` was set to `undefined` whenever `stagedColorPaletteUuid` was `null`, regardless of whether the saved chart had an existing color palette assigned. This caused incorrect palette resolution behavior.

The condition now also checks that `savedChart?.colorPaletteUuid` is not `null` before returning `undefined`, ensuring the chart's UUID is still passed to the palette resolver when the chart has no color palette configured.