### PR TITLE
fix(ai-agents): batch AI stream updates

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
@@ -1,7 +1,12 @@
+import { SHOULD_AUTOBATCH } from '@reduxjs/toolkit';
 import { describe, expect, it } from 'vitest';
 import {
+    addReasoning,
     addMcpUnavailableNotice,
+    addToolCall,
     aiAgentThreadStreamSlice,
+    setMessage,
+    setParts,
     startStreaming,
 } from './aiAgentThreadStreamSlice';
 
@@ -49,5 +54,48 @@ describe('aiAgentThreadStreamSlice', () => {
                 status: 'error',
             },
         ]);
+    });
+
+    it('marks high-frequency stream updates for Redux auto-batching', () => {
+        const expectedMeta = { [SHOULD_AUTOBATCH]: true };
+
+        expect(
+            setMessage({
+                threadUuid: 'thread-1',
+                content: 'hello',
+            }).meta,
+        ).toEqual(expectedMeta);
+        expect(
+            setParts({
+                threadUuid: 'thread-1',
+                parts: [{ type: 'text', text: 'hello' }],
+            }).meta,
+        ).toEqual(expectedMeta);
+        expect(
+            addToolCall({
+                threadUuid: 'thread-1',
+                toolCallId: 'tool-1',
+                toolName: 'findExplores',
+                toolArgs: {},
+            }).meta,
+        ).toEqual(expectedMeta);
+        expect(
+            addReasoning({
+                threadUuid: 'thread-1',
+                reasoningId: 'reasoning-1',
+                text: 'thinking',
+            }).meta,
+        ).toEqual(expectedMeta);
+        expect(
+            addMcpUnavailableNotice({
+                threadUuid: 'thread-1',
+                notice: {
+                    serverUuid: 'server-1',
+                    serverName: 'Docs MCP',
+                    message: 'Connection refused',
+                    status: 'error',
+                },
+            }).meta,
+        ).toEqual(expectedMeta);
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
@@ -2,7 +2,11 @@ import {
     type AiAgentToolName,
     type AiMcpServerConnectionStatus,
 } from '@lightdash/common';
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import {
+    createSlice,
+    prepareAutoBatched,
+    type PayloadAction,
+} from '@reduxjs/toolkit';
 
 type ToolCall = {
     toolCallId: string;
@@ -94,52 +98,70 @@ export const aiAgentThreadStreamSlice = createSlice({
                 ...initialThread,
             };
         },
-        setMessage: (
-            state,
-            action: PayloadAction<{
+        setMessage: {
+            reducer: (
+                state,
+                action: PayloadAction<{
+                    threadUuid: string;
+                    content: string;
+                }>,
+            ) => {
+                const { threadUuid, content } = action.payload;
+
+                const streamingThread = state[threadUuid];
+                if (streamingThread) {
+                    streamingThread.content = content;
+                } else {
+                    console.warn('Streaming thread or message not found:', {
+                        threadUuid,
+                    });
+                }
+            },
+            prepare: prepareAutoBatched<{
                 threadUuid: string;
                 content: string;
-            }>,
-        ) => {
-            const { threadUuid, content } = action.payload;
-
-            const streamingThread = state[threadUuid];
-            if (streamingThread) {
-                streamingThread.content = content;
-            } else {
-                console.warn('Streaming thread or message not found:', {
-                    threadUuid,
-                });
-            }
+            }>(),
         },
-        setParts: (
-            state,
-            action: PayloadAction<{
+        setParts: {
+            reducer: (
+                state,
+                action: PayloadAction<{
+                    threadUuid: string;
+                    parts: StreamPart[];
+                }>,
+            ) => {
+                const { threadUuid, parts } = action.payload;
+                const streamingThread = state[threadUuid];
+                if (streamingThread) {
+                    streamingThread.parts = parts;
+                }
+            },
+            prepare: prepareAutoBatched<{
                 threadUuid: string;
                 parts: StreamPart[];
-            }>,
-        ) => {
-            const { threadUuid, parts } = action.payload;
-            const streamingThread = state[threadUuid];
-            if (streamingThread) {
-                streamingThread.parts = parts;
-            }
+            }>(),
         },
-        markToolCallDecided: (
-            state,
-            action: PayloadAction<{
+        markToolCallDecided: {
+            reducer: (
+                state,
+                action: PayloadAction<{
+                    threadUuid: string;
+                    toolCallId: string;
+                }>,
+            ) => {
+                const { threadUuid, toolCallId } = action.payload;
+                const streamingThread = state[threadUuid];
+                if (
+                    streamingThread &&
+                    !streamingThread.decidedToolCallIds.includes(toolCallId)
+                ) {
+                    streamingThread.decidedToolCallIds.push(toolCallId);
+                }
+            },
+            prepare: prepareAutoBatched<{
                 threadUuid: string;
                 toolCallId: string;
-            }>,
-        ) => {
-            const { threadUuid, toolCallId } = action.payload;
-            const streamingThread = state[threadUuid];
-            if (
-                streamingThread &&
-                !streamingThread.decidedToolCallIds.includes(toolCallId)
-            ) {
-                streamingThread.decidedToolCallIds.push(toolCallId);
-            }
+            }>(),
         },
         stopStreaming: (
             state,
@@ -152,31 +174,34 @@ export const aiAgentThreadStreamSlice = createSlice({
                 streamingThread.isStreaming = false;
             }
         },
-        addToolCall: (
-            state,
-            action: PayloadAction<ToolCall & { threadUuid: string }>,
-        ) => {
-            const { threadUuid, toolCallId, toolName, toolArgs } =
-                action.payload;
-            const streamingThread = state[threadUuid];
-            if (streamingThread) {
-                const existingIndex = streamingThread.toolCalls.findIndex(
-                    (tc: ToolCall) => tc.toolCallId === toolCallId,
-                );
-                if (existingIndex !== -1) {
-                    streamingThread.toolCalls[existingIndex] = {
-                        ...streamingThread.toolCalls[existingIndex],
-                        toolName,
-                        toolArgs,
-                    };
-                } else {
-                    streamingThread.toolCalls.push({
-                        toolCallId,
-                        toolName,
-                        toolArgs,
-                    });
+        addToolCall: {
+            reducer: (
+                state,
+                action: PayloadAction<ToolCall & { threadUuid: string }>,
+            ) => {
+                const { threadUuid, toolCallId, toolName, toolArgs } =
+                    action.payload;
+                const streamingThread = state[threadUuid];
+                if (streamingThread) {
+                    const existingIndex = streamingThread.toolCalls.findIndex(
+                        (tc: ToolCall) => tc.toolCallId === toolCallId,
+                    );
+                    if (existingIndex !== -1) {
+                        streamingThread.toolCalls[existingIndex] = {
+                            ...streamingThread.toolCalls[existingIndex],
+                            toolName,
+                            toolArgs,
+                        };
+                    } else {
+                        streamingThread.toolCalls.push({
+                            toolCallId,
+                            toolName,
+                            toolArgs,
+                        });
+                    }
                 }
-            }
+            },
+            prepare: prepareAutoBatched<ToolCall & { threadUuid: string }>(),
         },
         setError: (
             state,
@@ -191,23 +216,30 @@ export const aiAgentThreadStreamSlice = createSlice({
                 streamingThread.error = error;
             }
         },
-        setImproveContextNotification: (
-            state,
-            action: PayloadAction<{
+        setImproveContextNotification: {
+            reducer: (
+                state,
+                action: PayloadAction<{
+                    threadUuid: string;
+                    toolCallId: string;
+                    suggestedInstruction: string;
+                }>,
+            ) => {
+                const { threadUuid, toolCallId, suggestedInstruction } =
+                    action.payload;
+                const streamingThread = state[threadUuid];
+                if (streamingThread) {
+                    streamingThread.improveContextNotification = {
+                        toolCallId,
+                        suggestedInstruction,
+                    };
+                }
+            },
+            prepare: prepareAutoBatched<{
                 threadUuid: string;
                 toolCallId: string;
                 suggestedInstruction: string;
-            }>,
-        ) => {
-            const { threadUuid, toolCallId, suggestedInstruction } =
-                action.payload;
-            const streamingThread = state[threadUuid];
-            if (streamingThread) {
-                streamingThread.improveContextNotification = {
-                    toolCallId,
-                    suggestedInstruction,
-                };
-            }
+            }>(),
         },
         clearImproveContextNotification: (
             state,
@@ -219,62 +251,76 @@ export const aiAgentThreadStreamSlice = createSlice({
                 streamingThread.improveContextNotification = undefined;
             }
         },
-        addReasoning: (
-            state,
-            action: PayloadAction<{
+        addReasoning: {
+            reducer: (
+                state,
+                action: PayloadAction<{
+                    threadUuid: string;
+                    reasoningId: string;
+                    text: string;
+                }>,
+            ) => {
+                const { threadUuid, reasoningId, text } = action.payload;
+                const streamingThread = state[threadUuid];
+                if (streamingThread) {
+                    const existingIndex = streamingThread.reasoning.findIndex(
+                        (r: Reasoning) => r.reasoningId === reasoningId,
+                    );
+                    if (existingIndex !== -1) {
+                        const existing =
+                            streamingThread.reasoning[existingIndex];
+
+                        // Find which part this text is continuing
+                        const matchingPartIndex = existing.parts.findIndex(
+                            (part) => text.startsWith(part),
+                        );
+
+                        if (matchingPartIndex !== -1) {
+                            // Update the matching part with longer text
+                            existing.parts[matchingPartIndex] = text;
+                        } else {
+                            // No match found - new part
+                            existing.parts.push(text);
+                        }
+                    } else {
+                        // New reasoning
+                        streamingThread.reasoning.push({
+                            reasoningId,
+                            parts: [text],
+                        });
+                    }
+                }
+            },
+            prepare: prepareAutoBatched<{
                 threadUuid: string;
                 reasoningId: string;
                 text: string;
-            }>,
-        ) => {
-            const { threadUuid, reasoningId, text } = action.payload;
-            const streamingThread = state[threadUuid];
-            if (streamingThread) {
-                const existingIndex = streamingThread.reasoning.findIndex(
-                    (r: Reasoning) => r.reasoningId === reasoningId,
-                );
-                if (existingIndex !== -1) {
-                    const existing = streamingThread.reasoning[existingIndex];
-
-                    // Find which part this text is continuing
-                    const matchingPartIndex = existing.parts.findIndex((part) =>
-                        text.startsWith(part),
-                    );
-
-                    if (matchingPartIndex !== -1) {
-                        // Update the matching part with longer text
-                        existing.parts[matchingPartIndex] = text;
-                    } else {
-                        // No match found - new part
-                        existing.parts.push(text);
-                    }
-                } else {
-                    // New reasoning
-                    streamingThread.reasoning.push({
-                        reasoningId,
-                        parts: [text],
-                    });
-                }
-            }
+            }>(),
         },
-        addMcpUnavailableNotice: (
-            state,
-            action: PayloadAction<{
+        addMcpUnavailableNotice: {
+            reducer: (
+                state,
+                action: PayloadAction<{
+                    threadUuid: string;
+                    notice: McpUnavailableNotice;
+                }>,
+            ) => {
+                const { threadUuid, notice } = action.payload;
+                const streamingThread = state[threadUuid];
+                if (
+                    streamingThread &&
+                    !streamingThread.mcpUnavailableNotices.some(
+                        (existingNotice) =>
+                            existingNotice.serverUuid === notice.serverUuid,
+                    )
+                ) {
+                    streamingThread.mcpUnavailableNotices.push(notice);
+                }
+            },
+            prepare: prepareAutoBatched<{
                 threadUuid: string;
                 notice: McpUnavailableNotice;
-            }>,
-        ) => {
-            const { threadUuid, notice } = action.payload;
-            const streamingThread = state[threadUuid];
-            if (
-                streamingThread &&
-                !streamingThread.mcpUnavailableNotices.some(
-                    (existingNotice) =>
-                        existingNotice.serverUuid === notice.serverUuid,
-                )
-            ) {
-                streamingThread.mcpUnavailableNotices.push(notice);
-            }
+            }>(),
         },
     },
 });

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -167,6 +167,8 @@ export function useAiAgentThreadStreamMutation() {
                 });
                 const rawChunkReader = rawChunkStream.getReader();
 
+                const handledToolInputIds = new Set<string>();
+                const handledToolDecisionIds = new Set<string>();
                 const handledToolOutputIds = new Set<string>();
 
                 const consumeRawChunks = (async () => {
@@ -287,8 +289,14 @@ export function useAiAgentThreadStreamMutation() {
                                     // any open approval card. Idempotent.
                                     if (
                                         part.type === 'tool-runSql' &&
-                                        part.state === 'output-available'
+                                        part.state === 'output-available' &&
+                                        !handledToolDecisionIds.has(
+                                            part.toolCallId,
+                                        )
                                     ) {
+                                        handledToolDecisionIds.add(
+                                            part.toolCallId,
+                                        );
                                         dispatch(
                                             markToolCallDecided({
                                                 threadUuid,
@@ -333,12 +341,20 @@ export function useAiAgentThreadStreamMutation() {
                                     break;
                                 }
 
+                                if (
+                                    handledToolInputIds.has(part.toolCallId)
+                                ) {
+                                    break;
+                                }
+
                                 const toolName = part.type.split('-')[1];
 
                                 try {
                                     if (!isAiAgentToolName(toolName)) {
                                         break;
                                     }
+
+                                    handledToolInputIds.add(part.toolCallId);
 
                                     // Store raw tool args (will be validated in rendering components)
                                     dispatch(
@@ -400,9 +416,17 @@ export function useAiAgentThreadStreamMutation() {
                                     part.state === 'output-available' ||
                                     part.state === 'output-error'
                                 ) {
+                                    if (
+                                        handledToolInputIds.has(part.toolCallId)
+                                    ) {
+                                        break;
+                                    }
+
                                     if (!isAiAgentToolName(part.toolName)) {
                                         break;
                                     }
+
+                                    handledToolInputIds.add(part.toolCallId);
 
                                     dispatch(
                                         addToolCall({

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -341,9 +341,7 @@ export function useAiAgentThreadStreamMutation() {
                                     break;
                                 }
 
-                                if (
-                                    handledToolInputIds.has(part.toolCallId)
-                                ) {
+                                if (handledToolInputIds.has(part.toolCallId)) {
                                     break;
                                 }
 


### PR DESCRIPTION
Relates to: Sentry Issue: [LIGHTDASH-FRONTEND-41T](https://lightdash.sentry.io/issues/7116262516/?referrer=Linear)

## Summary

- Mark high-frequency AI stream Redux actions as auto-batched updates.
- Avoid reprocessing already-seen tool input, SQL decision, and query output parts from repeated AI SDK message snapshots.
- Add reducer coverage that asserts stream update actions carry the RTK auto-batch metadata.

## Root cause

`readUIMessageStream` emits an ever-growing UI message snapshot on each stream chunk. For prompts with many tool calls, the frontend loop replayed prior tool parts and dispatched several synchronous Redux updates per snapshot. That could cascade through React subscribers and hit React's maximum update depth guard.

## Validation

- Ran `npx react-doctor@latest` on `@lightdash/frontend`; it completed with existing broad repo findings.
- Ran `git diff --check` successfully.
- Could not run `pnpm -F @lightdash/frontend test ...` or `pnpm -F @lightdash/frontend typecheck` in this worktree because `node_modules` are missing (`vitest` / `tsc` not found).