### PR TITLE
feat: add per-org OIDC account-linking toggles with organization_settings table and admin panel

### DIFF
--- a/docs/organization-settings.md
+++ b/docs/organization-settings.md
@@ -1,0 +1,123 @@
+# Organization settings
+
+Per-organization settings let an org admin override instance-wide configuration
+for **their** org. They're the mechanism for migrating Lightdash Pro config from
+instance-wide environment variables to per-org, admin-configurable settings on
+shared multi-tenant infrastructure.
+
+First use: the OIDC account-linking toggles (`AUTH_ENABLE_OIDC_LINKING`,
+`AUTH_ENABLE_OIDC_TO_EMAIL_LINKING`). More will follow (CSV/export limits,
+scheduled-delivery options, etc.).
+
+## Org settings vs. feature flags
+
+They look similar — both are "per-org override of an instance default" — but
+they are **deliberately two different tables/systems**. Don't unify them.
+
+| | Feature flags (`feature_flags` / `feature_flag_overrides`) | Organization settings (`organization_settings`) |
+|---|---|---|
+| **Purpose** | Roll out / kill-switch a feature during development | Customer-configurable, permanent product config |
+| **Lifecycle** | **Temporary** — added, then *graduated* and removed once GA | **Permanent** — lives as long as the feature does |
+| **Who sets it** | Engineering / ops (DB overrides inserted via SQL; no admin write API) | Org admins, via the admin panel / API |
+| **Value type** | Boolean only | Boolean now; structured values (ints, lists) later |
+| **Audience** | Internal | Customer-facing |
+
+There's real overlap (both resolve an org override against an instance
+default), but conflating them is confusing: a feature flag is something you
+expect to *delete*, an org setting is something you expect to *keep*. When in
+doubt: "Is this a temporary rollout switch?" → feature flag. "Is this config a
+customer will manage long-term?" → org setting.
+
+## How a setting resolves: DB wins, env is the fallback
+
+Each column in `organization_settings` is **nullable**:
+
+- `NULL` (no row, or a NULL column) → **not set; inherit the instance/env default**
+- explicit `true`/`false` → **per-org override that wins over the env** (including an explicit `false` that disables something the env turned on)
+
+Rows are **sparse**: only the columns an admin has actually changed are
+written; everything else stays `NULL` and keeps inheriting.
+
+Resolution happens in exactly **one** place — `resolveEffectiveOrganizationSettings`
+in `packages/common/src/types/organizationSettings.ts`:
+
+```ts
+effective = rawOverride ?? instanceDefault   // per field
+```
+
+Critically:
+
+- The **model is env-agnostic** — `OrganizationSettingsModel` returns the *raw*
+  `boolean | null` and never reads `lightdashConfig`. Don't put the env fallback
+  in the model (it's a data layer, and the setting→env-var mapping is config
+  knowledge).
+- The **backend returns the already-resolved (effective) value** from the API,
+  so the **frontend never resolves anything** — it just displays what `GET`
+  returns. This is why backend and frontend can't drift.
+- The **login flow uses the same resolver**, so the toggle's displayed state and
+  the actual runtime behavior are guaranteed identical.
+
+Do **not** expose the instance env defaults to the frontend (e.g. via `/health`)
+just so the UI can resolve — that pushes us back toward the env dependency we're
+migrating away from.
+
+## Architecture / where things live
+
+| Layer | File | Responsibility |
+|---|---|---|
+| Table | `migrations/*_create_organization_settings_table.ts` | nullable columns, 1:1 with `organizations` (org_uuid PK) |
+| Entity | `database/entities/organizationSettings.ts` | `DbOrganizationSettings` row type |
+| Model | `models/OrganizationSettingsModel.ts` | raw get/update via explicit, exhaustive literals; **env-agnostic** |
+| Common type + resolver | `common/src/types/organizationSettings.ts` | `OrganizationSettings`, `UpdateOrganizationSettings`, `resolveEffectiveOrganizationSettings` |
+| Service | `services/OrganizationSettingsService/OrganizationSettingsService.ts` | `manage Organization` check; returns **effective** values |
+| Controller | `controllers/organizationSettingsController.ts` | `GET` / `PATCH /api/v1/org/settings` (non-EE, no uuid in path — org from session) |
+| Consumers | e.g. `UserService` (login gates) | read effective via the shared resolver |
+| Frontend | `hooks/organization/useOrganizationSettings.ts`, `components/UserSettings/OrganizationSso/AccountLinkingPanel.tsx` | display + toggle |
+
+The model uses plain explicit literals (like the rest of the codebase), but
+typed so the compiler enforces completeness:
+
+- `get` returns the full `OrganizationSettings` shape, so adding a field to the
+  type makes `get` fail to compile until you read the new column.
+- `update` builds a `SettingsColumnPatch` literal — a mapped type over **all**
+  settings columns — so it also fails to compile until you map the new column.
+  Undefined entries are stripped, so omitted settings keep their stored value.
+
+So you can't silently forget to wire a new setting through the model — TS points
+at the exact spot.
+
+## Quick guide — adding a new org setting
+
+Say you're adding `csvCellsLimit` (migrating `RESULTS_S3_BUCKET`-style env config).
+
+1. **Migration** — add a nullable column to `organization_settings`:
+   ```ts
+   table.integer('csv_cells_limit').nullable();
+   ```
+2. **Entity** (`organizationSettings.ts`) — add `csv_cells_limit` to
+   `DbOrganizationSettings` and the insert/update `Pick` types.
+3. **Common type** (`common/src/types/organizationSettings.ts`):
+   - add `csvCellsLimit: number | null` to `OrganizationSettings`,
+   - resolve it in `resolveEffectiveOrganizationSettings` against its instance
+     default: `csvCellsLimit: raw.csvCellsLimit ?? instanceDefaults.csvCellsLimit`
+     (pass the relevant `lightdashConfig` slice in from the callers).
+4. **Model** (`OrganizationSettingsModel.ts`) — add the field to `get`'s
+   returned literal (`csvCellsLimit: row?.csv_cells_limit ?? null`) and to
+   `update`'s `columns` literal (`csv_cells_limit: patch.csvCellsLimit`). Both
+   won't compile until you do — that's the safety net.
+5. **Consume it** where the behavior lives, always via the resolver / the
+   service's effective value — never re-implement `?? default`.
+6. **Frontend** — add the control to the relevant panel, reading/writing through
+   `useOrganizationSettings`. The value is already effective; just display it.
+7. `pnpm generate-api`, then typecheck + the model/consumer tests.
+
+### Gotchas
+
+- **Don't add the fallback to the model.** Model returns raw `null`; resolution
+  is the resolver's job.
+- **One resolver only.** Backend returns effective; frontend displays. Never add
+  a second resolution path (frontend, another service, `/health`, …).
+- **`null` means inherit, not "off".** Read it as "no override".
+- **Stale `common` dist.** After editing `common`, the incremental build can
+  leave `dist/cjs` behind, surfacing as `X is not a function` at runtime. Force
+  it: `pnpm -F common exec tsc --build ./tsconfig.build.json --force`.

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -148,6 +148,10 @@ import {
     OrganizationAllowedEmailDomainsTableName,
 } from '../database/entities/organizationsAllowedEmailDomains';
 import {
+    OrganizationSettingsTable,
+    OrganizationSettingsTableName,
+} from '../database/entities/organizationSettings';
+import {
     OrganizationSsoConfigurationsTable,
     OrganizationSsoConfigurationsTableName,
 } from '../database/entities/organizationSsoConfigurations';
