### PR TITLE
feat(ai-agents): enable data access by default for new agents

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -118,7 +118,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             userAccess: [],
             spaceAccess: [],
             mcpServerUuids: [],
-            enableDataAccess: false,
+            enableDataAccess: true,
             enableSelfImprovement: false,
             version: 2, // INFO: Default to v2 for now
         },


### PR DESCRIPTION
Closes:

### Description:
Changes the default value of `enableDataAccess` to `true` when creating a new AI Agent, so that data access is enabled out of the box rather than requiring users to manually turn it on.