### PR TITLE
fix: preserve space cascade when clearing chart-level color palette

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -104,12 +104,17 @@ const VisualizationCard: FC<Props> = memo((props) => {
     const stagedColorPaletteUuid = useExplorerSelector(
         selectUnsavedColorPaletteUuid,
     );
-    const resolverChartUuid =
-        stagedColorPaletteUuid === null && savedChart?.colorPaletteUuid != null
-            ? undefined
-            : savedChart?.uuid;
+    // When the user has explicitly cleared a previously-set chart-level
+    // palette, ask the resolver to skip the chart-level branch but seed
+    // the space walk from the chart's own space — otherwise the resolver
+    // loses the space cascade entirely and falls back to project/org.
+    const isClearingChartLevelPalette =
+        stagedColorPaletteUuid === null && savedChart?.colorPaletteUuid != null;
     const { data: resolvedPalette } = useProjectColorPalette(projectUuid, {
-        chartUuid: resolverChartUuid,
+        chartUuid: isClearingChartLevelPalette ? undefined : savedChart?.uuid,
+        spaceUuid: isClearingChartLevelPalette
+            ? savedChart?.spaceUuid
+            : undefined,
         dashboardUuid: savedChart?.dashboardUuid ?? undefined,
     });
 


### PR DESCRIPTION
Closes: PROD-7902

### Description:
When a user explicitly clears a chart-level color palette (i.e., `stagedColorPaletteUuid` is `null` but the saved chart previously had a `colorPaletteUuid`), the color palette resolver was losing the space cascade entirely and falling back to the project/org level palette instead.

To fix this, when clearing a chart-level palette, the resolver now receives the chart's `spaceUuid` so it can correctly walk the space hierarchy, rather than receiving no context at all and skipping straight to the project/org fallback.