### PR TITLE
feat(ee): install Lightdash CLI via pnpm in agentic writeback sandbox

### DIFF
--- a/sandboxes/agentic-writeback/build-sandbox.ts
+++ b/sandboxes/agentic-writeback/build-sandbox.ts
@@ -2,8 +2,8 @@
 /**
  * Builds and uploads the e2b sandbox template for Lightdash agentic writeback.
  *
- * The template pre-installs dbt adapters and the Claude CLI — so sandboxes
- * start instantly ready to run.
+ * The template pre-installs dbt adapters, the Claude CLI, and the Lightdash
+ * CLI — so sandboxes start instantly ready to run.
  *
  * Prerequisites:
  *   npm install       # in this directory

--- a/sandboxes/agentic-writeback/e2b.Dockerfile
+++ b/sandboxes/agentic-writeback/e2b.Dockerfile
@@ -20,4 +20,10 @@ RUN pip install --no-cache-dir \
 
 RUN npm install -g @anthropic-ai/claude-code
 
+# pnpm for installing the Lightdash CLI
+ENV PNPM_HOME="/usr/local/pnpm"
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN npm install -g pnpm@10.33.0 \
+    && pnpm add -g @lightdash/cli
+
 WORKDIR /home/user

--- a/sandboxes/agentic-writeback/e2b.Dockerfile
+++ b/sandboxes/agentic-writeback/e2b.Dockerfile
@@ -18,12 +18,16 @@ RUN pip install --no-cache-dir \
         dbt-postgres \
         dbt-duckdb
 
-RUN npm install -g @anthropic-ai/claude-code
+# Socket Firewall (sfw) blocks known-malicious packages at install time.
+# Install it first, then route every npm/pnpm install through it.
+RUN npm install -g sfw
+
+RUN sfw npm install -g @anthropic-ai/claude-code
 
 # pnpm for installing the Lightdash CLI
 ENV PNPM_HOME="/usr/local/pnpm"
 ENV PATH="${PNPM_HOME}:${PATH}"
-RUN npm install -g pnpm@10.33.0 \
-    && pnpm add -g @lightdash/cli
+RUN sfw npm install -g pnpm@10.33.0 \
+    && sfw pnpm add -g @lightdash/cli
 
 WORKDIR /home/user


### PR DESCRIPTION
## What & why

The agentic writeback e2b sandbox pre-installs dbt adapters and the Claude CLI so sandboxes start ready to run. This adds the **Lightdash CLI** to that set so sandbox prompts can invoke `lightdash` commands without a per-session install.

## Changes

- `sandboxes/agentic-writeback/e2b.Dockerfile`: bootstrap `pnpm` (pinned to `10.33.0`, matching the data-apps sandbox) and `pnpm add -g @lightdash/cli`. `PNPM_HOME` is set and added to `PATH` so the global binary resolves.
- Updated the `build-sandbox.ts` header comment to mention the Lightdash CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)