### PR TITLE
feat(ee): add run_ai_writeback MCP tool

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -441,6 +441,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiOrganizationSettingsService:
                         repository.getAiOrganizationSettingsService(),
                     aiAgentService: repository.getAiAgentService(),
+                    aiWritebackService: repository.getAiWritebackService(),
                 }),
             slackService: ({ repository, clients }) =>
                 new CommercialSlackService({

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -7,6 +7,7 @@ import {
     CommercialFeatureFlags,
     convertAiTableCalcsSchemaToTableCalcs,
     Explore,
+    FeatureFlags,
     filterExploreByTags,
     ForbiddenError,
     getItemLabelWithoutTableName,
@@ -370,8 +371,94 @@ export class McpService extends BaseService {
         return this.mcpCompatLayer.processZodType(schema).shape;
     }
 
+    /**
+     * Registers the run_ai_writeback tool on the current server. Kept separate
+     * so setupHandlers can register it conditionally (dark launch — see the
+     * AiWriteback gate in setupHandlers).
+     */
+    private registerRunAiWritebackTool(): void {
+        this.mcpServer.registerTool(
+            McpToolName.RUN_AI_WRITEBACK,
+            {
+                description: mcpRunAiWritebackArgsSchema.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpRunAiWritebackArgsSchema,
+                ),
+                outputSchema: {
+                    output: z
+                        .string()
+                        .describe('The text output produced by the agent.'),
+                    exitCode: z
+                        .number()
+                        .int()
+                        .describe("The sandbox command's exit status."),
+                    prUrl: z
+                        .string()
+                        .nullable()
+                        .describe(
+                            'URL of the pull request opened from the agent changes, or null when the agent made no file changes.',
+                        ),
+                },
+                annotations: {
+                    readOnlyHint: false,
+                    destructiveHint: false,
+                    idempotentHint: false,
+                },
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+
+                const { user } = McpService.getAccount(ctx);
+                const projectUuid = await this.resolveProjectUuid(ctx);
+
+                this.trackToolCall(
+                    ctx,
+                    McpToolName.RUN_AI_WRITEBACK,
+                    projectUuid,
+                );
+
+                try {
+                    const result = await this.aiWritebackService.run(
+                        user,
+                        projectUuid,
+                        { prompt: args.prompt },
+                    );
+
+                    const summary = result.prUrl
+                        ? `AI writeback complete. Pull request opened: ${result.prUrl}`
+                        : 'AI writeback complete. The agent made no file changes, so no pull request was opened.';
+
+                    return await this.buildScopedResponse(
+                        ctx,
+                        `${summary}\n\n${result.output}`,
+                        {
+                            output: result.output,
+                            exitCode: result.exitCode,
+                            prUrl: result.prUrl,
+                        },
+                    );
+                } catch (e) {
+                    const errorMessage =
+                        e instanceof Error ? e.message : String(e);
+                    return {
+                        content: [
+                            {
+                                type: 'text' as const,
+                                text: `Error running AI writeback: ${errorMessage}`,
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+            },
+        );
+    }
+
     setupHandlers(
-        options: { projectPinned: boolean } = { projectPinned: false },
+        options: { projectPinned: boolean; aiWritebackEnabled: boolean } = {
+            projectPinned: false,
+            aiWritebackEnabled: false,
+        },
     ): void {
         this.mcpServer.registerTool(
             McpToolName.GET_LIGHTDASH_VERSION,
@@ -1530,81 +1617,14 @@ export class McpService extends BaseService {
             },
         );
 
-        this.mcpServer.registerTool(
-            McpToolName.RUN_AI_WRITEBACK,
-            {
-                description: mcpRunAiWritebackArgsSchema.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpRunAiWritebackArgsSchema,
-                ),
-                outputSchema: {
-                    output: z
-                        .string()
-                        .describe('The text output produced by the agent.'),
-                    exitCode: z
-                        .number()
-                        .int()
-                        .describe("The sandbox command's exit status."),
-                    prUrl: z
-                        .string()
-                        .nullable()
-                        .describe(
-                            'URL of the pull request opened from the agent changes, or null when the agent made no file changes.',
-                        ),
-                },
-                annotations: {
-                    readOnlyHint: false,
-                    destructiveHint: false,
-                    idempotentHint: false,
-                },
-            },
-            async (args, extra) => {
-                const ctx = getMcpContext(extra);
-
-                const { user } = McpService.getAccount(ctx);
-                const projectUuid = await this.resolveProjectUuid(ctx);
-
-                this.trackToolCall(
-                    ctx,
-                    McpToolName.RUN_AI_WRITEBACK,
-                    projectUuid,
-                );
-
-                try {
-                    const result = await this.aiWritebackService.run(
-                        user,
-                        projectUuid,
-                        { prompt: args.prompt },
-                    );
-
-                    const summary = result.prUrl
-                        ? `AI writeback complete. Pull request opened: ${result.prUrl}`
-                        : 'AI writeback complete. The agent made no file changes, so no pull request was opened.';
-
-                    return await this.buildScopedResponse(
-                        ctx,
-                        `${summary}\n\n${result.output}`,
-                        {
-                            output: result.output,
-                            exitCode: result.exitCode,
-                            prUrl: result.prUrl,
-                        },
-                    );
-                } catch (e) {
-                    const errorMessage =
-                        e instanceof Error ? e.message : String(e);
-                    return {
-                        content: [
-                            {
-                                type: 'text' as const,
-                                text: `Error running AI writeback: ${errorMessage}`,
-                            },
-                        ],
-                        isError: true,
-                    };
-                }
-            },
-        );
+        // Dark-launched: this tool is only registered — and therefore only
+        // advertised in tools/list and invocable — when the AiWriteback
+        // feature flag is enabled for the caller. Clients without the flag
+        // never see it. The flag is resolved per-request in the MCP router
+        // (mcpRouter.ts) and passed through createServer.
+        if (options.aiWritebackEnabled) {
+            this.registerRunAiWritebackTool();
+        }
 
         this.mcpServer.registerPrompt(
             'lightdash-analyst',
@@ -2359,7 +2379,10 @@ export class McpService extends BaseService {
      * Required for SDK 1.26.0+ stateful mode where each session needs its own server.
      * See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
      */
-    public createServer(options?: { projectPinned?: boolean }): McpServer {
+    public createServer(options?: {
+        projectPinned?: boolean;
+        aiWritebackEnabled?: boolean;
+    }): McpServer {
         const newServer = Sentry.wrapMcpServerWithSentry(
             new McpServer({
                 name: 'Lightdash MCP Server',
@@ -2387,7 +2410,10 @@ export class McpService extends BaseService {
         // Temporarily swap the server to register handlers on the new instance
         const originalServer = this.mcpServer;
         this.mcpServer = newServer;
-        this.setupHandlers({ projectPinned: options?.projectPinned ?? false });
+        this.setupHandlers({
+            projectPinned: options?.projectPinned ?? false,
+            aiWritebackEnabled: options?.aiWritebackEnabled ?? false,
+        });
         this.mcpServer = originalServer;
 
         return newServer;
@@ -2458,6 +2484,22 @@ export class McpService extends BaseService {
             aiCopilotFlag.enabled,
             user.organizationUuid,
         );
+    }
+
+    /**
+     * Whether the run_ai_writeback tool should be exposed to this caller.
+     * Gated behind the AiWriteback feature flag (off by default) so the tool
+     * can be dark launched — clients without the flag never see it in
+     * tools/list. Resolved per-request and passed into createServer.
+     */
+    public async isAiWritebackEnabled(
+        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+    ): Promise<boolean> {
+        const flag = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.AiWriteback,
+        });
+        return flag.enabled;
     }
 
     public getLightdashVersion(context: McpProtocolContext): string {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -14,6 +14,7 @@ import {
     getValidAiQueryLimit,
     isExploreError,
     JobPollTimeoutError,
+    mcpRunAiWritebackArgsSchema,
     mcpToolListExploresArgsSchema,
     MissingConfigError,
     NotFoundError,
@@ -110,6 +111,7 @@ import {
 import { serializeData } from '../ai/utils/serializeData';
 import { AiAgentService } from '../AiAgentService/AiAgentService';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
+import { AiWritebackService } from '../AiWritebackService/AiWritebackService';
 import {
     registerAppResource,
     registerAppTool,
@@ -134,6 +136,7 @@ export enum McpToolName {
     RUN_SQL = 'run_sql',
     SEARCH_FIELD_VALUES = 'search_field_values',
     LIST_VERIFIED_CONTENT = 'list_verified_content',
+    RUN_AI_WRITEBACK = 'run_ai_writeback',
 }
 
 type McpServiceArguments = {
@@ -154,6 +157,7 @@ type McpServiceArguments = {
     featureFlagService: FeatureFlagService;
     aiOrganizationSettingsService: AiOrganizationSettingsService;
     aiAgentService: AiAgentService;
+    aiWritebackService: AiWritebackService;
 };
 
 export type ExtraContext = {
@@ -240,6 +244,8 @@ export class McpService extends BaseService {
 
     private aiAgentService: AiAgentService;
 
+    private aiWritebackService: AiWritebackService;
+
     private mcpServer: McpServer;
 
     private mcpCompatLayer: McpSchemaCompatLayer;
@@ -262,6 +268,7 @@ export class McpService extends BaseService {
         featureFlagService,
         aiOrganizationSettingsService,
         aiAgentService,
+        aiWritebackService,
     }: McpServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -281,6 +288,7 @@ export class McpService extends BaseService {
         this.featureFlagService = featureFlagService;
         this.aiOrganizationSettingsService = aiOrganizationSettingsService;
         this.aiAgentService = aiAgentService;
+        this.aiWritebackService = aiWritebackService;
         this.mcpCompatLayer = new McpSchemaCompatLayer();
         try {
             this.mcpServer = Sentry.wrapMcpServerWithSentry(
@@ -1519,6 +1527,82 @@ export class McpService extends BaseService {
                     ctx,
                     JSON.stringify(verifiedContent, null, 2),
                 );
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.RUN_AI_WRITEBACK,
+            {
+                description: mcpRunAiWritebackArgsSchema.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpRunAiWritebackArgsSchema,
+                ),
+                outputSchema: {
+                    output: z
+                        .string()
+                        .describe('The text output produced by the agent.'),
+                    exitCode: z
+                        .number()
+                        .int()
+                        .describe("The sandbox command's exit status."),
+                    prUrl: z
+                        .string()
+                        .nullable()
+                        .describe(
+                            'URL of the pull request opened from the agent changes, or null when the agent made no file changes.',
+                        ),
+                },
+                annotations: {
+                    readOnlyHint: false,
+                    destructiveHint: false,
+                    idempotentHint: false,
+                },
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+
+                const { user } = McpService.getAccount(ctx);
+                const projectUuid = await this.resolveProjectUuid(ctx);
+
+                this.trackToolCall(
+                    ctx,
+                    McpToolName.RUN_AI_WRITEBACK,
+                    projectUuid,
+                );
+
+                try {
+                    const result = await this.aiWritebackService.run(
+                        user,
+                        projectUuid,
+                        { prompt: args.prompt },
+                    );
+
+                    const summary = result.prUrl
+                        ? `AI writeback complete. Pull request opened: ${result.prUrl}`
+                        : 'AI writeback complete. The agent made no file changes, so no pull request was opened.';
+
+                    return await this.buildScopedResponse(
+                        ctx,
+                        `${summary}\n\n${result.output}`,
+                        {
+                            output: result.output,
+                            exitCode: result.exitCode,
+                            prUrl: result.prUrl,
+                        },
+                    );
+                } catch (e) {
+                    const errorMessage =
+                        e instanceof Error ? e.message : String(e);
+                    return {
+                        content: [
+                            {
+                                type: 'text' as const,
+                                text: `Error running AI writeback: ${errorMessage}`,
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
             },
         );
 

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -170,8 +170,15 @@ mcpRouter.all(
                 // to prevent cross-client response data leaks (CVE-2026-25536)
                 // See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
                 const headerProjectUuid = extractProjectUuidFromHeader(req);
+                // Dark launch: the run_ai_writeback tool is only registered
+                // (and thus only listed/invocable) when the AiWriteback flag is
+                // enabled for this caller. Resolved here because tool
+                // registration in createServer/setupHandlers is synchronous.
+                const aiWritebackEnabled =
+                    await mcpService.isAiWritebackEnabled(req.user!);
                 const mcpServer = mcpService.createServer({
                     projectPinned: headerProjectUuid !== undefined,
+                    aiWritebackEnabled,
                 });
                 const transport = new StreamableHTTPServerTransport({
                     enableJsonResponse: true,

--- a/packages/common/src/ee/aiWriteback/types.ts
+++ b/packages/common/src/ee/aiWriteback/types.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { type ApiSuccess } from '../../types/api/success';
 
 /**
@@ -28,3 +29,47 @@ export type AiWritebackRunResult = {
 };
 
 export type ApiAiWritebackResponse = ApiSuccess<AiWritebackRunResult>;
+
+export const MCP_TOOL_RUN_AI_WRITEBACK_DESCRIPTION = `Tool: run_ai_writeback
+
+Purpose:
+Make a change to the dbt project that backs the active Lightdash project by describing it in natural language, then open a pull request with the result. The target GitHub repository and dbt sub-folder are resolved server-side from the active project's dbt connection — you never specify them.
+
+How it works:
+- A sandbox is created, the project's GitHub repository is cloned, and the prompt is executed by the Claude Code CLI against the dbt project.
+- If the agent changes any files, a branch is committed, pushed, and a pull request is opened. The PR URL is returned.
+- If the agent makes no file changes, no PR is opened and prUrl is null.
+
+Requirements:
+- An active project must be set first via set_project (or the X-Lightdash-Project header).
+- The project's dbt connection must be GitHub-backed, and the organization must have the GitHub App installed.
+- The AI writeback feature must be enabled for the organization.
+
+Important:
+- This tool is NOT read-only and NOT idempotent — each call can open a new pull request. Use it only when the user explicitly wants to change their dbt project.
+- The run is synchronous and can take a few minutes (cloning, running the agent, opening the PR).
+
+Parameters:
+- prompt: A clear, self-contained description of the change to make to the dbt project (e.g. "Add a 'total_revenue' metric to the orders model as the sum of amount").
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: "<human-readable summary including the PR URL>" }]
+- structuredContent: {
+    output:   string,           // the agent's text output
+    exitCode: number,           // the sandbox command's exit status
+    prUrl:    string | null     // URL of the opened pull request, or null when no changes were made
+  }
+`;
+
+export const mcpRunAiWritebackArgsSchema = z
+    .object({
+        prompt: z
+            .string()
+            .min(1)
+            .describe(
+                'A clear, self-contained description of the change to make to the dbt project that backs the active Lightdash project.',
+            ),
+    })
+    .describe(MCP_TOOL_RUN_AI_WRITEBACK_DESCRIPTION);
+
+export type McpRunAiWritebackArgs = z.infer<typeof mcpRunAiWritebackArgsSchema>;


### PR DESCRIPTION
## What

Adds a `run_ai_writeback` MCP tool that exposes the agentic dbt writeback pipeline to MCP clients. The tool lets a client describe a change in natural language and have Lightdash clone the project's dbt repo, run the change through the Claude Code CLI in a sandbox, and open a pull request with the result.

The tool is **dark-launched**: it is only registered when the `AiWriteback` feature flag is enabled for the caller (off by default).

## How

- **New shared schema** (`packages/common/src/ee/aiWriteback/types.ts`): `mcpRunAiWritebackArgsSchema` + description + `McpRunAiWritebackArgs` type.
- **Tool registration** (`McpService.ts`): new `RUN_AI_WRITEBACK` tool name, `aiWritebackService` dependency wired in, registration extracted to `registerRunAiWritebackTool()` and called conditionally from `setupHandlers()`.
- **Dark launch**: `setupHandlers`/`createServer` take an `aiWritebackEnabled` flag; `mcpRouter.ts` resolves it per-request via the new `McpService.isAiWritebackEnabled()` (which checks `FeatureFlags.AiWriteback`) and passes it through. Registration is synchronous, so the async flag check has to happen in the router.
- **DI** (`ee/index.ts`): pass `repository.getAiWritebackService()` into the `mcpService` provider.

### Design

- The tool takes only `{ prompt }`. The target project is resolved from the active MCP context (`set_project` / `X-Lightdash-Project` header), and the GitHub repo + dbt sub-folder are resolved server-side from the project's dbt connection — mirroring the existing `run_sql` active-project pattern. The caller never specifies the repo.
- It delegates to `AiWritebackService.run()`, which already enforces the `AiWriteback` feature flag and a CASL `view` check, so the tool stays thin. (The router-level flag check gates *visibility*; the service-level check remains the authoritative *invocation* guard.)
- Unlike the other (read-only) MCP tools, this is annotated `readOnlyHint: false` / `idempotentHint: false` since each call can open a new pull request.

## Testing

Verified end-to-end against a local dev stack with `MCP_ENABLED=true`:

- `pnpm -F common typecheck` / `pnpm -F backend typecheck` — clean
- `pnpm -F common lint` / `pnpm -F backend lint` — clean
- **Flag ON**: MCP `tools/list` returns the tool (17 total) with the correct input (`prompt`) and output (`output`, `exitCode`, `prUrl`) schema and annotations.
- **Flag OFF (dark launch)**: `tools/list` returns 16 tools with `run_ai_writeback` absent, and a direct `tools/call` is rejected with `MCP error -32602: Tool run_ai_writeback not found`.
- A real `tools/call` (flag on) requesting a small docs-only change produced a working PR (`lightdash compile` exit 0), confirming clone → compile → PR works through the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)