@@ -474,6 +478,7 @@ declare module 'knex/types/tables' {
         [SchedulerLogTableName]: SchedulerLogTable;
         [OrganizationAllowedEmailDomainsTableName]: OrganizationAllowedEmailDomainsTable;
         [OrganizationAllowedEmailDomainProjectsTableName]: OrganizationAllowedEmailDomainProjectsTable;
+        [OrganizationSettingsTableName]: OrganizationSettingsTable;
         [OrganizationSsoConfigurationsTableName]: OrganizationSsoConfigurationsTable;
         [ValidationTableName]: ValidationTable;
         [GroupTableName]: GroupTable;

--- a/packages/backend/src/controllers/organizationSettingsController.ts
+++ b/packages/backend/src/controllers/organizationSettingsController.ts
@@ -1,0 +1,72 @@
+import {
+    ApiErrorPayload,
+    ApiOrganizationSettingsResponse,
+    assertRegisteredAccount,
+    UpdateOrganizationSettings,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Middlewares,
+    OperationId,
+    Patch,
+    Request,
+    Response,
+    Route,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from './authentication';
+import { BaseController } from './baseController';
+
+@Route('/api/v1/org/settings')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Organizations')
+export class OrganizationSettingsController extends BaseController {
+    /**
+     * Returns the current organization's settings. Defaults are returned when
+     * no settings have been saved.
+     * @summary Get organization settings
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get()
+    @OperationId('GetOrganizationSettings')
+    async getOrganizationSettings(
+        @Request() req: express.Request,
+    ): Promise<ApiOrganizationSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationSettingsService()
+            .getOrganizationSettings(req.account);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Updates the current organization's settings. Only the provided fields
+     * are changed.
+     * @summary Update organization settings
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Patch()
+    @OperationId('UpdateOrganizationSettings')
+    async updateOrganizationSettings(
+        @Request() req: express.Request,
+        @Body() body: UpdateOrganizationSettings,
+    ): Promise<ApiOrganizationSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getOrganizationSettingsService()
+            .updateOrganizationSettings(req.account, body);
+        this.setStatus(200);
+        return { status: 'ok', results };
+    }
+}

--- a/packages/backend/src/database/entities/organizationSettings.ts
+++ b/packages/backend/src/database/entities/organizationSettings.ts
@@ -1,0 +1,41 @@
+import { Knex } from 'knex';
+
+export const OrganizationSettingsTableName = 'organization_settings';
+
+/**
+ * Per-organization settings migrated from instance-wide env vars. One row per
+ * organization (keyed by `organization_uuid`); absence of a row means every
+ * setting takes its default. Designed to grow as more Pro settings move
+ * org-level.
+ */
+export type DbOrganizationSettings = {
+    organization_uuid: string;
+    // Nullable: NULL means "not set — inherit the instance default".
+    oidc_linking_enabled: boolean | null;
+    oidc_to_email_linking_enabled: boolean | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+// The actual settings columns — everything except the key and timestamps.
+// Derived from `DbOrganizationSettings` so adding a setting column flows into
+// the insert/update types automatically (no extra edits here).
+export type DbOrganizationSettingsColumns = Omit<
+    DbOrganizationSettings,
+    'organization_uuid' | 'created_at' | 'updated_at'
+>;
+
+type DbOrganizationSettingsInsert = Pick<
+    DbOrganizationSettings,
+    'organization_uuid'
+> &
+    Partial<DbOrganizationSettingsColumns>;
+
+export type OrganizationSettingsTable = Knex.CompositeTableType<
+    DbOrganizationSettings,
+    DbOrganizationSettingsInsert,
+    Partial<
+        DbOrganizationSettingsColumns &
+            Pick<DbOrganizationSettings, 'updated_at'>
+    >
+>;

--- a/packages/backend/src/database/migrations/20260526133422_create_organization_settings_table.ts
+++ b/packages/backend/src/database/migrations/20260526133422_create_organization_settings_table.ts
@@ -1,0 +1,35 @@
+import { Knex } from 'knex';
+
+const ORGANIZATION_SETTINGS_TABLE = 'organization_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(ORGANIZATION_SETTINGS_TABLE, (table) => {
+        // 1:1 with organizations — the FK column is the primary key, which
+        // also serves as the index Postgres needs for the ON DELETE CASCADE.
+        table
+            .uuid('organization_uuid')
+            .primary()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+        // Per-org auth account-linking toggles (migrated from instance-wide
+        // AUTH_ENABLE_OIDC_LINKING / AUTH_ENABLE_OIDC_TO_EMAIL_LINKING env
+        // vars). Nullable: NULL means "not set — inherit the instance/env
+        // default"; an explicit true/false overrides the env. Rows are sparse —
+        // only columns an admin has set are written, the rest stay NULL.
+        table.boolean('oidc_linking_enabled').nullable();
+        table.boolean('oidc_to_email_linking_enabled').nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(ORGANIZATION_SETTINGS_TABLE);
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -57,6 +57,8 @@ import { OrganizationDesignController } from './../controllers/organizationDesig
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationRolesController } from './../controllers/OrganizationRolesController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { OrganizationSettingsController } from './../controllers/organizationSettingsController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { PinningController } from './../controllers/pinningController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ProjectCompileLogController } from './../controllers/projectCompileLogController';
@@ -11849,11 +11851,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12405,11 +12407,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12451,11 +12453,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12470,11 +12472,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12489,11 +12491,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12508,11 +12510,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -24670,7 +24672,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24680,7 +24682,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -24690,7 +24692,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -24703,7 +24705,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -25358,7 +25360,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -25368,7 +25370,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -25378,7 +25380,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -25391,7 +25393,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -26944,6 +26946,75 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    OrganizationSettings: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                oidcToEmailLinkingEnabled: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                oidcLinkingEnabled: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiOrganizationSettingsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'OrganizationSettings', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Partial_OrganizationSettings_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                oidcLinkingEnabled: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                oidcToEmailLinkingEnabled: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateOrganizationSettings: {
+        dataType: 'refAlias',
+        type: { ref: 'Partial_OrganizationSettings_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     OrganizationDesignFileKind: {
@@ -56076,6 +56147,122 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSettingsController_getOrganizationSettings: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/org/settings',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSettingsController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSettingsController.prototype.getOrganizationSettings,
+        ),
+
+        async function OrganizationSettingsController_getOrganizationSettings(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSettingsController_getOrganizationSettings,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSettingsController>(
+                        OrganizationSettingsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getOrganizationSettings',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationSettingsController_updateOrganizationSettings: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateOrganizationSettings',
+        },
+    };
+    app.patch(
+        '/api/v1/org/settings',
+        ...fetchMiddlewares<RequestHandler>(OrganizationSettingsController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationSettingsController.prototype.updateOrganizationSettings,
+        ),
+
+        async function OrganizationSettingsController_updateOrganizationSettings(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationSettingsController_updateOrganizationSettings,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationSettingsController>(
+                        OrganizationSettingsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateOrganizationSettings',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13412,19 +13412,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -25893,22 +25880,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -26468,22 +26455,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -27954,6 +27941,56 @@
                 },
                 "required": ["data", "type"],
                 "type": "object"
+            },
+            "OrganizationSettings": {
+                "properties": {
+                    "oidcToEmailLinkingEnabled": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "description": "Auto-link an OIDC identity to an existing user matched by verified\nprimary email, regardless of how they signed up (overrides\n`AUTH_ENABLE_OIDC_TO_EMAIL_LINKING`; `null` inherits it)."
+                    },
+                    "oidcLinkingEnabled": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "description": "Auto-link a new OIDC identity to an existing user who already has a\ndifferent OIDC identity with the same email (overrides\n`AUTH_ENABLE_OIDC_LINKING`; `null` inherits it)."
+                    }
+                },
+                "required": ["oidcToEmailLinkingEnabled", "oidcLinkingEnabled"],
+                "type": "object",
+                "description": "Per-organization settings migrated from instance-wide env vars. Surfaced in\nthe Pro admin panel and stored in the `organization_settings` table. Starts\nwith the OIDC account-linking toggles; designed to grow as more settings\nmove org-level.\n\nEach value is tri-state: `null` means \"not set — inherit the instance/env\ndefault\", while an explicit `true`/`false` overrides the env. The fallback\nto the env default is resolved in the auth layer, not here."
+            },
+            "ApiOrganizationSettingsResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/OrganizationSettings"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Partial_OrganizationSettings_": {
+                "properties": {
+                    "oidcLinkingEnabled": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "description": "Auto-link a new OIDC identity to an existing user who already has a\ndifferent OIDC identity with the same email (overrides\n`AUTH_ENABLE_OIDC_LINKING`; `null` inherits it)."
+                    },
+                    "oidcToEmailLinkingEnabled": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "description": "Auto-link an OIDC identity to an existing user matched by verified\nprimary email, regardless of how they signed up (overrides\n`AUTH_ENABLE_OIDC_TO_EMAIL_LINKING`; `null` inherits it)."
+                    }
+                },
+                "type": "object",
+                "description": "Make all properties in T optional"
+            },
+            "UpdateOrganizationSettings": {
+                "$ref": "#/components/schemas/Partial_OrganizationSettings_"
             },
             "OrganizationDesignFileKind": {
                 "type": "string",
@@ -35182,7 +35219,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3020.0",
+        "version": "0.3022.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -49871,6 +49908,78 @@
                                 },
                                 "type": "array",
                                 "description": "the new order of the pinned items"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/settings": {
