### PR TITLE
fix(prod-7889): pivot_offset walks across pivot columns within a row

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -3888,7 +3888,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // fieldAliasMap[ref] to handle interdependent table calculation references
             // Field references must be quoted to handle reserved words and special characters
             expect(result).toContain(
-                '"impressions_any" - CASE WHEN LAG("row_index", 1)',
+                '"impressions_any" - CASE WHEN LAG("column_index", 1)',
             );
             expect(result).toContain('LAG("impressions_any", 1)');
 

--- a/packages/common/src/utils/tableCalculationFunctions.test.ts
+++ b/packages/common/src/utils/tableCalculationFunctions.test.ts
@@ -658,7 +658,7 @@ describe('tableCalculationFunctions', () => {
                     const compiled = compiler.compileFunctions(sql, functions);
 
                     const expectedSql =
-                        'CASE WHEN LEAD("row_index", 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") = "row_index" + (1) THEN LEAD(revenue, 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") ELSE NULL END';
+                        'CASE WHEN LEAD("column_index", 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") = "column_index" + (1) THEN LEAD(revenue, 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") ELSE NULL END';
                     expect(compiled).toBe(expectedSql);
                 });
 
@@ -668,7 +668,7 @@ describe('tableCalculationFunctions', () => {
                     const compiled = compiler.compileFunctions(sql, functions);
 
                     const expectedSql =
-                        'CASE WHEN LAG("row_index", 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") = "row_index" + (-1) THEN LAG(revenue, 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") ELSE NULL END';
+                        'CASE WHEN LAG("column_index", 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") = "column_index" + (-1) THEN LAG(revenue, 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") ELSE NULL END';
                     expect(compiled).toBe(expectedSql);
                 });
 
@@ -687,7 +687,7 @@ describe('tableCalculationFunctions', () => {
                     const compiled = compiler.compileFunctions(sql, functions);
 
                     const expectedSql =
-                        'revenue - CASE WHEN LAG("row_index", 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") = "row_index" + (-1) THEN LAG(revenue, 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") ELSE NULL END';
+                        'revenue - CASE WHEN LAG("column_index", 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") = "column_index" + (-1) THEN LAG(revenue, 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") ELSE NULL END';
                     expect(compiled).toBe(expectedSql);
                 });
             });
@@ -1135,7 +1135,7 @@ describe('tableCalculationFunctions', () => {
                     const compiled = compiler.compileFunctions(sql, functions);
 
                     const expectedSql =
-                        '"column_index" * CASE WHEN LAG("row_index", 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") = "row_index" + (-1) THEN LAG(revenue, 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") ELSE NULL END + MAX(CASE WHEN "column_index" = 0 THEN revenue ELSE NULL END) OVER (PARTITION BY "row_index")';
+                        '"column_index" * CASE WHEN LAG("column_index", 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") = "column_index" + (-1) THEN LAG(revenue, 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") ELSE NULL END + MAX(CASE WHEN "column_index" = 0 THEN revenue ELSE NULL END) OVER (PARTITION BY "row_index")';
                     expect(compiled).toBe(expectedSql);
                 });
 
@@ -1146,7 +1146,7 @@ describe('tableCalculationFunctions', () => {
                     const compiled = compiler.compileFunctions(sql, functions);
 
                     const expectedSql =
-                        'CASE WHEN "column_index" = 0 THEN MAX(CASE WHEN "column_index" = (SELECT MIN("column_index") FROM (SELECT "column_index", status = "active" AS condition FROM DUAL) WHERE condition = TRUE) THEN revenue ELSE NULL END) OVER (PARTITION BY "row_index") ELSE CASE WHEN LAG("row_index", 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") = "row_index" + (-1) THEN LAG(revenue, 1) OVER (PARTITION BY "column_index" ORDER BY "row_index") ELSE NULL END END';
+                        'CASE WHEN "column_index" = 0 THEN MAX(CASE WHEN "column_index" = (SELECT MIN("column_index") FROM (SELECT "column_index", status = "active" AS condition FROM DUAL) WHERE condition = TRUE) THEN revenue ELSE NULL END) OVER (PARTITION BY "row_index") ELSE CASE WHEN LAG("column_index", 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") = "column_index" + (-1) THEN LAG(revenue, 1) OVER (PARTITION BY "row_index" ORDER BY "column_index") ELSE NULL END END';
                     expect(compiled).toBe(expectedSql);
                 });
             });

