### PR TITLE
fix: exclude PoP metrics from raw fanout CTE projections

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -356,15 +356,24 @@ export class MetricQueryBuilder {
             ),
         };
 
-        const selectedPopAdditionalMetrics = (
+        const metricFilterIds = new Set(
+            getFilterRulesFromGroup(compiledMetricQuery.filters.metrics).map(
+                (filter) => filter.target.fieldId,
+            ),
+        );
+        const selectedOrFilteredPopAdditionalMetrics = (
             compiledMetricQuery.additionalMetrics ?? []
         )
             .filter(isPeriodOverPeriodAdditionalMetric)
-            .filter((am) =>
-                compiledMetricQuery.metrics.includes(getItemId(am)),
-            );
+            .filter((am) => {
+                const popMetricId = getItemId(am);
+                return (
+                    compiledMetricQuery.metrics.includes(popMetricId) ||
+                    metricFilterIds.has(popMetricId)
+                );
+            });
 
-        if (selectedPopAdditionalMetrics.length > 0) {
+        if (selectedOrFilteredPopAdditionalMetrics.length > 0) {
             const configsByKey = new Map<
                 string,
                 {
@@ -375,7 +384,7 @@ export class MetricQueryBuilder {
                 }
             >();
 
-            selectedPopAdditionalMetrics.forEach((am) => {
+            selectedOrFilteredPopAdditionalMetrics.forEach((am) => {
                 const configKey = getPopComparisonConfigKey({
                     timeDimensionId: am.timeDimensionId,
                     granularity: am.granularity,
@@ -938,10 +947,13 @@ export class MetricQueryBuilder {
             metrics.filter((metricId) => !this.isPopMetricId(metricId)),
         );
 
-        // Add metrics from filters
-        getFilterRulesFromGroup(filters.metrics).forEach((filter) =>
-            referencedMetricIds.add(filter.target.fieldId),
-        );
+        // Add regular metrics from filters. PoP filter metrics are materialized
+        // by shifted comparison CTEs instead of the raw metric SELECT.
+        getFilterRulesFromGroup(filters.metrics).forEach((filter) => {
+            if (!this.isPopMetricId(filter.target.fieldId)) {
+                referencedMetricIds.add(filter.target.fieldId);
+            }
+        });
 
         // Add metrics referenced in PostCalculation metrics
         this.getPostCalculationMetricReferences(
@@ -1956,8 +1968,33 @@ export class MetricQueryBuilder {
             .map((filter) => filter.target.fieldId)
             .filter((metricId) => !metrics.includes(metricId));
 
-        // Include both selected metrics AND filter-only metrics for fanout protection
-        const allMetricsToProcess = [...metrics, ...filterOnlyMetricIds];
+        const selectedOrFilteredMetricIds = new Set([
+            ...metrics,
+            ...filterOnlyMetricIds,
+        ]);
+        const popMetricIds = new Set(
+            (compiledMetricQuery.additionalMetrics ?? [])
+                .filter(isPeriodOverPeriodAdditionalMetric)
+                .map((metric) => getItemId(metric)),
+        );
+        const selectedOrFilteredPopBaseMetricIds = (
+            compiledMetricQuery.additionalMetrics ?? []
+        )
+            .filter(isPeriodOverPeriodAdditionalMetric)
+            .filter((metric) =>
+                selectedOrFilteredMetricIds.has(getItemId(metric)),
+            )
+            .map((metric) => metric.baseMetricId);
+
+        // Include both selected metrics AND filter-only metrics for fanout protection.
+        // Selected PoP metrics also need their base metrics materialized in shifted CTEs.
+        const allMetricsToProcess = Array.from(
+            new Set([
+                ...metrics,
+                ...filterOnlyMetricIds,
+                ...selectedOrFilteredPopBaseMetricIds,
+            ]),
+        );
         const metricsObjects = allMetricsToProcess.map((field) =>
             this.getMetricFromId(field),
         );
@@ -2103,6 +2140,9 @@ export class MetricQueryBuilder {
             }
 
             metricsFromTable.forEach((metric) => {
+                if (popMetricIds.has(getItemId(metric))) {
+                    return;
+                }
                 // Nested aggregate outer metrics are materialized by the
                 // nested_agg CTE flow and must not also be emitted here.
                 if (nestedAggOuterIds.has(getItemId(metric))) {
@@ -2402,6 +2442,7 @@ export class MetricQueryBuilder {
                 return (
                     notInMetricCtes &&
                     notMetricWithCteReferences &&
+                    !popMetricIds.has(getItemId(metric)) &&
                     notSumDistinct &&
                     notNonAggReferencingDd &&
                     !nestedAggOuterIds.has(getItemId(metric))
@@ -2582,7 +2623,7 @@ export class MetricQueryBuilder {
                     metricCte.metrics
                         // excludes metrics only used for references
                         .filter((metric) =>
-                            metricsObjects.find((m) => metric === getItemId(m)),
+                            selectedOrFilteredMetricIds.has(metric),
                         )
                         .map(
                             (metricName) =>
@@ -2593,7 +2634,7 @@ export class MetricQueryBuilder {
                     metricCte.metrics
                         // excludes metrics only used for references
                         .filter((metricId) =>
-                            compiledMetricQuery.metrics.includes(metricId),
+                            selectedOrFilteredMetricIds.has(metricId),
                         )
                         .map(
                             (metricName) =>

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/periodOverPeriodQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/periodOverPeriodQueries.test.ts.snap
@@ -20,8 +20,7 @@ exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapsho
   cte_metrics_table2 AS (
     SELECT
       cte_keys_table2."table2_order_date_year",
-      SUM("table2".amount) AS "table2_metric_amount",
-      SUM("table2".amount) AS "table2_metric_amount__pop__year_1__fanout"
+      SUM("table2".amount) AS "table2_metric_amount"
     FROM
       cte_keys_table2
       LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_keys_table2."pk_id" = "table2".id
@@ -77,7 +76,6 @@ exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapsho
 SELECT
   cte_unaffected.*,
   cte_metrics_table2."table2_metric_amount" AS "table2_metric_amount",
-  cte_metrics_table2."table2_metric_amount__pop__year_1__fanout" AS "table2_metric_amount__pop__year_1__fanout",
   cte_pop_metrics_table2__year_1__00355f4s."table2_metric_amount__pop__year_1__fanout" AS "table2_metric_amount__pop__year_1__fanout"
 FROM
   cte_unaffected
@@ -114,8 +112,7 @@ exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapsho
       cte_keys_country_orders."country_orders_order_date_year",
       cte_keys_country_orders."country_orders_country",
       cte_keys_country_orders."order_currencies_currency",
-      SUM("country_orders".amount) AS "country_orders_total_order_amount",
-      SUM("country_orders".amount) AS "country_orders_total_order_amount__pop__year_1__country"
+      SUM("country_orders".amount) AS "country_orders_total_order_amount"
     FROM
       cte_keys_country_orders
       LEFT JOIN "postgres"."jaffle"."country_orders" AS "country_orders" ON cte_keys_country_orders."pk_order_id" = "country_orders".order_id
@@ -179,7 +176,6 @@ exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapsho
 SELECT
   cte_unaffected.*,
   cte_metrics_country_orders."country_orders_total_order_amount" AS "country_orders_total_order_amount",
-  cte_metrics_country_orders."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country",
   cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country"
 FROM
   cte_unaffected
@@ -392,4 +388,274 @@ ORDER BY
   "orders_order_date_year" DESC
 LIMIT
   500"
+`;
+
+exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapshot for filter-only period-over-period metric with fanout CTEs 1`] = `
+"WITH
+  cte_keys_country_orders AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      "country_orders".order_id AS "pk_order_id"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+  ),
+  cte_metrics_country_orders AS (
+    SELECT
+      cte_keys_country_orders."country_orders_order_date_year",
+      SUM("country_orders".amount) AS "country_orders_total_order_amount"
+    FROM
+      cte_keys_country_orders
+      LEFT JOIN "postgres"."jaffle"."country_orders" AS "country_orders" ON cte_keys_country_orders."pk_order_id" = "country_orders".order_id
+    GROUP BY
+      1
+  ),
+  cte_pop_min_max_country_orders__year_1__00rp9exa AS (
+    SELECT
+      MIN(
+        cte_keys_country_orders."country_orders_order_date_year"
+      ) as min_date,
+      MAX(
+        cte_keys_country_orders."country_orders_order_date_year"
+      ) as max_date
+    FROM
+      cte_keys_country_orders
+  ),
+  cte_pop_keys_country_orders__year_1__00rp9exa AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      "country_orders".order_id AS "pk_order_id"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+      LEFT JOIN cte_pop_min_max_country_orders__year_1__00rp9exa ON TRUE
+    WHERE
+      DATE_TRUNC('YEAR', "country_orders".order_date) >= cte_pop_min_max_country_orders__year_1__00rp9exa.min_date - INTERVAL '1 YEAR'
+      AND DATE_TRUNC('YEAR', "country_orders".order_date) <= cte_pop_min_max_country_orders__year_1__00rp9exa.max_date - INTERVAL '1 YEAR'
+  ),
+  cte_pop_metrics_country_orders__year_1__00rp9exa AS (
+    SELECT
+      cte_pop_keys_country_orders__year_1__00rp9exa."country_orders_order_date_year",
+      SUM("country_orders".amount) AS "country_orders_total_order_amount__pop__year_1__country"
+    FROM
+      cte_pop_keys_country_orders__year_1__00rp9exa
+      LEFT JOIN "postgres"."jaffle"."country_orders" AS "country_orders" ON cte_pop_keys_country_orders__year_1__00rp9exa."pk_order_id" = "country_orders".order_id
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      SUM("order_currencies".converted_amount) AS "order_currencies_total_converted_amount"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+    GROUP BY
+      1
+  ),
+  metrics AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_country_orders."country_orders_total_order_amount" AS "country_orders_total_order_amount",
+      cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country"
+    FROM
+      cte_unaffected
+      INNER JOIN cte_metrics_country_orders ON (
+        cte_unaffected."country_orders_order_date_year" = cte_metrics_country_orders."country_orders_order_date_year"
+        OR (
+          cte_unaffected."country_orders_order_date_year" IS NULL
+          AND cte_metrics_country_orders."country_orders_order_date_year" IS NULL
+        )
+      )
+      LEFT JOIN cte_pop_metrics_country_orders__year_1__00rp9exa ON (
+        cte_unaffected."country_orders_order_date_year" = cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_order_date_year" + INTERVAL '1 YEAR'
+      )
+  )
+SELECT
+  "country_orders_order_date_year",
+  "country_orders_total_order_amount",
+  "order_currencies_total_converted_amount"
+FROM
+  metrics
+WHERE
+  (
+    (
+      (
+        "country_orders_total_order_amount__pop__year_1__country"
+      ) > (100)
+    )
+  )
+ORDER BY
+  "country_orders_order_date_year" DESC
+LIMIT
+  100"
+`;
+
+exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapshot for period-over-period fanout query without selecting the base metric 1`] = `
+"WITH
+  cte_keys_country_orders AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      "country_orders".order_id AS "pk_order_id"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+  ),
+  cte_metrics_country_orders AS (
+    SELECT
+      cte_keys_country_orders."country_orders_order_date_year",
+      SUM("country_orders".amount) AS "country_orders_total_order_amount"
+    FROM
+      cte_keys_country_orders
+      LEFT JOIN "postgres"."jaffle"."country_orders" AS "country_orders" ON cte_keys_country_orders."pk_order_id" = "country_orders".order_id
+    GROUP BY
+      1
+  ),
+  cte_pop_min_max_country_orders__year_1__00rp9exa AS (
+    SELECT
+      MIN(
+        cte_keys_country_orders."country_orders_order_date_year"
+      ) as min_date,
+      MAX(
+        cte_keys_country_orders."country_orders_order_date_year"
+      ) as max_date
+    FROM
+      cte_keys_country_orders
+  ),
+  cte_pop_keys_country_orders__year_1__00rp9exa AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      "country_orders".order_id AS "pk_order_id"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+      LEFT JOIN cte_pop_min_max_country_orders__year_1__00rp9exa ON TRUE
+    WHERE
+      DATE_TRUNC('YEAR', "country_orders".order_date) >= cte_pop_min_max_country_orders__year_1__00rp9exa.min_date - INTERVAL '1 YEAR'
+      AND DATE_TRUNC('YEAR', "country_orders".order_date) <= cte_pop_min_max_country_orders__year_1__00rp9exa.max_date - INTERVAL '1 YEAR'
+  ),
+  cte_pop_metrics_country_orders__year_1__00rp9exa AS (
+    SELECT
+      cte_pop_keys_country_orders__year_1__00rp9exa."country_orders_order_date_year",
+      SUM("country_orders".amount) AS "country_orders_total_order_amount__pop__year_1__country"
+    FROM
+      cte_pop_keys_country_orders__year_1__00rp9exa
+      LEFT JOIN "postgres"."jaffle"."country_orders" AS "country_orders" ON cte_pop_keys_country_orders__year_1__00rp9exa."pk_order_id" = "country_orders".order_id
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      SUM("order_currencies".converted_amount) AS "order_currencies_total_converted_amount"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+    GROUP BY
+      1
+  )
+SELECT
+  cte_unaffected.*,
+  cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country"
+FROM
+  cte_unaffected
+  INNER JOIN cte_metrics_country_orders ON (
+    cte_unaffected."country_orders_order_date_year" = cte_metrics_country_orders."country_orders_order_date_year"
+    OR (
+      cte_unaffected."country_orders_order_date_year" IS NULL
+      AND cte_metrics_country_orders."country_orders_order_date_year" IS NULL
+    )
+  )
+  LEFT JOIN cte_pop_metrics_country_orders__year_1__00rp9exa ON (
+    cte_unaffected."country_orders_order_date_year" = cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_order_date_year" + INTERVAL '1 YEAR'
+  )
+ORDER BY
+  "country_orders_order_date_year" DESC
+LIMIT
+  100"
+`;
+
+exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapshot for period-over-period query combined with fanout metric CTEs 1`] = `
+"WITH
+  cte_keys_country_orders AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      "country_orders".order_id AS "pk_order_id"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+  ),
+  cte_metrics_country_orders AS (
+    SELECT
+      cte_keys_country_orders."country_orders_order_date_year",
+      SUM("country_orders".amount) AS "country_orders_total_order_amount"
+    FROM
+      cte_keys_country_orders
+      LEFT JOIN "postgres"."jaffle"."country_orders" AS "country_orders" ON cte_keys_country_orders."pk_order_id" = "country_orders".order_id
+    GROUP BY
+      1
+  ),
+  cte_pop_min_max_country_orders__year_1__00rp9exa AS (
+    SELECT
+      MIN(
+        cte_keys_country_orders."country_orders_order_date_year"
+      ) as min_date,
+      MAX(
+        cte_keys_country_orders."country_orders_order_date_year"
+      ) as max_date
+    FROM
+      cte_keys_country_orders
+  ),
+  cte_pop_keys_country_orders__year_1__00rp9exa AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      "country_orders".order_id AS "pk_order_id"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+      LEFT JOIN cte_pop_min_max_country_orders__year_1__00rp9exa ON TRUE
+    WHERE
+      DATE_TRUNC('YEAR', "country_orders".order_date) >= cte_pop_min_max_country_orders__year_1__00rp9exa.min_date - INTERVAL '1 YEAR'
+      AND DATE_TRUNC('YEAR', "country_orders".order_date) <= cte_pop_min_max_country_orders__year_1__00rp9exa.max_date - INTERVAL '1 YEAR'
+  ),
+  cte_pop_metrics_country_orders__year_1__00rp9exa AS (
+    SELECT
+      cte_pop_keys_country_orders__year_1__00rp9exa."country_orders_order_date_year",
+      SUM("country_orders".amount) AS "country_orders_total_order_amount__pop__year_1__country"
+    FROM
+      cte_pop_keys_country_orders__year_1__00rp9exa
+      LEFT JOIN "postgres"."jaffle"."country_orders" AS "country_orders" ON cte_pop_keys_country_orders__year_1__00rp9exa."pk_order_id" = "country_orders".order_id
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      SUM("order_currencies".converted_amount) AS "order_currencies_total_converted_amount"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+    GROUP BY
+      1
+  )
+SELECT
+  cte_unaffected.*,
+  cte_metrics_country_orders."country_orders_total_order_amount" AS "country_orders_total_order_amount",
+  cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country"
+FROM
+  cte_unaffected
+  INNER JOIN cte_metrics_country_orders ON (
+    cte_unaffected."country_orders_order_date_year" = cte_metrics_country_orders."country_orders_order_date_year"
+    OR (
+      cte_unaffected."country_orders_order_date_year" IS NULL
+      AND cte_metrics_country_orders."country_orders_order_date_year" IS NULL
+    )
+  )
+  LEFT JOIN cte_pop_metrics_country_orders__year_1__00rp9exa ON (
+    cte_unaffected."country_orders_order_date_year" = cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_order_date_year" + INTERVAL '1 YEAR'
+  )
+ORDER BY
+  "country_orders_order_date_year" DESC
+LIMIT
+  100"
 `;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/periodOverPeriodQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/periodOverPeriodQueries.test.ts
@@ -641,4 +641,75 @@ describe('MetricQueryBuilder snapshot: period-over-period queries', () => {
             }),
         ).toMatchSnapshot();
     });
+
+    // Covers PoP plus a separate fanout-protected metric in the same query.
+    // The generated PoP metric must only be emitted from shifted PoP CTEs.
+    test('matches snapshot for period-over-period query combined with fanout metric CTEs', () => {
+        expect(
+            buildQuery({
+                explore: POP_TEST_COUNTRY_FANOUT_EXPLORE,
+                compiledMetricQuery: {
+                    ...POP_TEST_COUNTRY_FANOUT_METRIC_QUERY,
+                    dimensions: ['country_orders_order_date_year'],
+                    metrics: [
+                        'country_orders_total_order_amount',
+                        POP_TEST_COUNTRY_FANOUT_POP_METRIC_ID,
+                        'order_currencies_total_converted_amount',
+                    ],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers PoP selected without the base metric while another metric requires fanout CTEs.
+    // The generated PoP metric still needs its base metric to be materialized in shifted PoP CTEs.
+    test('matches snapshot for period-over-period fanout query without selecting the base metric', () => {
+        expect(
+            buildQuery({
+                explore: POP_TEST_COUNTRY_FANOUT_EXPLORE,
+                compiledMetricQuery: {
+                    ...POP_TEST_COUNTRY_FANOUT_METRIC_QUERY,
+                    dimensions: ['country_orders_order_date_year'],
+                    metrics: [
+                        POP_TEST_COUNTRY_FANOUT_POP_METRIC_ID,
+                        'order_currencies_total_converted_amount',
+                    ],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers PoP used only in a metric filter while fanout CTEs are required.
+    // The filtered PoP metric must still be materialized before post-agg filtering.
+    test('matches snapshot for filter-only period-over-period metric with fanout CTEs', () => {
+        expect(
+            buildQuery({
+                explore: POP_TEST_COUNTRY_FANOUT_EXPLORE,
+                compiledMetricQuery: {
+                    ...POP_TEST_COUNTRY_FANOUT_METRIC_QUERY,
+                    dimensions: ['country_orders_order_date_year'],
+                    metrics: [
+                        'country_orders_total_order_amount',
+                        'order_currencies_total_converted_amount',
+                    ],
+                    filters: {
+                        metrics: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: 'previous-year-total',
+                                    target: {
+                                        fieldId:
+                                            POP_TEST_COUNTRY_FANOUT_POP_METRIC_ID,
+                                    },
+                                    operator: FilterOperator.GREATER_THAN,
+                                    values: [100],
+                                },
+                            ],
+                        },
+                    },
+                },
+            }),
+        ).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
## Summary
- Prevent PoP additional metrics from being emitted inside the raw fanout/unaffected metric CTEs.
- Ensure selected or filter-only PoP metrics are still materialized through the shifted PoP CTE path.
- Update snapshot coverage for PoP queries combined with fanout CTEs and filter-only PoP metrics.
- Closes: https://linear.app/lightdash/issue/PROD-7950/query-builder-pop-metric-emitted-in-cte-unaffected-with-wrong-date

## Testing
- Added regression coverage in `MetricQueryBuilder.test.ts`.
- Updated PoP snapshot expectations in `periodOverPeriodQueries.test.ts`.
- Ran targeted backend Jest suites for `MetricQueryBuilder` and PoP snapshot queries.