### PR TITLE
refactor(coder): consolidate upsert content options into a single object parameter

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -1382,10 +1382,12 @@ export class ProjectController extends BaseController {
                     ...chart,
                     description: chart.description ?? undefined,
                 },
-                chart.skipSpaceCreate,
-                chart.publicSpaceCreate,
-                chart.force,
-                chart.spaceNames,
+                {
+                    skipSpaceCreate: chart.skipSpaceCreate,
+                    publicSpaceCreate: chart.publicSpaceCreate,
+                    force: chart.force,
+                    spaceNames: chart.spaceNames,
+                },
             ),
         };
     }
@@ -1495,10 +1497,12 @@ export class ProjectController extends BaseController {
                     ...dashboard,
                     description: dashboard.description ?? undefined,
                 },
-                dashboard.skipSpaceCreate,
-                dashboard.publicSpaceCreate,
-                dashboard.force,
-                dashboard.spaceNames,
+                {
+                    skipSpaceCreate: dashboard.skipSpaceCreate,
+                    publicSpaceCreate: dashboard.publicSpaceCreate,
+                    force: dashboard.force,
+                    spaceNames: dashboard.spaceNames,
+                },
             ),
         };
     }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4537,9 +4537,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                                 projectUuid,
                                 slug,
                                 patchedContent as typeof currentContent.content,
-                                undefined,
-                                undefined,
-                                true,
+                                { force: true },
                             );
                             break;
                         case 'chart':
@@ -4548,9 +4546,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                                 projectUuid,
                                 slug,
                                 patchedContent as typeof currentContent.content,
-                                undefined,
-                                undefined,
-                                true,
+                                { force: true },
                             );
                             break;
                         default:

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -75,6 +75,14 @@ type CoderServiceArguments = {
     contentVerificationModel: ContentVerificationModel;
 };
 
+type UpsertContentAsCodeOptions = {
+    skipSpaceCreate?: boolean;
+    publicSpaceCreate?: boolean;
+    force?: boolean;
+    spaceNames?: Record<string, string>;
+    mode?: 'upsert' | 'create';
+};
+
 const normalizeFilterGroupItem = (
     item: FilterGroupItemInput,
 ): FilterGroupItem => {
@@ -1135,11 +1143,17 @@ export class CoderService extends BaseService {
         projectUuid: string,
         slug: string,
         chartAsCode: ChartAsCode,
-        skipSpaceCreate?: boolean,
-        publicSpaceCreate?: boolean,
-        force?: boolean,
-        spaceNames?: Record<string, string>,
+        options: UpsertContentAsCodeOptions = {},
     ) {
+        const {
+            skipSpaceCreate,
+            publicSpaceCreate,
+            force,
+            spaceNames,
+            mode = 'upsert',
+        } = options;
+        const shouldUpdateExistingContent = mode === 'upsert';
+        const shouldUseExactSlug = mode === 'upsert';
         const project = await this.projectModel.get(projectUuid);
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -1166,12 +1180,16 @@ export class CoderService extends BaseService {
             },
         };
 
-        const [chart] = await this.savedChartModel.find({
-            slug,
-            projectUuid,
-            excludeChartsSavedInDashboard: false,
-            includeOrphanChartsWithinDashboard: true,
-        });
+        // Create mode treats the requested slug as a base for a new unique
+        // slug instead of updating content that already owns it.
+        const [chart] = shouldUpdateExistingContent
+            ? await this.savedChartModel.find({
+                  slug,
+                  projectUuid,
+                  excludeChartsSavedInDashboard: false,
+                  includeOrphanChartsWithinDashboard: true,
+              })
+            : [undefined];
 
         // If chart does not exist, we can't use promoteService,
         // since it relies on information that's not available in ChartAsCode, and other uuids
@@ -1217,7 +1235,7 @@ export class CoderService extends BaseService {
                             name: friendlyName(chartWithDefaults.dashboardSlug),
                             tiles: [],
                             slug: chartWithDefaults.dashboardSlug,
-                            forceSlug: true,
+                            forceSlug: shouldUseExactSlug,
                             tabs: [],
                         },
                         user,
@@ -1231,7 +1249,7 @@ export class CoderService extends BaseService {
                     spaceUuid: null,
                     dashboardUuid,
                     updatedByUser: user,
-                    forceSlug: true,
+                    forceSlug: shouldUseExactSlug,
                 };
             } else {
                 createChart = {
@@ -1239,7 +1257,7 @@ export class CoderService extends BaseService {
                     spaceUuid: space.uuid,
                     dashboardUuid: null,
                     updatedByUser: user,
-                    forceSlug: true,
+                    forceSlug: shouldUseExactSlug,
                 };
             }
 
@@ -1645,11 +1663,17 @@ export class CoderService extends BaseService {
         projectUuid: string,
         slug: string,
         dashboardAsCode: DashboardAsCode,
-        skipSpaceCreate?: boolean,
-        publicSpaceCreate?: boolean,
-        force?: boolean,
-        spaceNames?: Record<string, string>,
+        options: UpsertContentAsCodeOptions = {},
     ): Promise<PromotionChanges> {
+        const {
+            skipSpaceCreate,
+            publicSpaceCreate,
+            force,
+            spaceNames,
+            mode = 'upsert',
+        } = options;
+        const shouldUpdateExistingContent = mode === 'upsert';
+        const shouldUseExactSlug = mode === 'upsert';
         const project = await this.projectModel.get(projectUuid);
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -1677,10 +1701,14 @@ export class CoderService extends BaseService {
             },
         };
 
-        const [dashboardSummary] = await this.dashboardModel.find({
-            slug,
-            projectUuid,
-        });
+        // Create mode treats the requested slug as a base for a new unique
+        // slug instead of updating content that already owns it.
+        const [dashboardSummary] = shouldUpdateExistingContent
+            ? await this.dashboardModel.find({
+                  slug,
+                  projectUuid,
+              })
+            : [undefined];
         const tilesWithUuids = await this.convertTileWithSlugsToUuids(
             projectUuid,
             dashboardWithDefaults.tiles,
@@ -1708,7 +1736,7 @@ export class CoderService extends BaseService {
                 {
                     ...dashboardWithDefaults,
                     tiles: tilesWithUuids,
-                    forceSlug: true,
+                    forceSlug: shouldUseExactSlug,
                     filters: dashboardFilters,
                 },
                 user,


### PR DESCRIPTION
Closes:

### Description:

Refactors the `upsertChartAsCode` and `upsertDashboardAsCode` methods in `CoderService` to accept a single `options` object instead of individual positional parameters. This makes call sites cleaner and easier to read, and introduces a new `mode` option (`'upsert'` | `'create'`) that controls whether the operation should update existing content that owns the given slug or treat the slug as a base for generating a new unique slug.

In `create` mode, the service skips looking up existing charts/dashboards by slug and does not force exact slug usage, allowing new content to be created without overwriting existing items. In `upsert` mode (the default), behavior remains unchanged from before.