### PR TITLE
feat(dashboard): autoscroll while dragging a tile (PROD-7891)

### DIFF
--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -56,6 +56,7 @@ import {
 } from './gridUtils';
 import DraggableTab from './Tab';
 import styles from './tabs.module.css';
+import { useAutoScrollOnDrag } from './useAutoScrollOnDrag';
 import { useGridStyles } from './useGridStyles';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
@@ -271,21 +272,32 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
         [currentCols, handleUpdateTiles],
     );
 
-    const handleDragStart = useCallback(() => setIsInteracting(true), []);
+    const { start: startAutoScroll, stop: stopAutoScroll } =
+        useAutoScrollOnDrag();
+
+    const handleDragStart = useCallback(() => {
+        setIsInteracting(true);
+        startAutoScroll();
+    }, [startAutoScroll]);
     const handleDragStop = useCallback(
         (layout: Layout[]) => {
+            stopAutoScroll();
             setIsInteracting(false);
             void handleUpdateTilesWithScaling(layout);
         },
-        [handleUpdateTilesWithScaling],
+        [handleUpdateTilesWithScaling, stopAutoScroll],
     );
-    const handleResizeStart = useCallback(() => setIsInteracting(true), []);
+    const handleResizeStart = useCallback(() => {
+        setIsInteracting(true);
+        startAutoScroll();
+    }, [startAutoScroll]);
     const handleResizeStop = useCallback(
         (layout: Layout[]) => {
+            stopAutoScroll();
             setIsInteracting(false);
             void handleUpdateTilesWithScaling(layout);
         },
-        [handleUpdateTilesWithScaling],
+        [handleUpdateTilesWithScaling, stopAutoScroll],
     );
     const handleBreakpointChange = useCallback(
         (_: string, cols: number) => setCurrentCols(cols),

--- a/packages/frontend/src/features/dashboardTabs/useAutoScrollOnDrag.ts
+++ b/packages/frontend/src/features/dashboardTabs/useAutoScrollOnDrag.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const THRESHOLD = 80;
+const MAX_SPEED = 18;
+
+const easedSpeed = (dist: number) =>
+    MAX_SPEED * (1 - Math.max(0, dist) / THRESHOLD);
+
+/**
+ * Scrolls the window vertically while the user drags or resizes a dashboard
+ * tile against the top or bottom of the viewport. The closer the pointer is
+ * to the edge, the faster the scroll.
+ */
+export const useAutoScrollOnDrag = () => {
+    const rafRef = useRef<number | null>(null);
+    const pointerYRef = useRef<number | null>(null);
+    const activeRef = useRef(false);
+
+    const handlePointerMove = useCallback((event: PointerEvent) => {
+        pointerYRef.current = event.clientY;
+    }, []);
+
+    const stop = useCallback(() => {
+        if (!activeRef.current) return;
+        activeRef.current = false;
+        if (rafRef.current !== null) {
+            cancelAnimationFrame(rafRef.current);
+            rafRef.current = null;
+        }
+        document.removeEventListener('pointermove', handlePointerMove);
+        pointerYRef.current = null;
+    }, [handlePointerMove]);
+
+    const tick = useCallback(() => {
+        if (!activeRef.current) return;
+
+        const y = pointerYRef.current;
+        if (y !== null) {
+            const topDist = y;
+            const bottomDist = window.innerHeight - y;
+
+            let delta = 0;
+            if (topDist < THRESHOLD) {
+                delta = -easedSpeed(topDist);
+            } else if (bottomDist < THRESHOLD) {
+                delta = easedSpeed(bottomDist);
+            }
+
+            if (delta !== 0) {
+                window.scrollBy(0, delta);
+            }
+        }
+
+        rafRef.current = requestAnimationFrame(tick);
+    }, []);
+
+    const start = useCallback(() => {
+        if (activeRef.current) return;
+        activeRef.current = true;
+        document.addEventListener('pointermove', handlePointerMove, {
+            passive: true,
+        });
+        rafRef.current = requestAnimationFrame(tick);
+    }, [handlePointerMove, tick]);
+
+    useEffect(() => stop, [stop]);
+
+    return { start, stop };
+};


### PR DESCRIPTION
Closes: PROD-7891

### Description:
Dragging a dashboard tile near the top or bottom of the viewport now auto-scrolls the page, so the user can move tiles past the visible area without releasing the drag. Resizing a tile against the bottom edge behaves the same way.

Implemented as a small `useAutoScrollOnDrag` hook that tracks the pointer via `pointermove` and runs a `requestAnimationFrame` loop while a drag/resize is active, calling `window.scrollBy` with an eased delta when the pointer is within 80px of the viewport edge.

### Demo 

https://github.com/user-attachments/assets/9dd7076e-470f-4c50-aed5-a838746a9ff0

