### PR TITLE
feat(dev): deterministic fast-path script for /docker-dev start

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -5,7 +5,7 @@ Manage Docker dev environment. Args: (none) = show status & help, `start` = auto
 ## Arguments
 
 - **No arguments**: Show current status, assigned ports, and available commands. Read-only, safe to run anytime.
-- **`start`**: Auto-detect state and run what's needed (fresh setup, migrations, or just start PM2). Uses shared base snapshot to bootstrap new instances fast.
+- **`start`**: Bring this instance up. Runs the deterministic `scripts/dev-fast-start.sh` first (idempotent, non-interactive — no agentic step-by-step); only falls back to agentic setup + **self-repair** if the script fails. Uses the shared base snapshot to bootstrap new instances fast.
 - **`start ee`** (also `start --ee`, "start with ee enabled", "enterprise"): Same as `start`, but provisions an Enterprise Edition license (`LIGHTDASH_LICENSE_KEY`) and runs the EE migration/seed pass. See **Enterprise Edition (EE) Mode** below. Auto-enabled if `.env.development.local` already contains `LIGHTDASH_LICENSE_KEY`.
 - **`stop`**: Stop this instance's PM2 processes and PostgreSQL. Shared services stay running. Releases port slot.
 - **`stop-all`**: Stop ALL instances — all PM2 processes, all per-instance PostgreSQL containers, shared services, and release all port slots. Use when shutting down for the day.
@@ -276,6 +276,40 @@ Expect `Enterprise license for <site> is valid.` and no `no factory or provider`
 ---
 
 ## `start`: Auto-detect and Setup
+
+**ALWAYS try the deterministic fast path first.** Only fall back to the agentic steps when the script fails — this is what keeps worktree iteration fast.
+
+### Fast path (do this first, every time)
+
+`scripts/dev-fast-start.sh` encodes the entire happy path of this section as one idempotent, non-interactive run. Run it directly instead of executing the steps below one at a time:
+
+```bash
+./scripts/dev-fast-start.sh          # core
+./scripts/dev-fast-start.sh --ee     # EE mode (or if .env.development.local already has a license)
+```
+
+Interpreting the result:
+
+- **Exit 0, ends with `READY: ...`** → done. Report the printed frontend/API/Spotlight URLs and start the **Monitor watchers** (see "Monitor Logs with Monitor Tool"). **Do not run any of the agentic steps below** — the environment is up.
+- **Non-zero exit with a `FAIL: <step> -- <reason>` line** → enter **self-repair** (next section). Do NOT blindly re-run the script; diagnose first.
+
+The script prints `STEP:`/`OK:`/`SKIP:` markers so you can see exactly how far it got. Steady-state runs (everything cached) finish in well under a minute; a fresh worktree pays for `pnpm install` + builds once.
+
+### Self-repair protocol (when the script fails)
+
+The `FAIL: <step> -- <reason>` line names the failing phase and usually the exact log command to inspect. Repair the **root cause**, then **patch the script so the same failure cannot recur** — that is how the fast path stays reliable as the codebase drifts.
+
+1. **Identify the failing step** from the `FAIL:` line (e.g. `health`, `migrate`, `deps`, `pm2`, `bootstrap`, `ee-migrate`).
+2. **Run the matching agentic step(s) below** to understand and fix the underlying problem (read logs, apply migrations, rebuild a package, free a port, etc.). The detailed steps in this file remain the source of truth for each phase.
+3. **Patch `scripts/dev-fast-start.sh`** so the fix is baked in for next time — e.g. add a reconciling command, widen a readiness wait, handle a new required build artifact. Keep the script's contract intact: `STEP:`/`OK:`/`SKIP:`/`FAIL:` markers, idempotent, exit 0 only after `/api/v1/health` returns 200.
+4. **Re-run `./scripts/dev-fast-start.sh`** to confirm it now reaches `READY:`.
+5. Mention the script change in your summary so it can be committed — repairs are version-controlled and shared across worktrees, not re-derived per machine.
+
+> Example: a stale shared base snapshot caused `FAIL: health -- ... Database has not been migrated yet`. The repair was an idempotent "Apply pending migrations" step after bootstrap; the script now reconciles drift automatically.
+
+If the script is **missing** (e.g. an older checkout) or you suspect its logic is stale relative to this document, regenerate it from these agentic steps and the script contract above, then commit it.
+
+### Agentic steps (fallback + first-instance reference)
 
 Run State Detection first. For each `NEED:`, run the corresponding setup step below. If all checks show `OK:`, just start PM2.
 
