### PR TITLE
fix: stringify custom_groups when copying chart versions to previews (SPK-461)

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2851,7 +2851,10 @@ export class ProjectModel {
             await copyChartVersionContent(
                 'saved_queries_version_custom_dimensions',
                 ['saved_queries_version_custom_dimension_id'],
-                { custom_range: (value: AnyType) => JSON.stringify(value) },
+                {
+                    custom_range: (value: AnyType) => JSON.stringify(value),
+                    custom_groups: (value: AnyType) => JSON.stringify(value),
+                },
             );
             await copyChartVersionContent(
                 SavedChartCustomSqlDimensionsTableName,


### PR DESCRIPTION
Closes: SPK-461

### Description:

Creating a preview project failed with `invalid input syntax for type json` when the source project contained any saved chart with a `CUSTOM_GROUP` custom dimension. The new `custom_groups` JSONB column (added in #20893) was missing from the `JSON.stringify` preprocess map in `copyChartVersionContent`, so Knex `batchInsert` sent a raw JS object to Postgres. This mirrors the existing handling for `custom_range` and `pivot_values` (#23130).

🤖 Generated with [Claude Code](https://claude.com/claude-code)