### PR TITLE
fix(ai-agent): recover pending SQL approvals

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -1,6 +1,7 @@
 import {
     type AiAgentToolName,
     type AiAgentMessageAssistant,
+    type AiAgentToolCall,
     type AiMcpServer,
     isToolProposeChangeResult,
     type ToolProposeChangeArgs,
@@ -171,6 +172,20 @@ const groupPersistedToolCalls = (
         }
     }
     return groups;
+};
+
+const getPendingPersistedSqlApprovals = (
+    message: AiAgentMessageAssistant,
+): AiAgentToolCall[] => {
+    const resolvedToolCallIds = new Set(
+        message.toolResults.map((result) => result.toolCallId),
+    );
+
+    return message.toolCalls.filter(
+        (toolCall) =>
+            toolCall.toolName === 'runSql' &&
+            !resolvedToolCallIds.has(toolCall.toolCallId),
+    );
 };
 
 const getToolOutputStatus = (toolOutput: unknown) => {
@@ -669,6 +684,28 @@ const AssistantBubbleContent: FC<{
                 );
                 const persistedToolGroups: LiveActivityToolGroup[] =
                     groupPersistedToolCalls(renderableToolCalls);
+                const persistedSqlApprovals =
+                    getPendingPersistedSqlApprovals(message);
+                const pendingApprovalContent =
+                    persistedSqlApprovals.length > 0 ? (
+                        <Stack gap={6}>
+                            {persistedSqlApprovals.map((toolCall) => (
+                                <SqlApprovalCard
+                                    key={toolCall.toolCallId}
+                                    projectUuid={projectUuid}
+                                    agentUuid={agentUuid}
+                                    threadUuid={message.threadUuid}
+                                    toolCallId={toolCall.toolCallId}
+                                    toolArgs={
+                                        toolCall.toolArgs as {
+                                            sql: string;
+                                            limit?: number;
+                                        }
+                                    }
+                                />
+                            ))}
+                        </Stack>
+                    ) : null;
                 return (
                     <>
                         <ImproveContextToolCall
@@ -684,8 +721,20 @@ const AssistantBubbleContent: FC<{
                                 toolResults={message.toolResults}
                                 toolCalls={message.toolCalls}
                                 mcpServers={mcpServers}
+                                pendingContent={pendingApprovalContent}
                             />
                         )}
+                        {persistedToolGroups.length === 0 &&
+                            pendingApprovalContent && (
+                                <LiveActivityCard
+                                    toolGroups={[]}
+                                    isLive={isStreaming || isPending}
+                                    toolResults={message.toolResults}
+                                    toolCalls={message.toolCalls}
+                                    mcpServers={mcpServers}
+                                    pendingContent={pendingApprovalContent}
+                                />
+                            )}
                         {message.reasoning && message.reasoning.length > 0 && (
                             <ReasoningHistoryRow
                                 texts={toReasoningTexts(


### PR DESCRIPTION
## Summary
- render pending SQL approval cards from persisted runSql tool calls when live stream state is unavailable
- keep the approval UI inside the existing live activity card fallback
- link recovery to unresolved runSql calls without matching tool results

Fixes #23495

## Test plan
- pnpm -F frontend typecheck *(blocked: node_modules missing; tsc not found)*
- pnpm -F frontend lint -- packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx *(blocked: node_modules missing; oxlint not found)*