### PR TITLE
feat(ai-router): Ask AI router with low-confidence disambiguation

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -394,6 +394,12 @@ import {
     AiEvalTableName,
 } from '../ee/database/entities/aiEvals';
 import {
+    AiRouterDecisionTable,
+    AiRouterDecisionTableName,
+    AiRouterTable,
+    AiRouterTableName,
+} from '../ee/database/entities/aiRouter';
+import {
     DashboardSummariesTable,
     DashboardSummariesTableName,
 } from '../ee/database/entities/dashboardSummaries';
@@ -574,5 +580,7 @@ declare module 'knex/types/tables' {
         [ContentVerificationTableName]: ContentVerificationTable;
         [AppsTableName]: AppsTable;
         [AppVersionsTableName]: AppVersionsTable;
+        [AiRouterTableName]: AiRouterTable;
+        [AiRouterDecisionTableName]: AiRouterDecisionTable;
     }
 }

--- a/packages/backend/src/database/entities/slackAuthentication.ts
+++ b/packages/backend/src/database/entities/slackAuthentication.ts
@@ -15,7 +15,6 @@ export type DbSlackAuthTokens = {
     ai_thread_access_consent: boolean;
     ai_require_oauth: boolean;
     ai_multi_agent_channel_id: string | null;
-    ai_multi_agent_project_uuids: string[] | null;
     unfurls_enabled: boolean;
     // Channel sync status
     channels_last_sync_at: Date | null;
@@ -38,7 +37,6 @@ export type UpdateDbSlackAuthTokens = Partial<
         | 'ai_thread_access_consent'
         | 'ai_require_oauth'
         | 'ai_multi_agent_channel_id'
-        | 'ai_multi_agent_project_uuids'
         | 'unfurls_enabled'
         | 'channels_last_sync_at'
         | 'channels_sync_started_at'

--- a/packages/backend/src/ee/controllers/aiRouterController.ts
+++ b/packages/backend/src/ee/controllers/aiRouterController.ts
@@ -1,0 +1,159 @@
+import {
+    assertRegisteredAccount,
+    type AiRouterDecisionCommitRequest,
+    type AiRouterDecisionConfidence,
+    type AiRouterRouteRequest,
+    type AiRouterSelectionMode,
+    type ApiAiRouterDecisionCommitResponse,
+    type ApiAiRouterDecisionListResponse,
+    type ApiAiRouterResponse,
+    type ApiAiRouterRouteResponse,
+    type ApiErrorPayload,
+    type UpsertAiRouterRequest,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Put,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { AiRouterService } from '../services/AiRouterService/AiRouterService';
+
+@Route('/api/v1/org/aiRouter')
+@Response<ApiErrorPayload>('default', 'Error')
+export class AiRouterController extends BaseController {
+    /**
+     * Get the AI router configuration for the organization. Returns 404 when the
+     * router has not been configured yet — clients use this to detect first-use.
+     * @summary Get AI router config
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('getAiRouterConfig')
+    async getConfig(
+        @Request() req: express.Request,
+    ): Promise<ApiAiRouterResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.routerService().getConfig(req.account),
+        };
+    }
+
+    /**
+     * Upsert the AI router configuration. Creates the row lazily on first save.
+     * @summary Upsert AI router config
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Put('/')
+    @OperationId('upsertAiRouterConfig')
+    async upsertConfig(
+        @Request() req: express.Request,
+        @Body() body: UpsertAiRouterRequest,
+    ): Promise<ApiAiRouterResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.routerService().upsertConfig(req.account, body),
+        };
+    }
+
+    /**
+     * Route a user prompt to the best candidate agent in the current project.
+     * @summary Route prompt
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/route')
+    @OperationId('routeAiAgent')
+    async route(
+        @Request() req: express.Request,
+        @Body() body: AiRouterRouteRequest,
+    ): Promise<ApiAiRouterRouteResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.routerService().route(req.account, body),
+        };
+    }
+
+    /**
+     * Commit a router decision once the user has resolved it (router
+     * auto-routed and the thread is created, or the user picked an agent
+     * from the picker). Decisions left uncommitted indicate the user
+     * abandoned the flow.
+     * @summary Commit router decision
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/decisions/{decisionUuid}/commit')
+    @OperationId('commitAiRouterDecision')
+    async commit(
+        @Request() req: express.Request,
+        @Path() decisionUuid: string,
+        @Body() body: AiRouterDecisionCommitRequest,
+    ): Promise<ApiAiRouterDecisionCommitResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        await this.routerService().commitDecision(
+            req.account,
+            decisionUuid,
+            body,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * List recent routing decisions for the org's router.
+     * @summary List router decisions
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/decisions')
+    @OperationId('listAiRouterDecisions')
+    async listDecisions(
+        @Request() req: express.Request,
+        @Query() confidence?: AiRouterDecisionConfidence,
+        @Query() selectionMode?: AiRouterSelectionMode,
+        @Query() fromDate?: string,
+        @Query() toDate?: string,
+    ): Promise<ApiAiRouterDecisionListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.routerService().listDecisions(req.account, {
+                confidence,
+                selectionMode,
+                fromDate,
+                toDate,
+            }),
+        };
+    }
+
+    private routerService(): AiRouterService {
+        return this.services.getAiRouterService<AiRouterService>();
+    }
+}

--- a/packages/backend/src/ee/database/entities/aiRouter.ts
+++ b/packages/backend/src/ee/database/entities/aiRouter.ts
@@ -1,0 +1,62 @@
+import { Knex } from 'knex';
+
+export const AiRouterTableName = 'ai_router';
+
+export type DbAiRouter = {
+    ai_router_uuid: string;
+    organization_uuid: string;
+    enabled: boolean;
+    project_uuids: string[];
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiRouterTable = Knex.CompositeTableType<
+    DbAiRouter,
+    Pick<DbAiRouter, 'organization_uuid'> &
+        Partial<Pick<DbAiRouter, 'enabled' | 'project_uuids'>>,
+    Partial<Pick<DbAiRouter, 'enabled' | 'project_uuids'>> & {
+        updated_at?: Knex.Raw;
+    }
+>;
+
+export const AiRouterDecisionTableName = 'ai_router_decision';
+
+export type AiRouterDecisionConfidence = 'high' | 'medium' | 'low';
+
+export type AiRouterSelectionMode = 'auto_routed' | 'manual_pick';
+
+export type DbAiRouterDecision = {
+    ai_router_decision_uuid: string;
+    ai_router_uuid: string;
+    thread_uuid: string | null;
+    user_uuid: string;
+    prompt: string;
+    suggested_agent_uuid: string;
+    chosen_agent_uuid: string | null;
+    confidence: AiRouterDecisionConfidence;
+    reasoning: string;
+    candidate_agent_uuids: string[];
+    selection_mode: AiRouterSelectionMode | null;
+    created_at: Date;
+    committed_at: Date | null;
+};
+
+export type AiRouterDecisionTable = Knex.CompositeTableType<
+    DbAiRouterDecision,
+    Omit<
+        DbAiRouterDecision,
+        | 'ai_router_decision_uuid'
+        | 'created_at'
+        | 'committed_at'
+        | 'chosen_agent_uuid'
+        | 'selection_mode'
+        | 'thread_uuid'
+    >,
+    Partial<
+        Pick<
+            DbAiRouterDecision,
+            'thread_uuid' | 'chosen_agent_uuid' | 'selection_mode'
+        >
+    > & { committed_at?: Knex.Raw | Date | null }
+>;

--- a/packages/backend/src/ee/database/migrations/20260526135858_add_ai_router_tables.ts
+++ b/packages/backend/src/ee/database/migrations/20260526135858_add_ai_router_tables.ts
@@ -1,0 +1,128 @@
+import { Knex } from 'knex';
+
+const AiRouterTableName = 'ai_router';
+const AiRouterDecisionTableName = 'ai_router_decision';
+const SlackAuthTokensTableName = 'slack_auth_tokens';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AiRouterTableName, (table) => {
+        table
+            .uuid('ai_router_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .unique()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+        table.boolean('enabled').notNullable().defaultTo(false);
+        table
+            .specificType('project_uuids', 'uuid[]')
+            .notNullable()
+            .defaultTo(knex.raw("'{}'::uuid[]"));
+        table
+            .timestamp('created_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+
+    await knex.schema.createTable(AiRouterDecisionTableName, (table) => {
+        table
+            .uuid('ai_router_decision_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_router_uuid')
+            .notNullable()
+            .references('ai_router_uuid')
+            .inTable(AiRouterTableName)
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('thread_uuid')
+            .nullable()
+            .references('ai_thread_uuid')
+            .inTable('ai_thread')
+            .onDelete('SET NULL')
+            .index();
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE')
+            .index();
+        table.text('prompt').notNullable();
+        table
+            .uuid('suggested_agent_uuid')
+            .notNullable()
+            .references('ai_agent_uuid')
+            .inTable('ai_agent')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('chosen_agent_uuid')
+            .nullable()
+            .references('ai_agent_uuid')
+            .inTable('ai_agent')
+            .onDelete('SET NULL')
+            .index();
+        table.text('confidence').notNullable();
+        table.text('reasoning').notNullable();
+        table
+            .specificType('candidate_agent_uuids', 'uuid[]')
+            .notNullable()
+            .defaultTo(knex.raw("'{}'::uuid[]"));
+        table.text('selection_mode').nullable();
+        table
+            .timestamp('created_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.timestamp('committed_at', { useTz: true }).nullable();
+    });
+
+    await knex.raw(
+        `INSERT INTO ${AiRouterTableName} (organization_uuid, enabled, project_uuids)
+         SELECT
+           o.organization_uuid,
+           false,
+           COALESCE(
+             (SELECT array_agg(elem::uuid) FROM unnest(s.ai_multi_agent_project_uuids) AS elem),
+             '{}'::uuid[]
+           )
+         FROM ${SlackAuthTokensTableName} s
+         JOIN organizations o ON o.organization_id = s.organization_id
+         WHERE s.ai_multi_agent_channel_id IS NOT NULL`,
+    );
+
+    await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+        table.dropColumn('ai_multi_agent_project_uuids');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+        table.specificType('ai_multi_agent_project_uuids', 'text[]').nullable();
+    });
+
+    await knex.raw(
+        `UPDATE ${SlackAuthTokensTableName} s
+         SET ai_multi_agent_project_uuids = (
+           SELECT array_agg(elem::text)
+           FROM unnest(r.project_uuids) AS elem
+         )
+         FROM ${AiRouterTableName} r
+         JOIN organizations o ON o.organization_uuid = r.organization_uuid
+         WHERE s.organization_id = o.organization_id
+           AND array_length(r.project_uuids, 1) > 0`,
+    );
+
+    await knex.schema.dropTableIfExists(AiRouterDecisionTableName);
+    await knex.schema.dropTableIfExists(AiRouterTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -19,6 +19,7 @@ import { AiAgentDocumentModel } from './models/AiAgentDocumentModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
+import { AiRouterModel } from './models/AiRouterModel';
 import { AiWritebackThreadModel } from './models/AiWritebackThreadModel';
 import { CommercialFeatureFlagModel } from './models/CommercialFeatureFlagModel';
 import { CommercialSlackAuthenticationModel } from './models/CommercialSlackAuthenticationModel';
@@ -36,6 +37,7 @@ import { AiAgentDocumentService } from './services/AiAgentDocumentService';
 import { AiAgentReviewClassifierService } from './services/AiAgentReviewClassifierService';
 import { AiAgentService } from './services/AiAgentService/AiAgentService';
 import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
+import { AiRouterService } from './services/AiRouterService/AiRouterService';
 import { AiService } from './services/AiService/AiService';
 import { AiWritebackService } from './services/AiWritebackService/AiWritebackService';
 import { AppGenerateService } from './services/AppGenerateService/AppGenerateService';
@@ -198,6 +200,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
                     featureFlagService: repository.getFeatureFlagService(),
                     lightdashConfig: context.lightdashConfig,
+                }),
+            aiRouterService: ({ models, repository, context }) =>
+                new AiRouterService({
+                    lightdashConfig: context.lightdashConfig,
+                    aiRouterModel: models.getAiRouterModel<AiRouterModel>(),
+                    aiAgentService:
+                        repository.getAiAgentService<AiAgentService>(),
                 }),
             aiAgentDocumentService: ({ models, repository, context }) =>
                 new AiAgentDocumentService({
@@ -520,6 +529,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiWritebackThreadModel({ database }),
             aiAgentReviewClassifierModel: ({ database }) =>
                 new AiAgentReviewClassifierModel({ database }),
+            aiRouterModel: ({ database }) => new AiRouterModel({ database }),
             aiOrganizationSettingsModel: ({ database }) =>
                 new AiOrganizationSettingsModel({ database }),
             embedModel: ({ database }) => new EmbedModel({ database }),

--- a/packages/backend/src/ee/models/AiRouterModel.ts
+++ b/packages/backend/src/ee/models/AiRouterModel.ts
@@ -1,0 +1,178 @@
+import {
+    NotFoundError,
+    type AiRouter,
+    type AiRouterDecision,
+    type AiRouterDecisionConfidence,
+    type AiRouterDecisionListFilters,
+    type AiRouterSelectionMode,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    AiRouterDecisionTableName,
+    AiRouterTableName,
+    type DbAiRouter,
+    type DbAiRouterDecision,
+} from '../database/entities/aiRouter';
+
+const toAiRouter = (row: DbAiRouter): AiRouter => ({
+    routerUuid: row.ai_router_uuid,
+    organizationUuid: row.organization_uuid,
+    enabled: row.enabled,
+    projectUuids: row.project_uuids,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+});
+
+const toAiRouterDecision = (row: DbAiRouterDecision): AiRouterDecision => ({
+    decisionUuid: row.ai_router_decision_uuid,
+    routerUuid: row.ai_router_uuid,
+    threadUuid: row.thread_uuid,
+    userUuid: row.user_uuid,
+    prompt: row.prompt,
+    suggestedAgentUuid: row.suggested_agent_uuid,
+    chosenAgentUuid: row.chosen_agent_uuid,
+    confidence: row.confidence,
+    reasoning: row.reasoning,
+    candidateAgentUuids: row.candidate_agent_uuids,
+    selectionMode: row.selection_mode,
+    createdAt: row.created_at,
+    committedAt: row.committed_at,
+});
+
+export class AiRouterModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async findByOrganization(
+        organizationUuid: string,
+    ): Promise<AiRouter | null> {
+        const row = await this.database(AiRouterTableName)
+            .where({ organization_uuid: organizationUuid })
+            .first();
+        return row ? toAiRouter(row) : null;
+    }
+
+    async upsert({
+        organizationUuid,
+        enabled,
+        projectUuids,
+    }: {
+        organizationUuid: string;
+        enabled?: boolean;
+        projectUuids?: string[];
+    }): Promise<AiRouter> {
+        const insertPayload: {
+            organization_uuid: string;
+            enabled?: boolean;
+            project_uuids?: string[];
+        } = { organization_uuid: organizationUuid };
+
+        if (enabled !== undefined) insertPayload.enabled = enabled;
+        if (projectUuids !== undefined)
+            insertPayload.project_uuids = projectUuids;
+
+        const updatePayload: Record<string, unknown> = {
+            updated_at: this.database.fn.now(),
+        };
+        if (enabled !== undefined) updatePayload.enabled = enabled;
+        if (projectUuids !== undefined)
+            updatePayload.project_uuids = projectUuids;
+
+        const [row] = await this.database(AiRouterTableName)
+            .insert(insertPayload)
+            .onConflict('organization_uuid')
+            .merge(updatePayload)
+            .returning('*');
+
+        return toAiRouter(row);
+    }
+
+    async createDecision(args: {
+        routerUuid: string;
+        userUuid: string;
+        prompt: string;
+        suggestedAgentUuid: string;
+        confidence: AiRouterDecisionConfidence;
+        reasoning: string;
+        candidateAgentUuids: string[];
+    }): Promise<AiRouterDecision> {
+        const [row] = await this.database(AiRouterDecisionTableName)
+            .insert({
+                ai_router_uuid: args.routerUuid,
+                user_uuid: args.userUuid,
+                prompt: args.prompt,
+                suggested_agent_uuid: args.suggestedAgentUuid,
+                confidence: args.confidence,
+                reasoning: args.reasoning,
+                candidate_agent_uuids: args.candidateAgentUuids,
+            })
+            .returning('*');
+        return toAiRouterDecision(row);
+    }
+
+    async commitDecision(args: {
+        decisionUuid: string;
+        chosenAgentUuid: string;
+        threadUuid: string;
+        selectionMode: AiRouterSelectionMode;
+    }): Promise<AiRouterDecision> {
+        const [row] = await this.database(AiRouterDecisionTableName)
+            .where({ ai_router_decision_uuid: args.decisionUuid })
+            .whereNull('chosen_agent_uuid')
+            .update({
+                chosen_agent_uuid: args.chosenAgentUuid,
+                thread_uuid: args.threadUuid,
+                selection_mode: args.selectionMode,
+                committed_at: this.database.fn.now(),
+            })
+            .returning('*');
+        if (!row) {
+            throw new NotFoundError(
+                `AI router decision ${args.decisionUuid} not found or already committed`,
+            );
+        }
+        return toAiRouterDecision(row);
+    }
+
+    async getDecision(decisionUuid: string): Promise<AiRouterDecision> {
+        const row = await this.database(AiRouterDecisionTableName)
+            .where({ ai_router_decision_uuid: decisionUuid })
+            .first();
+        if (!row) {
+            throw new NotFoundError(
+                `AI router decision ${decisionUuid} not found`,
+            );
+        }
+        return toAiRouterDecision(row);
+    }
+
+    async listDecisions({
+        routerUuid,
+        filters,
+        limit = 100,
+    }: {
+        routerUuid: string;
+        filters?: AiRouterDecisionListFilters;
+        limit?: number;
+    }): Promise<AiRouterDecision[]> {
+        let query = this.database(AiRouterDecisionTableName)
+            .where({ ai_router_uuid: routerUuid })
+            .orderBy('created_at', 'desc')
+            .limit(limit);
+
+        if (filters?.confidence)
+            query = query.andWhere('confidence', filters.confidence);
+        if (filters?.selectionMode)
+            query = query.andWhere('selection_mode', filters.selectionMode);
+        if (filters?.fromDate)
+            query = query.andWhere('created_at', '>=', filters.fromDate);
+        if (filters?.toDate)
+            query = query.andWhere('created_at', '<=', filters.toDate);
+
+        const rows = await query;
+        return rows.map(toAiRouterDecision);
+    }
+}

--- a/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
+++ b/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import { SlackAuthTokensTableName } from '../../database/entities/slackAuthentication';
 import { SlackAuthenticationModel } from '../../models/SlackAuthenticationModel';
+import { AiRouterTableName } from '../database/entities/aiRouter';
 import { SlackChannelProjectMappingsTableName } from '../database/entities/slackChannelProjectMappings';
 
 export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel {
@@ -35,8 +36,17 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
                 'slack_auth_tokens.organization_id',
                 'organizations.organization_id',
             )
-            .select('*')
-            .where('organization_uuid', organizationUuid);
+            .leftJoin(
+                AiRouterTableName,
+                `${AiRouterTableName}.organization_uuid`,
+                'organizations.organization_uuid',
+            )
+            .select(
+                'slack_auth_tokens.*',
+                'organizations.organization_uuid',
+                `${AiRouterTableName}.project_uuids as ai_router_project_uuids`,
+            )
+            .where('organizations.organization_uuid', organizationUuid);
 
         if (row === undefined) return undefined;
 
@@ -51,7 +61,11 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
             aiThreadAccessConsent: row.ai_thread_access_consent ?? false,
             aiRequireOAuth: row.ai_require_oauth,
             aiMultiAgentChannelId: row.ai_multi_agent_channel_id ?? undefined,
-            aiMultiAgentProjectUuids: row.ai_multi_agent_project_uuids ?? null,
+            aiMultiAgentProjectUuids:
+                row.ai_router_project_uuids &&
+                row.ai_router_project_uuids.length > 0
+                    ? row.ai_router_project_uuids
+                    : null,
             unfurlsEnabled: row.unfurls_enabled ?? true,
         };
 
@@ -115,11 +129,10 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
     ) {
         const organizationId = await this.getOrganizationId(organizationUuid);
 
-        // Convert empty array to null for text[] column
         const projectUuidsToSave =
             aiMultiAgentProjectUuids && aiMultiAgentProjectUuids.length > 0
                 ? aiMultiAgentProjectUuids
-                : null;
+                : [];
 
         await this.database.transaction(async (trx) => {
             await trx(SlackAuthTokensTableName)
@@ -129,10 +142,22 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
                     ai_thread_access_consent: aiThreadAccessConsent ?? false,
                     ai_require_oauth: aiRequireOAuth ?? false,
                     ai_multi_agent_channel_id: aiMultiAgentChannelId ?? null,
-                    ai_multi_agent_project_uuids: projectUuidsToSave,
                     unfurls_enabled: unfurlsEnabled,
                 })
                 .where('organization_id', organizationId);
+
+            if (aiMultiAgentChannelId) {
+                await trx(AiRouterTableName)
+                    .insert({
+                        organization_uuid: organizationUuid,
+                        project_uuids: projectUuidsToSave,
+                    })
+                    .onConflict('organization_uuid')
+                    .merge({
+                        project_uuids: projectUuidsToSave,
+                        updated_at: trx.fn.now(),
+                    });
+            }
 
             const insertItems = slackChannelProjectMappings?.map((mapping) => ({
                 organization_uuid: organizationUuid,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7028,7 +7028,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     /**
      * Get available agents for a user with their full context, filtered by access if OAuth is required
      */
-    private async getAvailableAgents(
+    public async getAvailableAgents(
         organizationUuid: string,
         userUuid: string,
         slackSettings: { aiRequireOAuth?: boolean },

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -169,7 +169,7 @@ import {
 } from '../../models/AiAgentModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
-import { selectBestAgentWithContext } from '../ai/agents/agentSelector';
+import { selectAgent } from '../ai/agents/agentSelector';
 import {
     generateAgentResponse,
     streamAgentResponse,
@@ -7364,34 +7364,36 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             };
         }
 
-        // Multiple agents - use LLM to select the best one
         const { model } = getModel(this.lightdashConfig.ai.copilot);
 
-        const { agent: selectedAgent, selection } =
-            await selectBestAgentWithContext(
-                model,
-                availableAgents,
-                messageText,
-            );
+        const decision = await selectAgent({
+            model,
+            candidates: availableAgents,
+            prompt: messageText,
+        });
+
+        const selectedAgent =
+            availableAgents.find(
+                (a) => a.uuid === decision.selectedAgentUuid,
+            ) ?? availableAgents[0];
 
         Logger.info(
             `Agent selected by LLM ${JSON.stringify({
                 agentUuid: selectedAgent.uuid,
                 agentName: selectedAgent.name,
-                reasoning: selection.reasoning,
-                confidence: selection.confidence,
-                shouldSkipForwardingQuery: selection.shouldSkipForwardingQuery,
+                reasoning: decision.reasoning,
+                confidence: decision.confidence,
+                shouldSkipForwardingQuery: decision.shouldSkipForwardingQuery,
             })}`,
         );
 
-        // If confidence is low, show selection UI instead
-        if (selection.confidence === 'low') {
+        if (decision.confidence === 'low') {
             Logger.info(
                 `Low confidence in agent selection - showing manual selection UI,
                 ${JSON.stringify({
-                    reasoning: selection.reasoning,
+                    reasoning: decision.reasoning,
                     shouldSkipForwardingQuery:
-                        selection.shouldSkipForwardingQuery,
+                        decision.shouldSkipForwardingQuery,
                 })},`,
             );
             await this.showAgentSelectionUI(
@@ -7399,7 +7401,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 channelId,
                 threadTs,
                 say,
-                selection.shouldSkipForwardingQuery,
+                decision.shouldSkipForwardingQuery,
             );
             return undefined;
         }
@@ -7419,7 +7421,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         return {
             agent: selectedAgent,
-            shouldSkipForwardingQuery: selection.shouldSkipForwardingQuery,
+            shouldSkipForwardingQuery: decision.shouldSkipForwardingQuery,
         };
     }
 

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -1,0 +1,235 @@
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    NotFoundError,
+    ParameterError,
+    type AiRouter,
+    type AiRouterDecision,
+    type AiRouterDecisionListFilters,
+    type AiRouterRouteResponseResult,
+    type AiRouterSelectionMode,
+    type RegisteredAccount,
+    type UpsertAiRouterRequest,
+} from '@lightdash/common';
+import { LightdashConfig } from '../../../config/parseConfig';
+import { BaseService } from '../../../services/BaseService';
+import { type AiRouterModel } from '../../models/AiRouterModel';
+import { selectAgent } from '../ai/agents/agentSelector';
+import { getModel } from '../ai/models';
+import { type AiAgentService } from '../AiAgentService/AiAgentService';
+
+type Deps = {
+    lightdashConfig: LightdashConfig;
+    aiRouterModel: AiRouterModel;
+    aiAgentService: AiAgentService;
+};
+
+export class AiRouterService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly aiRouterModel: AiRouterModel;
+
+    private readonly aiAgentService: AiAgentService;
+
+    constructor({ lightdashConfig, aiRouterModel, aiAgentService }: Deps) {
+        super({ serviceName: 'AiRouterService' });
+        this.lightdashConfig = lightdashConfig;
+        this.aiRouterModel = aiRouterModel;
+        this.aiAgentService = aiAgentService;
+    }
+
+    private static organizationUuidOf(account: RegisteredAccount): string {
+        const organizationUuid = account.organization?.organizationUuid;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not a member of an organization');
+        }
+        return organizationUuid;
+    }
+
+    private assertManageAiAgent(
+        account: RegisteredAccount,
+        organizationUuid: string,
+    ): void {
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot('manage', subject('AiAgent', { organizationUuid }))
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private assertViewAiAgent(
+        account: RegisteredAccount,
+        organizationUuid: string,
+    ): void {
+        const ability = this.createAuditedAbility(account);
+        if (ability.cannot('view', subject('AiAgent', { organizationUuid }))) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private async getEnabledRouter(
+        organizationUuid: string,
+    ): Promise<AiRouter> {
+        const router =
+            await this.aiRouterModel.findByOrganization(organizationUuid);
+        if (!router || !router.enabled) {
+            throw new NotFoundError('AI router is not enabled');
+        }
+        return router;
+    }
+
+    async getConfig(account: RegisteredAccount): Promise<AiRouter> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertManageAiAgent(account, organizationUuid);
+        const router =
+            await this.aiRouterModel.findByOrganization(organizationUuid);
+        if (!router) {
+            throw new NotFoundError('AI router not configured');
+        }
+        return router;
+    }
+
+    async upsertConfig(
+        account: RegisteredAccount,
+        body: UpsertAiRouterRequest,
+    ): Promise<AiRouter> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertManageAiAgent(account, organizationUuid);
+        return this.aiRouterModel.upsert({
+            organizationUuid,
+            enabled: body.enabled,
+            projectUuids: body.projectUuids,
+        });
+    }
+
+    async listDecisions(
+        account: RegisteredAccount,
+        filters?: AiRouterDecisionListFilters,
+    ): Promise<AiRouterDecision[]> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertManageAiAgent(account, organizationUuid);
+        const router =
+            await this.aiRouterModel.findByOrganization(organizationUuid);
+        if (!router) return [];
+        return this.aiRouterModel.listDecisions({
+            routerUuid: router.routerUuid,
+            filters,
+        });
+    }
+
+    /**
+     * Runs the router for a prompt and persists a pending decision row.
+     * The caller must follow up with {@link commitDecision} once the thread
+     * is created (or never, in which case the row stays uncommitted and
+     * serves as an abandonment signal).
+     *
+     * Requires at least two candidate agents — the frontend short-circuits
+     * the routing UI when there are zero or one accessible agents in scope.
+     */
+    async route(
+        account: RegisteredAccount,
+        { prompt, projectUuid }: { prompt: string; projectUuid: string },
+    ): Promise<AiRouterRouteResponseResult> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertViewAiAgent(account, organizationUuid);
+
+        const router = await this.getEnabledRouter(organizationUuid);
+
+        const candidates = await this.aiAgentService.getAvailableAgents(
+            organizationUuid,
+            account.user.userUuid,
+            { aiRequireOAuth: true },
+            { projectFilter: { projectUuid } },
+        );
+
+        if (candidates.length < 2) {
+            throw new ParameterError(
+                'AI router requires at least two accessible agents',
+            );
+        }
+
+        const { model } = getModel(this.lightdashConfig.ai.copilot);
+        const brain = await selectAgent({ model, candidates, prompt });
+
+        const nextAction =
+            brain.confidence === 'high' && !brain.shouldSkipForwardingQuery
+                ? 'create_thread'
+                : 'show_picker';
+
+        const decision = await this.aiRouterModel.createDecision({
+            routerUuid: router.routerUuid,
+            userUuid: account.user.userUuid,
+            prompt,
+            suggestedAgentUuid: brain.selectedAgentUuid,
+            confidence: brain.confidence,
+            reasoning: brain.reasoning,
+            candidateAgentUuids: candidates.map((c) => c.uuid),
+        });
+
+        return {
+            decision: {
+                decisionUuid: decision.decisionUuid,
+                suggestedAgentUuid: brain.selectedAgentUuid,
+                confidence: brain.confidence,
+                reasoning: brain.reasoning,
+                candidates: candidates.map((c) => ({
+                    agentUuid: c.uuid,
+                    name: c.name,
+                    description: c.description ?? null,
+                })),
+            },
+            nextAction,
+        };
+    }
+
+    /**
+     * Commits a pending decision once the user has resolved it (router
+     * auto-routed and the thread is created, or the user picked an agent
+     * from the picker). Sets the chosen agent, thread linkage, and
+     * derives the selection_mode from the recorded confidence.
+     */
+    async commitDecision(
+        account: RegisteredAccount,
+        decisionUuid: string,
+        {
+            chosenAgentUuid,
+            threadUuid,
+        }: {
+            chosenAgentUuid: string;
+            threadUuid: string;
+        },
+    ): Promise<void> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertViewAiAgent(account, organizationUuid);
+
+        const decision = await this.aiRouterModel.getDecision(decisionUuid);
+        if (decision.userUuid !== account.user.userUuid) {
+            throw new ForbiddenError();
+        }
+        const router =
+            await this.aiRouterModel.findByOrganization(organizationUuid);
+        if (!router || router.routerUuid !== decision.routerUuid) {
+            throw new ForbiddenError();
+        }
+
+        if (!decision.candidateAgentUuids.includes(chosenAgentUuid)) {
+            throw new ParameterError(
+                'Chosen agent was not among the routing candidates',
+            );
+        }
+
+        const selectionMode: AiRouterSelectionMode =
+            decision.confidence === 'high' &&
+            chosenAgentUuid === decision.suggestedAgentUuid
+                ? 'auto_routed'
+                : 'manual_pick';
+
+        await this.aiRouterModel.commitDecision({
+            decisionUuid,
+            chosenAgentUuid,
+            threadUuid,
+            selectionMode,
+        });
+    }
+}

