### PR TITLE
refactor(ai-router): extract locked router prompt and pure selectAgent

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -163,7 +163,7 @@ import {
 } from '../../models/AiAgentModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
-import { selectBestAgentWithContext } from '../ai/agents/agentSelector';
+import { selectAgent } from '../ai/agents/agentSelector';
 import {
     generateAgentResponse,
     streamAgentResponse,
@@ -7000,34 +7000,36 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             };
         }
 
-        // Multiple agents - use LLM to select the best one
         const { model } = getModel(this.lightdashConfig.ai.copilot);
 
-        const { agent: selectedAgent, selection } =
-            await selectBestAgentWithContext(
-                model,
-                availableAgents,
-                messageText,
-            );
+        const decision = await selectAgent({
+            model,
+            candidates: availableAgents,
+            prompt: messageText,
+        });
+
+        const selectedAgent =
+            availableAgents.find(
+                (a) => a.uuid === decision.selectedAgentUuid,
+            ) ?? availableAgents[0];
 
         Logger.info(
             `Agent selected by LLM ${JSON.stringify({
                 agentUuid: selectedAgent.uuid,
                 agentName: selectedAgent.name,
-                reasoning: selection.reasoning,
-                confidence: selection.confidence,
-                shouldSkipForwardingQuery: selection.shouldSkipForwardingQuery,
+                reasoning: decision.reasoning,
+                confidence: decision.confidence,
+                shouldSkipForwardingQuery: decision.shouldSkipForwardingQuery,
             })}`,
         );
 
-        // If confidence is low, show selection UI instead
-        if (selection.confidence === 'low') {
+        if (decision.confidence === 'low') {
             Logger.info(
                 `Low confidence in agent selection - showing manual selection UI,
                 ${JSON.stringify({
-                    reasoning: selection.reasoning,
+                    reasoning: decision.reasoning,
                     shouldSkipForwardingQuery:
-                        selection.shouldSkipForwardingQuery,
+                        decision.shouldSkipForwardingQuery,
                 })},`,
             );
             await this.showAgentSelectionUI(
@@ -7035,7 +7037,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 channelId,
                 threadTs,
                 say,
-                selection.shouldSkipForwardingQuery,
+                decision.shouldSkipForwardingQuery,
             );
             return undefined;
         }
@@ -7055,7 +7057,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         return {
             agent: selectedAgent,
-            shouldSkipForwardingQuery: selection.shouldSkipForwardingQuery,
+            shouldSkipForwardingQuery: decision.shouldSkipForwardingQuery,
         };
     }
 

