### PR TITLE
fix: make sql runner search behave like explores

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -319,6 +319,7 @@ export const Tables: FC = () => {
                 const fuse = new Fuse(tableNames, {
                     threshold: 0.3,
                     isCaseSensitive: false,
+                    ignoreLocation: true,
                 });
 
                 const fuseResult = fuse

--- a/packages/frontend/src/features/sqlRunner/hooks/useTableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useTableFields.tsx
@@ -74,6 +74,7 @@ export const useTableFields = ({
             const fuse = new Fuse(fields, {
                 threshold: 0.3,
                 isCaseSensitive: false,
+                ignoreLocation: true,
                 keys: ['name'],
             });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #23532

### Description:

Ignore position in SQL runner search. This makes it match the explores table search. 
