### PR TITLE
fix(explorer): surface table-calc errors with pivot, dedupe error toasts

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -123,6 +123,21 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
         // The main query has a different row structure (pivoted) that would cause
         // the first column to show "-" because the pivot dimension key is missing.
         if (needsUnpivotedData && !hasUnpivotedQuery) {
+            // If the create-query call itself failed (e.g. table calculation
+            // references an unknown field), neither query will ever produce a
+            // queryUuid. Surface the error instead of waiting forever.
+            const createQueryError = query.error ?? unpivotedQuery.error;
+            if (createQueryError) {
+                return {
+                    rows: [],
+                    totalResults: undefined,
+                    isFetchingRows: false,
+                    fetchMoreRows: () => {},
+                    status: 'error' as const,
+                    apiError: createQueryError,
+                    queryStatus: unpivotedQueryResults.queryStatus,
+                };
+            }
             return {
                 rows: [],
                 totalResults: undefined,
@@ -385,6 +400,18 @@ export const ExplorerResults = memo(({ viewMode }: ExplorerResultsProps) => {
 
     // Render grouped view content
     const renderGroupedView = () => {
+        // Surface query errors (e.g. table calculation references an unknown
+        // field) before any loading checks, so the user isn't stuck on a
+        // spinner when the query will never produce results.
+        if (groupedResultsData?.apiError) {
+            return (
+                <Text c="red" ta="center">
+                    {groupedResultsData.apiError.error?.message ||
+                        'Error loading grouped results'}
+                </Text>
+            );
+        }
+
         if (pivotTableQuery.isLoading || groupedResultsData?.isFetchingRows) {
             return (
                 <Box

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -338,8 +338,32 @@ const useToaster = () => {
                 errorData: notificationData,
                 updateErrorsFunction: (key, errorData) => {
                     if (!errorData) return;
-                    if (currentErrors.current[key]) {
-                        currentErrors.current[key].push({
+                    // Dedupe by content: when several parallel queries fail
+                    // with the same error (e.g. main metric-query +
+                    // useCompiledSql preview both hitting a table-calc
+                    // compile error), we'd otherwise stack identical entries
+                    // in the toast. Primitive fields only; ReactNode
+                    // subtitles fall back to reference identity.
+                    const fingerprintOf = (e: NotificationData) => [
+                        e.title ?? null,
+                        typeof e.subtitle === 'string' ? e.subtitle : null,
+                        e.apiError?.message ?? null,
+                        e.apiError?.name ?? null,
+                        e.apiError?.statusCode ?? null,
+                    ];
+                    const fpA = fingerprintOf(errorData);
+                    const existing = currentErrors.current[key];
+                    if (existing) {
+                        const alreadyPresent = existing.some((e) => {
+                            const fpB = fingerprintOf(e);
+                            return (
+                                fpA.every((v, i) => v === fpB[i]) &&
+                                (typeof errorData.subtitle === 'string' ||
+                                    e.subtitle === errorData.subtitle)
+                            );
+                        });
+                        if (alreadyPresent) return;
+                        existing.push({
                             ...notificationData,
                             messageKey: uuid(),
                         });


### PR DESCRIPTION
Closes: PROD-7936
Closes: #23515

### Description:

When SQL pivot was enabled and a table calculation referenced an unknown field, the synchronous create-query call failed at compile time and never returned a `queryUuid`, leaving the Results pane on an infinite loading spinner because the hardcoded loading branch in `ExplorerResults` never checked for that error. Now we surface the backend error in both the regular Table and grouped Pivot views.

Also dedupes toasts so identical errors fired in parallel by the main metric-query and the `useCompiledSql` preview no longer stack into a "Show 2" group — `addToastError` checks a content fingerprint (title, primitive subtitle, `apiError.message`/`name`/`statusCode`) before appending.

### Before / After

Before: infinite spinner in the Results pane, double "Show 2" error toast.
After: inline "Error loading results" message with the backend error, single toast entry.

<img width="2950" height="2440" alt="CleanShot 2026-05-27 at 11 53 28@2x" src="https://github.com/user-attachments/assets/dd0e4003-c1f3-4c05-aa6e-7d16e268802d" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)