+            "get": {
+                "operationId": "GetOrganizationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationSettingsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Returns the current organization's settings. Defaults are returned when\nno settings have been saved.",
+                "summary": "Get organization settings",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
+            },
+            "patch": {
+                "operationId": "UpdateOrganizationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiOrganizationSettingsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Updates the current organization's settings. Only the provided fields\nare changed.",
+                "summary": "Update organization settings",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateOrganizationSettings"
                             }
                         }
                     }

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -32,6 +32,7 @@ import { OrganizationAllowedEmailDomainsModel } from './OrganizationAllowedEmail
 import { OrganizationDesignModel } from './OrganizationDesignModel';
 import { OrganizationMemberProfileModel } from './OrganizationMemberProfileModel';
 import { OrganizationModel } from './OrganizationModel';
+import { OrganizationSettingsModel } from './OrganizationSettingsModel';
 import { OrganizationSsoModel } from './OrganizationSsoModel';
 import { OrganizationWarehouseCredentialsModel } from './OrganizationWarehouseCredentialsModel';
 import { PasswordResetLinkModel } from './PasswordResetLinkModel';
@@ -93,6 +94,7 @@ export type ModelManifest = {
     organizationDesignModel: OrganizationDesignModel;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
     organizationModel: OrganizationModel;
+    organizationSettingsModel: OrganizationSettingsModel;
     organizationSsoModel: OrganizationSsoModel;
     organizationWarehouseCredentialsModel: OrganizationWarehouseCredentialsModel;
     passwordResetLinkModel: PasswordResetLinkModel;
@@ -437,6 +439,13 @@ export class ModelRepository
                     database: this.database,
                     encryptionUtil: this.utils.getEncryptionUtil(),
                 }),
+        );
+    }
+
+    public getOrganizationSettingsModel(): OrganizationSettingsModel {
+        return this.getModel(
+            'organizationSettingsModel',
+            () => new OrganizationSettingsModel({ database: this.database }),
         );
     }
 

