### PR TITLE
fix(ai-agent): avoid runSql retry after timeout

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -109,4 +109,23 @@ describe('getRunSql', () => {
         );
         expect(output.metadata?.status).toBe('success');
     });
+
+    it('does not open another approval wait after approval times out', async () => {
+        const waitForSqlApproval = jest.fn().mockResolvedValue('timeout');
+        const { tool, dependencies } = makeTool({ waitForSqlApproval });
+
+        const firstOutput = await executeRunSql(tool, 'tool-call-1');
+        const secondOutput = await executeRunSql(tool, 'tool-call-2');
+
+        expect(firstOutput.metadata?.status).toBe('timeout');
+        expect(secondOutput.metadata?.status).toBe('timeout');
+        expect(secondOutput.result).toContain(
+            'Do not call runSql again in this response',
+        );
+        expect(dependencies.waitForSqlApproval).toHaveBeenCalledTimes(1);
+        expect(dependencies.waitForSqlApproval).toHaveBeenCalledWith(
+            'tool-call-1',
+        );
+        expect(dependencies.runSqlJob).not.toHaveBeenCalled();
+    });
 });

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -77,11 +77,20 @@ export const getRunSql = ({
     recordSqlApproval,
     autoApproveSql = false,
     autoApproveSqlUserUuid = null,
-}: Dependencies) =>
-    tool({
+}: Dependencies) => {
+    let sqlApprovalTimedOut = false;
+
+    return tool({
         description: toolRunSqlArgsSchema.description,
         inputSchema: toolRunSqlArgsSchema,
         execute: async ({ sql, limit }, { toolCallId }) => {
+            if (sqlApprovalTimedOut) {
+                return {
+                    result: 'A previous SQL approval timed out in this response. Do not call runSql again in this response; tell the user the SQL was not approved and ask them to retry when ready.',
+                    metadata: { status: 'timeout' },
+                };
+            }
+
             // Pre-section errors (bad SQL shape) — no Slack message exists
             // yet, just return the error to the agent.
             try {
@@ -146,6 +155,7 @@ export const getRunSql = ({
                     };
                 }
                 if (decision === 'timeout') {
+                    sqlApprovalTimedOut = true;
                     await renderState({ kind: 'timeout', sql });
                     return {
                         result: 'SQL approval timed out after 5 minutes with no response. The user may have stepped away — acknowledge politely and wait for them to re-ask.',
@@ -268,3 +278,4 @@ export const getRunSql = ({
             }
         },
     });
+};


### PR DESCRIPTION
Fixes #23496.

## Summary
- Stops a single agent response from opening repeated runSql approval waits after one approval timeout.
- Returns an explicit timeout tool result that tells the model to stop retrying and ask the user to retry when ready.
- Adds regression coverage for the retry guard.

## Testing
- `git diff --check`
- `pnpm -F backend test -- runSql.test.ts` *(blocked: `jest: command not found`; this worktree has no `node_modules`)*