--- a/packages/backend/src/ee/services/ai/agents/agentSelector.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentSelector.ts
@@ -25,9 +25,49 @@ const AgentSelectionSchema = z.object({
 
 export type AgentSelectionResult = z.infer<typeof AgentSelectionSchema>;
 
-/**
- * Builds a formatted description for a single agent.
- */
+export type RouterDecision = {
+    selectedAgentUuid: string;
+    confidence: 'high' | 'medium' | 'low';
+    reasoning: string;
+    shouldSkipForwardingQuery: boolean;
+};
+
+export const ROUTER_SYSTEM_PROMPT = `You are an intelligent agent router for a data analytics platform. Your job is to select the most appropriate AI agent to handle a user's query.
+
+All agents share the same core capabilities:
+- Specialized in data analytics and exploration
+- Can find and query data from available explores
+- Can create visualizations (tables, bar charts, line charts, pie charts, scatter plots, funnels, etc.)
+- Can search for existing dashboards and charts
+- Can perform table calculations on query results
+- Can create custom metrics
+- Can learn from user feedback to improve context understanding
+
+What differentiates agents are:
+1. **Description & Instructions**: The agent's purpose and custom instructions that guide its behavior
+2. **Data Access**: Which data explores/tables the agent has access to
+3. **Verified Questions**: Past successful queries that demonstrate the agent's expertise
+4. **Specialization**: Domain-specific focus areas defined by the agent creator
+
+Available Agents:
+{{candidates}}
+
+Selection Guidelines:
+- Choose the agent whose specialization best matches the query topic
+- Prioritize agents with relevant data access (explores)
+- Consider agents that have answered similar questions before
+- If no perfect match, choose the most general-purpose agent
+- Be confident in your choice, but indicate lower confidence if the match is uncertain
+
+Meta-Query Detection (shouldSkipForwardingQuery):
+- Set shouldSkipForwardingQuery to TRUE for queries about agent selection itself:
+  * "What agents are available?"
+  * "Show me the available agents"
+- Set shouldSkipForwardingQuery to FALSE for actual data/analytics questions
+- When shouldSkipForwardingQuery is TRUE, set confidence to 'low' to show the agent selector UI
+
+You must select exactly ONE agent from the list above by providing its exact UUID.`;
+
 function buildAgentDescription(
     agent: AiAgentWithContext,
     index: number,
@@ -52,12 +92,6 @@ function buildAgentDescription(
     return parts.filter((part): part is string => part !== null).join('\n');
 }
 
-/**
- * Builds formatted descriptions for all agents.
- *
- * @param agents - Array of agents to describe
- * @returns Formatted descriptions joined by double newlines
- */
 function buildAgentDescriptions(agents: AiAgentWithContext[]): string {
     return agents
         .map((agent, index) => buildAgentDescription(agent, index))
@@ -67,111 +101,61 @@ function buildAgentDescriptions(agents: AiAgentWithContext[]): string {
 /**
  * Uses an LLM to select the most appropriate agent for a given user query.
  */
-export async function selectBestAgent(
-    model: LanguageModel,
-    agents: AiAgentWithContext[],
-    userQuery: string,
-): Promise<AgentSelectionResult> {
-    if (agents.length === 0) {
+export async function selectAgent({
+    model,
+    candidates,
+    prompt,
+}: {
+    model: LanguageModel;
+    candidates: AiAgentWithContext[];
+    prompt: string;
+}): Promise<RouterDecision> {
+    if (candidates.length === 0) {
         throw new Error('No agents available for selection');
     }
 
-    if (agents.length === 1) {
+    if (candidates.length === 1) {
         return {
-            agentUuid: agents[0].uuid,
+            selectedAgentUuid: candidates[0].uuid,
             reasoning: 'Only one agent available',
             confidence: 'high',
             shouldSkipForwardingQuery: false,
         };
     }
 
-    const agentDescriptions = buildAgentDescriptions(agents);
+    const systemPrompt = ROUTER_SYSTEM_PROMPT.replace(
+        '{{candidates}}',
+        buildAgentDescriptions(candidates),
+    );
 
     const result = await generateObject({
         model,
         schema: AgentSelectionSchema,
         messages: [
-            {
-                role: 'system',
-                content: `You are an intelligent agent router for a data analytics platform. Your job is to select the most appropriate AI agent to handle a user's query.
-
-All agents share the same core capabilities:
-- Specialized in data analytics and exploration
-- Can find and query data from available explores
-- Can create visualizations (tables, bar charts, line charts, pie charts, scatter plots, funnels, etc.)
-- Can search for existing dashboards and charts
-- Can perform table calculations on query results
-- Can create custom metrics
-- Can learn from user feedback to improve context understanding
-
-What differentiates agents are:
-1. **Description & Instructions**: The agent's purpose and custom instructions that guide its behavior
-2. **Data Access**: Which data explores/tables the agent has access to
-3. **Verified Questions**: Past successful queries that demonstrate the agent's expertise
-4. **Specialization**: Domain-specific focus areas defined by the agent creator
-
-Available Agents:
-${agentDescriptions}
-
-Selection Guidelines:
-- Choose the agent whose specialization best matches the query topic
-- Prioritize agents with relevant data access (explores)
-- Consider agents that have answered similar questions before
-- If no perfect match, choose the most general-purpose agent
-- Be confident in your choice, but indicate lower confidence if the match is uncertain
-
-Meta-Query Detection (shouldSkipForwardingQuery):
-- Set shouldSkipForwardingQuery to TRUE for queries about agent selection itself:
-  * "What agents are available?"
-  * "Show me the available agents"
-- Set shouldSkipForwardingQuery to FALSE for actual data/analytics questions
-- When shouldSkipForwardingQuery is TRUE, set confidence to 'low' to show the agent selector UI
-
-You must select exactly ONE agent from the list above by providing its exact UUID.`,
-            },
+            { role: 'system', content: systemPrompt },
             {
                 role: 'user',
-                content: `User Query: "${userQuery}"
-
-Please select the best agent to handle this query and explain your reasoning.`,
+                content: `User Query: "${prompt}"\n\nPlease select the best agent to handle this query and explain your reasoning.`,
             },
         ],
     });
 
-    return result.object;
-}
+    const selection = result.object;
+    const exists = candidates.some((c) => c.uuid === selection.agentUuid);
 
-/**
- * Helper function to select an agent and return the full agent context.
- */
-export async function selectBestAgentWithContext(
-    model: LanguageModel,
-    agents: AiAgentWithContext[],
-    userQuery: string,
-): Promise<{
-    agent: AiAgentWithContext;
-    selection: AgentSelectionResult;
-}> {
-    const selection = await selectBestAgent(model, agents, userQuery);
-
-    const selectedAgent = agents.find(
-        (agent) => agent.uuid === selection.agentUuid,
-    );
-
-    if (!selectedAgent) {
+    if (!exists) {
         return {
-            agent: agents[0],
-            selection: {
-                agentUuid: agents[0].uuid,
-                reasoning: `Selected agent "${selection.agentUuid}" not found. Defaulting to first available agent.`,
-                confidence: 'low',
-                shouldSkipForwardingQuery: false,
-            },
+            selectedAgentUuid: candidates[0].uuid,
+            reasoning: `Selected agent "${selection.agentUuid}" not found. Defaulting to first available agent.`,
+            confidence: 'low',
+            shouldSkipForwardingQuery: false,
         };
     }
 
     return {
-        agent: selectedAgent,
-        selection,
+        selectedAgentUuid: selection.agentUuid,
+        confidence: selection.confidence,
+        reasoning: selection.reasoning,
+        shouldSkipForwardingQuery: selection.shouldSkipForwardingQuery,
     };
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -127,6 +127,8 @@ import { AiAgentDocumentController } from './../ee/controllers/aiAgentDocumentCo
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiController } from './../ee/controllers/aiController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AiRouterController } from './../ee/controllers/aiRouterController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiWritebackController } from './../ee/controllers/AiWritebackController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AppGenerateController } from './../ee/controllers/appGenerateController';
@@ -9405,6 +9407,280 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouter: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                projectUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                enabled: { dataType: 'boolean', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+                routerUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiRouter_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiRouter', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiRouterResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiRouter_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpsertAiRouterRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
+                enabled: { dataType: 'boolean' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterDecisionConfidence: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['high'] },
+                { dataType: 'enum', enums: ['medium'] },
+                { dataType: 'enum', enums: ['low'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterDecisionCandidate: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                agentUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterRouteDecision: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                candidates: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiRouterDecisionCandidate',
+                    },
+                    required: true,
+                },
+                reasoning: { dataType: 'string', required: true },
+                confidence: {
+                    ref: 'AiRouterDecisionConfidence',
+                    required: true,
+                },
+                suggestedAgentUuid: { dataType: 'string', required: true },
+                decisionUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterRouteNextAction: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['create_thread'] },
+                { dataType: 'enum', enums: ['show_picker'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterRouteResponseResult: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                nextAction: { ref: 'AiRouterRouteNextAction', required: true },
+                decision: { ref: 'AiRouterRouteDecision', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiRouterRouteResponseResult_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiRouterRouteResponseResult', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiRouterRouteResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiRouterRouteResponseResult_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterRouteRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                projectUuid: { dataType: 'string', required: true },
+                prompt: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiRouterDecisionCommitResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccessEmpty', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterDecisionCommitRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                threadUuid: { dataType: 'string', required: true },
+                chosenAgentUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterSelectionMode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['auto_routed'] },
+                { dataType: 'enum', enums: ['manual_pick'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiRouterDecision: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                committedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdAt: { dataType: 'datetime', required: true },
+                selectionMode: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiRouterSelectionMode' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                candidateAgentUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                reasoning: { dataType: 'string', required: true },
+                confidence: {
+                    ref: 'AiRouterDecisionConfidence',
+                    required: true,
+                },
+                chosenAgentUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                suggestedAgentUuid: { dataType: 'string', required: true },
+                prompt: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+                threadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                routerUuid: { dataType: 'string', required: true },
+                decisionUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiRouterDecision-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiRouterDecision' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiRouterDecisionListResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiRouterDecision-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardSummaryTone: {
         dataType: 'refEnum',
         enums: ['friendly', 'formal', 'direct', 'enthusiastic'],
@@ -12437,11 +12713,11 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -39919,6 +40195,305 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'listMyApps',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_getConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/org/aiRouter',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiRouterController.prototype.getConfig,
+        ),
+
+        async function AiRouterController_getConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_getConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_upsertConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpsertAiRouterRequest',
+        },
+    };
+    app.put(
+        '/api/v1/org/aiRouter',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiRouterController.prototype.upsertConfig,
+        ),
+
+        async function AiRouterController_upsertConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_upsertConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_route: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'AiRouterRouteRequest',
+        },
+    };
+    app.post(
+        '/api/v1/org/aiRouter/route',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(AiRouterController.prototype.route),
+
+        async function AiRouterController_route(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_route,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'route',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_commit: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        decisionUuid: {
+            in: 'path',
+            name: 'decisionUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'AiRouterDecisionCommitRequest',
+        },
+    };
+    app.post(
+        '/api/v1/org/aiRouter/decisions/:decisionUuid/commit',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiRouterController.prototype.commit,
+        ),
+
+        async function AiRouterController_commit(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_commit,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'commit',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiRouterController_listDecisions: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        confidence: {
+            in: 'query',
+            name: 'confidence',
+            ref: 'AiRouterDecisionConfidence',
+        },
+        selectionMode: {
+            in: 'query',
+            name: 'selectionMode',
+            ref: 'AiRouterSelectionMode',
+        },
+        fromDate: { in: 'query', name: 'fromDate', dataType: 'string' },
+        toDate: { in: 'query', name: 'toDate', dataType: 'string' },
+    };
+    app.get(
+        '/api/v1/org/aiRouter/decisions',
+        ...fetchMiddlewares<RequestHandler>(AiRouterController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiRouterController.prototype.listDecisions,
+        ),
+
+        async function AiRouterController_listDecisions(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiRouterController_listDecisions,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiRouterController>(AiRouterController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listDecisions',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12031,11 +12031,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12093,11 +12093,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12153,11 +12153,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12172,11 +12172,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12191,11 +12191,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12295,24 +12295,24 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                name: {
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -12390,12 +12390,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -12427,11 +12427,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12576,24 +12576,24 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
-                                                                                                        },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
+                                                                                                    name: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    name: {
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
+                                                                                                    label: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
@@ -12624,11 +12624,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12642,13 +12661,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -12671,11 +12690,326 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: [
+                                                                'not_found',
+                                                            ],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                streamingMessage: {
+                                                    dataType: 'any',
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['streaming'],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                streamingMessage: {
+                                                    dataType: 'any',
+                                                },
+                                                discovery: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType:
+                                                                'nestedObjectLiteral',
+                                                            nestedProperties: {
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
+                                                                    required: true,
+                                                                },
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
+                                                                status: {
+                                                                    dataType:
+                                                                        'enum',
+                                                                    enums: [
+                                                                        'resolved',
+                                                                    ],
+                                                                    required: true,
+                                                                },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'nestedObjectLiteral',
+                                                            nestedProperties: {
+                                                                suggestedQuestion:
+                                                                    {
+                                                                        dataType:
+                                                                            'string',
+                                                                        required: true,
+                                                                    },
+                                                                candidates: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                exploreLabel:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                exploreName:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
+                                                                status: {
+                                                                    dataType:
+                                                                        'enum',
+                                                                    enums: [
+                                                                        'ambiguous',
+                                                                    ],
+                                                                    required: true,
+                                                                },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'nestedObjectLiteral',
+                                                            nestedProperties: {
+                                                                reason: {
+                                                                    dataType:
+                                                                        'string',
+                                                                    required: true,
+                                                                },
+                                                                status: {
+                                                                    dataType:
+                                                                        'enum',
+                                                                    enums: [
+                                                                        'no_match',
+                                                                    ],
+                                                                    required: true,
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12710,14 +13044,140 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                prUrl: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        { dataType: 'string' },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -25934,7 +26394,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -25944,7 +26404,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -25954,7 +26414,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -25967,7 +26427,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -26622,7 +27082,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26632,7 +27092,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -26642,7 +27102,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -26655,7 +27115,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12134,11 +12134,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12690,11 +12690,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12736,11 +12736,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12755,11 +12755,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12774,11 +12774,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12793,11 +12793,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10923,6 +10923,279 @@
             "ApiMyAppsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__data-ApiAppSummary-Array--pagination_63_-KnexPaginateArgs-and-_totalPageCount-number--totalResults-number___"
             },
+            "AiRouter": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "projectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "routerUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "createdAt",
+                    "projectUuids",
+                    "enabled",
+                    "organizationUuid",
+                    "routerUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiRouter_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiRouter"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiRouterResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiRouter_"
+            },
+            "UpsertAiRouterRequest": {
+                "properties": {
+                    "projectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "AiRouterDecisionConfidence": {
+                "type": "string",
+                "enum": ["high", "medium", "low"]
+            },
+            "AiRouterDecisionCandidate": {
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "agentUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["description", "name", "agentUuid"],
+                "type": "object"
+            },
+            "AiRouterRouteDecision": {
+                "properties": {
+                    "candidates": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiRouterDecisionCandidate"
+                        },
+                        "type": "array"
+                    },
+                    "reasoning": {
+                        "type": "string"
+                    },
+                    "confidence": {
+                        "$ref": "#/components/schemas/AiRouterDecisionConfidence"
+                    },
+                    "suggestedAgentUuid": {
+                        "type": "string"
+                    },
+                    "decisionUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "candidates",
+                    "reasoning",
+                    "confidence",
+                    "suggestedAgentUuid",
+                    "decisionUuid"
+                ],
+                "type": "object"
+            },
+            "AiRouterRouteNextAction": {
+                "type": "string",
+                "enum": ["create_thread", "show_picker"]
+            },
+            "AiRouterRouteResponseResult": {
+                "properties": {
+                    "nextAction": {
+                        "$ref": "#/components/schemas/AiRouterRouteNextAction"
+                    },
+                    "decision": {
+                        "$ref": "#/components/schemas/AiRouterRouteDecision"
+                    }
+                },
+                "required": ["nextAction", "decision"],
+                "type": "object"
+            },
+            "ApiSuccess_AiRouterRouteResponseResult_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiRouterRouteResponseResult"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiRouterRouteResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiRouterRouteResponseResult_"
+            },
+            "AiRouterRouteRequest": {
+                "properties": {
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "prompt": {
+                        "type": "string"
+                    }
+                },
+                "required": ["projectUuid", "prompt"],
+                "type": "object"
+            },
+            "ApiAiRouterDecisionCommitResponse": {
+                "$ref": "#/components/schemas/ApiSuccessEmpty"
+            },
+            "AiRouterDecisionCommitRequest": {
+                "properties": {
+                    "threadUuid": {
+                        "type": "string"
+                    },
+                    "chosenAgentUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["threadUuid", "chosenAgentUuid"],
+                "type": "object"
+            },
+            "AiRouterSelectionMode": {
+                "type": "string",
+                "enum": ["auto_routed", "manual_pick"]
+            },
+            "AiRouterDecision": {
+                "properties": {
+                    "committedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "selectionMode": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiRouterSelectionMode"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "candidateAgentUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "reasoning": {
+                        "type": "string"
+                    },
+                    "confidence": {
+                        "$ref": "#/components/schemas/AiRouterDecisionConfidence"
+                    },
+                    "chosenAgentUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "suggestedAgentUuid": {
+                        "type": "string"
+                    },
+                    "prompt": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string"
+                    },
+                    "threadUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "routerUuid": {
+                        "type": "string"
+                    },
+                    "decisionUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "committedAt",
+                    "createdAt",
+                    "selectionMode",
+                    "candidateAgentUuids",
+                    "reasoning",
+                    "confidence",
+                    "chosenAgentUuid",
+                    "suggestedAgentUuid",
+                    "prompt",
+                    "userUuid",
+                    "threadUuid",
+                    "routerUuid",
+                    "decisionUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiRouterDecision-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiRouterDecision"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiRouterDecisionListResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiRouterDecision-Array_"
+            },
             "DashboardSummaryTone": {
                 "enum": ["friendly", "formal", "direct", "enthusiastic"],
                 "type": "string"
@@ -13323,8 +13596,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13382,8 +13655,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -13417,8 +13690,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -13447,24 +13720,24 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "tableName": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
                                                                             "type": "string"
+                                                                        },
+                                                                        "fieldType": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "label": {
+                                                                            "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
-                                                                        "label",
-                                                                        "name"
+                                                                        "name",
+                                                                        "fieldType",
+                                                                        "label"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -13485,16 +13758,16 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "label",
-                                                                        "name"
+                                                                        "name",
+                                                                        "label"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -13512,8 +13785,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -13572,24 +13845,24 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "label": {
+                                                                                        "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
-                                                                                    "label",
-                                                                                    "name"
+                                                                                    "name",
+                                                                                    "fieldType",
+                                                                                    "label"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -13616,8 +13889,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -13630,20 +13903,240 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "status",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error",
+                                                            "not_found"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "streamingMessage": {},
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["streaming"],
+                                                        "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "streamingMessage": {},
+                                                    "discovery": {
+                                                        "anyOf": [
+                                                            {
+                                                                "properties": {
+                                                                    "explore": {
+                                                                        "properties": {
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "joinedTables": {
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "label": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "baseTable",
+                                                                            "joinedTables",
+                                                                            "name",
+                                                                            "label"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "fieldValueType",
+                                                                                "description",
+                                                                                "name",
+                                                                                "fieldFilterType",
+                                                                                "fieldType",
+                                                                                "fieldId",
+                                                                                "label",
+                                                                                "table"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "status": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "resolved"
+                                                                        ],
+                                                                        "nullable": false
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "explore",
+                                                                    "rationale",
+                                                                    "fields",
+                                                                    "status"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            {
+                                                                "properties": {
+                                                                    "suggestedQuestion": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "candidates": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "reason": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "exploreLabel": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "exploreName": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "reason",
+                                                                                "exploreLabel",
+                                                                                "exploreName"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "status": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "ambiguous"
+                                                                        ],
+                                                                        "nullable": false
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "suggestedQuestion",
+                                                                    "candidates",
+                                                                    "status"
+                                                                ],
+                                                                "type": "object"
+                                                            },
+                                                            {
+                                                                "properties": {
+                                                                    "reason": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "status": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "no_match"
+                                                                        ],
+                                                                        "nullable": false
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "reason",
+                                                                    "status"
+                                                                ],
+                                                                "type": "object"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
+                                                    }
+                                                },
+                                                "required": [
+                                                    "discovery",
+                                                    "status"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "prUrl": {
+                                                        "type": "string",
+                                                        "nullable": true
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
+                                                    }
+                                                },
+                                                "required": ["prUrl", "status"],
                                                 "type": "object"
                                             },
                                             {
@@ -26920,22 +27413,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -27495,22 +27988,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -36273,7 +36766,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3036.0",
+        "version": "0.3038.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -37671,6 +38164,231 @@
                 "tags": ["Projects"],
                 "security": [],
                 "parameters": []
+            }
+        },
+        "/api/v1/org/aiRouter": {
+            "get": {
+                "operationId": "getAiRouterConfig",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the AI router configuration for the organization. Returns 404 when the\nrouter has not been configured yet — clients use this to detect first-use.",
+                "summary": "Get AI router config",
+                "security": [],
+                "parameters": []
+            },
+            "put": {
+                "operationId": "upsertAiRouterConfig",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Upsert the AI router configuration. Creates the row lazily on first save.",
+                "summary": "Upsert AI router config",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpsertAiRouterRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/aiRouter/route": {
+            "post": {
+                "operationId": "routeAiAgent",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterRouteResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Route a user prompt to the best candidate agent in the current project.",
+                "summary": "Route prompt",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AiRouterRouteRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/aiRouter/decisions/{decisionUuid}/commit": {
+            "post": {
+                "operationId": "commitAiRouterDecision",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterDecisionCommitResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Commit a router decision once the user has resolved it (router\nauto-routed and the thread is created, or the user picked an agent\nfrom the picker). Decisions left uncommitted indicate the user\nabandoned the flow.",
+                "summary": "Commit router decision",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "decisionUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AiRouterDecisionCommitRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/org/aiRouter/decisions": {
+            "get": {
+                "operationId": "listAiRouterDecisions",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiRouterDecisionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List recent routing decisions for the org's router.",
+                "summary": "List router decisions",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "confidence",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/AiRouterDecisionConfidence"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "selectionMode",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/AiRouterSelectionMode"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "fromDate",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "toDate",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/aiAgents/documents": {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -140,6 +140,7 @@ export type ModelManifest = {
     aiAgentDocumentModel: unknown;
     aiWritebackThreadModel: unknown;
     aiAgentReviewClassifierModel: unknown;
+    aiRouterModel: unknown;
     managedAgentModel: unknown;
     aiOrganizationSettingsModel: unknown;
     embedModel: unknown;
@@ -741,6 +742,8 @@ export class ModelRepository
 
     public getAiAgentReviewClassifierModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentReviewClassifierModel');
+    public getAiRouterModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiRouterModel');
     }
 
     public getAiOrganizationSettingsModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -742,6 +742,8 @@ export class ModelRepository
 
     public getAiAgentReviewClassifierModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentReviewClassifierModel');
+    }
+
     public getAiRouterModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiRouterModel');
     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -139,6 +139,7 @@ interface ServiceManifest {
     aiAgentAdminService: unknown;
     aiAgentDocumentService: unknown;
     aiAgentReviewClassifierService: unknown;
+    aiRouterService: unknown;
     aiOrganizationSettingsService: unknown;
     scimService: unknown;
     supportService: unknown;
@@ -1275,6 +1276,8 @@ export class ServiceRepository
         AiAgentReviewClassifierServiceImplT,
     >(): AiAgentReviewClassifierServiceImplT {
         return this.getService('aiAgentReviewClassifierService');
+    public getAiRouterService<AiRouterServiceImplT>(): AiRouterServiceImplT {
+        return this.getService('aiRouterService');
     }
 
     public getRolesService(): RolesService {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1276,6 +1276,8 @@ export class ServiceRepository
         AiAgentReviewClassifierServiceImplT,
     >(): AiAgentReviewClassifierServiceImplT {
         return this.getService('aiAgentReviewClassifierService');
+    }
+
     public getAiRouterService<AiRouterServiceImplT>(): AiRouterServiceImplT {
         return this.getService('aiRouterService');
     }

--- a/packages/common/src/ee/AiRouter/index.ts
+++ b/packages/common/src/ee/AiRouter/index.ts
@@ -1,0 +1,81 @@
+import { type ApiSuccess, type ApiSuccessEmpty } from '../../types/api/success';
+
+export type AiRouter = {
+    routerUuid: string;
+    organizationUuid: string;
+    enabled: boolean;
+    projectUuids: string[];
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type ApiAiRouterResponse = ApiSuccess<AiRouter>;
+
+export type UpsertAiRouterRequest = {
+    enabled?: boolean;
+    projectUuids?: string[];
+};
+
+export type AiRouterDecisionConfidence = 'high' | 'medium' | 'low';
+
+export type AiRouterSelectionMode = 'auto_routed' | 'manual_pick';
+
+export type AiRouterDecisionCandidate = {
+    agentUuid: string;
+    name: string;
+    description: string | null;
+};
+
+export type AiRouterDecision = {
+    decisionUuid: string;
+    routerUuid: string;
+    threadUuid: string | null;
+    userUuid: string;
+    prompt: string;
+    suggestedAgentUuid: string;
+    chosenAgentUuid: string | null;
+    confidence: AiRouterDecisionConfidence;
+    reasoning: string;
+    candidateAgentUuids: string[];
+    selectionMode: AiRouterSelectionMode | null;
+    createdAt: Date;
+    committedAt: Date | null;
+};
+
+export type AiRouterRouteRequest = {
+    prompt: string;
+    projectUuid: string;
+};
+
+export type AiRouterRouteNextAction = 'create_thread' | 'show_picker';
+
+export type AiRouterRouteDecision = {
+    decisionUuid: string;
+    suggestedAgentUuid: string;
+    confidence: AiRouterDecisionConfidence;
+    reasoning: string;
+    candidates: AiRouterDecisionCandidate[];
+};
+
+export type AiRouterRouteResponseResult = {
+    decision: AiRouterRouteDecision;
+    nextAction: AiRouterRouteNextAction;
+};
+
+export type ApiAiRouterRouteResponse = ApiSuccess<AiRouterRouteResponseResult>;
+
+export type AiRouterDecisionCommitRequest = {
+    chosenAgentUuid: string;
+    threadUuid: string;
+};
+
+export type ApiAiRouterDecisionCommitResponse = ApiSuccessEmpty;
+
+export type AiRouterDecisionListFilters = {
+    confidence?: AiRouterDecisionConfidence;
+    selectionMode?: AiRouterSelectionMode;
+    fromDate?: string;
+    toDate?: string;
+};
+
+export type ApiAiRouterDecisionListResponse = ApiSuccess<AiRouterDecision[]>;

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -1,5 +1,6 @@
 export * from './AiAgent';
 export * from './aiWriteback/types';
+export * from './AiRouter';
 export * from './apps/types';
 export * from './ambientAi';
 export * from './commercialFeatureFlags';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -24,6 +24,10 @@ import type {
     ApiAiGenerateTableCalculationResponse,
     ApiAiGetDashboardSummaryResponse,
     ApiAiOrganizationSettingsResponse,
+    ApiAiRouterDecisionCommitResponse,
+    ApiAiRouterDecisionListResponse,
+    ApiAiRouterResponse,
+    ApiAiRouterRouteResponse,
     ApiAppendInstructionResponse,
     ApiAppImageUploadResponse,
     ApiCreateEvaluationResponse,
@@ -1061,6 +1065,10 @@ type ApiResults =
     | ApiGetChangeResponse['results']
     | ApiAiOrganizationSettingsResponse['results']
     | ApiUpdateAiOrganizationSettingsResponse['results']
+    | ApiAiRouterResponse['results']
+    | ApiAiRouterRouteResponse['results']
+    | ApiAiRouterDecisionCommitResponse['results']
+    | ApiAiRouterDecisionListResponse['results']
     | ApiProjectCompileLogsResponse['results']
     | ApiProjectCompileLogResponse['results']
     | ApiSingleValidationResponse['results']

--- a/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
+++ b/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
@@ -2,7 +2,6 @@ import type { AiModelOption } from '@lightdash/common';
 import {
     Button,
     Menu,
-    rem,
     ScrollArea,
     Stack,
     Text,
@@ -57,10 +56,7 @@ export const ModelSelector: FC<Props> = ({
         >
             <Menu.Target>
                 <Button
-                    variant="subtle"
-                    color="gray"
                     px="xs"
-                    h={rem(36)}
                     {...buttonProps}
                     rightSection={
                         <MantineIcon
@@ -70,7 +66,7 @@ export const ModelSelector: FC<Props> = ({
                         />
                     }
                 >
-                    <Text size="sm" fw={500}>
+                    <Text size="xs" fw={500} c="dimmed">
                         {selectedModel?.displayName ?? 'Select model'}
                     </Text>
                 </Button>

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -79,16 +79,17 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
         },
     });
 
-    const { mutateAsync: createAgentThread } = useCreateAgentThreadMutation(
-        selectedAgent?.uuid,
-        projectUuid,
-    );
+    const { mutateAsync: createAgentThread } =
+        useCreateAgentThreadMutation(projectUuid);
 
     const handleSubmit = form.onSubmit(async (values) => {
         if (!selectedAgent) {
             void navigate(`/projects/${projectUuid}/ai-agents`);
         } else {
-            await createAgentThread({ prompt: values.prompt.trim() });
+            await createAgentThread({
+                agentUuid: selectedAgent.uuid,
+                prompt: values.prompt.trim(),
+            });
         }
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.module.css
@@ -1,0 +1,67 @@
+.target {
+    display: inline-flex;
+    align-items: center;
+    width: 200px;
+    padding: 4px 8px;
+    border-radius: var(--mantine-radius-md);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    background: transparent;
+    box-shadow: var(--mantine-shadow-subtle);
+    cursor: pointer;
+    font-size: var(--mantine-font-size-xs);
+    transition:
+        background-color 120ms ease,
+        border-color 120ms ease;
+}
+
+.target:hover {
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldGray-2);
+    }
+}
+
+.label {
+    flex: 1;
+    text-align: left;
+}
+
+/* Compact: icon-only at rest, no border. On hover / focus / open, the chip
+ * grows a border + light background to match the adjacent model+thinking
+ * group, then snaps back when interaction ends. The default 1px transparent
+ * border reserves the same footprint so the chip doesn't shift on hover. */
+.compact {
+    width: auto;
+    border-color: transparent;
+    box-shadow: none;
+    background: transparent;
+}
+
+.compact:hover,
+.compact:focus-visible,
+.compact[data-open='true'] {
+    border-color: var(--mantine-color-ldGray-2);
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldGray-2);
+    }
+}
+
+.compact .label {
+    flex: none;
+    width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    transition: width 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.compact:hover .label,
+.compact:focus-visible .label,
+.compact[data-open='true'] .label {
+    width: 140px;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -3,27 +3,35 @@ import {
     Center,
     Combobox,
     Group,
-    InputBase,
     Stack,
     Text,
+    UnstyledButton,
     useCombobox,
 } from '@mantine-8/core';
 import {
     IconCheck,
+    IconChevronDown,
     IconCirclePlus,
-    IconSelector,
     IconSparkles,
 } from '@tabler/icons-react';
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiRouterConfig } from '../../hooks/useAiRouter';
+import styles from './AgentSelector.module.css';
 import { getAgentOptions, type Agent } from './AgentSelectorUtils';
 
 type Props = {
     agents: Agent[];
     selectedAgent: Agent | 'auto';
     projectUuid: string;
+    /**
+     * Render the target as an icon-only chip; the label reveals on hover,
+     * focus, or while the dropdown is open. Used when toolbar space is
+     * tight (e.g. the chat input).
+     */
+    compact?: boolean;
 };
 
 const AUTO_VALUE = '__auto__';
@@ -32,10 +40,13 @@ export const AgentSelector = ({
     agents,
     selectedAgent,
     projectUuid,
+    compact = false,
 }: Props) => {
     const navigate = useNavigate();
     const { search } = useLocation();
+    const [opened, setOpened] = useState(false);
     const combobox = useCombobox({
+        onOpenedChange: setOpened,
         onDropdownClose: () => combobox.resetSelectedOption(),
     });
 
@@ -77,16 +88,20 @@ export const AgentSelector = ({
             store={combobox}
             onOptionSubmit={handleOptionSubmit}
             withinPortal={false}
+            width={compact ? 260 : 'target'}
+            position="bottom-start"
         >
             <Combobox.Target>
-                <InputBase
-                    w="230px"
-                    component="button"
+                <UnstyledButton
                     type="button"
-                    pointer
                     onClick={() => combobox.toggleDropdown()}
-                    leftSection={
-                        isAuto ? (
+                    className={`${styles.target} ${
+                        compact ? styles.compact : ''
+                    }`}
+                    data-open={opened ? 'true' : undefined}
+                >
+                    <Group gap={6} wrap="nowrap" align="center" w="100%">
+                        {isAuto ? (
                             <Avatar size={22} color="violet" radius="xl">
                                 <MantineIcon
                                     icon={IconSparkles}
@@ -100,22 +115,17 @@ export const AgentSelector = ({
                                 name={selectedAgent.name}
                                 src={selectedAgent.imageUrl}
                             />
-                        )
-                    }
-                    rightSection={<MantineIcon icon={IconSelector} />}
-                    styles={(theme) => ({
-                        input: {
-                            borderColor: theme.colors.ldGray[2],
-                            borderRadius: theme.radius.md,
-                            boxShadow: `var(--mantine-shadow-subtle)`,
-                            fontSize: theme.fontSizes.xs,
-                        },
-                    })}
-                >
-                    <Text size="xs" truncate="end" ml={2}>
-                        {isAuto ? 'Auto' : selectedAgent.name}
-                    </Text>
-                </InputBase>
+                        )}
+                        <Text size="xs" truncate="end" className={styles.label}>
+                            {isAuto ? 'Auto' : selectedAgent.name}
+                        </Text>
+                        <MantineIcon
+                            icon={IconChevronDown}
+                            size="sm"
+                            color="ldGray.6"
+                        />
+                    </Group>
+                </UnstyledButton>
             </Combobox.Target>
 
             <Combobox.Dropdown>
@@ -135,7 +145,7 @@ export const AgentSelector = ({
                                         Auto
                                     </Text>
                                     <Text size="xs" c="dimmed" truncate="end">
-                                        Let AI pick the best agent
+                                        We'll route to the besy-fit agent
                                     </Text>
                                 </Stack>
                                 {isAuto && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -1,22 +1,32 @@
 import {
+    Avatar,
     Center,
     Combobox,
     Group,
     InputBase,
+    Stack,
     Text,
     useCombobox,
 } from '@mantine-8/core';
-import { IconCheck, IconCirclePlus, IconSelector } from '@tabler/icons-react';
+import {
+    IconCheck,
+    IconCirclePlus,
+    IconSelector,
+    IconSparkles,
+} from '@tabler/icons-react';
 import { useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiRouterConfig } from '../../hooks/useAiRouter';
 import { getAgentOptions, type Agent } from './AgentSelectorUtils';
 
 type Props = {
     agents: Agent[];
-    selectedAgent: Agent;
+    selectedAgent: Agent | 'auto';
     projectUuid: string;
 };
+
+const AUTO_VALUE = '__auto__';
 
 export const AgentSelector = ({
     agents,
@@ -30,12 +40,24 @@ export const AgentSelector = ({
     });
 
     const agentOptions = getAgentOptions(agents);
+    const isAuto = selectedAgent === 'auto';
+    // Auto is only meaningful when there's more than one agent AND the router
+    // is enabled. Treat any non-`enabled: true` state (loading, error, disabled)
+    // as "no Auto" to avoid flashing the option in and out.
+    const { data: aiRouterConfig } = useAiRouterConfig();
+    const showAutoOption =
+        agents.length > 1 && aiRouterConfig?.enabled === true;
 
     const handleOptionSubmit = (value: string) => {
         if (value === 'new') {
             void navigate(`/projects/${projectUuid}/ai-agents/new`, {
                 viewTransition: true,
             });
+        } else if (value === AUTO_VALUE) {
+            void navigate(
+                { pathname: `/projects/${projectUuid}/ai-agents`, search },
+                { viewTransition: true },
+            );
         } else {
             void navigate(
                 {
@@ -64,11 +86,21 @@ export const AgentSelector = ({
                     pointer
                     onClick={() => combobox.toggleDropdown()}
                     leftSection={
-                        <LightdashUserAvatar
-                            size={22}
-                            name={selectedAgent.name}
-                            src={selectedAgent.imageUrl}
-                        />
+                        isAuto ? (
+                            <Avatar size={22} color="violet" radius="xl">
+                                <MantineIcon
+                                    icon={IconSparkles}
+                                    size="sm"
+                                    color="violet.6"
+                                />
+                            </Avatar>
+                        ) : (
+                            <LightdashUserAvatar
+                                size={22}
+                                name={selectedAgent.name}
+                                src={selectedAgent.imageUrl}
+                            />
+                        )
                     }
                     rightSection={<MantineIcon icon={IconSelector} />}
                     styles={(theme) => ({
@@ -81,12 +113,42 @@ export const AgentSelector = ({
                     })}
                 >
                     <Text size="xs" truncate="end" ml={2}>
-                        {selectedAgent.name}
+                        {isAuto ? 'Auto' : selectedAgent.name}
                     </Text>
                 </InputBase>
             </Combobox.Target>
 
             <Combobox.Dropdown>
+                {showAutoOption && (
+                    <Combobox.Header p={4} pr={6}>
+                        <Combobox.Option value={AUTO_VALUE} p={2}>
+                            <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
+                                <Avatar size={22} color="violet" radius="xl">
+                                    <MantineIcon
+                                        icon={IconSparkles}
+                                        size="sm"
+                                        color="violet.6"
+                                    />
+                                </Avatar>
+                                <Stack gap={0} flex={1} miw={0}>
+                                    <Text size="xs" fw={600} c="violet.7">
+                                        Auto
+                                    </Text>
+                                    <Text size="xs" c="dimmed" truncate="end">
+                                        Let AI pick the best agent
+                                    </Text>
+                                </Stack>
+                                {isAuto && (
+                                    <MantineIcon
+                                        icon={IconCheck}
+                                        size="sm"
+                                        color="violet"
+                                    />
+                                )}
+                            </Group>
+                        </Combobox.Option>
+                    </Combobox.Header>
+                )}
                 <Combobox.Options>
                     {agentOptions.map((item) => (
                         <Combobox.Option
@@ -106,13 +168,14 @@ export const AgentSelector = ({
                                     {item.label}
                                 </Text>
 
-                                {item.value === selectedAgent.uuid && (
-                                    <MantineIcon
-                                        icon={IconCheck}
-                                        size="sm"
-                                        color="violet"
-                                    />
-                                )}
+                                {!isAuto &&
+                                    item.value === selectedAgent.uuid && (
+                                        <MantineIcon
+                                            icon={IconCheck}
+                                            size="sm"
+                                            color="violet"
+                                        />
+                                    )}
                             </Group>
                         </Combobox.Option>
                     ))}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
@@ -1,0 +1,63 @@
+import { Box, Button, Group } from '@mantine-8/core';
+import { IconSettings, IconWindowMinimize } from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+
+type Props = {
+    leftSection?: ReactNode;
+    onMinimize?: () => void;
+    settingsHref?: string;
+};
+
+export const AgentPageHeader: FC<Props> = ({
+    leftSection,
+    onMinimize,
+    settingsHref,
+}) => (
+    <Group align="center" justify="space-between">
+        <Box>{leftSection}</Box>
+        <Group gap="xs">
+            {onMinimize && (
+                <Button
+                    variant="default"
+                    onClick={onMinimize}
+                    leftSection={
+                        <MantineIcon
+                            icon={IconWindowMinimize}
+                            style={{ transform: 'scaleX(-1)' }}
+                        />
+                    }
+                    styles={(theme) => ({
+                        root: {
+                            borderColor: theme.colors.ldGray[2],
+                            boxShadow: `var(--mantine-shadow-subtle)`,
+                            color: theme.colors.ldGray[9],
+                            fontSize: theme.fontSizes.xs,
+                        },
+                    })}
+                >
+                    Minimize
+                </Button>
+            )}
+            {settingsHref && (
+                <Button
+                    component={Link}
+                    variant="default"
+                    to={settingsHref}
+                    leftSection={<MantineIcon icon={IconSettings} />}
+                    styles={(theme) => ({
+                        root: {
+                            borderColor: theme.colors.ldGray[2],
+                            boxShadow: `var(--mantine-shadow-subtle)`,
+                            color: theme.colors.ldGray[9],
+                            fontSize: theme.fontSizes.xs,
+                        },
+                    })}
+                >
+                    Settings
+                </Button>
+            )}
+        </Group>
+    </Group>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
@@ -1,0 +1,231 @@
+import { type AiAgent, type AiAgentThreadSummary } from '@lightdash/common';
+import {
+    Alert,
+    Box,
+    Button,
+    Paper,
+    rem,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+    NavLink,
+} from '@mantine-8/core';
+import {
+    IconBrandSlack,
+    IconChevronDown,
+    IconCirclePlus,
+    IconInfoCircle,
+    IconSparkles,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings';
+import { useAiAgentThreads } from '../../hooks/useProjectAiAgents';
+import { SidebarButton } from './SidebarButton';
+
+const INITIAL_MAX_THREADS = 10;
+const MAX_THREADS_INCREMENT = 10;
+
+type ThreadNavLinkProps = {
+    thread: AiAgentThreadSummary;
+    isActive: boolean;
+    projectUuid: string;
+};
+
+const ThreadNavLink: FC<ThreadNavLinkProps> = ({
+    thread,
+    isActive,
+    projectUuid,
+}) => (
+    <NavLink
+        color="gray"
+        component={Link}
+        key={thread.uuid}
+        to={`/projects/${projectUuid}/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
+        px="xs"
+        py={rem(4)}
+        style={(theme) => ({
+            borderRadius: theme.radius.sm,
+        })}
+        label={
+            <Text truncate="end" size="sm" c="ldGray.9">
+                {thread.title || thread.firstMessage.message}
+            </Text>
+        }
+        active={isActive}
+        rightSection={
+            thread.createdFrom === 'slack' && (
+                <Tooltip label={'Threads created in slack are read only'}>
+                    <IconBrandSlack size={18} stroke={1} />
+                </Tooltip>
+            )
+        }
+        viewTransition
+    />
+);
+
+const TrialAlert = () => (
+    <Alert
+        icon={<MantineIcon icon={IconSparkles} />}
+        variant="outline"
+        color="indigo.6"
+        bg="indigo.0"
+        fz="xs"
+        p="xs"
+        title={
+            <Text size="xs" fw={500}>
+                You're currently using Lightdash AI Agents in free trial mode
+            </Text>
+        }
+    >
+        <Button
+            size="compact-xs"
+            variant="light"
+            color="indigo"
+            leftSection={<MantineIcon icon={IconInfoCircle} size="sm" />}
+            component={Link}
+            to="https://docs.lightdash.com/guides/ai-agents"
+            target="_blank"
+        >
+            Learn more
+        </Button>
+    </Alert>
+);
+
+type AgentSidebarProps = {
+    agent: AiAgent;
+    projectUuid: string;
+    threadUuid?: string;
+    isAgentSidebarCollapsed: boolean;
+};
+
+export const AgentSidebar: FC<AgentSidebarProps> = ({
+    agent,
+    projectUuid,
+    threadUuid,
+    isAgentSidebarCollapsed,
+}) => {
+    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
+    const isTrial =
+        aiOrganizationSettingsQuery.isSuccess &&
+        aiOrganizationSettingsQuery.data.isTrial;
+    const { data: threads } = useAiAgentThreads(projectUuid, agent.uuid);
+    const [showMaxItems, setShowMaxItems] = useState(INITIAL_MAX_THREADS);
+
+    return (
+        <Stack gap="md" style={{ flexGrow: 1, overflowY: 'auto' }}>
+            <Box>
+                <SidebarButton
+                    leftSection={<MantineIcon icon={IconCirclePlus} />}
+                    component={Link}
+                    to={`/projects/${projectUuid}/ai-agents/${agent.uuid}/threads`}
+                    size="sm"
+                    {...(!isAgentSidebarCollapsed && {
+                        fullWidth: true,
+                        justify: 'flex-start',
+                    })}
+                >
+                    {isAgentSidebarCollapsed ? '' : 'New thread'}
+                </SidebarButton>
+            </Box>
+
+            {projectUuid && threads && !isAgentSidebarCollapsed && (
+                <Stack gap="xs" style={{ flexGrow: 1, overflowY: 'auto' }}>
+                    <Title
+                        order={6}
+                        c="dimmed"
+                        tt="uppercase"
+                        size="xs"
+                        ml="xs"
+                    >
+                        Recent
+                    </Title>
+
+                    <Stack gap={2}>
+                        {threads.length === 0 && (
+                            <Paper variant="dotted" p="sm">
+                                <Text
+                                    truncate="end"
+                                    size="sm"
+                                    c="ldGray.6"
+                                    ta="center"
+                                >
+                                    No threads yet
+                                </Text>
+                            </Paper>
+                        )}
+
+                        <Box>
+                            {threads.slice(0, showMaxItems).map((thread) => (
+                                <ThreadNavLink
+                                    key={thread.uuid}
+                                    thread={thread}
+                                    isActive={thread.uuid === threadUuid}
+                                    projectUuid={projectUuid}
+                                />
+                            ))}
+                        </Box>
+                    </Stack>
+
+                    <Box>
+                        {threads.length >= showMaxItems && (
+                            <Button
+                                size="compact-xs"
+                                variant="subtle"
+                                onClick={() =>
+                                    setShowMaxItems(
+                                        (s) => s + MAX_THREADS_INCREMENT,
+                                    )
+                                }
+                                leftSection={
+                                    <MantineIcon icon={IconChevronDown} />
+                                }
+                            >
+                                View more
+                            </Button>
+                        )}
+                    </Box>
+                </Stack>
+            )}
+            {isTrial && <TrialAlert />}
+        </Stack>
+    );
+};
+
+type AutoModeSidebarProps = {
+    projectUuid: string;
+    isAgentSidebarCollapsed: boolean;
+};
+
+export const AutoModeSidebar: FC<AutoModeSidebarProps> = ({
+    projectUuid,
+    isAgentSidebarCollapsed,
+}) => {
+    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
+    const isTrial =
+        aiOrganizationSettingsQuery.isSuccess &&
+        aiOrganizationSettingsQuery.data.isTrial;
+
+    return (
+        <Stack gap="md" style={{ flexGrow: 1, overflowY: 'auto' }}>
+            <Box>
+                <SidebarButton
+                    leftSection={<MantineIcon icon={IconCirclePlus} />}
+                    component={Link}
+                    to={`/projects/${projectUuid}/ai-agents`}
+                    size="sm"
+                    {...(!isAgentSidebarCollapsed && {
+                        fullWidth: true,
+                        justify: 'flex-start',
+                    })}
+                >
+                    {isAgentSidebarCollapsed ? '' : 'New thread'}
+                </SidebarButton>
+            </Box>
+
+            {isTrial && <TrialAlert />}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -3,6 +3,40 @@
     padding-bottom: var(--mantine-spacing-lg);
 }
 
+/* Bordered shell that hosts the model selector + thinking toggle as a single
+ * segmented control. Inner controls stay borderless (variant="subtle"); the
+ * shell owns the outer border and one hairline divider sits between them. */
+.modelGroup {
+    display: inline-flex;
+    align-items: stretch;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    background: transparent;
+}
+
+.modelGroup > button {
+    border-radius: 0;
+    border: none;
+}
+
+/* Mantine size="xs" Buttons set min-width for label-bearing buttons; the
+ * icon-only ActionIcon doesn't need it. Keep both square at the ends. */
+.modelGroup > button:first-child {
+    border-top-left-radius: calc(var(--mantine-radius-md) - 1px);
+    border-bottom-left-radius: calc(var(--mantine-radius-md) - 1px);
+}
+
+.modelGroup > button:last-child {
+    border-top-right-radius: calc(var(--mantine-radius-md) - 1px);
+    border-bottom-right-radius: calc(var(--mantine-radius-md) - 1px);
+}
+
+.modelGroupDivider {
+    width: 1px;
+    background: var(--mantine-color-ldGray-2);
+    align-self: stretch;
+}
+
 .inputCard {
     border-radius: var(--mantine-radius-lg);
     overflow: hidden;
@@ -124,20 +158,6 @@
 .disabledBannerVisible .inputCard {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-}
-
-.thinkingButton {
-    font-weight: 500;
-    color: var(--mantine-color-ldGray-7);
-    border-radius: var(--mantine-radius-md);
-}
-
-.thinkingButtonOn {
-    color: var(--mantine-color-indigo-5);
-}
-
-.thinkingButtonOn:hover {
-    color: var(--mantine-color-indigo-5);
 }
 
 /* Minimal mode styles for existing threads */

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -7,8 +7,6 @@ import {
     ActionIcon,
     Anchor,
     Box,
-    Button,
-    Divider,
     Group,
     Paper,
     Switch,
@@ -16,7 +14,12 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { RichTextEditor } from '@mantine/tiptap';
-import { IconArrowUp, IconBrain, IconTerminal2 } from '@tabler/icons-react';
+import {
+    IconArrowUp,
+    IconBulb,
+    IconBulbFilled,
+    IconTerminal2,
+} from '@tabler/icons-react';
 import Mention from '@tiptap/extension-mention';
 import Placeholder from '@tiptap/extension-placeholder';
 import { useEditor, type Editor } from '@tiptap/react';
@@ -584,54 +587,80 @@ export const AgentChatInput = ({
 
                 <Box className={styles.toolbar}>
                     <Box className={styles.toolbarActions}>
+                        {(showModelSelector || onExtendedThinkingChange) && (
+                            <Box className={styles.modelGroup}>
+                                {showModelSelector && (
+                                    <ModelSelector
+                                        models={models}
+                                        value={selectedModelId ?? null}
+                                        onChange={onModelChange}
+                                        variant="subtle"
+                                        color="gray"
+                                        size="xs"
+                                    />
+                                )}
+
+                                {showModelSelector &&
+                                    onExtendedThinkingChange && (
+                                        <div
+                                            className={styles.modelGroupDivider}
+                                        />
+                                    )}
+
+                                {onExtendedThinkingChange && (
+                                    <Tooltip
+                                        multiline
+                                        w={240}
+                                        withArrow
+                                        position="top"
+                                        label="Let the model spend extra reasoning time before answering. Slower but better on complex questions."
+                                    >
+                                        <ActionIcon
+                                            variant={
+                                                extendedThinking
+                                                    ? 'light'
+                                                    : 'subtle'
+                                            }
+                                            color={
+                                                extendedThinking
+                                                    ? 'indigo'
+                                                    : 'gray'
+                                            }
+                                            size={30}
+                                            onClick={() =>
+                                                onExtendedThinkingChange(
+                                                    !extendedThinking,
+                                                )
+                                            }
+                                            aria-label="Toggle extended thinking"
+                                            aria-pressed={extendedThinking}
+                                        >
+                                            <MantineIcon
+                                                icon={
+                                                    extendedThinking
+                                                        ? IconBulbFilled
+                                                        : IconBulb
+                                                }
+                                                size="sm"
+                                                color={
+                                                    extendedThinking
+                                                        ? 'indigo.5'
+                                                        : 'ldGray.6'
+                                                }
+                                            />
+                                        </ActionIcon>
+                                    </Tooltip>
+                                )}
+                            </Box>
+                        )}
+
                         {showAgentSelector && (
                             <AgentSelector
                                 projectUuid={projectUuid!}
                                 agents={agents!}
                                 selectedAgent={selectedAgent!}
+                                compact
                             />
-                        )}
-
-                        {showModelSelector && (
-                            <ModelSelector
-                                models={models}
-                                value={selectedModelId ?? null}
-                                onChange={onModelChange}
-                            />
-                        )}
-
-                        {onExtendedThinkingChange && (
-                            <Group>
-                                <Divider orientation="vertical" />
-                                <Button
-                                    variant="subtle"
-                                    size="compact-sm"
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconBrain}
-                                            color={
-                                                extendedThinking
-                                                    ? 'indigo.5'
-                                                    : 'ldGray.7'
-                                            }
-                                        />
-                                    }
-                                    className={
-                                        styles.thinkingButton +
-                                        ' ' +
-                                        (extendedThinking
-                                            ? styles.thinkingButtonOn
-                                            : '')
-                                    }
-                                    onClick={() =>
-                                        onExtendedThinkingChange(
-                                            !extendedThinking,
-                                        )
-                                    }
-                                >
-                                    Thinking
-                                </Button>
-                            </Group>
                         )}
                     </Box>
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -77,7 +77,7 @@ interface AgentChatInputProps {
     threadUuid?: string;
     latestAssistantMessageUuid?: string;
     agents?: Agent[];
-    selectedAgent?: Agent;
+    selectedAgent?: Agent | 'auto';
     models?: AiModelOption[];
     selectedModelId?: string | null;
     onModelChange?: (modelId: string) => void;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -91,6 +91,7 @@ interface AgentChatInputProps {
     defaultValue?: string;
     onValueChange?: (value: string) => void;
     fullWidth?: boolean;
+    clearOnSubmit?: boolean;
 }
 
 const extractToolHints = (editor: Editor | null): string[] => {
@@ -130,6 +131,7 @@ export const AgentChatInput = ({
     defaultValue,
     onValueChange,
     fullWidth = false,
+    clearOnSubmit = true,
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
@@ -144,6 +146,8 @@ export const AgentChatInput = ({
     loadingRef.current = loading;
     const disabledRef = useRef(disabled);
     disabledRef.current = disabled;
+    const clearOnSubmitRef = useRef(clearOnSubmit);
+    clearOnSubmitRef.current = clearOnSubmit;
 
     // Hide the chip strip while the user is scrolled away from the input.
     // Reappears as they scroll back toward the bottom of the thread — chips
@@ -280,8 +284,10 @@ export const AgentChatInput = ({
                         message: text,
                         toolHints: extractToolHints(ed),
                     });
-                    ed.commands.clearContent();
-                    setValueState('');
+                    if (clearOnSubmitRef.current) {
+                        ed.commands.clearContent();
+                        setValueState('');
+                    }
                     return true;
                 }
                 return false;
@@ -348,8 +354,10 @@ export const AgentChatInput = ({
                 message: chip.label,
                 toolHints: [chip.tool],
             });
-            editor?.commands.clearContent();
-            setValueState('');
+            if (clearOnSubmitRef.current) {
+                editor?.commands.clearContent();
+                setValueState('');
+            }
             trackClick();
         },
         [
@@ -399,8 +407,10 @@ export const AgentChatInput = ({
             message: text,
             toolHints: extractToolHints(ed),
         });
-        ed.commands.clearContent();
-        setValueState('');
+        if (clearOnSubmitRef.current) {
+            ed.commands.clearContent();
+            setValueState('');
+        }
     };
 
     const chipRow = useMemo(() => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -30,6 +30,8 @@ import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeat
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import { useAgentSuggestions } from '../../hooks/useAgentSuggestions';
+import { AgentSelector } from '../AgentSelector';
+import { type Agent } from '../AgentSelector/AgentSelectorUtils';
 import styles from './AgentChatInput.module.css';
 import { AgentSuggestionChips } from './AgentSuggestionChips';
 import { getAgentSuggestionModes } from './suggestionModes';
@@ -74,6 +76,8 @@ interface AgentChatInputProps {
     agentUuid?: string;
     threadUuid?: string;
     latestAssistantMessageUuid?: string;
+    agents?: Agent[];
+    selectedAgent?: Agent;
     models?: AiModelOption[];
     selectedModelId?: string | null;
     onModelChange?: (modelId: string) => void;
@@ -111,6 +115,8 @@ export const AgentChatInput = ({
     agentUuid,
     threadUuid,
     latestAssistantMessageUuid,
+    agents,
+    selectedAgent,
     models,
     selectedModelId,
     onModelChange,
@@ -186,7 +192,13 @@ export const AgentChatInput = ({
 
     const showModelSelector =
         models && models.length > 1 && onModelChange !== undefined;
-    const isMinimalMode = !showModelSelector;
+    const showAgentSelector = !!(
+        agents &&
+        selectedAgent &&
+        projectUuid &&
+        agents.length > 0
+    );
+    const isMinimalMode = !showModelSelector && !showAgentSelector;
 
     const suggestionsFlag = useServerFeatureFlag(
         FeatureFlags.AiAgentSuggestions,
@@ -572,6 +584,14 @@ export const AgentChatInput = ({
 
                 <Box className={styles.toolbar}>
                     <Box className={styles.toolbarActions}>
+                        {showAgentSelector && (
+                            <AgentSelector
+                                projectUuid={projectUuid!}
+                                agents={agents!}
+                                selectedAgent={selectedAgent!}
+                            />
+                        )}
+
                         {showModelSelector && (
                             <ModelSelector
                                 models={models}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -101,7 +101,7 @@ const NewThreadPanel: FC<{
     });
 
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
-        useCreateAgentThreadMutation(agent.uuid, projectUuid, {
+        useCreateAgentThreadMutation(projectUuid, {
             // Launcher does its own routing via panels/dock — skip the default
             // page navigation that other surfaces want.
             skipNavigation: true,
@@ -142,6 +142,7 @@ const NewThreadPanel: FC<{
         toolHints: string[];
     }) => {
         void createAgentThread({
+            agentUuid: agent.uuid,
             prompt: message,
             context: contextInput.length > 0 ? contextInput : undefined,
             optimisticContext:

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
@@ -1,0 +1,21 @@
+import { type AiRouter, type ApiError } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+const ROUTER_BASE = '/org/aiRouter';
+
+const getAiRouterConfig = () =>
+    lightdashApi<AiRouter>({
+        url: ROUTER_BASE,
+        method: 'GET',
+        body: undefined,
+    });
+
+// Returns the org's router configuration. 404 (no config yet) and other
+// failures resolve to `isError`; callers treat that as "router disabled".
+export const useAiRouterConfig = () =>
+    useQuery<AiRouter, ApiError>({
+        queryKey: ['ai-router'],
+        queryFn: getAiRouterConfig,
+        retry: false,
+    });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
@@ -1,5 +1,11 @@
-import { type AiRouter, type ApiError } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import {
+    type AiRouter,
+    type AiRouterDecisionCommitRequest,
+    type AiRouterRouteRequest,
+    type AiRouterRouteResponseResult,
+    type ApiError,
+} from '@lightdash/common';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
 
 const ROUTER_BASE = '/org/aiRouter';
@@ -18,4 +24,35 @@ export const useAiRouterConfig = () =>
         queryKey: ['ai-router'],
         queryFn: getAiRouterConfig,
         retry: false,
+    });
+
+const routePrompt = (body: AiRouterRouteRequest) =>
+    lightdashApi<AiRouterRouteResponseResult>({
+        url: `${ROUTER_BASE}/route`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+export const useAiRouterRoute = () =>
+    useMutation<AiRouterRouteResponseResult, ApiError, AiRouterRouteRequest>({
+        mutationFn: routePrompt,
+    });
+
+const commitDecision = ({
+    decisionUuid,
+    ...body
+}: { decisionUuid: string } & AiRouterDecisionCommitRequest) =>
+    lightdashApi<undefined>({
+        url: `${ROUTER_BASE}/decisions/${decisionUuid}/commit`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
+export const useAiRouterCommit = () =>
+    useMutation<
+        undefined,
+        ApiError,
+        { decisionUuid: string } & AiRouterDecisionCommitRequest
+    >({
+        mutationFn: commitDecision,
     });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -531,19 +531,16 @@ const generateAgentThreadTitle = async (
         body: JSON.stringify({}),
     });
 
-const useGenerateAgentThreadTitleMutation = (
-    projectUuid: string,
-    agentUuid: string,
-) => {
+const useGenerateAgentThreadTitleMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
     return useMutation<
         ApiAiAgentThreadGenerateTitleResponse['results'],
         ApiError,
-        { threadUuid: string }
+        { agentUuid: string; threadUuid: string }
     >({
-        mutationFn: ({ threadUuid }) =>
+        mutationFn: ({ agentUuid, threadUuid }) =>
             generateAgentThreadTitle(projectUuid, agentUuid, threadUuid),
-        onSuccess: (data, { threadUuid }) => {
+        onSuccess: (data, { agentUuid, threadUuid }) => {
             queryClient.setQueryData(
                 [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', 'user'],
                 (
@@ -579,7 +576,6 @@ const createAgentThread = async (
     });
 
 export const useCreateAgentThreadMutation = (
-    agentUuid: string | undefined,
     projectUuid: string,
     options?: {
         onCreated?: (thread: ApiAiAgentThreadCreateResponse['results']) => void;
@@ -592,48 +588,51 @@ export const useCreateAgentThreadMutation = (
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
     const { user } = useApp();
-    const { data: agent } = useProjectAiAgent(projectUuid, agentUuid);
     const { streamMessage } = useAiAgentThreadStreamMutation();
     const { mutateAsync: generateThreadTitle } =
-        useGenerateAgentThreadTitleMutation(projectUuid!, agentUuid!);
+        useGenerateAgentThreadTitleMutation(projectUuid);
 
     return useMutation<
         ApiAiAgentThreadCreateResponse['results'],
         ApiError,
         ApiAiAgentThreadCreateRequest & {
+            agentUuid: string;
             optimisticContext?: AiPromptContext;
             enableSqlMode?: boolean;
             toolHints?: string[];
         }
     >({
         mutationFn: ({
+            agentUuid,
             optimisticContext: _optimisticContext,
             enableSqlMode: _enableSqlMode,
             toolHints: _toolHints,
             ...data
-        }) =>
-            agentUuid
-                ? createAgentThread(projectUuid, agentUuid, data)
-                : Promise.reject(),
+        }) => createAgentThread(projectUuid, agentUuid, data),
         onSuccess: async (thread, variables) => {
+            const { agentUuid } = variables;
             // Invalidate both user-specific and all-users thread queries
             await queryClient.invalidateQueries({
                 queryKey: [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads'],
             });
 
-            void generateThreadTitle({ threadUuid: thread.uuid });
+            void generateThreadTitle({ agentUuid, threadUuid: thread.uuid });
+
+            // The agent is loaded by whichever page kicked off this mutation —
+            // read it from the cache instead of re-fetching here.
+            const agent = queryClient.getQueryData<
+                ApiAiAgentResponse['results']
+            >([PROJECT_AI_AGENTS_KEY, projectUuid, agentUuid]);
 
             queryClient.setQueryData(
                 [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', thread.uuid],
                 () => {
-                    if (!agentUuid) {
-                        return undefined;
-                    }
+                    if (!agent) return undefined;
 
                     return {
                         createdFrom: 'web_app',
                         firstMessage: thread.firstMessage,
-                        agentUuid: agentUuid,
+                        agentUuid,
                         uuid: thread.uuid,
                         title: null,
                         titleGeneratedAt: null,
@@ -643,7 +642,7 @@ export const useCreateAgentThreadMutation = (
                             thread.firstMessage.uuid,
                             thread.firstMessage.message,
                             user!.data!,
-                            agent!,
+                            agent,
                             // Prefer the caller's resolved metadata (name,
                             // chartKind) if provided so the pinned card
                             // renders correctly in the optimistic state.

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,222 +1,30 @@
-import { type AiAgent, type AiAgentThreadSummary } from '@lightdash/common';
+import { type AiAgent } from '@lightdash/common';
+import { Box, Loader } from '@mantine-8/core';
+import { useState } from 'react';
 import {
-    Alert,
-    Box,
-    Button,
-    Group,
-    Loader,
-    NavLink,
-    Paper,
-    rem,
-    Stack,
-    Text,
-    Title,
-    Tooltip,
-} from '@mantine-8/core';
-import {
-    IconBrandSlack,
-    IconChevronDown,
-    IconCirclePlus,
-    IconInfoCircle,
-    IconSettings,
-    IconSparkles,
-    IconWindowMinimize,
-} from '@tabler/icons-react';
-import { useState, type FC } from 'react';
-import {
-    Link,
     Navigate,
     Outlet,
     useNavigate,
     useParams,
     useSearchParams,
 } from 'react-router';
-import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import { AgentSelector } from '../../features/aiCopilot/components/AgentSelector';
+import { AgentPageHeader } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader';
+import { AgentSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
-import { SidebarButton } from '../../features/aiCopilot/components/AiAgentPageLayout/SidebarButton';
 import { launcherSession } from '../../features/aiCopilot/components/Launcher/launcherSession';
 import { useLauncherDock } from '../../features/aiCopilot/components/Launcher/useLauncherDock';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
-import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import {
     useProjectAiAgent as useAiAgent,
     useAiAgentThread,
-    useAiAgentThreads,
     useProjectAiAgents,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 import { store as aiAgentStore } from '../../features/aiCopilot/store';
 import { openPanel } from '../../features/aiCopilot/store/aiAgentLauncherSlice';
-
-const INITIAL_MAX_THREADS = 10;
-const MAX_THREADS_INCREMENT = 10;
-
-type ThreadNavLinkProps = {
-    thread: AiAgentThreadSummary;
-    isActive: boolean;
-    projectUuid: string;
-};
-
-const ThreadNavLink: FC<ThreadNavLinkProps> = ({
-    thread,
-    isActive,
-    projectUuid,
-}) => (
-    <NavLink
-        color="gray"
-        component={Link}
-        key={thread.uuid}
-        to={`/projects/${projectUuid}/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
-        px="xs"
-        py={rem(4)}
-        style={(theme) => ({
-            borderRadius: theme.radius.sm,
-        })}
-        label={
-            <Text truncate="end" size="sm" c="ldGray.9">
-                {thread.title || thread.firstMessage.message}
-            </Text>
-        }
-        active={isActive}
-        rightSection={
-            thread.createdFrom === 'slack' && (
-                <Tooltip label={'Threads created in slack are read only'}>
-                    <IconBrandSlack size={18} stroke={1} />
-                </Tooltip>
-            )
-        }
-        viewTransition
-    />
-);
-
-const AgentSidebar: FC<{
-    agent: AiAgent;
-    projectUuid: string;
-    threadUuid?: string;
-    isAgentSidebarCollapsed: boolean;
-}> = ({ agent, projectUuid, threadUuid, isAgentSidebarCollapsed }) => {
-    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
-    const isTrial =
-        aiOrganizationSettingsQuery.isSuccess &&
-        aiOrganizationSettingsQuery.data.isTrial;
-    const { data: threads } = useAiAgentThreads(projectUuid, agent.uuid);
-    const [showMaxItems, setShowMaxItems] = useState(INITIAL_MAX_THREADS);
-
-    return (
-        <Stack gap="md" style={{ flexGrow: 1, overflowY: 'auto' }}>
-            <Box>
-                <SidebarButton
-                    leftSection={<MantineIcon icon={IconCirclePlus} />}
-                    component={Link}
-                    to={`/projects/${projectUuid}/ai-agents/${agent.uuid}/threads`}
-                    size="sm"
-                    {...(!isAgentSidebarCollapsed && {
-                        fullWidth: true,
-                        justify: 'flex-start',
-                    })}
-                >
-                    {isAgentSidebarCollapsed ? '' : 'New thread'}
-                </SidebarButton>
-            </Box>
-
-            {projectUuid && threads && !isAgentSidebarCollapsed && (
-                <Stack gap="xs" style={{ flexGrow: 1, overflowY: 'auto' }}>
-                    <Title
-                        order={6}
-                        c="dimmed"
-                        tt="uppercase"
-                        size="xs"
-                        ml="xs"
-                    >
-                        Recent
-                    </Title>
-
-                    <Stack gap={2}>
-                        {threads.length === 0 && (
-                            <Paper variant="dotted" p="sm">
-                                <Text
-                                    truncate="end"
-                                    size="sm"
-                                    c="ldGray.6"
-                                    ta="center"
-                                >
-                                    No threads yet
-                                </Text>
-                            </Paper>
-                        )}
-
-                        <Box>
-                            {threads.slice(0, showMaxItems).map((thread) => (
-                                <ThreadNavLink
-                                    key={thread.uuid}
-                                    thread={thread}
-                                    isActive={thread.uuid === threadUuid}
-                                    projectUuid={projectUuid}
-                                />
-                            ))}
-                        </Box>
-                    </Stack>
-
-                    <Box>
-                        {threads.length >= showMaxItems && (
-                            <Button
-                                size="compact-xs"
-                                variant="subtle"
-                                onClick={() =>
-                                    setShowMaxItems(
-                                        (s) => s + MAX_THREADS_INCREMENT,
-                                    )
-                                }
-                                leftSection={
-                                    <MantineIcon icon={IconChevronDown} />
-                                }
-                                style={{
-                                    root: {
-                                        border: 'none',
-                                    },
-                                }}
-                            >
-                                View more
-                            </Button>
-                        )}
-                    </Box>
-                </Stack>
-            )}
-            {isTrial && (
-                <Alert
-                    icon={<MantineIcon icon={IconSparkles} />}
-                    variant="outline"
-                    color="indigo.6"
-                    bg="indigo.0"
-                    fz="xs"
-                    p="xs"
-                    title={
-                        <Text size="xs" fw={500}>
-                            You're currently using Lightdash AI Agents in free
-                            trial mode
-                        </Text>
-                    }
-                >
-                    <Button
-                        size="compact-xs"
-                        variant="light"
-                        color="indigo"
-                        leftSection={
-                            <MantineIcon icon={IconInfoCircle} size="sm" />
-                        }
-                        component={Link}
-                        to="https://docs.lightdash.com/guides/ai-agents"
-                        target="_blank"
-                    >
-                        Learn more
-                    </Button>
-                </Alert>
-            )}
-        </Stack>
-    );
-};
 
 const AgentPage = () => {
     const { agentUuid, threadUuid, projectUuid } = useParams();
@@ -334,50 +142,23 @@ const AgentPage = () => {
                 />
             }
             Header={
-                <Group align="center" justify="flex-end">
-                    <Group gap="xs">
-                        <Button
-                            variant="default"
-                            onClick={handleMinimize}
-                            leftSection={
-                                <MantineIcon
-                                    icon={IconWindowMinimize}
-                                    style={{ transform: 'scaleX(-1)' }}
-                                />
-                            }
-                            styles={(theme) => ({
-                                root: {
-                                    borderColor: theme.colors.ldGray[2],
-                                    boxShadow: `var(--mantine-shadow-subtle)`,
-                                    color: theme.colors.ldGray[9],
-                                    fontSize: theme.fontSizes.xs,
-                                },
-                            })}
-                        >
-                            Minimize
-                        </Button>
-                        {canManageAgents && (
-                            <Button
-                                component={Link}
-                                variant="default"
-                                to={`/projects/${projectUuid}/ai-agents/${agent.uuid}/edit`}
-                                leftSection={
-                                    <MantineIcon icon={IconSettings} />
-                                }
-                                styles={(theme) => ({
-                                    root: {
-                                        borderColor: theme.colors.ldGray[2],
-                                        boxShadow: `var(--mantine-shadow-subtle)`,
-                                        color: theme.colors.ldGray[9],
-                                        fontSize: theme.fontSizes.xs,
-                                    },
-                                })}
-                            >
-                                Settings
-                            </Button>
-                        )}
-                    </Group>
-                </Group>
+                <AgentPageHeader
+                    leftSection={
+                        threadUuid && agentsList && agentsList.length > 0 ? (
+                            <AgentSelector
+                                projectUuid={projectUuid!}
+                                agents={agentsList}
+                                selectedAgent={agent}
+                            />
+                        ) : undefined
+                    }
+                    onMinimize={handleMinimize}
+                    settingsHref={
+                        canManageAgents
+                            ? `/projects/${projectUuid}/ai-agents/${agent.uuid}/edit`
+                            : undefined
+                    }
+                />
             }
         >
             <Outlet context={{ agent, agents: agentsList ?? [] }} />

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -35,7 +35,6 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
-import { AgentSelector } from '../../features/aiCopilot/components/AgentSelector';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { SidebarButton } from '../../features/aiCopilot/components/AiAgentPageLayout/SidebarButton';
 import { launcherSession } from '../../features/aiCopilot/components/Launcher/launcherSession';
@@ -335,17 +334,7 @@ const AgentPage = () => {
                 />
             }
             Header={
-                <Group align="center" justify="space-between">
-                    <Box>
-                        {agentsList && agentsList.length && (
-                            <AgentSelector
-                                projectUuid={projectUuid!}
-                                agents={agentsList}
-                                selectedAgent={agent}
-                            />
-                        )}
-                    </Box>
-
+                <Group align="center" justify="flex-end">
                     <Group gap="xs">
                         <Button
                             variant="default"
@@ -391,13 +380,14 @@ const AgentPage = () => {
                 </Group>
             }
         >
-            <Outlet context={{ agent }} />
+            <Outlet context={{ agent, agents: agentsList ?? [] }} />
         </AiAgentPageLayout>
     );
 };
 
 export interface AgentContext {
     agent: AiAgent;
+    agents: AiAgent[];
 }
 
 export default AgentPage;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -44,7 +44,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
 
     const agentQuery = useAiAgent(projectUuid!, agentUuid!);
-    const { agent } = useOutletContext<AgentContext>();
+    const { agent, agents } = useOutletContext<AgentContext>();
 
     const canManage = useAiAgentPermission({
         action: 'manage',
@@ -155,6 +155,8 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 projectUuid={projectUuid}
                 agentUuid={agentUuid}
                 threadUuid={threadUuid}
+                agents={agents}
+                selectedAgent={agent}
                 latestAssistantMessageUuid={
                     [...(thread.messages ?? [])]
                         .reverse()

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -44,7 +44,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
 
     const agentQuery = useAiAgent(projectUuid!, agentUuid!);
-    const { agent, agents } = useOutletContext<AgentContext>();
+    const { agent } = useOutletContext<AgentContext>();
 
     const canManage = useAiAgentPermission({
         action: 'manage',
@@ -155,8 +155,6 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 projectUuid={projectUuid}
                 agentUuid={agentUuid}
                 threadUuid={threadUuid}
-                agents={agents}
-                selectedAgent={agent}
                 latestAssistantMessageUuid={
                     [...(thread.messages ?? [])]
                         .reverse()

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -1,8 +1,13 @@
+.pickerStack {
+    animation: pickerStackIn 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
 .pickerHeader {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--mantine-spacing-sm);
+    animation: pickerItemIn 360ms cubic-bezier(0.16, 1, 0.3, 1) 40ms both;
 }
 
 .candidateButton {
@@ -21,6 +26,23 @@
         background-color 120ms ease-out,
         transform 120ms ease-out;
     text-align: left;
+    animation: pickerItemIn 380ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.candidateButton:nth-of-type(1) {
+    animation-delay: 120ms;
+}
+.candidateButton:nth-of-type(2) {
+    animation-delay: 200ms;
+}
+.candidateButton:nth-of-type(3) {
+    animation-delay: 260ms;
+}
+.candidateButton:nth-of-type(4) {
+    animation-delay: 310ms;
+}
+.candidateButton:nth-of-type(5) {
+    animation-delay: 350ms;
 }
 
 .candidateButton:hover {
@@ -47,6 +69,9 @@
         var(--mantine-color-violet-0),
         rgba(118, 65, 232, 0.12)
     );
+    animation:
+        pickerItemIn 380ms cubic-bezier(0.16, 1, 0.3, 1) 120ms both,
+        recommendedSettle 900ms cubic-bezier(0.16, 1, 0.3, 1) 460ms 1 both;
 }
 
 .candidateButton.recommended:hover {
@@ -81,4 +106,45 @@
 
 .candidateButton.recommended .chevron {
     color: var(--mantine-color-violet-6);
+}
+
+@keyframes pickerStackIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes pickerItemIn {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes recommendedSettle {
+    0% {
+        box-shadow: 0 0 0 0 rgba(118, 65, 232, 0);
+    }
+    45% {
+        box-shadow: 0 0 0 5px rgba(118, 65, 232, 0.14);
+    }
+    100% {
+        box-shadow: 0 0 0 0 rgba(118, 65, 232, 0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pickerStack,
+    .pickerHeader,
+    .candidateButton,
+    .candidateButton.recommended {
+        animation: none;
+    }
 }

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -115,10 +115,10 @@
     width: 100%;
     border-radius: var(--mantine-radius-md);
     border: 1px solid
-        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-3));
     background-color: light-dark(
         var(--mantine-color-white),
-        var(--mantine-color-ldDark-6)
+        var(--mantine-color-ldDark-5)
     );
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
     transition:
@@ -148,11 +148,11 @@
 .candidateButton:hover {
     border-color: light-dark(
         var(--mantine-color-ldGray-4),
-        var(--mantine-color-ldDark-3)
+        var(--mantine-color-ldDark-2)
     );
     background-color: light-dark(
         var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-5)
+        var(--mantine-color-ldDark-4)
     );
 }
 
@@ -163,11 +163,15 @@
 .candidateButton.recommended {
     border-color: light-dark(
         var(--mantine-color-violet-3),
-        var(--mantine-color-violet-7)
+        var(--mantine-color-violet-6)
     );
     background-color: light-dark(
         var(--mantine-color-violet-0),
-        rgba(118, 65, 232, 0.12)
+        color-mix(
+            in oklab,
+            var(--mantine-color-violet-9) 42%,
+            var(--mantine-color-ldDark-5)
+        )
     );
     animation:
         pickerItemIn 380ms cubic-bezier(0.16, 1, 0.3, 1) 120ms both,
@@ -177,18 +181,22 @@
 .candidateButton.recommended:hover {
     border-color: light-dark(
         var(--mantine-color-violet-5),
-        var(--mantine-color-violet-6)
+        var(--mantine-color-violet-5)
     );
     background-color: light-dark(
         var(--mantine-color-violet-1),
-        rgba(118, 65, 232, 0.18)
+        color-mix(
+            in oklab,
+            var(--mantine-color-violet-9) 55%,
+            var(--mantine-color-ldDark-5)
+        )
     );
 }
 
 .chevron {
     color: light-dark(
         var(--mantine-color-ldGray-5),
-        var(--mantine-color-ldGray-6)
+        var(--mantine-color-ldGray-4)
     );
     flex-shrink: 0;
     transition:
@@ -200,12 +208,15 @@
     transform: translateX(2px);
     color: light-dark(
         var(--mantine-color-ldGray-7),
-        var(--mantine-color-ldGray-4)
+        var(--mantine-color-ldGray-2)
     );
 }
 
 .candidateButton.recommended .chevron {
-    color: var(--mantine-color-violet-6);
+    color: light-dark(
+        var(--mantine-color-violet-6),
+        var(--mantine-color-violet-3)
+    );
 }
 
 @keyframes pickerStackIn {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -169,7 +169,7 @@
         var(--mantine-color-violet-0),
         color-mix(
             in oklab,
-            var(--mantine-color-violet-9) 42%,
+            var(--mantine-color-violet-9) 22%,
             var(--mantine-color-ldDark-5)
         )
     );
@@ -187,9 +187,30 @@
         var(--mantine-color-violet-1),
         color-mix(
             in oklab,
-            var(--mantine-color-violet-9) 55%,
+            var(--mantine-color-violet-9) 32%,
             var(--mantine-color-ldDark-5)
         )
+    );
+}
+
+.candidateName {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldGray-0)
+    );
+}
+
+.candidateDescription {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-3)
+    );
+}
+
+.candidateButton.recommended .candidateDescription {
+    color: light-dark(
+        var(--mantine-color-violet-9),
+        var(--mantine-color-violet-1)
     );
 }
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -1,3 +1,103 @@
+.heroAvatar {
+    position: relative;
+    transition: transform 240ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.heroAvatar::after {
+    content: '';
+    position: absolute;
+    inset: -6px;
+    border-radius: 50%;
+    border: 1px solid var(--mantine-color-violet-4);
+    opacity: 0;
+    pointer-events: none;
+}
+
+.heroAvatarWorking {
+    transform: scale(1.04);
+}
+
+.heroAvatarWorking::after {
+    animation: heroHaloPulse 1600ms cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.heroAvatarWorking .heroSparkles {
+    animation: heroSparkleSpin 3200ms cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+@keyframes heroHaloPulse {
+    0% {
+        transform: scale(0.9);
+        opacity: 0;
+    }
+    35% {
+        opacity: 0.6;
+    }
+    100% {
+        transform: scale(1.45);
+        opacity: 0;
+    }
+}
+
+@keyframes heroSparkleSpin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.routingStatus {
+    animation: routingFadeIn 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.routingDots {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.routingDots span {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background-color: var(--mantine-color-violet-5);
+    animation: routingDotBlink 1100ms cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+.routingDots span:nth-child(2) {
+    animation-delay: 160ms;
+}
+
+.routingDots span:nth-child(3) {
+    animation-delay: 320ms;
+}
+
+@keyframes routingFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes routingDotBlink {
+    0%,
+    80%,
+    100% {
+        opacity: 0.25;
+        transform: scale(0.85);
+    }
+    40% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
 .pickerStack {
     animation: pickerStackIn 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
@@ -144,7 +244,14 @@
     .pickerStack,
     .pickerHeader,
     .candidateButton,
-    .candidateButton.recommended {
+    .candidateButton.recommended,
+    .heroAvatar,
+    .heroAvatarWorking,
+    .heroAvatarWorking::after,
+    .heroAvatarWorking .heroSparkles,
+    .routingStatus,
+    .routingDots span {
         animation: none;
+        transform: none;
     }
 }

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -115,10 +115,10 @@
     width: 100%;
     border-radius: var(--mantine-radius-md);
     border: 1px solid
-        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-3));
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
     background-color: light-dark(
         var(--mantine-color-white),
-        var(--mantine-color-ldDark-5)
+        var(--mantine-color-dark-6)
     );
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
     transition:
@@ -147,12 +147,12 @@
 
 .candidateButton:hover {
     border-color: light-dark(
-        var(--mantine-color-ldGray-4),
-        var(--mantine-color-ldDark-2)
+        var(--mantine-color-gray-4),
+        var(--mantine-color-dark-3)
     );
     background-color: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-4)
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-5)
     );
 }
 
@@ -165,14 +165,6 @@
         var(--mantine-color-violet-3),
         var(--mantine-color-violet-6)
     );
-    background-color: light-dark(
-        var(--mantine-color-violet-0),
-        color-mix(
-            in oklab,
-            var(--mantine-color-violet-9) 22%,
-            var(--mantine-color-ldDark-5)
-        )
-    );
     animation:
         pickerItemIn 380ms cubic-bezier(0.16, 1, 0.3, 1) 120ms both,
         recommendedSettle 900ms cubic-bezier(0.16, 1, 0.3, 1) 460ms 1 both;
@@ -183,28 +175,7 @@
         var(--mantine-color-violet-5),
         var(--mantine-color-violet-5)
     );
-    background-color: light-dark(
-        var(--mantine-color-violet-1),
-        color-mix(
-            in oklab,
-            var(--mantine-color-violet-9) 32%,
-            var(--mantine-color-ldDark-5)
-        )
-    );
-}
-
-.candidateName {
-    color: light-dark(
-        var(--mantine-color-ldGray-9),
-        var(--mantine-color-ldGray-0)
-    );
-}
-
-.candidateDescription {
-    color: light-dark(
-        var(--mantine-color-ldGray-6),
-        var(--mantine-color-ldGray-3)
-    );
+    background-color: var(--mantine-color-violet-light);
 }
 
 .candidateButton.recommended .candidateDescription {
@@ -227,10 +198,7 @@
 
 .candidateButton:hover .chevron {
     transform: translateX(2px);
-    color: light-dark(
-        var(--mantine-color-ldGray-7),
-        var(--mantine-color-ldGray-2)
-    );
+    color: var(--mantine-color-ldGray-7);
 }
 
 .candidateButton.recommended .chevron {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.module.css
@@ -1,0 +1,84 @@
+.pickerHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--mantine-spacing-sm);
+}
+
+.candidateButton {
+    display: block;
+    width: 100%;
+    border-radius: var(--mantine-radius-md);
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-ldDark-6)
+    );
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+    transition:
+        border-color 120ms ease-out,
+        background-color 120ms ease-out,
+        transform 120ms ease-out;
+    text-align: left;
+}
+
+.candidateButton:hover {
+    border-color: light-dark(
+        var(--mantine-color-ldGray-4),
+        var(--mantine-color-ldDark-3)
+    );
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-5)
+    );
+}
+
+.candidateButton:active {
+    transform: translateY(1px);
+}
+
+.candidateButton.recommended {
+    border-color: light-dark(
+        var(--mantine-color-violet-3),
+        var(--mantine-color-violet-7)
+    );
+    background-color: light-dark(
+        var(--mantine-color-violet-0),
+        rgba(118, 65, 232, 0.12)
+    );
+}
+
+.candidateButton.recommended:hover {
+    border-color: light-dark(
+        var(--mantine-color-violet-5),
+        var(--mantine-color-violet-6)
+    );
+    background-color: light-dark(
+        var(--mantine-color-violet-1),
+        rgba(118, 65, 232, 0.18)
+    );
+}
+
+.chevron {
+    color: light-dark(
+        var(--mantine-color-ldGray-5),
+        var(--mantine-color-ldGray-6)
+    );
+    flex-shrink: 0;
+    transition:
+        transform 120ms ease-out,
+        color 120ms ease-out;
+}
+
+.candidateButton:hover .chevron {
+    transform: translateX(2px);
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldGray-4)
+    );
+}
+
+.candidateButton.recommended .chevron {
+    color: var(--mantine-color-violet-6);
+}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -258,11 +258,6 @@ const AgentsRouterPage = () => {
                             />
                         </Avatar>
                         <Title order={2}>Ask AI</Title>
-                        <Text c="dimmed" size="sm" ta="center" maw={520}>
-                            Ask anything about your data. We&apos;ll route your
-                            question to the right agent — or pin one if
-                            you&apos;d like.
-                        </Text>
                     </Stack>
 
                     <AgentChatInput

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -232,13 +232,15 @@ const AgentsRouterPage = () => {
     }, [phase]);
 
     const isLocked = phase.kind !== 'idle';
-
-    const placeholder =
+    const isWorking = phase.kind === 'routing' || phase.kind === 'creating';
+    const workingLabel =
         phase.kind === 'routing'
-            ? 'Finding the best agent…'
+            ? 'Finding the right agent…'
             : phase.kind === 'creating'
-              ? 'Sending…'
-              : 'Ask anything about your data...';
+              ? 'Opening the conversation…'
+              : null;
+
+    const placeholder = 'Ask anything about your data...';
 
     return (
         <AiAgentPageLayout
@@ -266,11 +268,19 @@ const AgentsRouterPage = () => {
                     py="xl"
                 >
                     <Stack align="center" gap="xxs">
-                        <Avatar size="lg" color="violet" radius="xl">
+                        <Avatar
+                            size="lg"
+                            color="violet"
+                            radius="xl"
+                            className={`${classes.heroAvatar} ${
+                                isWorking ? classes.heroAvatarWorking : ''
+                            }`}
+                        >
                             <MantineIcon
                                 icon={IconSparkles}
                                 size="xl"
                                 color="violet.6"
+                                className={classes.heroSparkles}
                             />
                         </Avatar>
                         <Title order={2}>Ask AI</Title>
@@ -300,8 +310,27 @@ const AgentsRouterPage = () => {
                         onSqlModeChange={
                             sqlModeAvailable ? setSqlMode : undefined
                         }
+                        clearOnSubmit={false}
                         fullWidth
                     />
+
+                    {isWorking && workingLabel && (
+                        <Group
+                            gap={8}
+                            justify="center"
+                            className={classes.routingStatus}
+                            aria-live="polite"
+                        >
+                            <span className={classes.routingDots}>
+                                <span />
+                                <span />
+                                <span />
+                            </span>
+                            <Text size="xs" c="dimmed">
+                                {workingLabel}
+                            </Text>
+                        </Group>
+                    )}
 
                     {phase.kind === 'picker' && (
                         <Stack gap="xs" className={classes.pickerStack}>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -1,0 +1,147 @@
+import { Avatar, Center, Stack, Text, Title } from '@mantine-8/core';
+import { IconSparkles } from '@tabler/icons-react';
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { getModelKey } from '../../../components/common/ModelSelector/utils';
+import { AgentPageHeader } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader';
+import { AutoModeSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
+import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
+import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
+import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
+import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
+import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
+import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+
+const AgentsRouterPage = () => {
+    const { projectUuid } = useParams();
+
+    const { data: agents } = useProjectAiAgents({
+        projectUuid: projectUuid!,
+        redirectOnUnauthorized: true,
+    });
+
+    const canManageAgents = useAiAgentPermission({
+        action: 'manage',
+        projectUuid,
+    });
+
+    const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+
+    // The router doesn't have its own agent, so the model lineup is borrowed
+    // from the first agent — this is a prototype stand-in until the backend
+    // picks the model based on the routed agent.
+    const placeholderAgentUuid = agents?.[0]?.uuid;
+    const { data: modelOptions } = useModelOptions({
+        projectUuid,
+        agentUuid: placeholderAgentUuid,
+    });
+
+    const [selectedModelKey, setSelectedModelKey] = useState<string | null>(
+        null,
+    );
+    const [extendedThinking, setExtendedThinking] = useState(false);
+    const [sqlMode, setSqlMode] = useState(false);
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+
+    const handleSelectedModelKeyChange = useCallback(
+        (modelKey: string) => {
+            setSelectedModelKey(modelKey);
+            const model = modelOptions?.find(
+                (m) => getModelKey(m) === modelKey,
+            );
+            if (model && !model.supportsReasoning) {
+                setExtendedThinking(false);
+            }
+        },
+        [modelOptions],
+    );
+
+    useEffect(() => {
+        if (modelOptions && !selectedModelKey) {
+            const defaultModel = modelOptions.find((m) => m.default);
+            if (defaultModel) {
+                handleSelectedModelKeyChange(getModelKey(defaultModel));
+            }
+        }
+    }, [modelOptions, selectedModelKey, handleSelectedModelKeyChange]);
+
+    const selectedModel = modelOptions?.find(
+        (m) => getModelKey(m) === selectedModelKey,
+    );
+    const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
+
+    return (
+        <AiAgentPageLayout
+            isAgentSidebarCollapsed={isSidebarCollapsed}
+            setIsAgentSidebarCollapsed={setIsSidebarCollapsed}
+            Sidebar={
+                <AutoModeSidebar
+                    projectUuid={projectUuid!}
+                    isAgentSidebarCollapsed={isSidebarCollapsed}
+                />
+            }
+            Header={
+                <AgentPageHeader
+                    settingsHref={
+                        canManageAgents ? '/ai-agents/admin/agents' : undefined
+                    }
+                />
+            }
+        >
+            <Center h="100%">
+                <Stack
+                    gap="lg"
+                    {...ChatElementsUtils.centeredElementProps}
+                    h="unset"
+                    py="xl"
+                >
+                    <Stack align="center" gap="xxs">
+                        <Avatar size="lg" color="violet" radius="xl">
+                            <MantineIcon
+                                icon={IconSparkles}
+                                size="xl"
+                                color="violet.6"
+                            />
+                        </Avatar>
+                        <Title order={2}>Ask AI</Title>
+                        <Text c="dimmed" size="sm" ta="center" maw={520}>
+                            Ask anything about your data. We&apos;ll route your
+                            question to the right agent — or pin one if
+                            you&apos;d like.
+                        </Text>
+                    </Stack>
+
+                    <AgentChatInput
+                        projectUuid={projectUuid}
+                        agents={agents ?? []}
+                        selectedAgent="auto"
+                        placeholder="Ask anything about your data..."
+                        onSubmit={() => {
+                            // TODO: wire to /route endpoint
+                        }}
+                        models={modelOptions}
+                        selectedModelId={selectedModelKey}
+                        onModelChange={handleSelectedModelKeyChange}
+                        extendedThinking={
+                            showExtendedThinking ? extendedThinking : undefined
+                        }
+                        onExtendedThinkingChange={
+                            showExtendedThinking
+                                ? setExtendedThinking
+                                : undefined
+                        }
+                        sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                        onSqlModeChange={
+                            sqlModeAvailable ? setSqlMode : undefined
+                        }
+                        fullWidth
+                    />
+                </Stack>
+            </Center>
+        </AiAgentPageLayout>
+    );
+};
+
+export default AgentsRouterPage;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -402,9 +402,6 @@ const AgentsRouterPage = () => {
                                                         size="sm"
                                                         fw={600}
                                                         truncate="end"
-                                                        className={
-                                                            classes.candidateName
-                                                        }
                                                     >
                                                         {c.name}
                                                     </Text>
@@ -422,6 +419,7 @@ const AgentsRouterPage = () => {
                                                 {c.description && (
                                                     <Text
                                                         size="xs"
+                                                        c="dimmed"
                                                         truncate="end"
                                                         className={
                                                             classes.candidateDescription

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -14,7 +14,7 @@ import {
     UnstyledButton,
 } from '@mantine-8/core';
 import { IconSparkles } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -40,7 +40,12 @@ import {
 type Phase =
     | { kind: 'idle' }
     | { kind: 'routing' }
-    | { kind: 'picker'; decision: AiRouterRouteResponseResult }
+    | {
+          kind: 'picker';
+          decision: AiRouterRouteResponseResult;
+          prompt: string;
+          toolHints: string[];
+      }
     | { kind: 'creating' };
 
 const AgentsRouterPage = () => {
@@ -102,10 +107,6 @@ const AgentsRouterPage = () => {
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
 
     const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
-    const [decisionUuid, setDecisionUuid] = useState<string | null>(null);
-    const [chosenAgentUuid, setChosenAgentUuid] = useState<string | null>(null);
-    const [routedPrompt, setRoutedPrompt] = useState<string>('');
-    const [routedToolHints, setRoutedToolHints] = useState<string[]>([]);
 
     const agentsByUuid = useMemo(() => {
         const m = new Map<string, AiAgentSummary>();
@@ -116,46 +117,30 @@ const AgentsRouterPage = () => {
     const route = useAiRouterRoute();
     const { mutate: commitDecisionMutate } = useAiRouterCommit();
     const { mutateAsync: createThread } = useCreateAgentThreadMutation(
-        chosenAgentUuid ?? undefined,
         projectUuid!,
     );
 
-    const startedDecisionRef = useRef<string | null>(null);
-
-    // Once the router (or the user via picker) has chosen an agent and we've
-    // re-rendered with that agentUuid, fire the thread creation. The mutation
-    // hook is keyed on agentUuid so we have to wait a render before calling it.
-    useEffect(() => {
-        if (
-            phase.kind !== 'creating' ||
-            !chosenAgentUuid ||
-            !decisionUuid ||
-            !routedPrompt
-        ) {
-            return;
-        }
-        if (startedDecisionRef.current === decisionUuid) return;
-        startedDecisionRef.current = decisionUuid;
-
-        void createThread({
-            prompt: routedPrompt,
-            toolHints: routedToolHints,
-        }).then((thread) => {
+    const startThreadForDecision = useCallback(
+        async (args: {
+            agentUuid: string;
+            decisionUuid: string;
+            prompt: string;
+            toolHints: string[];
+        }) => {
+            const thread = await createThread({
+                agentUuid: args.agentUuid,
+                prompt: args.prompt,
+                toolHints: args.toolHints,
+            });
+            // Fire-and-forget telemetry — the user is already navigating away.
             commitDecisionMutate({
-                decisionUuid,
-                chosenAgentUuid,
+                decisionUuid: args.decisionUuid,
+                chosenAgentUuid: args.agentUuid,
                 threadUuid: thread.uuid,
             });
-        });
-    }, [
-        phase.kind,
-        chosenAgentUuid,
-        decisionUuid,
-        routedPrompt,
-        routedToolHints,
-        createThread,
-        commitDecisionMutate,
-    ]);
+        },
+        [createThread, commitDecisionMutate],
+    );
 
     const handleSubmit = useCallback(
         async ({
@@ -167,8 +152,6 @@ const AgentsRouterPage = () => {
         }) => {
             if (!projectUuid) return;
             setPhase({ kind: 'routing' });
-            setRoutedPrompt(message);
-            setRoutedToolHints(toolHints);
             setPendingPrompt('');
 
             try {
@@ -176,13 +159,22 @@ const AgentsRouterPage = () => {
                     prompt: message,
                     projectUuid,
                 });
-                setDecisionUuid(result.decision.decisionUuid);
 
                 if (result.nextAction === 'create_thread') {
-                    setChosenAgentUuid(result.decision.suggestedAgentUuid);
                     setPhase({ kind: 'creating' });
+                    await startThreadForDecision({
+                        agentUuid: result.decision.suggestedAgentUuid,
+                        decisionUuid: result.decision.decisionUuid,
+                        prompt: message,
+                        toolHints,
+                    });
                 } else {
-                    setPhase({ kind: 'picker', decision: result });
+                    setPhase({
+                        kind: 'picker',
+                        decision: result,
+                        prompt: message,
+                        toolHints,
+                    });
                 }
             } catch {
                 // Router unreachable — fall back to the first accessible
@@ -190,8 +182,6 @@ const AgentsRouterPage = () => {
                 // which the new-thread page reads on mount.
                 setPhase({ kind: 'idle' });
                 setPendingPrompt(message);
-                setRoutedPrompt('');
-                setRoutedToolHints([]);
                 const fallback = agents?.[0];
                 if (fallback && projectUuid) {
                     void navigate(
@@ -200,13 +190,30 @@ const AgentsRouterPage = () => {
                 }
             }
         },
-        [agents, navigate, projectUuid, route, setPendingPrompt],
+        [
+            agents,
+            navigate,
+            projectUuid,
+            route,
+            setPendingPrompt,
+            startThreadForDecision,
+        ],
     );
 
-    const confirmPick = useCallback((agentUuid: string) => {
-        setChosenAgentUuid(agentUuid);
-        setPhase({ kind: 'creating' });
-    }, []);
+    const confirmPick = useCallback(
+        async (agentUuid: string) => {
+            if (phase.kind !== 'picker') return;
+            const { decision, prompt, toolHints } = phase;
+            setPhase({ kind: 'creating' });
+            await startThreadForDecision({
+                agentUuid,
+                decisionUuid: decision.decision.decisionUuid,
+                prompt,
+                toolHints,
+            });
+        },
+        [phase, startThreadForDecision],
+    );
 
     const isLocked = phase.kind !== 'idle';
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -304,7 +304,7 @@ const AgentsRouterPage = () => {
                     />
 
                     {phase.kind === 'picker' && (
-                        <Stack gap="xs">
+                        <Stack gap="xs" className={classes.pickerStack}>
                             <div className={classes.pickerHeader}>
                                 <Text size="sm" fw={600}>
                                     Which agent should answer?

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -1,7 +1,22 @@
-import { Avatar, Center, Stack, Text, Title } from '@mantine-8/core';
+import {
+    type AiAgentSummary,
+    type AiRouterRouteResponseResult,
+} from '@lightdash/common';
+import {
+    Avatar,
+    Card,
+    Center,
+    Group,
+    SimpleGrid,
+    Stack,
+    Text,
+    Title,
+    UnstyledButton,
+} from '@mantine-8/core';
 import { IconSparkles } from '@tabler/icons-react';
-import { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { getModelKey } from '../../../components/common/ModelSelector/utils';
 import { AgentPageHeader } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader';
@@ -9,13 +24,28 @@ import { AutoModeSidebar } from '../../features/aiCopilot/components/AiAgentPage
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
+import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
+import {
+    useAiRouterCommit,
+    useAiRouterRoute,
+} from '../../features/aiCopilot/hooks/useAiRouter';
 import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
-import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import {
+    useCreateAgentThreadMutation,
+    useProjectAiAgents,
+} from '../../features/aiCopilot/hooks/useProjectAiAgents';
+
+type Phase =
+    | { kind: 'idle' }
+    | { kind: 'routing' }
+    | { kind: 'picker'; decision: AiRouterRouteResponseResult }
+    | { kind: 'creating' };
 
 const AgentsRouterPage = () => {
     const { projectUuid } = useParams();
+    const navigate = useNavigate();
 
     const { data: agents } = useProjectAiAgents({
         projectUuid: projectUuid!,
@@ -29,9 +59,6 @@ const AgentsRouterPage = () => {
 
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
-    // The router doesn't have its own agent, so the model lineup is borrowed
-    // from the first agent — this is a prototype stand-in until the backend
-    // picks the model based on the routed agent.
     const placeholderAgentUuid = agents?.[0]?.uuid;
     const { data: modelOptions } = useModelOptions({
         projectUuid,
@@ -71,6 +98,124 @@ const AgentsRouterPage = () => {
         (m) => getModelKey(m) === selectedModelKey,
     );
     const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
+
+    const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
+
+    const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+    const [decisionUuid, setDecisionUuid] = useState<string | null>(null);
+    const [chosenAgentUuid, setChosenAgentUuid] = useState<string | null>(null);
+    const [routedPrompt, setRoutedPrompt] = useState<string>('');
+    const [routedToolHints, setRoutedToolHints] = useState<string[]>([]);
+
+    const agentsByUuid = useMemo(() => {
+        const m = new Map<string, AiAgentSummary>();
+        (agents ?? []).forEach((a) => m.set(a.uuid, a));
+        return m;
+    }, [agents]);
+
+    const route = useAiRouterRoute();
+    const { mutate: commitDecisionMutate } = useAiRouterCommit();
+    const { mutateAsync: createThread } = useCreateAgentThreadMutation(
+        chosenAgentUuid ?? undefined,
+        projectUuid!,
+    );
+
+    const startedDecisionRef = useRef<string | null>(null);
+
+    // Once the router (or the user via picker) has chosen an agent and we've
+    // re-rendered with that agentUuid, fire the thread creation. The mutation
+    // hook is keyed on agentUuid so we have to wait a render before calling it.
+    useEffect(() => {
+        if (
+            phase.kind !== 'creating' ||
+            !chosenAgentUuid ||
+            !decisionUuid ||
+            !routedPrompt
+        ) {
+            return;
+        }
+        if (startedDecisionRef.current === decisionUuid) return;
+        startedDecisionRef.current = decisionUuid;
+
+        void createThread({
+            prompt: routedPrompt,
+            toolHints: routedToolHints,
+        }).then((thread) => {
+            commitDecisionMutate({
+                decisionUuid,
+                chosenAgentUuid,
+                threadUuid: thread.uuid,
+            });
+        });
+    }, [
+        phase.kind,
+        chosenAgentUuid,
+        decisionUuid,
+        routedPrompt,
+        routedToolHints,
+        createThread,
+        commitDecisionMutate,
+    ]);
+
+    const handleSubmit = useCallback(
+        async ({
+            message,
+            toolHints,
+        }: {
+            message: string;
+            toolHints: string[];
+        }) => {
+            if (!projectUuid) return;
+            setPhase({ kind: 'routing' });
+            setRoutedPrompt(message);
+            setRoutedToolHints(toolHints);
+            setPendingPrompt('');
+
+            try {
+                const result = await route.mutateAsync({
+                    prompt: message,
+                    projectUuid,
+                });
+                setDecisionUuid(result.decision.decisionUuid);
+
+                if (result.nextAction === 'create_thread') {
+                    setChosenAgentUuid(result.decision.suggestedAgentUuid);
+                    setPhase({ kind: 'creating' });
+                } else {
+                    setPhase({ kind: 'picker', decision: result });
+                }
+            } catch {
+                // Router unreachable — fall back to the first accessible
+                // agent silently. The draft survives via PendingPromptContext,
+                // which the new-thread page reads on mount.
+                setPhase({ kind: 'idle' });
+                setPendingPrompt(message);
+                setRoutedPrompt('');
+                setRoutedToolHints([]);
+                const fallback = agents?.[0];
+                if (fallback && projectUuid) {
+                    void navigate(
+                        `/projects/${projectUuid}/ai-agents/${fallback.uuid}/threads`,
+                    );
+                }
+            }
+        },
+        [agents, navigate, projectUuid, route, setPendingPrompt],
+    );
+
+    const confirmPick = useCallback((agentUuid: string) => {
+        setChosenAgentUuid(agentUuid);
+        setPhase({ kind: 'creating' });
+    }, []);
+
+    const isLocked = phase.kind !== 'idle';
+
+    const placeholder =
+        phase.kind === 'routing'
+            ? 'Finding the best agent…'
+            : phase.kind === 'creating'
+              ? 'Sending…'
+              : 'Ask anything about your data...';
 
     return (
         <AiAgentPageLayout
@@ -117,10 +262,11 @@ const AgentsRouterPage = () => {
                         projectUuid={projectUuid}
                         agents={agents ?? []}
                         selectedAgent="auto"
-                        placeholder="Ask anything about your data..."
-                        onSubmit={() => {
-                            // TODO: wire to /route endpoint
-                        }}
+                        placeholder={placeholder}
+                        loading={isLocked}
+                        onSubmit={handleSubmit}
+                        defaultValue={pendingPrompt}
+                        onValueChange={setPendingPrompt}
                         models={modelOptions}
                         selectedModelId={selectedModelKey}
                         onModelChange={handleSelectedModelKeyChange}
@@ -138,6 +284,76 @@ const AgentsRouterPage = () => {
                         }
                         fullWidth
                     />
+
+                    {phase.kind === 'picker' && (
+                        <Stack gap="sm">
+                            <Stack align="center" gap={4}>
+                                <Title order={5}>Pick the right agent</Title>
+                                <Text size="sm" c="dimmed" ta="center">
+                                    {phase.decision.decision.reasoning}
+                                </Text>
+                            </Stack>
+                            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+                                {phase.decision.decision.candidates.map((c) => {
+                                    const agent = agentsByUuid.get(c.agentUuid);
+                                    return (
+                                        <UnstyledButton
+                                            key={c.agentUuid}
+                                            onClick={() =>
+                                                confirmPick(c.agentUuid)
+                                            }
+                                        >
+                                            <Card
+                                                withBorder
+                                                radius="md"
+                                                p="sm"
+                                                styles={(theme) => ({
+                                                    root: {
+                                                        borderColor:
+                                                            theme.colors
+                                                                .ldGray[2],
+                                                    },
+                                                })}
+                                            >
+                                                <Group
+                                                    gap="sm"
+                                                    wrap="nowrap"
+                                                    align="flex-start"
+                                                >
+                                                    <LightdashUserAvatar
+                                                        size={32}
+                                                        name={c.name}
+                                                        src={agent?.imageUrl}
+                                                    />
+                                                    <Stack
+                                                        gap={2}
+                                                        miw={0}
+                                                        flex={1}
+                                                    >
+                                                        <Text
+                                                            size="sm"
+                                                            fw={600}
+                                                        >
+                                                            {c.name}
+                                                        </Text>
+                                                        {c.description && (
+                                                            <Text
+                                                                size="xs"
+                                                                c="dimmed"
+                                                                truncate="end"
+                                                            >
+                                                                {c.description}
+                                                            </Text>
+                                                        )}
+                                                    </Stack>
+                                                </Group>
+                                            </Card>
+                                        </UnstyledButton>
+                                    );
+                                })}
+                            </SimpleGrid>
+                        </Stack>
+                    )}
                 </Stack>
             </Center>
         </AiAgentPageLayout>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -402,6 +402,9 @@ const AgentsRouterPage = () => {
                                                         size="sm"
                                                         fw={600}
                                                         truncate="end"
+                                                        className={
+                                                            classes.candidateName
+                                                        }
                                                     >
                                                         {c.name}
                                                     </Text>
@@ -419,8 +422,10 @@ const AgentsRouterPage = () => {
                                                 {c.description && (
                                                     <Text
                                                         size="xs"
-                                                        c="dimmed"
                                                         truncate="end"
+                                                        className={
+                                                            classes.candidateDescription
+                                                        }
                                                     >
                                                         {c.description}
                                                     </Text>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -3,17 +3,22 @@ import {
     type AiRouterRouteResponseResult,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Avatar,
-    Card,
+    Badge,
     Center,
     Group,
-    SimpleGrid,
+    Popover,
     Stack,
     Text,
     Title,
     UnstyledButton,
 } from '@mantine-8/core';
-import { IconSparkles } from '@tabler/icons-react';
+import {
+    IconChevronRight,
+    IconInfoCircle,
+    IconSparkles,
+} from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
@@ -36,6 +41,7 @@ import {
     useCreateAgentThreadMutation,
     useProjectAiAgents,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import classes from './AgentsRouterPage.module.css';
 
 type Phase =
     | { kind: 'idle' }
@@ -215,6 +221,16 @@ const AgentsRouterPage = () => {
         [phase, startThreadForDecision],
     );
 
+    const sortedCandidates = useMemo(() => {
+        if (phase.kind !== 'picker') return [];
+        const { candidates, suggestedAgentUuid } = phase.decision.decision;
+        return [...candidates].sort((a, b) => {
+            if (a.agentUuid === suggestedAgentUuid) return -1;
+            if (b.agentUuid === suggestedAgentUuid) return 1;
+            return 0;
+        });
+    }, [phase]);
+
     const isLocked = phase.kind !== 'idle';
 
     const placeholder =
@@ -288,72 +304,108 @@ const AgentsRouterPage = () => {
                     />
 
                     {phase.kind === 'picker' && (
-                        <Stack gap="sm">
-                            <Stack align="center" gap={4}>
-                                <Title order={5}>Pick the right agent</Title>
-                                <Text size="sm" c="dimmed" ta="center">
-                                    {phase.decision.decision.reasoning}
+                        <Stack gap="xs">
+                            <div className={classes.pickerHeader}>
+                                <Text size="sm" fw={600}>
+                                    Which agent should answer?
                                 </Text>
-                            </Stack>
-                            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
-                                {phase.decision.decision.candidates.map((c) => {
-                                    const agent = agentsByUuid.get(c.agentUuid);
-                                    return (
-                                        <UnstyledButton
-                                            key={c.agentUuid}
-                                            onClick={() =>
-                                                confirmPick(c.agentUuid)
-                                            }
-                                        >
-                                            <Card
-                                                withBorder
-                                                radius="md"
-                                                p="sm"
-                                                styles={(theme) => ({
-                                                    root: {
-                                                        borderColor:
-                                                            theme.colors
-                                                                .ldGray[2],
-                                                    },
-                                                })}
+                                {phase.decision.decision.reasoning && (
+                                    <Popover
+                                        width={280}
+                                        position="bottom-end"
+                                        withArrow
+                                        shadow="md"
+                                    >
+                                        <Popover.Target>
+                                            <ActionIcon
+                                                size="sm"
+                                                variant="subtle"
+                                                color="gray"
+                                                aria-label="Why these agents?"
                                             >
-                                                <Group
-                                                    gap="sm"
-                                                    wrap="nowrap"
-                                                    align="flex-start"
-                                                >
-                                                    <LightdashUserAvatar
-                                                        size={32}
-                                                        name={c.name}
-                                                        src={agent?.imageUrl}
-                                                    />
-                                                    <Stack
-                                                        gap={2}
-                                                        miw={0}
-                                                        flex={1}
+                                                <MantineIcon
+                                                    icon={IconInfoCircle}
+                                                    size={14}
+                                                />
+                                            </ActionIcon>
+                                        </Popover.Target>
+                                        <Popover.Dropdown>
+                                            <Text size="xs" c="dimmed">
+                                                {
+                                                    phase.decision.decision
+                                                        .reasoning
+                                                }
+                                            </Text>
+                                        </Popover.Dropdown>
+                                    </Popover>
+                                )}
+                            </div>
+
+                            {sortedCandidates.map((c) => {
+                                const agent = agentsByUuid.get(c.agentUuid);
+                                const isRecommended =
+                                    c.agentUuid ===
+                                    phase.decision.decision.suggestedAgentUuid;
+                                return (
+                                    <UnstyledButton
+                                        key={c.agentUuid}
+                                        onClick={() => confirmPick(c.agentUuid)}
+                                        className={`${classes.candidateButton} ${
+                                            isRecommended
+                                                ? classes.recommended
+                                                : ''
+                                        }`}
+                                        aria-label={`Send to ${c.name}`}
+                                    >
+                                        <Group
+                                            gap="sm"
+                                            wrap="nowrap"
+                                            align="center"
+                                        >
+                                            <LightdashUserAvatar
+                                                size={32}
+                                                name={c.name}
+                                                src={agent?.imageUrl}
+                                            />
+                                            <Stack gap={2} miw={0} flex={1}>
+                                                <Group gap="xs" wrap="nowrap">
+                                                    <Text
+                                                        size="sm"
+                                                        fw={600}
+                                                        truncate="end"
                                                     >
-                                                        <Text
-                                                            size="sm"
-                                                            fw={600}
+                                                        {c.name}
+                                                    </Text>
+                                                    {isRecommended && (
+                                                        <Badge
+                                                            size="xs"
+                                                            color="violet"
+                                                            variant="light"
+                                                            radius="sm"
                                                         >
-                                                            {c.name}
-                                                        </Text>
-                                                        {c.description && (
-                                                            <Text
-                                                                size="xs"
-                                                                c="dimmed"
-                                                                truncate="end"
-                                                            >
-                                                                {c.description}
-                                                            </Text>
-                                                        )}
-                                                    </Stack>
+                                                            Recommended
+                                                        </Badge>
+                                                    )}
                                                 </Group>
-                                            </Card>
-                                        </UnstyledButton>
-                                    );
-                                })}
-                            </SimpleGrid>
+                                                {c.description && (
+                                                    <Text
+                                                        size="xs"
+                                                        c="dimmed"
+                                                        truncate="end"
+                                                    >
+                                                        {c.description}
+                                                    </Text>
+                                                )}
+                                            </Stack>
+                                            <MantineIcon
+                                                icon={IconChevronRight}
+                                                size={16}
+                                                className={classes.chevron}
+                                            />
+                                        </Group>
+                                    </UnstyledButton>
+                                );
+                            })}
                         </Stack>
                     )}
                 </Stack>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -24,7 +24,7 @@ import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPa
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
-import { useGetUserAgentPreferences } from '../../features/aiCopilot/hooks/useUserAgentPreferences';
+import AgentsRouterPage from './AgentsRouterPage';
 
 const AGENT_FEATURES = [
     {
@@ -85,9 +85,6 @@ const AgentsWelcome = () => {
             enabled: isAiCopilotEnabledOrTrial,
         },
     });
-    const userAgentPreferencesQuery = useGetUserAgentPreferences(projectUuid, {
-        enabled: isAiCopilotEnabledOrTrial,
-    });
 
     if (aiOrganizationSettingsQuery.isLoading) {
         return <AiPageLoading />;
@@ -96,30 +93,16 @@ const AgentsWelcome = () => {
         return <Navigate to="/" replace />;
     }
 
-    if (agentsQuery.isError || userAgentPreferencesQuery.isError) {
+    if (agentsQuery.isError) {
         return <div>something went wrong...</div>;
     }
 
-    if (agentsQuery.isLoading || userAgentPreferencesQuery.isLoading) {
+    if (agentsQuery.isLoading) {
         return <AiPageLoading />;
     }
 
-    if (userAgentPreferencesQuery.data?.defaultAgentUuid) {
-        return (
-            <Navigate
-                to={`/projects/${projectUuid}/ai-agents/${userAgentPreferencesQuery.data.defaultAgentUuid}`}
-                replace
-            />
-        );
-    }
-
     if (agentsQuery.data.length > 0) {
-        return (
-            <Navigate
-                to={`/projects/${projectUuid}/ai-agents/${agentsQuery.data[0].uuid}`}
-                replace
-            />
-        );
+        return <AgentsRouterPage />;
     }
 
     return (

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -23,7 +23,9 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
+import { useAiRouterConfig } from '../../features/aiCopilot/hooks/useAiRouter';
 import { useProjectAiAgents } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import { useGetUserAgentPreferences } from '../../features/aiCopilot/hooks/useUserAgentPreferences';
 import AgentsRouterPage from './AgentsRouterPage';
 
 const AGENT_FEATURES = [
@@ -85,6 +87,10 @@ const AgentsWelcome = () => {
             enabled: isAiCopilotEnabledOrTrial,
         },
     });
+    const userAgentPreferencesQuery = useGetUserAgentPreferences(projectUuid, {
+        enabled: isAiCopilotEnabledOrTrial,
+    });
+    const aiRouterConfigQuery = useAiRouterConfig();
 
     if (aiOrganizationSettingsQuery.isLoading) {
         return <AiPageLoading />;
@@ -93,16 +99,44 @@ const AgentsWelcome = () => {
         return <Navigate to="/" replace />;
     }
 
-    if (agentsQuery.isError) {
+    if (agentsQuery.isError || userAgentPreferencesQuery.isError) {
         return <div>something went wrong...</div>;
     }
 
-    if (agentsQuery.isLoading) {
+    if (
+        agentsQuery.isLoading ||
+        userAgentPreferencesQuery.isLoading ||
+        // Router config: wait until we know whether it's enabled.
+        // 404 / other errors mean "not configured" — that resolves the query.
+        aiRouterConfigQuery.isLoading
+    ) {
         return <AiPageLoading />;
     }
 
-    if (agentsQuery.data.length > 0) {
+    if (agentsQuery.data.length === 0) {
+        // Fall through to the empty state below.
+    } else if (agentsQuery.data.length === 1) {
+        // Only one agent — no routing decision to make.
+        return (
+            <Navigate
+                to={`/projects/${projectUuid}/ai-agents/${agentsQuery.data[0].uuid}`}
+                replace
+            />
+        );
+    } else if (aiRouterConfigQuery.data?.enabled) {
         return <AgentsRouterPage />;
+    } else {
+        // Router disabled or not configured: prior behaviour — prefer the
+        // user's default agent, otherwise the first agent in the list.
+        const defaultAgentUuid =
+            userAgentPreferencesQuery.data?.defaultAgentUuid ??
+            agentsQuery.data[0].uuid;
+        return (
+            <Navigate
+                to={`/projects/${projectUuid}/ai-agents/${defaultAgentUuid}`}
+                replace
+            />
+        );
     }
 
     return (

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -50,7 +50,7 @@ const AiAgentNewThreadPage: FC = () => {
     const dispatch = useAiAgentStoreDispatch();
 
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
-        useCreateAgentThreadMutation(agentUuid, projectUuid!, {
+        useCreateAgentThreadMutation(projectUuid!, {
             // Seed the per-thread slice with the user's choice so subsequent
             // prompts in this thread default to the same state. Navigation
             // still happens (we only override the slice, not the routing).
@@ -108,8 +108,10 @@ const AiAgentNewThreadPage: FC = () => {
 
     const onSubmit = useCallback(
         ({ message, toolHints }: { message: string; toolHints: string[] }) => {
+            if (!agentUuid) return;
             setPendingPrompt('');
             void createAgentThread({
+                agentUuid,
                 prompt: message,
                 context: contextInput.length > 0 ? contextInput : undefined,
                 optimisticContext:
@@ -128,6 +130,7 @@ const AiAgentNewThreadPage: FC = () => {
             });
         },
         [
+            agentUuid,
             setPendingPrompt,
             createAgentThread,
             contextInput,

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -62,7 +62,7 @@ const AiAgentNewThreadPage: FC = () => {
                     }),
                 ),
         });
-    const { agent } = useOutletContext<AgentContext>();
+    const { agent, agents } = useOutletContext<AgentContext>();
     const { data: verifiedQuestions } = useVerifiedQuestions(
         projectUuid,
         agentUuid,
@@ -262,6 +262,8 @@ const AiAgentNewThreadPage: FC = () => {
                         placeholder={`Ask ${agent.name} anything about your data...`}
                         projectUuid={projectUuid}
                         agentUuid={agent.uuid}
+                        agents={agents}
+                        selectedAgent={agent}
                         models={modelOptions}
                         selectedModelId={selectedModelKey}
                         onModelChange={handleSelectedModelKeyChange}


### PR DESCRIPTION
## Summary

Adds an AI router that picks the right agent for a prompt automatically, with a disambiguation UI when it isn't confident. Ships end-to-end: schema, backend service, API, frontend page, and the composer changes that make it work alongside direct agent threads.

## What's in it

**Schema and backfill**
- `ai_router` (one row per org): `enabled`, `project_uuids[]`, timestamps.
- `ai_router_decision`: append on route, mutate on commit — `suggested_agent_uuid` (always), `chosen_agent_uuid` / `selection_mode` (null until the user commits or abandons), `confidence`, `reasoning`, `candidate_agent_uuids[]`, `thread_uuid`.
- Backfill: every org with an existing Slack multi-agent setup gets an `ai_router` row (disabled by default). `slack_auth_tokens.ai_multi_agent_project_uuids` is dropped in favour of `ai_router.project_uuids`.
- `confidence` and `selection_mode` are plain `text` (no CHECK constraints) — the TypeScript unions are the source of truth.

**Backend**
- `AiRouterModel`, `AiRouterService`, TSOA controller exposing `POST /aiRouter/route` and `POST /aiRouter/decisions/:uuid/commit`.
- Routing logic lives in a pure `selectAgent` function with a locked prompt, extracted so it's independently testable and the prompt can't drift per-caller.

**Frontend — Ask AI router page**
- New `/ai-agents` landing page with an `Auto` agent selector. Submitting hits `/route`; high-confidence decisions create the thread silently and redirect, low-confidence decisions surface a picker on the same page.
- Picker is a vertical list with the suggested agent at the top, marked `Recommended` and tinted violet on a `color-mix` of the surrounding surface so it reads as the router's pick without flashing or bouncing. The model's reasoning lives behind an info popover instead of being shouted at the user.
- Routing state has visible motion: violet hero avatar pulses, sparkles slowly rotates, three staggered dots animate next to a "Finding the right agent…" status line (`aria-live=\"polite\"`). The user's prompt stays in the input through routing and commit so they can see what's being routed.
- Entrance: header lands first, candidates stagger in starting with the recommended row, single `box-shadow` ring settles around it. `prefers-reduced-motion` disables everything.

**Composer redesign**
- Agent selector moved into the chat input toolbar; toolbar reorganized — model picker first, extended-thinking toggle inline next to it, agent selector compact on the right, SQL mode at the far right.
- New `clearOnSubmit?: boolean` prop on `AgentChatInput` (defaults `true` so every existing caller is unchanged); the router page opts out so the prompt persists during routing.

**Refactors that came along**
- Extracted the locked router prompt + pure `selectAgent` function out of the service for testability.
- `useCreateAgentThreadMutation`: `agentUuid` moved from hook parameter to mutate args so the same hook instance can target different agents (needed for the picker, which only knows the chosen agent at click time).

Closes #23451