### PR TITLE
fix: replace fixed max-height with responsive scroll area for tile filter configuration

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterConfiguration.module.css
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterConfiguration.module.css
@@ -1,0 +1,4 @@
+.tileScrollArea {
+    max-height: min(50vh, calc(100vh - 200px));
+    overflow: auto;
+}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -35,6 +35,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { getChartIcon } from '../../../components/common/ResourceIcon/utils';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import { FilterActions } from './constants';
+import classes from './FilterConfiguration.module.css';
 import { getFilterTileRelation } from './utils';
 
 type TileWithTargetFields = {
@@ -629,7 +630,7 @@ const TileFilterConfiguration: FC<Props> = ({
         );
 
     return (
-        <Stack spacing="xl" mah={600} style={{ overflow: 'auto' }}>
+        <Stack spacing="xl" className={classes.tileScrollArea}>
             <Checkbox
                 size="xs"
                 checked={isAllChecked}


### PR DESCRIPTION
Closes:

### Description:
Replaces the hardcoded `max-height: 600px` on the tile filter configuration scroll area with a responsive CSS value (`min(50vh, calc(100vh - 200px))`). This ensures the filter tile list scales appropriately across different screen sizes and viewport heights rather than being fixed at a static pixel value.