### PR TITLE
fix: bump qs arrayLimit to 1000 for dashboards with 100+ tiles

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -249,10 +249,13 @@ export default class App {
 
         const expressApp = express();
 
-        // Increase query string array limit from default (20) to 100
-        // to support endpoints that accept large arrays (e.g. chart IDs)
+        // Increase query string array limit from default (20) to 1000
+        // to support endpoints that accept large arrays (e.g. chart IDs for
+        // dashboards with many tiles). Without this, qs silently converts
+        // overflowing arrays into indexed-key objects, breaking TSOA
+        // validation for `string[]` query params.
         expressApp.set('query parser', (str: string) =>
-            qs.parse(str, { arrayLimit: 100 }),
+            qs.parse(str, { arrayLimit: 1000 }),
         );
 
         // Slack must be initialized before our own middleware / routes, which cause the slack app to fail


### PR DESCRIPTION
Closes: PROD-7937
Relates: #23516

### Description:

Downloading a dashboard as YAML (content-as-code) failed with `ValidateError: ids.$0: invalid string value` when the dashboard had more than 100 chart tiles. The Express `qs` parser was configured with `arrayLimit: 100`, which silently converts overflowing arrays into indexed-key objects, breaking TSOA validation for `string[]` query params.

Bumps `arrayLimit` from 100 to 1000 in `packages/backend/src/App.ts`. This also fixes any other `string[]` query-param endpoints (charts/code, sqlCharts/code, ContentController, catalogController) for the same overflow scenario.