### PR TITLE
chore: bump `browserless/chromium` to `v2.49.0`

### DIFF
--- a/docker/Dockerfile.headless-browser
+++ b/docker/Dockerfile.headless-browser
@@ -1,1 +1,1 @@
-FROM ghcr.io/browserless/chromium:v2.38.2
+FROM ghcr.io/browserless/chromium:v2.49.0


### PR DESCRIPTION
### Description:
Bumping to keep in sync with our cloud deployments.
