### PR TITLE
fix(pivot): correct passthrough merge index for `metricsAsRows` fanout

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1,4 +1,10 @@
 import { type ItemsMap } from '../types/field';
+import { type ResultRow } from '../types/results';
+import {
+    SortByDirection,
+    VizAggregationOptions,
+    VizIndexType,
+} from '../visualizations/types';
 import {
     convertSqlPivotedRowsToPivotData,
     pivotQueryResults,
@@ -2022,5 +2028,159 @@ describe('passthrough dimensions (PROD-7873)', () => {
             (c) => c.columnType === 'passthrough',
         );
         expect(passthroughEntries).toEqual([]);
+    });
+
+    // PROD-7933 regression. Before the fix, the post-retrofit merge did
+    // `rows[outputRowIndex]` — but in `metricsAsRows: true` mode each input row
+    // fans out to `baseMetricsArray.length` output rows, so the off-by-N
+    // shifted passthrough values onto unrelated rows. Customer-visible symptom
+    // was four metric rows of the same product carrying four *different*
+    // product images.
+    it('metricsAsRows: each metric row carries the passthrough value of its originating input row', () => {
+        // Two input rows × two metrics → four output rows. If the merge ever
+        // regresses back to `rows[rowIndex]`:
+        //   - output 0 (row 0, metric 0) reads rows[0] → image_a ✓ (coincidence)
+        //   - output 1 (row 0, metric 1) reads rows[1] → image_b ✗
+        //   - output 2 (row 1, metric 0) reads rows[2] → undefined ✗
+        //   - output 3 (row 1, metric 1) reads rows[3] → undefined ✗
+        // The assertions below pin down all four positions, so any regression
+        // (off-by-one, undefined-on-overflow, swapped pairing) will fail loudly.
+        const rows: ResultRow[] = [
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2025-01-01T00:00:00Z',
+                        formatted: '2025',
+                    },
+                },
+                orders_status_image_url: {
+                    value: {
+                        raw: 'https://placehold.co/60?text=A',
+                        formatted: 'https://placehold.co/60?text=A',
+                    },
+                },
+                payments_total_revenue_any_bank_transfer: {
+                    value: { raw: 100, formatted: '100' },
+                },
+                orders_total_order_amount_any_bank_transfer: {
+                    value: { raw: 200, formatted: '200' },
+                },
+            },
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2024-01-01T00:00:00Z',
+                        formatted: '2024',
+                    },
+                },
+                orders_status_image_url: {
+                    value: {
+                        raw: 'https://placehold.co/60?text=B',
+                        formatted: 'https://placehold.co/60?text=B',
+                    },
+                },
+                payments_total_revenue_any_bank_transfer: {
+                    value: { raw: 50, formatted: '50' },
+                },
+                orders_total_order_amount_any_bank_transfer: {
+                    value: { raw: 75, formatted: '75' },
+                },
+            },
+        ];
+
+        const result = convertSqlPivotedRowsToPivotData({
+            rows,
+            pivotDetails: {
+                totalColumnCount: 1,
+                valuesColumns: [
+                    {
+                        aggregation: VizAggregationOptions.ANY,
+                        pivotValues: [
+                            {
+                                value: 'bank_transfer',
+                                referenceField: 'payments_payment_method',
+                            },
+                        ],
+                        referenceField: 'payments_total_revenue',
+                        pivotColumnName:
+                            'payments_total_revenue_any_bank_transfer',
+                    },
+                    {
+                        aggregation: VizAggregationOptions.ANY,
+                        pivotValues: [
+                            {
+                                value: 'bank_transfer',
+                                referenceField: 'payments_payment_method',
+                            },
+                        ],
+                        referenceField: 'orders_total_order_amount',
+                        pivotColumnName:
+                            'orders_total_order_amount_any_bank_transfer',
+                    },
+                ],
+                indexColumn: [
+                    {
+                        type: VizIndexType.TIME,
+                        reference: 'orders_order_date_year',
+                    },
+                ],
+                groupByColumns: [{ reference: 'payments_payment_method' }],
+                passthroughDimensions: [
+                    { reference: 'orders_status_image_url' },
+                ],
+                sortBy: [
+                    {
+                        direction: SortByDirection.DESC,
+                        reference: 'orders_order_date_year',
+                    },
+                ],
+                originalColumns: {},
+            },
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: true,
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_payment_method',
+                    'payments_total_revenue',
+                    'orders_total_order_amount',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        // Sanity: two input rows × two metrics = four output rows.
+        expect(result.retrofitData.allCombinedData).toHaveLength(4);
+
+        // Output rows 0 and 1 are both expansions of input row 0 (year=2025)
+        // — both must carry image A. Output rows 2 and 3 are both expansions
+        // of input row 1 (year=2024) — both must carry image B.
+        const imageUrls = result.retrofitData.allCombinedData.map(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (r) => (r.orders_status_image_url as any)?.value?.raw,
+        );
+        expect(imageUrls).toEqual([
+            'https://placehold.co/60?text=A',
+            'https://placehold.co/60?text=A',
+            'https://placehold.co/60?text=B',
+            'https://placehold.co/60?text=B',
+        ]);
+
+        // The passthrough column is also registered with the right marker so
+        // the frontend hides it via TanStack columnVisibility (PR #23452 flow).
+        const passthroughEntries = result.retrofitData.pivotColumnInfo.filter(
+            (c) => c.columnType === 'passthrough',
+        );
+        expect(passthroughEntries).toEqual([
+            {
+                fieldId: 'orders_status_image_url',
+                baseId: 'orders_status_image_url',
+                underlyingId: undefined,
+                columnType: 'passthrough',
+            },
+        ]);
     });
 });

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -260,12 +260,15 @@ const getColSpanByKey = (
  * a flat row shape per output row.
  *
  * INVARIANT: `allCombinedData.length === indexValues.length`. The
- * `convertSqlPivotedRowsToPivotData` caller emits one row per input warehouse
- * row (1-to-1), and a separate post-processing step in that caller attaches
- * passthrough dimension values onto each output row positionally by index.
- * If this function ever starts coalescing/dropping rows, the positional
- * merge will silently associate passthrough values with the wrong rows.
- * The caller has a dev-mode warn that catches this during testing.
+ * `convertSqlPivotedRowsToPivotData` caller emits `rows.length` output rows
+ * in the standard pivot path, or `rows.length * baseMetricsArray.length`
+ * when `metricsAsRows: true` (each input row fans out to one output row per
+ * metric). A separate post-processing step in that caller attaches
+ * passthrough dimension values onto each output row positionally, dividing
+ * the output index by the fanout factor to land back on the originating
+ * input row. If this function ever starts coalescing/dropping rows, the
+ * positional merge will silently associate passthrough values with the
+ * wrong rows. The caller has a dev-mode warn that catches this during testing.
  */
 const combinedRetrofit = (
     data: PivotData,
@@ -1725,17 +1728,31 @@ export const convertSqlPivotedRowsToPivotData = ({
     // to the wrong row. The dev-mode warn below catches that during testing
     // without crashing prod for users.
     if (passthroughDimensions.length > 0) {
+        // In metricsAsRows mode, combinedRetrofit fans each input row out to
+        // baseMetricsArray.length output rows (one per metric). The positional
+        // merge below must divide the output index by that factor to land back
+        // on the originating input row — otherwise each metric row reads the
+        // passthrough value from a *different* input row, surfacing as
+        // mismatched images / cross-field template values for repeated row
+        // dims (PROD-7873 follow-up to PR #23452).
+        const inputRowsPerOutputRow =
+            pivotConfig.metricsAsRows && baseMetricsArray.length > 0
+                ? baseMetricsArray.length
+                : 1;
+        const expectedOutputLength = rows.length * inputRowsPerOutputRow;
         if (
             process.env.NODE_ENV !== 'production' &&
-            retrofitted.retrofitData.allCombinedData.length !== rows.length
+            retrofitted.retrofitData.allCombinedData.length !==
+                expectedOutputLength
         ) {
             // eslint-disable-next-line no-console
             console.warn(
                 `[pivot] passthrough positional merge invariant violated: ` +
                     `allCombinedData.length=${retrofitted.retrofitData.allCombinedData.length} ` +
-                    `!= rows.length=${rows.length}. Passthrough values may be ` +
-                    `attached to the wrong rows. Investigate combinedRetrofit ` +
-                    `for row coalescing.`,
+                    `!= rows.length*metricsFanout=${expectedOutputLength} ` +
+                    `(rows.length=${rows.length}, fanout=${inputRowsPerOutputRow}). ` +
+                    `Passthrough values may be attached to the wrong rows. ` +
+                    `Investigate combinedRetrofit for row coalescing.`,
             );
         }
         retrofitted.retrofitData.pivotColumnInfo = [
@@ -1750,7 +1767,8 @@ export const convertSqlPivotedRowsToPivotData = ({
         retrofitted.retrofitData.allCombinedData =
             retrofitted.retrofitData.allCombinedData.map(
                 (combinedRow, rowIndex) => {
-                    const inputRow = rows[rowIndex];
+                    const inputRow =
+                        rows[Math.floor(rowIndex / inputRowsPerOutputRow)];
                     if (!inputRow) return combinedRow;
                     const enriched: ResultRow = { ...combinedRow };
                     for (const dim of passthroughDimensions) {


### PR DESCRIPTION
Closes: PROD-7933

### Description:

In `metricsAsRows: true` mode, each input row fans out to `baseMetricsArray.length` output rows (one per metric). The passthrough dimension merge was using the raw output row index to look up the originating input row, causing it to read from the wrong input row. For example, with 2 input rows and 2 metrics producing 4 output rows, output rows 1, 2, and 3 would read from incorrect or undefined input rows — resulting in mismatched passthrough values (e.g. product images) across metric rows for the same dimension value.

The fix divides the output row index by the fanout factor (`baseMetricsArray.length`) before indexing into the original `rows` array, ensuring all metric rows expanded from the same input row correctly inherit that row's passthrough values.

The invariant warning in dev mode has also been updated to account for the fanout, so it correctly validates `allCombinedData.length === rows.length * metricsFanout` rather than a strict 1-to-1 match.

A regression test covering the 2 input rows × 2 metrics = 4 output rows case has been added, pinning all four output positions to their expected passthrough values.