--- a/packages/backend/src/ee/services/ai/agents/agentSelector.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentSelector.ts
@@ -25,9 +25,49 @@ const AgentSelectionSchema = z.object({
 
 export type AgentSelectionResult = z.infer<typeof AgentSelectionSchema>;
 
-/**
- * Builds a formatted description for a single agent.
- */
+export type RouterDecision = {
+    selectedAgentUuid: string;
+    confidence: 'high' | 'medium' | 'low';
+    reasoning: string;
+    shouldSkipForwardingQuery: boolean;
+};
+
+export const ROUTER_SYSTEM_PROMPT = `You are an intelligent agent router for a data analytics platform. Your job is to select the most appropriate AI agent to handle a user's query.
+
+All agents share the same core capabilities:
+- Specialized in data analytics and exploration
+- Can find and query data from available explores
+- Can create visualizations (tables, bar charts, line charts, pie charts, scatter plots, funnels, etc.)
+- Can search for existing dashboards and charts
+- Can perform table calculations on query results
+- Can create custom metrics
+- Can learn from user feedback to improve context understanding
+
+What differentiates agents are:
+1. **Description & Instructions**: The agent's purpose and custom instructions that guide its behavior
+2. **Data Access**: Which data explores/tables the agent has access to
+3. **Verified Questions**: Past successful queries that demonstrate the agent's expertise
+4. **Specialization**: Domain-specific focus areas defined by the agent creator
+
+Available Agents:
+{{candidates}}
+
+Selection Guidelines:
+- Choose the agent whose specialization best matches the query topic
+- Prioritize agents with relevant data access (explores)
+- Consider agents that have answered similar questions before
+- If no perfect match, choose the most general-purpose agent
+- Be confident in your choice, but indicate lower confidence if the match is uncertain
+
+Meta-Query Detection (shouldSkipForwardingQuery):
+- Set shouldSkipForwardingQuery to TRUE for queries about agent selection itself:
+  * "What agents are available?"
+  * "Show me the available agents"
+- Set shouldSkipForwardingQuery to FALSE for actual data/analytics questions
+- When shouldSkipForwardingQuery is TRUE, set confidence to 'low' to show the agent selector UI
+
+You must select exactly ONE agent from the list above by providing its exact UUID.`;
+
 function buildAgentDescription(
     agent: AiAgentWithContext,
     index: number,
@@ -52,12 +92,6 @@ function buildAgentDescription(
     return parts.filter((part): part is string => part !== null).join('\n');
 }
 
-/**
- * Builds formatted descriptions for all agents.
- *
- * @param agents - Array of agents to describe
- * @returns Formatted descriptions joined by double newlines
- */
 function buildAgentDescriptions(agents: AiAgentWithContext[]): string {
     return agents
         .map((agent, index) => buildAgentDescription(agent, index))
@@ -67,111 +101,61 @@ function buildAgentDescriptions(agents: AiAgentWithContext[]): string {
 /**
  * Uses an LLM to select the most appropriate agent for a given user query.
  */
-export async function selectBestAgent(
-    model: LanguageModel,
-    agents: AiAgentWithContext[],
-    userQuery: string,
-): Promise<AgentSelectionResult> {
-    if (agents.length === 0) {
+export async function selectAgent({
+    model,
+    candidates,
+    prompt,
+}: {
+    model: LanguageModel;
+    candidates: AiAgentWithContext[];
+    prompt: string;
+}): Promise<RouterDecision> {
+    if (candidates.length === 0) {
         throw new Error('No agents available for selection');
     }
 
-    if (agents.length === 1) {
+    if (candidates.length === 1) {
         return {
-            agentUuid: agents[0].uuid,
+            selectedAgentUuid: candidates[0].uuid,
             reasoning: 'Only one agent available',
             confidence: 'high',
             shouldSkipForwardingQuery: false,
         };
     }
 
-    const agentDescriptions = buildAgentDescriptions(agents);
+    const systemPrompt = ROUTER_SYSTEM_PROMPT.replace(
+        '{{candidates}}',
+        buildAgentDescriptions(candidates),
+    );
 
     const result = await generateObject({
         model,
         schema: AgentSelectionSchema,
         messages: [
-            {
-                role: 'system',
-                content: `You are an intelligent agent router for a data analytics platform. Your job is to select the most appropriate AI agent to handle a user's query.
-
-All agents share the same core capabilities:
-- Specialized in data analytics and exploration
-- Can find and query data from available explores
-- Can create visualizations (tables, bar charts, line charts, pie charts, scatter plots, funnels, etc.)
-- Can search for existing dashboards and charts
-- Can perform table calculations on query results
-- Can create custom metrics
-- Can learn from user feedback to improve context understanding
-
-What differentiates agents are:
-1. **Description & Instructions**: The agent's purpose and custom instructions that guide its behavior
-2. **Data Access**: Which data explores/tables the agent has access to
-3. **Verified Questions**: Past successful queries that demonstrate the agent's expertise
-4. **Specialization**: Domain-specific focus areas defined by the agent creator
-
-Available Agents:
-${agentDescriptions}
-
-Selection Guidelines:
-- Choose the agent whose specialization best matches the query topic
-- Prioritize agents with relevant data access (explores)
-- Consider agents that have answered similar questions before
-- If no perfect match, choose the most general-purpose agent
-- Be confident in your choice, but indicate lower confidence if the match is uncertain
-
-Meta-Query Detection (shouldSkipForwardingQuery):
-- Set shouldSkipForwardingQuery to TRUE for queries about agent selection itself:
-  * "What agents are available?"
-  * "Show me the available agents"
-- Set shouldSkipForwardingQuery to FALSE for actual data/analytics questions
-- When shouldSkipForwardingQuery is TRUE, set confidence to 'low' to show the agent selector UI
-
-You must select exactly ONE agent from the list above by providing its exact UUID.`,
-            },
+            { role: 'system', content: systemPrompt },
             {
                 role: 'user',
-                content: `User Query: "${userQuery}"
-
-Please select the best agent to handle this query and explain your reasoning.`,
+                content: `User Query: "${prompt}"\n\nPlease select the best agent to handle this query and explain your reasoning.`,
             },
         ],
     });
 
-    return result.object;
-}
+    const selection = result.object;
+    const exists = candidates.some((c) => c.uuid === selection.agentUuid);
 
-/**
- * Helper function to select an agent and return the full agent context.
- */
-export async function selectBestAgentWithContext(
-    model: LanguageModel,
-    agents: AiAgentWithContext[],
-    userQuery: string,
-): Promise<{
-    agent: AiAgentWithContext;
-    selection: AgentSelectionResult;
-}> {
-    const selection = await selectBestAgent(model, agents, userQuery);
-
-    const selectedAgent = agents.find(
-        (agent) => agent.uuid === selection.agentUuid,
-    );
-
-    if (!selectedAgent) {
+    if (!exists) {
         return {
-            agent: agents[0],
-            selection: {
-                agentUuid: agents[0].uuid,
-                reasoning: `Selected agent "${selection.agentUuid}" not found. Defaulting to first available agent.`,
-                confidence: 'low',
-                shouldSkipForwardingQuery: false,
-            },
+            selectedAgentUuid: candidates[0].uuid,
+            reasoning: `Selected agent "${selection.agentUuid}" not found. Defaulting to first available agent.`,
+            confidence: 'low',
+            shouldSkipForwardingQuery: false,
         };
     }
 
     return {
-        agent: selectedAgent,
-        selection,
+        selectedAgentUuid: selection.agentUuid,
+        confidence: selection.confidence,
+        reasoning: selection.reasoning,
+        shouldSkipForwardingQuery: selection.shouldSkipForwardingQuery,
     };
 }


### PR DESCRIPTION
## Summary

Pure refactor — no behaviour change. Pulls the LLM-driven agent selection out of `AiAgentService` into a standalone `selectAgent` function in `services/ai/agents/agentSelector.ts`, with the system prompt locked in one place.

This lets both the Slack flow and the upcoming web router endpoint share the same selector logic and the same prompt, instead of each owning their own copy.

Closes #23451