--- a/packages/common/src/utils/tableCalculationFunctions.ts
+++ b/packages/common/src/utils/tableCalculationFunctions.ts
@@ -918,10 +918,13 @@ export class TableCalculationFunctionCompiler {
     /**
      * Compiles a pivot_offset function call to a guarded SQL window function.
      * Converts pivot_offset(expression, n) to LAG or LEAD with adjacency checks.
-     * Returns NULL if the offset row is not exactly n time periods away.
+     * Walks across pivot columns within the same row (Looker semantics): negative
+     * n looks at the pivot column n positions to the left, positive n to the right.
+     * Returns NULL if the adjacent pivot column at the offset position is not exactly
+     * n columns away (i.e. when the offset would skip over missing pivot columns).
      * @param expression - The SQL expression inside pivot_offset
-     * @param columnOffset - The offset value (negative for LAG/previous, positive for LEAD/next)
-     * @returns Compiled SQL with CASE statement checking for adjacent time periods
+     * @param columnOffset - The offset value (negative for LAG/previous pivot column, positive for LEAD/next pivot column)
+     * @returns Compiled SQL with CASE statement checking for adjacent pivot columns on the same row
      */
     private compilePivotOffset(
         expression: string,
@@ -937,16 +940,14 @@ export class TableCalculationFunctionCompiler {
         const windowFunction = columnOffset < 0 ? 'LAG' : 'LEAD';
         const offsetValue = Math.abs(columnOffset);
 
-        // The window partitions by column_index (pivot dimension like status)
-        // and orders by row_index
-        const windowClause = `OVER (PARTITION BY ${q}column_index${q} ORDER BY ${q}row_index${q})`;
+        // Partition by row_index so the window walks across pivot columns within a row,
+        // ordered by column_index (the pivoted dimension position).
+        const windowClause = `OVER (PARTITION BY ${q}row_index${q} ORDER BY ${q}column_index${q})`;
 
-        // For offset of 1, check if the previous/next row_index is exactly 1 away
-        // For offset of n, check if the nth row_index is exactly n away
-        const expectedDiff = columnOffset < 0 ? -offsetValue : offsetValue;
-
-        // Build the guarded expression that returns NULL for non-adjacent time periods
-        return `CASE WHEN ${windowFunction}(${q}row_index${q}, ${offsetValue}) ${windowClause} = ${q}row_index${q} + (${expectedDiff}) THEN ${windowFunction}(${expression}, ${offsetValue}) ${windowClause} ELSE NULL END`;
+        // Guard: only return the value if the column_index at the offset position
+        // is exactly columnOffset away, otherwise return NULL. This prevents
+        // skipping over missing pivot columns (e.g. jumping from column 2 to column 5).
+        return `CASE WHEN ${windowFunction}(${q}column_index${q}, ${offsetValue}) ${windowClause} = ${q}column_index${q} + (${columnOffset}) THEN ${windowFunction}(${expression}, ${offsetValue}) ${windowClause} ELSE NULL END`;
     }
 
     /**


### PR DESCRIPTION
Closes: PROD-7889

### Description:

`pivot_offset(expr, n)` was emitting `OVER (PARTITION BY column_index ORDER BY row_index)`, which walks `LAG`/`LEAD` across rows within a single pivot column — the opposite of the Looker semantic and typically producing NULL (each partition contained one row, so the adjacency guard collapsed). This inverts the window to `OVER (PARTITION BY row_index ORDER BY column_index)` with the guard checking `column_index`, mirroring the already-correct sibling `compilePivotOffsetList`. Unit + integration test expectations that pinned the old direction are updated.