### PR TITLE
fix(mcp): resolve project UUID from context in list/set agent tools

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -824,7 +824,7 @@ export class McpService extends BaseService {
             McpToolName.LIST_AGENTS,
             {
                 description:
-                    'List all accessible AI agents. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Use this to discover which agents are available before calling set_agent.',
+                    'List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Use this to discover which agents are available before calling set_agent.',
                 inputSchema: {
                     projectUuid: z.string().optional(),
                 },
@@ -843,9 +843,13 @@ export class McpService extends BaseService {
 
                 this.trackToolCall(ctx, McpToolName.LIST_AGENTS);
 
+                const projectUuid =
+                    args.projectUuid ??
+                    (await this.getProjectUuidFromContext(ctx));
+
                 const agents = await this.aiAgentService.listAgents(
                     user,
-                    args.projectUuid,
+                    projectUuid,
                 );
 
                 const agentList = agents.map((agent) => ({
@@ -871,7 +875,7 @@ export class McpService extends BaseService {
             McpToolName.SET_AGENT,
             {
                 description:
-                    "Set the active AI agent. Returns the agent's full context including: explores it has access to, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+                    "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
                 inputSchema: {
                     agentUuid: z.string(),
                 },
@@ -894,11 +898,13 @@ export class McpService extends BaseService {
                     throw new ParameterError('Agent UUID is required');
                 }
 
+                const projectUuid = await this.resolveProjectUuid(ctx);
+
                 // Validates copilot enabled, agent exists, user has access, and returns summary context
                 const agent = await this.aiAgentService.getAgent(
                     user,
                     args.agentUuid,
-                    undefined,
+                    projectUuid,
                     { includeSummaryContext: true },
                 );
 


### PR DESCRIPTION
Closes:

### Description:

Updates the `list_agents` and `set_agent` MCP tools to resolve the project UUID from context when one is not explicitly provided, rather than passing `undefined`. This ensures both tools operate against the active project by default.

The tool descriptions for `list_agents` and `set_agent` have also been updated to clarify they operate on the **active project**.