--- a/packages/backend/src/models/OrganizationSettingsModel.test.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.test.ts
@@ -1,0 +1,128 @@
+import { Knex } from 'knex';
+import { OrganizationSettingsModel } from './OrganizationSettingsModel';
+
+type Captured = {
+    insert?: Record<string, unknown>;
+    merge?: Record<string, unknown>;
+};
+
+/**
+ * Builds an OrganizationSettingsModel backed by a chainable Knex mock. `row`
+ * is what `.first()` resolves to (the row `get` reads — also what `update`
+ * re-reads at the end), and `captured` records the args passed to `.insert()`
+ * / `.merge()` so we can assert exactly which columns a write touched.
+ */
+const createModel = (row: Record<string, unknown> | undefined) => {
+    const captured: Captured = {};
+    const builder: Record<string, jest.Mock> = {};
+    Object.assign(builder, {
+        where: jest.fn(() => builder),
+        first: jest.fn(async () => row),
+        insert: jest.fn((arg: Record<string, unknown>) => {
+            captured.insert = arg;
+            return builder;
+        }),
+        onConflict: jest.fn(() => builder),
+        merge: jest.fn(async (arg: Record<string, unknown>) => {
+            captured.merge = arg;
+        }),
+    });
+    const database = jest.fn(() => builder) as unknown as Knex;
+    return {
+        model: new OrganizationSettingsModel({ database }),
+        captured,
+    };
+};
+
+const ORG = 'org-1';
+
+describe('OrganizationSettingsModel', () => {
+    describe('get', () => {
+        test('returns all-null (nothing overridden → inherit) when no row exists', async () => {
+            const { model } = createModel(undefined);
+            expect(await model.get(ORG)).toEqual({
+                oidcLinkingEnabled: null,
+                oidcToEmailLinkingEnabled: null,
+            });
+        });
+
+        test('maps a sparse stored row, passing NULL columns through as null', async () => {
+            // Only one setting was ever written; the other stays NULL (inherit).
+            const { model } = createModel({
+                oidc_linking_enabled: true,
+                oidc_to_email_linking_enabled: null,
+            });
+            expect(await model.get(ORG)).toEqual({
+                oidcLinkingEnabled: true,
+                oidcToEmailLinkingEnabled: null,
+            });
+        });
+    });
+
+    describe('update', () => {
+        test('a partial update only writes the provided column (does not touch the others)', async () => {
+            // DB state after the write: the untouched setting kept its value.
+            const { model, captured } = createModel({
+                oidc_linking_enabled: true,
+                oidc_to_email_linking_enabled: false,
+            });
+
+            const result = await model.update(ORG, {
+                oidcLinkingEnabled: true,
+            });
+
+            // insert carries only the org + the one provided column
+            expect(captured.insert).toEqual({
+                organization_uuid: ORG,
+                oidc_linking_enabled: true,
+            });
+            // merge updates only that column (+ updated_at) — crucially it does
+            // NOT include oidc_to_email_linking_enabled, so the existing value
+            // is preserved rather than overwritten.
+            expect(captured.merge).toHaveProperty('oidc_linking_enabled', true);
+            expect(captured.merge).not.toHaveProperty(
+                'oidc_to_email_linking_enabled',
+            );
+            expect(captured.merge?.updated_at).toBeInstanceOf(Date);
+
+            // returns the re-read settings
+            expect(result).toEqual({
+                oidcLinkingEnabled: true,
+                oidcToEmailLinkingEnabled: false,
+            });
+        });
+
+        test('updating multiple settings writes all provided columns', async () => {
+            const { model, captured } = createModel({
+                oidc_linking_enabled: true,
+                oidc_to_email_linking_enabled: true,
+            });
+
+            await model.update(ORG, {
+                oidcLinkingEnabled: true,
+                oidcToEmailLinkingEnabled: true,
+            });
+
+            expect(captured.merge).toMatchObject({
+                oidc_linking_enabled: true,
+                oidc_to_email_linking_enabled: true,
+            });
+        });
+
+        test('an empty patch touches no setting columns (only updated_at)', async () => {
+            const { model, captured } = createModel({
+                oidc_linking_enabled: false,
+                oidc_to_email_linking_enabled: false,
+            });
+
+            await model.update(ORG, {});
+
+            expect(captured.merge).not.toHaveProperty('oidc_linking_enabled');
+            expect(captured.merge).not.toHaveProperty(
+                'oidc_to_email_linking_enabled',
+            );
+            expect(captured.merge?.updated_at).toBeInstanceOf(Date);
+            expect(captured.insert).toEqual({ organization_uuid: ORG });
+        });
+    });
+});

--- a/packages/backend/src/models/OrganizationSettingsModel.ts
+++ b/packages/backend/src/models/OrganizationSettingsModel.ts
@@ -1,0 +1,74 @@
+import {
+    OrganizationSettings,
+    UpdateOrganizationSettings,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import isUndefined from 'lodash/isUndefined';
+import omitBy from 'lodash/omitBy';
+import {
+    DbOrganizationSettingsColumns,
+    OrganizationSettingsTableName,
+} from '../database/entities/organizationSettings';
+
+/**
+ * Every settings column, each optionally provided. Used to build the upsert in
+ * `update` — because all keys are required, adding a field to
+ * `OrganizationSettings`/`DbOrganizationSettings` makes the object literal
+ * below fail to compile until you map it. (`get` is likewise forced to read it
+ * by returning the full `OrganizationSettings` shape.)
+ */
+type SettingsColumnPatch = {
+    [K in keyof DbOrganizationSettingsColumns]:
+        | DbOrganizationSettingsColumns[K]
+        | undefined;
+};
+
+export class OrganizationSettingsModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    /**
+     * Returns the org's raw stored overrides — `null` for anything not set (no
+     * row, or a NULL column), which the resolver treats as "inherit the
+     * instance default". The model is env-agnostic; resolving the fallback is
+     * the caller's job.
+     */
+    async get(organizationUuid: string): Promise<OrganizationSettings> {
+        const row = await this.database(OrganizationSettingsTableName)
+            .where('organization_uuid', organizationUuid)
+            .first();
+        return {
+            oidcLinkingEnabled: row?.oidc_linking_enabled ?? null,
+            oidcToEmailLinkingEnabled:
+                row?.oidc_to_email_linking_enabled ?? null,
+        };
+    }
+
+    /**
+     * Upserts only the settings present in `patch` (undefined entries are
+     * dropped, so omitted settings keep their stored value). Returns the new
+     * raw state.
+     */
+    async update(
+        organizationUuid: string,
+        patch: UpdateOrganizationSettings,
+    ): Promise<OrganizationSettings> {
+        const columns: SettingsColumnPatch = {
+            oidc_linking_enabled: patch.oidcLinkingEnabled,
+            oidc_to_email_linking_enabled: patch.oidcToEmailLinkingEnabled,
+        };
+        const toWrite = omitBy(
+            columns,
+            isUndefined,
+        ) as Partial<DbOrganizationSettingsColumns>;
+
+        await this.database(OrganizationSettingsTableName)
+            .insert({ organization_uuid: organizationUuid, ...toWrite })
+            .onConflict('organization_uuid')
+            .merge({ ...toWrite, updated_at: new Date() });
+        return this.get(organizationUuid);
+    }
+}

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -1,0 +1,81 @@
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    OrganizationSettings,
+    resolveEffectiveOrganizationSettings,
+    UpdateOrganizationSettings,
+    type RegisteredAccount,
+} from '@lightdash/common';
+import { LightdashConfig } from '../../config/parseConfig';
+import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
+import { BaseService } from '../BaseService';
+
+type OrganizationSettingsServiceArguments = {
+    lightdashConfig: LightdashConfig;
+    organizationSettingsModel: OrganizationSettingsModel;
+};
+
+/**
+ * Generic per-organization settings (account-linking toggles today, more to
+ * come). Stored in `organization_settings`, gated by `manage Organization`.
+ * Reads/writes raw overrides but always returns the EFFECTIVE value (override
+ * resolved against the instance default via the shared resolver), so callers —
+ * including the frontend — never re-implement the fallback.
+ */
+export class OrganizationSettingsService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly organizationSettingsModel: OrganizationSettingsModel;
+
+    constructor({
+        lightdashConfig,
+        organizationSettingsModel,
+    }: OrganizationSettingsServiceArguments) {
+        super({ serviceName: 'OrganizationSettingsService' });
+        this.lightdashConfig = lightdashConfig;
+        this.organizationSettingsModel = organizationSettingsModel;
+    }
+
+    private assertCanManageOrganization(account: RegisteredAccount): string {
+        const organizationUuid = account.organization?.organizationUuid;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return organizationUuid;
+    }
+
+    async getOrganizationSettings(
+        account: RegisteredAccount,
+    ): Promise<OrganizationSettings> {
+        const organizationUuid = this.assertCanManageOrganization(account);
+        const raw = await this.organizationSettingsModel.get(organizationUuid);
+        return resolveEffectiveOrganizationSettings(
+            raw,
+            this.lightdashConfig.auth,
+        );
+    }
+
+    async updateOrganizationSettings(
+        account: RegisteredAccount,
+        data: UpdateOrganizationSettings,
+    ): Promise<OrganizationSettings> {
+        const organizationUuid = this.assertCanManageOrganization(account);
+        const raw = await this.organizationSettingsModel.update(
+            organizationUuid,
+            data,
+        );
+        return resolveEffectiveOrganizationSettings(
+            raw,
+            this.lightdashConfig.auth,
+        );
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -38,6 +38,7 @@ import { OAuthService } from './OAuthService/OAuthService';
 import { OrganizationAccessService } from './OrganizationAccessService/OrganizationAccessService';
 import { OrganizationDesignService } from './OrganizationDesignService/OrganizationDesignService';
 import { OrganizationService } from './OrganizationService/OrganizationService';
+import { OrganizationSettingsService } from './OrganizationSettingsService/OrganizationSettingsService';
 import { OrganizationSsoService } from './OrganizationSsoService/OrganizationSsoService';
 import { PermissionsService } from './PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from './PersistentDownloadFileService/PersistentDownloadFileService';
@@ -90,6 +91,7 @@ interface ServiceManifest {
 
     organizationDesignService: OrganizationDesignService;
     organizationService: OrganizationService;
+    organizationSettingsService: OrganizationSettingsService;
     organizationSsoService: OrganizationSsoService;
     organizationAccessService: OrganizationAccessService;
     preAggregateMaterializationService: PreAggregateMaterializationService;
@@ -573,6 +575,18 @@ export class ServiceRepository
         );
     }
 