@@ -581,7 +615,7 @@ fi
 If PM2 shows `MISMATCH`, delete this instance's processes first:
 
 ```bash
-pm2 delete "${LD_INSTANCE_ID}-api" "${LD_INSTANCE_ID}-scheduler" "${LD_INSTANCE_ID}-frontend" "${LD_INSTANCE_ID}-common-watch" "${LD_INSTANCE_ID}-warehouses-watch" "${LD_INSTANCE_ID}-sdk-test" "${LD_INSTANCE_ID}-spotlight" 2>/dev/null || true
+pm2 delete "${LD_INSTANCE_ID}-api" "${LD_INSTANCE_ID}-scheduler" "${LD_INSTANCE_ID}-frontend" "${LD_INSTANCE_ID}-common-watch" "${LD_INSTANCE_ID}-formula-watch" "${LD_INSTANCE_ID}-warehouses-watch" "${LD_INSTANCE_ID}-sdk-test" "${LD_INSTANCE_ID}-spotlight" 2>/dev/null || true
 ```
 
 Then start:
@@ -651,7 +685,7 @@ If a monitor fires, investigate the error. Common responses:
 Stop this instance's services. Shared services and other instances are not affected.
 
 ```bash
-pm2 delete "${LD_INSTANCE_ID}-api" "${LD_INSTANCE_ID}-scheduler" "${LD_INSTANCE_ID}-frontend" "${LD_INSTANCE_ID}-common-watch" "${LD_INSTANCE_ID}-warehouses-watch" "${LD_INSTANCE_ID}-sdk-test" "${LD_INSTANCE_ID}-spotlight" 2>/dev/null || true
+pm2 delete "${LD_INSTANCE_ID}-api" "${LD_INSTANCE_ID}-scheduler" "${LD_INSTANCE_ID}-frontend" "${LD_INSTANCE_ID}-common-watch" "${LD_INSTANCE_ID}-formula-watch" "${LD_INSTANCE_ID}-warehouses-watch" "${LD_INSTANCE_ID}-sdk-test" "${LD_INSTANCE_ID}-spotlight" 2>/dev/null || true
 
 docker compose -p "$LD_COMPOSE_PROJECT" -f docker/docker-compose.dev.instance.yml down
 
@@ -669,7 +703,7 @@ Stop ALL instances, shared services, and release all port slots.
 for f in ~/.lightdash/dev-instances/*.json; do
   [ -f "$f" ] || continue
   INST_ID=$(python3 -c "import json; print(json.load(open('$f'))['instanceId'])")
-  pm2 delete "${INST_ID}-api" "${INST_ID}-scheduler" "${INST_ID}-frontend" "${INST_ID}-common-watch" "${INST_ID}-warehouses-watch" "${INST_ID}-sdk-test" "${INST_ID}-spotlight" 2>/dev/null || true
+  pm2 delete "${INST_ID}-api" "${INST_ID}-scheduler" "${INST_ID}-frontend" "${INST_ID}-common-watch" "${INST_ID}-formula-watch" "${INST_ID}-warehouses-watch" "${INST_ID}-sdk-test" "${INST_ID}-spotlight" 2>/dev/null || true
 done
 
 for f in ~/.lightdash/dev-instances/*.json; do

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# Deterministic fast-path bootstrap for the Lightdash Docker dev environment.
+#
+# Encodes the happy path of `/docker-dev start` so a worktree can be brought up
+# in a single non-interactive run — no agentic step-by-step. The first agentic
+# run produces a working environment; this script captures that path so every
+# subsequent run (and every new worktree) is fast.
+#
+# Contract relied on by the /docker-dev command for self-repair:
+#   - Prints "STEP: <name>"  before each phase.
+#   - Prints "OK: ..." / "SKIP: ..." for done / already-satisfied phases.
+#   - On failure prints "FAIL: <step> -- <reason>" to stderr and exits non-zero.
+#   - Exits 0 only after the backend /api/v1/health endpoint returns 200.
+#   - Idempotent: safe to re-run at any time.
+#
+# Usage: scripts/dev-fast-start.sh [--ee]
+#
+# When this script fails, /docker-dev reads the FAIL line, fixes the root cause
+# using the documented agentic steps, then patches this script so it won't recur.
+
+set -uo pipefail
+
+SCHEMA_VERSION=1
+EE_MODE=false
+for arg in "$@"; do
+    case "$arg" in
+        --ee|ee) EE_MODE=true ;;
+        *) echo "FAIL: args -- unknown argument '$arg'" >&2; exit 2 ;;
+    esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || { echo "FAIL: cd -- cannot enter repo root $REPO_ROOT" >&2; exit 1; }
+
+SHARED_COMPOSE="docker/docker-compose.dev.shared.yml"
+INSTANCE_COMPOSE="docker/docker-compose.dev.instance.yml"
+SHARED_BASE_VOLUME="ld-shared_postgres_base"
+
+fail() { echo "FAIL: $1 -- $2" >&2; exit 1; }
+step() { echo "STEP: $1"; }
+
+instance_pm2_names() {
+    for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+        echo "${LD_INSTANCE_ID}-${suffix}"
+    done
+}
+
+dotenv_args() {
+    if [ "$EE_MODE" = true ]; then
+        echo "-e .env.development.local -e .env.development"
+    else
+        echo "-e .env.development"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+step "Claim port slot and load instance env"
+./scripts/dev-ports.sh claim >/dev/null 2>&1 || fail "ports" "dev-ports.sh claim failed (run ./scripts/dev-ports.sh claim to see why)"
+ENV_EXPORTS="$(./scripts/dev-ports.sh env 2>/dev/null)" || fail "ports" "dev-ports.sh env failed"
+eval "$ENV_EXPORTS"
+: "${LD_INSTANCE_ID:?}" "${LD_COMPOSE_PROJECT:?}" "${LD_VOLUME_PREFIX:?}" "${LD_CONTAINER_PREFIX:?}" "${LD_PG_PORT:?}" "${PORT:?}" "${FE_PORT:?}"
+DB_CONTAINER="${LD_CONTAINER_PREFIX}-db-dev-1"
+echo "OK: instance=$LD_INSTANCE_ID api=$PORT frontend=$FE_PORT pg=$LD_PG_PORT"
+
+# ---------------------------------------------------------------------------
+step "Ensure correct Node version"
+REQUIRED_NODE="$(cat .nvmrc 2>/dev/null || cat .node-version 2>/dev/null || echo "")"
+CURRENT_NODE="$(node -v 2>/dev/null | sed 's/^v//')"
+if [ -n "$REQUIRED_NODE" ] && ! echo "$CURRENT_NODE" | grep -q "^${REQUIRED_NODE}"; then
+    if command -v fnm >/dev/null 2>&1; then
+        eval "$(fnm env)"; fnm use "$REQUIRED_NODE" --install-if-missing >/dev/null 2>&1
+    elif [ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
+        . "${NVM_DIR:-$HOME/.nvm}/nvm.sh"; nvm use "$REQUIRED_NODE" >/dev/null 2>&1 || nvm install "$REQUIRED_NODE" >/dev/null 2>&1
+    elif command -v mise >/dev/null 2>&1; then
+        mise use "node@$REQUIRED_NODE" >/dev/null 2>&1
+    fi
+    CURRENT_NODE="$(node -v 2>/dev/null | sed 's/^v//')"
+    echo "$CURRENT_NODE" | grep -q "^${REQUIRED_NODE}" || fail "node" "need Node $REQUIRED_NODE, have ${CURRENT_NODE:-none}; install a version manager (fnm/nvm/mise)"
+fi
+echo "OK: node $(node -v 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+step "Ensure dependencies installed and built"
+if test -d node_modules \
+    && test -f packages/common/dist/cjs/index.js \
+    && test -f packages/formula/dist/grammar/parser.js \
+    && test -f packages/warehouses/dist/warehouseClients/ca-bundle-aws-redshift.crt; then
+    echo "SKIP: dependencies already present"
+else
+    command -v sfw >/dev/null 2>&1 || npm i -g sfw >/dev/null 2>&1 || fail "deps" "could not install sfw"
+    sfw pnpm install || fail "deps" "sfw pnpm install failed"
+    pnpm -F common build && pnpm -F warehouses build && pnpm -F @lightdash/formula build || fail "deps" "package builds failed"
+    echo "OK: installed and built"
+fi
+
+# ---------------------------------------------------------------------------
+step "Ensure Python/dbt venv"
+if test -f venv/bin/dbt && test -f venv/bin/dbt1.7; then
+    echo "SKIP: venv present"
+else
+    python3 -m venv venv || fail "venv" "python3 -m venv failed"
+    ./venv/bin/pip install dbt-core==1.7.0 dbt-postgres==1.7.0 'protobuf>=4.0.0,<5.0.0' >/dev/null 2>&1 \
+        || fail "venv" "pip install dbt failed"
+    ln -sf dbt venv/bin/dbt1.7
+    echo "OK: venv ready"
+fi
+
+# ---------------------------------------------------------------------------
+step "Ensure .env.development.local"
+if test -f .env.development.local; then
+    echo "SKIP: env file exists"
+else
+    cat > .env.development.local << EOF
+# Local development overrides (instance: ${LD_INSTANCE_ID})
+LD_INSTANCE_ID=${LD_INSTANCE_ID}
+PGHOST=localhost
+PGPORT=${LD_PG_PORT}
+PORT=${PORT}
+FE_PORT=${FE_PORT}
+SCHEDULER_PORT=${SCHEDULER_PORT}
+DEBUG_PORT=${DEBUG_PORT}
+SDK_TEST_PORT=${SDK_TEST_PORT}
+SPOTLIGHT_PORT=${SPOTLIGHT_PORT}
+LIGHTDASH_PROMETHEUS_PORT=${LIGHTDASH_PROMETHEUS_PORT}
+SITE_URL=http://localhost:${FE_PORT}
+S3_ENDPOINT=http://localhost:9000
+HEADLESS_BROWSER_HOST=localhost
+HEADLESS_BROWSER_PORT=3001
+INTERNAL_LIGHTDASH_HOST=http://localhost:${FE_PORT}
+
+# Email - Mailpit (shared service, view emails at http://localhost:8025)
+EMAIL_SMTP_HOST=localhost
+EMAIL_SMTP_PORT=1025
+EMAIL_SMTP_SECURE=false
+EMAIL_SMTP_USE_AUTH=false
+EMAIL_SMTP_ALLOW_INVALID_CERT=true
+EMAIL_SMTP_SENDER_NAME=Lightdash
+EMAIL_SMTP_SENDER_EMAIL=noreply@lightdash.local
+
+# Dev API access (auto-provisioned PAT from seed data)
+LIGHTDASH_API_URL=http://localhost:${PORT}
+LDPAT=ldpat_deadbeefdeadbeefdeadbeefdeadbeef
+EOF
+    echo "DBT_DEMO_DIR=$(pwd)/examples/full-jaffle-shop-demo" >> .env.development.local
+    echo "OK: env file created"
+fi
+
+# EE auto-detect: license already in env file => treat as EE for migrate/seed.
+if grep -q "^LIGHTDASH_LICENSE_KEY=" .env.development.local 2>/dev/null; then
+    EE_MODE=true
+fi
+if [ "$EE_MODE" = true ] && ! grep -q "^LIGHTDASH_LICENSE_KEY=eyJ" .env.development.local 2>/dev/null; then
+    fail "ee-license" "EE requested but no LIGHTDASH_LICENSE_KEY in .env.development.local; run Step EE-1 (1Password) first"
+fi
+
+# ---------------------------------------------------------------------------
+step "Start Docker services"
+docker compose -p ld-shared -f "$SHARED_COMPOSE" --env-file .env.development up -d \
+    || fail "docker-shared" "could not start shared services (minio/headless-browser/mailpit/nats)"
+docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" --env-file .env.development up -d \
+    || fail "docker-instance" "could not start per-instance PostgreSQL"
+
+step "Wait for PostgreSQL"
+PG_READY=false
+for _ in $(seq 1 30); do
+    if docker exec "$DB_CONTAINER" pg_isready -U postgres >/dev/null 2>&1; then PG_READY=true; break; fi
+    sleep 1
+done
+[ "$PG_READY" = true ] || fail "postgres" "container $DB_CONTAINER not ready after 30s"
+echo "OK: postgres ready"
+
+# ---------------------------------------------------------------------------
+step "Ensure database content"
+db_has() {
+    docker exec "$DB_CONTAINER" psql -U postgres -tAc \
+        "SELECT CASE WHEN EXISTS($1) THEN 'yes' ELSE 'no' END" 2>/dev/null
+}
+MIGRATED="$(db_has "SELECT 1 FROM information_schema.tables WHERE table_name='sessions'")"
+SEEDED="$(db_has "SELECT 1 FROM emails WHERE email='demo@lightdash.com'")"
+DBT_BUILT="$(db_has "SELECT 1 FROM information_schema.tables WHERE table_schema='jaffle' AND table_name='orders'")"
+BOOTSTRAPPED=false
+
+if [ "$MIGRATED" = yes ] && [ "$SEEDED" = yes ] && [ "$DBT_BUILT" = yes ]; then
+    echo "SKIP: database already migrated, seeded, dbt built"
+elif docker volume inspect "$SHARED_BASE_VOLUME" >/dev/null 2>&1; then
+    echo "Bootstrapping from shared base snapshot..."
+    docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" stop db-dev >/dev/null 2>&1
+    docker run --rm \
+        -v "${SHARED_BASE_VOLUME}:/source:ro" \
+        -v "${LD_VOLUME_PREFIX}_postgres_data:/target" \
+        alpine sh -c "rm -rf /target/* && cd /source && tar cf - . | (cd /target && tar xf -)" \
+        || fail "bootstrap" "failed to clone shared base volume"
+    docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" start db-dev >/dev/null 2>&1
+    for _ in $(seq 1 30); do docker exec "$DB_CONTAINER" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+    BOOTSTRAPPED=true
+    echo "OK: bootstrapped from shared base"
+else
+    echo "No shared base snapshot — running full setup (first instance)..."
+    export PATH="$(pwd)/venv/bin:$PATH"
+    export DBT_DEMO_DIR="$(pwd)/examples/full-jaffle-shop-demo"
+    # shellcheck disable=SC2046
+    PGHOST=localhost PGPORT=$LD_PG_PORT pnpx dotenv-cli $(dotenv_args) -- pnpm -F backend migrate \
+        || fail "migrate" "backend migrate failed"
+    # shellcheck disable=SC2046
+    PGHOST=localhost PGPORT=$LD_PG_PORT pnpx dotenv-cli $(dotenv_args) -- pnpm -F backend seed \
+        || fail "seed" "backend seed failed"
+    PGHOST=localhost PGPORT=$LD_PG_PORT PGUSER=postgres PGPASSWORD=password PGDATABASE=postgres \
+        "$(pwd)/venv/bin/dbt" seed --project-dir examples/full-jaffle-shop-demo/dbt --profiles-dir examples/full-jaffle-shop-demo/profiles \
+        || fail "dbt-seed" "dbt seed failed"
+    PGHOST=localhost PGPORT=$LD_PG_PORT PGUSER=postgres PGPASSWORD=password PGDATABASE=postgres \
+        "$(pwd)/venv/bin/dbt" run --project-dir examples/full-jaffle-shop-demo/dbt --profiles-dir examples/full-jaffle-shop-demo/profiles \
+        || fail "dbt-run" "dbt run failed"
+    echo "OK: full setup complete"
+    if [ "$EE_MODE" != true ] && ! docker volume inspect "$SHARED_BASE_VOLUME" >/dev/null 2>&1; then
+        echo "Creating shared base snapshot for future instances..."
+        docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" stop db-dev >/dev/null 2>&1
+        docker volume create "$SHARED_BASE_VOLUME" >/dev/null
+        docker run --rm \
+            -v "${LD_VOLUME_PREFIX}_postgres_data:/source:ro" \
+            -v "${SHARED_BASE_VOLUME}:/snapshot" \
+            alpine sh -c "cd /source && tar cf - . | (cd /snapshot && tar xf -)" \
+            || fail "shared-base" "failed to create shared base snapshot"
+        docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" start db-dev >/dev/null 2>&1
+        for _ in $(seq 1 30); do docker exec "$DB_CONTAINER" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# The shared base snapshot can lag behind this branch's migrations. knex migrate
+# is idempotent (no-op when current), so always reconcile before snapshotting.
+# EE mode runs its own core+EE migrate below, so skip the core-only pass here.
+if [ "$EE_MODE" != true ]; then
+    step "Apply pending migrations"
+    export PATH="$(pwd)/venv/bin:$PATH"
+    PGHOST=localhost PGPORT=$LD_PG_PORT pnpx dotenv-cli -e .env.development -- pnpm -F backend migrate \
+        || fail "migrate" "applying pending migrations failed (shared base may be stale)"
+    echo "OK: migrations current"
+fi
+
+# ---------------------------------------------------------------------------
+if [ "$EE_MODE" = true ]; then
+    step "EE migration + seed pass"
+    export PATH="$(pwd)/venv/bin:$PATH"
+    EE_APPLIED="$(db_has "SELECT 1 FROM information_schema.tables WHERE table_name='ai_agent_document'")"
+    if [ "$EE_APPLIED" = yes ]; then
+        echo "SKIP: EE migrations already applied"
+    else
+        PGHOST=localhost PGPORT=$LD_PG_PORT pnpx dotenv-cli -e .env.development.local -e .env.development -- pnpm -F backend migrate \
+            || fail "ee-migrate" "EE migrate failed"
+        if [ "$BOOTSTRAPPED" = true ]; then
+            PGHOST=localhost PGPORT=$LD_PG_PORT pnpx dotenv-cli -e .env.development.local -e .env.development -- \
+                pnpm -F backend exec knex seed:run --specific=01_embed.ts --knexfile src/knexfile.ts \
+                || fail "ee-seed" "EE seed failed"
+        fi
+        echo "OK: EE migration pass complete"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+step "Ensure instance snapshot"
+if docker volume inspect "${LD_VOLUME_PREFIX}_postgres_data_snapshot" >/dev/null 2>&1; then
+    echo "SKIP: snapshot exists"
+else
+    docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" stop db-dev >/dev/null 2>&1
+    docker volume create "${LD_VOLUME_PREFIX}_postgres_data_snapshot" >/dev/null
+    docker run --rm \
+        -v "${LD_VOLUME_PREFIX}_postgres_data:/source:ro" \
+        -v "${LD_VOLUME_PREFIX}_postgres_data_snapshot:/snapshot" \
+        alpine sh -c "cd /source && tar cf - . | (cd /snapshot && tar xf -)" \
+        || fail "snapshot" "failed to create instance snapshot"
+    docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" start db-dev >/dev/null 2>&1
+    for _ in $(seq 1 30); do docker exec "$DB_CONTAINER" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+    echo "OK: snapshot created"
+fi
+
+# ---------------------------------------------------------------------------
+step "Start PM2"
+RUNNING_CWD="$(pm2 jlist 2>/dev/null | INSTANCE="$LD_INSTANCE_ID" python3 -c "
+import sys, json, os
+inst = os.environ['INSTANCE']
+try:
+    procs = json.load(sys.stdin)
+except Exception:
+    procs = []
+mine = [p for p in procs if p['name'].startswith(inst + '-')]
+if mine:
+    cwd = mine[0]['pm2_env'].get('pm_cwd', '')
+    root = cwd.rsplit('/packages/', 1)[0] if '/packages/' in cwd else cwd
+    print(root)
+" 2>/dev/null || true)"
+if [ -n "$RUNNING_CWD" ] && [ "$RUNNING_CWD" != "$(pwd)" ]; then
+    echo "Instance PM2 was running from $RUNNING_CWD — switching to this worktree"
+    # shellcheck disable=SC2046
+    pm2 delete $(instance_pm2_names) >/dev/null 2>&1 || true
+fi
+pnpm pm2:start >/dev/null 2>&1 || fail "pm2" "pnpm pm2:start failed (check 'pm2 logs ${LD_INSTANCE_ID}-api')"
+echo "OK: pm2 started"
+
+# ---------------------------------------------------------------------------
+step "Verify backend health"
+HEALTH=""
+for _ in $(seq 1 60); do
+    HEALTH="$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${PORT}/api/v1/health" 2>/dev/null || true)"
+    [ "$HEALTH" = "200" ] && break
+    sleep 2
+done
+[ "$HEALTH" = "200" ] || fail "health" "backend /api/v1/health returned '${HEALTH:-no response}' after 120s (check 'pm2 logs ${LD_INSTANCE_ID}-api --lines 80 --nostream')"
+
+echo "OK: backend healthy"
+echo "READY: instance=$LD_INSTANCE_ID frontend=http://localhost:${FE_PORT} api=http://localhost:${PORT} spotlight=http://localhost:${SPOTLIGHT_PORT}"


### PR DESCRIPTION
## What

Adds `scripts/dev-fast-start.sh` — an idempotent, non-interactive script that encodes the happy path of `/docker-dev start`, and rewires the `/docker-dev` command to run it first, falling back to the agentic steps only to **self-repair** when the script fails.

## Why

`/docker-dev start` previously ran ~15 shell snippets one at a time, with a reasoning turn between each. Most of that reasoning was wasted because the happy path is identical every run — claim ports, write env, bootstrap the DB from the shared snapshot, start PM2, health-check. Wall-clock was dominated by model round-trip latency, making per-worktree iteration slow and non-deterministic.

## How it works

- **Fast path:** `/docker-dev start` runs `scripts/dev-fast-start.sh` (add `--ee` for Enterprise). On `READY:` it's done — no agentic steps.
- **Self-repair:** the script emits `STEP:`/`OK:`/`SKIP:` markers and, on failure, a single `FAIL: <step> -- <reason>` line to stderr with a non-zero exit. The command doc tells the agent to diagnose the root cause via the documented step, **patch the script so it can't recur**, then re-run. Repairs are version-controlled and shared across worktrees.
- The script handles both branches: fast bootstrap from the shared base, and first-instance full setup (migrate + seed + dbt) including shared-base creation. Supports EE (license guard, EE migrate + seed pass).

## Notable fixes folded in

- **Migration drift:** the shared base snapshot can lag a branch's migrations, so a fresh bootstrap 500s on health (`Database has not been migrated yet`). The script applies pending migrations (idempotent) after bootstrap and before snapshotting.
- **Orphaned `formula-watch`:** added to the `stop` / `stop-all` / PM2-mismatch delete lists so it's no longer left running after teardown.

## Testing

Exercised end-to-end on real worktrees:

| Case | Result |
|------|--------|
| Cold first run (install + builds + bootstrap) | ✅ `READY:` |
| Warm restart | ✅ ~18s, exit 0 |
| Fresh second worktree (bootstrap path) | ✅ caught + reconciled 11-migration drift, health 200 |
| Full EE with license | ✅ 83 migrations, EE seed, `Enterprise license valid`, health 200 |
| First-instance full setup + shared-base creation | ✅ 345 migrations + dbt (PASS 45/61), shared base recreated drift-free |
| EE flag without license | ✅ `FAIL: ee-license`, fails fast before Docker |
| PM2 cross-worktree switch detection | ✅ all 5 input cases correct |

🤖 Generated with [Claude Code](https://claude.com/claude-code)