### PR TITLE
fix(ai-agent): preserve instructions on partial agent updates (#23510)

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1887,7 +1887,10 @@ export class AiAgentModel {
                 { tx: trx },
             );
 
-            if (args.instruction !== instruction) {
+            if (
+                args.instruction !== undefined &&
+                args.instruction !== instruction
+            ) {
                 const [result] = await trx(AiAgentInstructionVersionsTableName)
                     .insert({
                         ai_agent_uuid: agent.ai_agent_uuid,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7931/ai-agent-instructions-cleared-when-adding-an-mcp-via-the-edit-ui

### Description:
Previously, any update that omitted `instruction` (e.g. the MCP-only update from the edit UI) inserted a new ai_agent_instruction_versions row with an empty string, wiping the agent's instructions. Only write a new version when `instruction` is actually present in the payload; `null` / empty string still represents an explicit clear.