+    public getOrganizationSettingsService(): OrganizationSettingsService {
+        return this.getService(
+            'organizationSettingsService',
+            () =>
+                new OrganizationSettingsService({
+                    lightdashConfig: this.context.lightdashConfig,
+                    organizationSettingsModel:
+                        this.models.getOrganizationSettingsModel(),
+                }),
+        );
+    }
+
     public getPermissionsService(): PermissionsService {
         return this.getService(
             'permissionsService',
@@ -970,6 +984,8 @@ export class ServiceRepository
                     organizationAllowedEmailDomainsModel:
                         this.models.getOrganizationAllowedEmailDomainsModel(),
                     organizationSsoModel: this.models.getOrganizationSsoModel(),
+                    organizationSettingsModel:
+                        this.models.getOrganizationSettingsModel(),
                     userWarehouseCredentialsModel:
                         this.models.getUserWarehouseCredentialsModel(),
                     warehouseAvailableTablesModel:

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -21,6 +21,7 @@ import { OpenIdIdentityModel } from '../models/OpenIdIdentitiesModel';
 import { OrganizationAllowedEmailDomainsModel } from '../models/OrganizationAllowedEmailDomainsModel';
 import { OrganizationMemberProfileModel } from '../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../models/OrganizationModel';
+import { OrganizationSettingsModel } from '../models/OrganizationSettingsModel';
 import { OrganizationSsoModel } from '../models/OrganizationSsoModel';
 import { PasswordResetLinkModel } from '../models/PasswordResetLinkModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
@@ -103,6 +104,14 @@ const organizationSsoModel = {
     findGoogleMethodsForEmailDomain: jest.fn(async () => []),
 };
 
+const organizationSettingsModel = {
+    get: jest.fn(async () => ({
+        oidcLinkingEnabled: null,
+        oidcToEmailLinkingEnabled: null,
+    })),
+    update: jest.fn(),
+};
+
 const createUserService = (lightdashConfig: LightdashConfig) =>
     new UserService({
         analytics: analyticsMock,
@@ -123,6 +132,8 @@ const createUserService = (lightdashConfig: LightdashConfig) =>
             {} as OrganizationAllowedEmailDomainsModel,
         organizationSsoModel:
             organizationSsoModel as unknown as OrganizationSsoModel,
+        organizationSettingsModel:
+            organizationSettingsModel as unknown as OrganizationSettingsModel,
         userWarehouseCredentialsModel: {} as UserWarehouseCredentialsModel,
         warehouseAvailableTablesModel: {} as WarehouseAvailableTablesModel,
         projectModel: projectModel as unknown as ProjectModel,
@@ -1217,6 +1228,43 @@ describe('UserService', () => {
                 0,
             );
         });
+        test('links via per-org OIDC linking even when the instance env flag is off', async () => {
+            // Instance env flags are off (default config); the org opts in
+            // through organization_settings.
+            (organizationSettingsModel.get as jest.Mock).mockResolvedValueOnce({
+                oidcLinkingEnabled: true,
+                oidcToEmailLinkingEnabled: false,
+            });
+
+            await userService.loginWithOpenId(openIdUser, undefined, undefined);
+
+            expect(
+                openIdIdentityModel.createIdentity as jest.Mock,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: sessionUser.userId }),
+            );
+            expect(userModel.createUser as jest.Mock).toHaveBeenCalledTimes(0);
+        });
+        test('links via per-org OIDC-to-email linking even when the instance env flag is off', async () => {
+            // No matching OIDC identity → the OIDC-linking gate is skipped; the
+            // user is matched by verified primary email and the org opts in.
+            (
+                openIdIdentityModel.findIdentitiesByEmail as jest.Mock
+            ).mockResolvedValueOnce([]);
+            (organizationSettingsModel.get as jest.Mock).mockResolvedValueOnce({
+                oidcLinkingEnabled: false,
+                oidcToEmailLinkingEnabled: true,
+            });
+
+            await userService.loginWithOpenId(openIdUser, undefined, undefined);
+
+            expect(
+                openIdIdentityModel.createIdentity as jest.Mock,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: sessionUser.userId }),
+            );
+            expect(userModel.createUser as jest.Mock).toHaveBeenCalledTimes(0);
+        });
         test('should update openid ', async () => {
             // Mock that identity is found for that openid
             (
@@ -1308,6 +1356,13 @@ describe('UserService', () => {
                         async () => undefined,
                     ),
                 } as unknown as OrganizationSsoModel,
+                organizationSettingsModel: {
+                    get: jest.fn(async () => ({
+                        oidcLinkingEnabled: null,
+                        oidcToEmailLinkingEnabled: null,
+                    })),
+                    update: jest.fn(),
+                } as unknown as OrganizationSettingsModel,
                 userWarehouseCredentialsModel:
                     {} as UserWarehouseCredentialsModel,
                 warehouseAvailableTablesModel:
@@ -1377,6 +1432,13 @@ describe('UserService', () => {
                         async () => undefined,
                     ),
                 } as unknown as OrganizationSsoModel,
+                organizationSettingsModel: {
+                    get: jest.fn(async () => ({
+                        oidcLinkingEnabled: null,
+                        oidcToEmailLinkingEnabled: null,
+                    })),
+                    update: jest.fn(),
+                } as unknown as OrganizationSettingsModel,
                 userWarehouseCredentialsModel:
                     {} as UserWarehouseCredentialsModel,
                 warehouseAvailableTablesModel:

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -41,6 +41,7 @@ import {
     PasswordReset,
     ProjectMemberRole,
     RegisterOrActivateUser,
+    resolveEffectiveOrganizationSettings,
     ServiceAccount,
     SessionUser,
     SnowflakeAuthenticationType,
@@ -81,6 +82,7 @@ import { OpenIdIdentityModel } from '../models/OpenIdIdentitiesModel';
 import { OrganizationAllowedEmailDomainsModel } from '../models/OrganizationAllowedEmailDomainsModel';
 import { OrganizationMemberProfileModel } from '../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../models/OrganizationModel';
+import { OrganizationSettingsModel } from '../models/OrganizationSettingsModel';
 import { OrganizationSsoModel } from '../models/OrganizationSsoModel';
 import { PasswordResetLinkModel } from '../models/PasswordResetLinkModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
@@ -107,6 +109,7 @@ type UserServiceArguments = {
     personalAccessTokenModel: PersonalAccessTokenModel;
     organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
     organizationSsoModel: OrganizationSsoModel;
+    organizationSettingsModel: OrganizationSettingsModel;
     userWarehouseCredentialsModel: UserWarehouseCredentialsModel;
     warehouseAvailableTablesModel: WarehouseAvailableTablesModel;
     projectModel: ProjectModel;
@@ -213,6 +216,8 @@ export class UserService extends BaseService {
 
     private readonly organizationSsoModel: OrganizationSsoModel;
 
+    private readonly organizationSettingsModel: OrganizationSettingsModel;
+
     private readonly userWarehouseCredentialsModel: UserWarehouseCredentialsModel;
 
     private readonly warehouseAvailableTablesModel: WarehouseAvailableTablesModel;
@@ -241,6 +246,7 @@ export class UserService extends BaseService {
         personalAccessTokenModel,
         organizationAllowedEmailDomainsModel,
         organizationSsoModel,
+        organizationSettingsModel,
         userWarehouseCredentialsModel,
         warehouseAvailableTablesModel,
         projectModel,
@@ -263,6 +269,7 @@ export class UserService extends BaseService {
         this.organizationAllowedEmailDomainsModel =
             organizationAllowedEmailDomainsModel;
         this.organizationSsoModel = organizationSsoModel;
+        this.organizationSettingsModel = organizationSettingsModel;
         this.userWarehouseCredentialsModel = userWarehouseCredentialsModel;
         this.warehouseAvailableTablesModel = warehouseAvailableTablesModel;
         this.projectModel = projectModel;
@@ -749,6 +756,42 @@ export class UserService extends BaseService {
         }
     }
 
+    /**
+     * Whether auto-linking a new OIDC identity to an existing user (matched by
+     * a shared OIDC email) is allowed for the target user's org. The per-org
+     * `organization_settings.oidc_linking_enabled` takes priority; when it's
+     * unset (null) we fall back to the instance `AUTH_ENABLE_OIDC_LINKING`.
+     */
+    private async isOidcLinkingEnabledForOrg(
+        organizationUuid: string | undefined,
+    ): Promise<boolean> {
+        const raw = organizationUuid
+            ? await this.organizationSettingsModel.get(organizationUuid)
+            : {};
+        return (
+            resolveEffectiveOrganizationSettings(raw, this.lightdashConfig.auth)
+                .oidcLinkingEnabled ?? false
+        );
+    }
+
+    /**
+     * Whether auto-linking an OIDC identity to an existing user matched by
+     * verified primary email is allowed for the target user's org. The per-org
+     * `organization_settings.oidc_to_email_linking_enabled` takes priority;
+     * when unset (null) we fall back to `AUTH_ENABLE_OIDC_TO_EMAIL_LINKING`.
+     */
+    private async isOidcToEmailLinkingEnabledForOrg(
+        organizationUuid: string | undefined,
+    ): Promise<boolean> {
+        const raw = organizationUuid
+            ? await this.organizationSettingsModel.get(organizationUuid)
+            : {};
+        return (
+            resolveEffectiveOrganizationSettings(raw, this.lightdashConfig.auth)
+                .oidcToEmailLinkingEnabled ?? false
+        );
+    }
+
     private async loginWithOpenIdInner(
         openIdUser: OpenIdUser,
         authenticatedUser: SessionUser | undefined,
@@ -857,17 +900,20 @@ export class UserService extends BaseService {
             return loginUser;
         }
 
-        // Link the new openid identity to an existing user if they already have another OIDC with the same email
-        if (!authenticatedUser && this.lightdashConfig.auth.enableOidcLinking) {
+        // Link the new openid identity to an existing user if they already
+        // have another OIDC with the same email. Allowed instance-wide via env
+        // OR per-org via organization_settings — so we resolve the candidate
+        // user first, then check the effective toggle for their org.
+        if (!authenticatedUser) {
             const identities =
                 await this.openIdIdentityModel.findIdentitiesByEmail(
                     openIdUser.openId.email,
                 );
-            this.logger.info(
-                `OIDC linking enabled - Found ${identities.length} existing identities for email ${openIdUser.openId.email}`,
-            );
             const identitiesUsers = uniq(
                 identities.map((identity) => identity.userUuid),
+            );
+            this.logger.info(
+                `OIDC account-linking check for ${openIdUser.openId.email} — found ${identities.length} existing identities (linking decided per-org)`,
             );
             if (identitiesUsers.length > 1) {
                 this.logger.warn(
@@ -877,51 +923,60 @@ export class UserService extends BaseService {
                 const sessionUser = await this.userModel.findSessionUserByUUID(
                     identitiesUsers[0],
                 );
-                this.logger.info(
-                    `Linking new OpenID identity to existing user ${sessionUser.userUuid}`,
-                );
 
                 if (
-                    this.lightdashConfig.groups.enabled === true &&
-                    this.lightdashConfig.auth.enableGroupSync === true &&
-                    Array.isArray(openIdUser.openId.groups) &&
-                    openIdUser.openId.groups.length &&
-                    sessionUser.organizationUuid
+                    await this.isOidcLinkingEnabledForOrg(
+                        sessionUser.organizationUuid,
+                    )
                 ) {
                     this.logger.info(
-                        `Syncing groups for existing user ${
-                            sessionUser.userUuid
-                        } - Groups: ${openIdUser.openId.groups.join(', ')}`,
+                        `Linking new OpenID identity to existing user ${sessionUser.userUuid}`,
                     );
-                    await this.tryAddUserToGroups({
-                        userUuid: sessionUser.userUuid,
-                        groups: openIdUser.openId.groups,
-                        organizationUuid: sessionUser.organizationUuid,
-                    });
-                }
 
-                return this.linkOpenIdIdentityToUser(
-                    sessionUser,
-                    openIdUser,
-                    refreshToken,
-                );
+                    if (
+                        this.lightdashConfig.groups.enabled === true &&
+                        this.lightdashConfig.auth.enableGroupSync === true &&
+                        Array.isArray(openIdUser.openId.groups) &&
+                        openIdUser.openId.groups.length &&
+                        sessionUser.organizationUuid
+                    ) {
+                        this.logger.info(
+                            `Syncing groups for existing user ${
+                                sessionUser.userUuid
+                            } - Groups: ${openIdUser.openId.groups.join(', ')}`,
+                        );
+                        await this.tryAddUserToGroups({
+                            userUuid: sessionUser.userUuid,
+                            groups: openIdUser.openId.groups,
+                            organizationUuid: sessionUser.organizationUuid,
+                        });
+                    }
+
+                    return this.linkOpenIdIdentityToUser(
+                        sessionUser,
+                        openIdUser,
+                        refreshToken,
+                    );
+                }
             }
         }
 
-        // Link the new openid identity to an existing user if they already have the same primary email and it's verified
-        if (
-            !authenticatedUser &&
-            this.lightdashConfig.auth.enableOidcToEmailLinking
-        ) {
+        // Link the new openid identity to an existing user if they already
+        // have the same verified primary email. Allowed instance-wide via env
+        // OR per-org via organization_settings — resolve the candidate user,
+        // then check the effective toggle for their org.
+        if (!authenticatedUser) {
             const userWithSameEmail =
                 await this.userModel.findSessionUserByPrimaryEmail(
                     openIdUser.openId.email,
                 );
-            this.logger.info(
-                `Email linking enabled - Found user with same email: ${!!userWithSameEmail}`,
-            );
 
-            if (userWithSameEmail) {
+            if (
+                userWithSameEmail &&
+                (await this.isOidcToEmailLinkingEnabledForOrg(
+                    userWithSameEmail.organizationUuid,
+                ))
+            ) {
                 const emailStatus = await this.emailModel.getPrimaryEmailStatus(
                     userWithSameEmail.userUuid,
                 );

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -135,6 +135,7 @@ export * from './types/openIdIdentity';
 export * from './types/organization';
 export * from './types/organizationAccess';
 export * from './types/organizationMemberProfile';
+export * from './types/organizationSettings';
 export * from './types/organizationSso';
 export * from './types/organizationWarehouseCredentials';
 export * from './types/paginateResults';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -149,6 +149,7 @@ import {
     type OrganizationMemberProfile,
     type OrganizationMemberRole,
 } from './organizationMemberProfile';
+import { type OrganizationSettings } from './organizationSettings';
 import {
     type AzureAdSsoConfigSummary,
     type GenericOidcSsoConfigSummary,
@@ -941,6 +942,7 @@ type ApiResults =
     | OktaSsoConfigSummary
     | GenericOidcSsoConfigSummary
     | OneLoginSsoConfigSummary
+    | OrganizationSettings
     | UpdateAllowedEmailDomains
     | UserAllowedOrganization[]
     | EmailStatusExpiring

--- a/packages/common/src/types/organizationSettings.ts
+++ b/packages/common/src/types/organizationSettings.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-organization settings migrated from instance-wide env vars. Surfaced in
+ * the Pro admin panel and stored in the `organization_settings` table. Starts
+ * with the OIDC account-linking toggles; designed to grow as more settings
+ * move org-level.
+ *
+ * Each value is tri-state: `null` means "not set — inherit the instance/env
+ * default", while an explicit `true`/`false` overrides the env. The fallback
+ * to the env default is resolved in the auth layer, not here.
+ */
+export type OrganizationSettings = {
+    /**
+     * Auto-link a new OIDC identity to an existing user who already has a
+     * different OIDC identity with the same email (overrides
+     * `AUTH_ENABLE_OIDC_LINKING`; `null` inherits it).
+     */
+    oidcLinkingEnabled: boolean | null;
+    /**
+     * Auto-link an OIDC identity to an existing user matched by verified
+     * primary email, regardless of how they signed up (overrides
+     * `AUTH_ENABLE_OIDC_TO_EMAIL_LINKING`; `null` inherits it).
+     */
+    oidcToEmailLinkingEnabled: boolean | null;
+};
+
+export type UpdateOrganizationSettings = Partial<OrganizationSettings>;
+
+export type ApiOrganizationSettingsResponse = {
+    status: 'ok';
+    results: OrganizationSettings;
+};
+
+/**
+ * The single source of truth for resolving a stored (raw) org settings record
+ * against the instance defaults: an explicit per-org value wins; a value that's
+ * `null`, or simply absent (an unset column / no row at all), falls back to the
+ * instance default. Used by the backend for both the API response (so the
+ * frontend just displays the effective value) and the login flow, so the two
+ * can never drift. `instanceDefaults` is structurally satisfied by
+ * `lightdashConfig.auth`.
+ */
+export const resolveEffectiveOrganizationSettings = (
+    raw: Partial<OrganizationSettings>,
+    instanceDefaults: {
+        enableOidcLinking: boolean;
+        enableOidcToEmailLinking: boolean;
+    },
+): OrganizationSettings => ({
+    oidcLinkingEnabled:
+        raw.oidcLinkingEnabled ?? instanceDefaults.enableOidcLinking,
+    oidcToEmailLinkingEnabled:
+        raw.oidcToEmailLinkingEnabled ??
+        instanceDefaults.enableOidcToEmailLinking,
+});

--- a/packages/frontend/src/components/UserSettings/OrganizationSso/AccountLinkingPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationSso/AccountLinkingPanel.tsx
@@ -1,0 +1,82 @@
+import { Group, Stack, Switch, Text, ThemeIcon, Title } from '@mantine-8/core';
+import { IconLink } from '@tabler/icons-react';
+import { type FC } from 'react';
+import {
+    useOrganizationSettings,
+    useUpdateOrganizationSettings,
+} from '../../../hooks/organization/useOrganizationSettings';
+import EmptyStateLoader from '../../common/EmptyStateLoader';
+import MantineIcon from '../../common/MantineIcon';
+import { SettingsCard } from '../../common/Settings/SettingsCard';
+
+const AccountLinkingPanel: FC = () => {
+    const { data, isLoading } = useOrganizationSettings();
+    const update = useUpdateOrganizationSettings();
+
+    // The API already returns the effective value (org override resolved
+    // against the instance default on the backend), so the panel just shows
+    // it. `pending` reflects an in-flight edit optimistically so the toggle
+    // doesn't snap back while saving.
+    const pending = update.isLoading ? update.variables : undefined;
+    const oidcLinkingEnabled =
+        pending?.oidcLinkingEnabled ?? data?.oidcLinkingEnabled ?? false;
+    const oidcToEmailLinkingEnabled =
+        pending?.oidcToEmailLinkingEnabled ??
+        data?.oidcToEmailLinkingEnabled ??
+        false;
+
+    return (
+        <SettingsCard p="lg">
+            {isLoading || !data ? (
+                <EmptyStateLoader mih={80} />
+            ) : (
+                <Stack gap="md">
+                    <Group gap="sm" wrap="nowrap" align="flex-start">
+                        <ThemeIcon
+                            variant="light"
+                            color="gray"
+                            size="lg"
+                            radius="sm"
+                        >
+                            <MantineIcon icon={IconLink} />
+                        </ThemeIcon>
+                        <Stack gap={2}>
+                            <Title order={5}>Account linking</Title>
+                            <Text c="dimmed" size="sm" maw={520}>
+                                Control whether single sign-on logins are
+                                automatically linked to existing accounts.
+                            </Text>
+                        </Stack>
+                    </Group>
+
+                    <Switch
+                        label="Link SSO identities across providers"
+                        description="When a user signs in with a new SSO provider, link it to an existing account that already uses a different provider with the same email."
+                        checked={oidcLinkingEnabled}
+                        disabled={update.isLoading}
+                        onChange={(event) =>
+                            update.mutate({
+                                oidcLinkingEnabled: event.currentTarget.checked,
+                            })
+                        }
+                    />
+
+                    <Switch
+                        label="Link SSO logins to existing accounts by email"
+                        description="Link an SSO sign-in to an existing account that has the same verified primary email, regardless of how that account was created."
+                        checked={oidcToEmailLinkingEnabled}
+                        disabled={update.isLoading}
+                        onChange={(event) =>
+                            update.mutate({
+                                oidcToEmailLinkingEnabled:
+                                    event.currentTarget.checked,
+                            })
+                        }
+                    />
+                </Stack>
+            )}
+        </SettingsCard>
+    );
+};
+
+export default AccountLinkingPanel;

--- a/packages/frontend/src/hooks/organization/useOrganizationSettings.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationSettings.ts
@@ -1,0 +1,52 @@
+import {
+    type ApiError,
+    type OrganizationSettings,
+    type UpdateOrganizationSettings,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+import useToaster from '../toaster/useToaster';
+
+const QUERY_KEY = ['organization_settings'];
+
+const getOrganizationSettings = async () =>
+    lightdashApi<OrganizationSettings>({
+        url: '/org/settings',
+        method: 'GET',
+        body: undefined,
+    });
+
+const updateOrganizationSettings = async (data: UpdateOrganizationSettings) =>
+    lightdashApi<OrganizationSettings>({
+        url: '/org/settings',
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useOrganizationSettings = () =>
+    useQuery<OrganizationSettings, ApiError>({
+        queryKey: QUERY_KEY,
+        queryFn: getOrganizationSettings,
+    });
+
+export const useUpdateOrganizationSettings = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<
+        OrganizationSettings,
+        ApiError,
+        UpdateOrganizationSettings
+    >(updateOrganizationSettings, {
+        mutationKey: ['organization_settings', 'update'],
+        onSuccess: async () => {
+            await queryClient.invalidateQueries(QUERY_KEY);
+            showToastSuccess({ title: 'Account linking settings saved' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to save account linking settings',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -62,6 +62,7 @@ import MyAppsPanel from '../components/UserSettings/MyAppsPanel';
 import { MyWarehouseConnectionsPanel } from '../components/UserSettings/MyWarehouseConnectionsPanel';
 import OAuthClientsPanel from '../components/UserSettings/OAuthClientsPanel';
 import OrganizationPanel from '../components/UserSettings/OrganizationPanel';
+import AccountLinkingPanel from '../components/UserSettings/OrganizationSso/AccountLinkingPanel';
 import AzureAdSsoPanel from '../components/UserSettings/OrganizationSso/AzureAdSsoPanel';
 import GenericOidcSsoPanel from '../components/UserSettings/OrganizationSso/GenericOidcSsoPanel';
 import GoogleSsoPanel from '../components/UserSettings/OrganizationSso/GoogleSsoPanel';
@@ -503,6 +504,7 @@ const Settings: FC = () => {
                         {/* Google has no per-org credentials; only show the
                             toggle when Google is enabled instance-wide. */}
                         {health?.auth.google.enabled && <GoogleSsoPanel />}
+                        <AccountLinkingPanel />
                     </Stack>
                 ),
             });


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-7553/admin-panel-auth-toggles-oidc-linking](https://linear.app/lightdash/issue/PROD-7553/admin-panel-auth-toggles-oidc-linking)

<img width="927" height="265" alt="CleanShot 2026-05-26 at 16 34 18" src="https://github.com/user-attachments/assets/da42b44b-801a-4876-a960-3b062c492d1d" />

### Description:

Introduces a new `organization_settings` table and supporting infrastructure to allow per-organization control over OIDC account-linking behaviour, moving these settings away from being purely instance-wide environment variables (`AUTH_ENABLE_OIDC_LINKING` / `AUTH_ENABLE_OIDC_TO_EMAIL_LINKING`).

**Backend:**

- Adds the `organization_settings` table via a new migration, with a 1:1 relationship to `organizations` (keyed by `organization_uuid`, cascades on delete). Stores `oidc_linking_enabled` and `oidc_to_email_linking_enabled` boolean columns, both defaulting to `false`. Absence of a row means all defaults apply.
- Adds `OrganizationSettingsModel` with `get` (returns defaults when no row exists) and `update` (upserts only the provided fields) methods.
- Extends `OrganizationSsoService` with `getOrganizationSettings` and `updateOrganizationSettings` methods, gated behind the existing SSO feature flag and `manage Organization` permission check.
- Adds `GET /api/v1/org/sso/settings` and `PATCH /api/v1/org/sso/settings` endpoints to `OrganizationSsoController`.
- Updates `UserService.loginWithOpenId` so that both OIDC linking paths check the effective toggle as an OR of the instance-wide env var and the per-org setting, rather than only the env var.

**Common:**

- Adds `OrganizationSettings`, `UpdateOrganizationSettings`, and `ApiOrganizationSettingsResponse` types exported from `@lightdash/common`.

**Frontend:**

- Adds `useOrganizationSettings` and `useUpdateOrganizationSettings` React Query hooks.
- Adds an `AccountLinkingPanel` component with two toggles ("Link SSO identities across providers" and "Link SSO logins to existing accounts by email"), rendered in the SSO settings page. Optimistic UI reflects in-flight toggle state while the PATCH is saving.

**Tests:**

- Adds unit tests to `UserService.test.ts` covering per-org OIDC linking and OIDC-to-email linking when the instance env flags are off but the org has opted in.